### PR TITLE
Add --list-connections and --list-datasets CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md   # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md # Org-wide report guide
 │   └── ...                  # Additional guides
-├── tests/                   # Test suite (1,264+ tests)
+├── tests/                   # Test suite (1,270+ tests)
 ├── sample_outputs/          # Example output files
 │   ├── excel/               # Sample Excel SDR
 │   ├── csv/                 # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md   # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md # Org-wide report guide
 │   └── ...                  # Additional guides
-├── tests/                   # Test suite (1,231+ tests)
+├── tests/                   # Test suite (1,259+ tests)
 ├── sample_outputs/          # Example output files
 │   ├── excel/               # Sample Excel SDR
 │   ├── csv/                 # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md   # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md # Org-wide report guide
 │   └── ...                  # Additional guides
-├── tests/                   # Test suite (1,270+ tests)
+├── tests/                   # Test suite (1,271+ tests)
 ├── sample_outputs/          # Example output files
 │   ├── excel/               # Sample Excel SDR
 │   ├── csv/                 # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md   # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md # Org-wide report guide
 │   └── ...                  # Additional guides
-├── tests/                   # Test suite (1,259+ tests)
+├── tests/                   # Test suite (1,264+ tests)
 ├── sample_outputs/          # Example output files
 │   ├── excel/               # Sample Excel SDR
 │   ├── csv/                 # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md   # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md # Org-wide report guide
 │   └── ...                  # Additional guides
-├── tests/                   # Test suite (1,271+ tests)
+├── tests/                   # Test suite (1,275+ tests)
 ├── sample_outputs/          # Example output files
 │   ├── excel/               # Sample Excel SDR
 │   ├── csv/                 # Sample CSV output

--- a/src/cja_auto_sdr/core/version.py
+++ b/src/cja_auto_sdr/core/version.py
@@ -1,3 +1,3 @@
 """Version information for CJA Auto SDR."""
 
-__version__ = "3.2.0"
+__version__ = "3.2.1"

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -9766,12 +9766,14 @@ def list_connections(config_file: str = "config.json", output_format: str = "tab
                 if output_format == 'json':
                     output_data = json.dumps({"connections": [], "count": 0}, indent=2)
                 else:  # csv
-                    output_data = "connection_id,connection_name,owner,dataset_id,dataset_name\n"
+                    output_data = "connection_id,connection_name,owner,dataset_id,dataset_name"
                 if is_stdout:
                     print(output_data)
                 elif output_file:
                     with open(output_file, 'w') as f:
                         f.write(output_data)
+                else:
+                    print(output_data)
             else:
                 print()
                 print(ConsoleColors.warning("No connections found or no access to any connections."))
@@ -9963,21 +9965,23 @@ def list_datasets(config_file: str = "config.json", output_format: str = "table"
                 if output_format == 'json':
                     output_data = json.dumps({"dataViews": [], "count": 0}, indent=2)
                 else:  # csv
-                    output_data = "dataview_id,dataview_name,connection_id,connection_name,dataset_id,dataset_name\n"
+                    output_data = "dataview_id,dataview_name,connection_id,connection_name,dataset_id,dataset_name"
                 if is_stdout:
                     print(output_data)
                 elif output_file:
                     with open(output_file, 'w') as f:
                         f.write(output_data)
+                else:
+                    print(output_data)
             else:
                 print()
                 print(ConsoleColors.warning("No data views found or no access to any data views."))
                 print()
             return True
 
-        # Step 3: Fetch detail for each data view to get parentDataGroupId
+        # Step 3: Build output records using parentDataGroupId from list response
         if not is_machine_readable:
-            print(f"Fetching details for {len(available_dvs)} data view(s)...")
+            print(f"Processing {len(available_dvs)} data view(s)...")
         display_data = []
         for i, dv in enumerate(available_dvs):
             if not isinstance(dv, dict):
@@ -9988,14 +9992,7 @@ def list_datasets(config_file: str = "config.json", output_format: str = "table"
             if not is_machine_readable:
                 print(f"  [{i + 1}/{len(available_dvs)}] {dv_name}...", end='\r')
 
-            # Get full data view detail for parentDataGroupId
-            parent_conn_id = None
-            try:
-                dv_detail = cja.getDataView(dv_id, full=True)
-                if isinstance(dv_detail, dict):
-                    parent_conn_id = dv_detail.get('parentDataGroupId')
-            except Exception:
-                pass  # Gracefully skip if detail fetch fails
+            parent_conn_id = dv.get('parentDataGroupId')
 
             conn_info = conn_map.get(parent_conn_id, {}) if parent_conn_id else {}
             conn_name = conn_info.get('name', 'Unknown')

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -8378,22 +8378,23 @@ Requirements:
 
     discovery_group = parser.add_argument_group(
         'Discovery',
-        'Commands to explore available CJA resources'
+        'Commands to explore available CJA resources (mutually exclusive)'
     )
+    discovery_mx = discovery_group.add_mutually_exclusive_group()
 
-    discovery_group.add_argument(
+    discovery_mx.add_argument(
         '--list-dataviews',
         action='store_true',
         help='List all accessible data views and exit (no data view ID required)'
     )
 
-    discovery_group.add_argument(
+    discovery_mx.add_argument(
         '--list-connections',
         action='store_true',
         help='List all accessible connections with their datasets and exit'
     )
 
-    discovery_group.add_argument(
+    discovery_mx.add_argument(
         '--list-datasets',
         action='store_true',
         help='List all data views with their backing connections and datasets, then exit'

--- a/tests/README.md
+++ b/tests/README.md
@@ -39,7 +39,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 1,271 comprehensive tests**
+**Total: 1,275 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -49,7 +49,7 @@ tests/
 | `test_ux_features.py` | 116 | UX features: --open, --stats, --output, --list-dataviews formats, inventory validation, inventory summary, include-all-inventory |
 | `test_org_report.py` | 144 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
 | `test_org_report_integration.py` | 17 | Org-wide analysis integration tests: end-to-end flows, caching, filtering, governance |
-| `test_cli.py` | 116 | Command-line interface and argument parsing |
+| `test_cli.py` | 120 | Command-line interface and argument parsing |
 | `test_profiles.py` | 43 | Multi-organization profile support |
 | `test_derived_inventory.py` | 43 | Derived fields inventory feature |
 | `test_inventory_utils.py` | 41 | Inventory utilities and helpers |
@@ -78,7 +78,7 @@ tests/
 | `test_early_exit.py` | 11 | Early exit optimizations |
 | `test_data_quality.py` | 10 | Data quality validation logic |
 | `test_parallel_validation.py` | 8 | Parallel validation operations |
-| **Total** | **1,271** | **Collected via pytest --collect-only** |
+| **Total** | **1,275** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -482,7 +482,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (1,271 tests total)
+- [x] Comprehensive test coverage (1,275 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 144 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 43 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -39,7 +39,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 1,264 comprehensive tests**
+**Total: 1,270 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -49,7 +49,7 @@ tests/
 | `test_ux_features.py` | 116 | UX features: --open, --stats, --output, --list-dataviews formats, inventory validation, inventory summary, include-all-inventory |
 | `test_org_report.py` | 144 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
 | `test_org_report_integration.py` | 17 | Org-wide analysis integration tests: end-to-end flows, caching, filtering, governance |
-| `test_cli.py` | 109 | Command-line interface and argument parsing |
+| `test_cli.py` | 115 | Command-line interface and argument parsing |
 | `test_profiles.py` | 43 | Multi-organization profile support |
 | `test_derived_inventory.py` | 43 | Derived fields inventory feature |
 | `test_inventory_utils.py` | 41 | Inventory utilities and helpers |
@@ -78,7 +78,7 @@ tests/
 | `test_early_exit.py` | 11 | Early exit optimizations |
 | `test_data_quality.py` | 10 | Data quality validation logic |
 | `test_parallel_validation.py` | 8 | Parallel validation operations |
-| **Total** | **1,264** | **Collected via pytest --collect-only** |
+| **Total** | **1,270** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -482,7 +482,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (1,264 tests total)
+- [x] Comprehensive test coverage (1,270 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 144 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 43 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -39,7 +39,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 1,270 comprehensive tests**
+**Total: 1,271 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -49,7 +49,7 @@ tests/
 | `test_ux_features.py` | 116 | UX features: --open, --stats, --output, --list-dataviews formats, inventory validation, inventory summary, include-all-inventory |
 | `test_org_report.py` | 144 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
 | `test_org_report_integration.py` | 17 | Org-wide analysis integration tests: end-to-end flows, caching, filtering, governance |
-| `test_cli.py` | 115 | Command-line interface and argument parsing |
+| `test_cli.py` | 116 | Command-line interface and argument parsing |
 | `test_profiles.py` | 43 | Multi-organization profile support |
 | `test_derived_inventory.py` | 43 | Derived fields inventory feature |
 | `test_inventory_utils.py` | 41 | Inventory utilities and helpers |
@@ -78,7 +78,7 @@ tests/
 | `test_early_exit.py` | 11 | Early exit optimizations |
 | `test_data_quality.py` | 10 | Data quality validation logic |
 | `test_parallel_validation.py` | 8 | Parallel validation operations |
-| **Total** | **1,270** | **Collected via pytest --collect-only** |
+| **Total** | **1,271** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -482,7 +482,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (1,270 tests total)
+- [x] Comprehensive test coverage (1,271 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 144 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 43 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -39,7 +39,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 1,231 comprehensive tests**
+**Total: 1,259 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -49,7 +49,7 @@ tests/
 | `test_ux_features.py` | 116 | UX features: --open, --stats, --output, --list-dataviews formats, inventory validation, inventory summary, include-all-inventory |
 | `test_org_report.py` | 144 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
 | `test_org_report_integration.py` | 17 | Org-wide analysis integration tests: end-to-end flows, caching, filtering, governance |
-| `test_cli.py` | 76 | Command-line interface and argument parsing |
+| `test_cli.py` | 104 | Command-line interface and argument parsing |
 | `test_profiles.py` | 43 | Multi-organization profile support |
 | `test_derived_inventory.py` | 43 | Derived fields inventory feature |
 | `test_inventory_utils.py` | 41 | Inventory utilities and helpers |
@@ -78,7 +78,7 @@ tests/
 | `test_early_exit.py` | 11 | Early exit optimizations |
 | `test_data_quality.py` | 10 | Data quality validation logic |
 | `test_parallel_validation.py` | 8 | Parallel validation operations |
-| **Total** | **1,231** | **Collected via pytest --collect-only** |
+| **Total** | **1,259** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -482,7 +482,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (1,231 tests total)
+- [x] Comprehensive test coverage (1,259 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 144 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 43 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -39,7 +39,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 1,259 comprehensive tests**
+**Total: 1,264 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -49,7 +49,7 @@ tests/
 | `test_ux_features.py` | 116 | UX features: --open, --stats, --output, --list-dataviews formats, inventory validation, inventory summary, include-all-inventory |
 | `test_org_report.py` | 144 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
 | `test_org_report_integration.py` | 17 | Org-wide analysis integration tests: end-to-end flows, caching, filtering, governance |
-| `test_cli.py` | 104 | Command-line interface and argument parsing |
+| `test_cli.py` | 109 | Command-line interface and argument parsing |
 | `test_profiles.py` | 43 | Multi-organization profile support |
 | `test_derived_inventory.py` | 43 | Derived fields inventory feature |
 | `test_inventory_utils.py` | 41 | Inventory utilities and helpers |
@@ -78,7 +78,7 @@ tests/
 | `test_early_exit.py` | 11 | Early exit optimizations |
 | `test_data_quality.py` | 10 | Data quality validation logic |
 | `test_parallel_validation.py` | 8 | Parallel validation operations |
-| **Total** | **1,259** | **Collected via pytest --collect-only** |
+| **Total** | **1,264** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -482,7 +482,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (1,259 tests total)
+- [x] Comprehensive test coverage (1,264 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 144 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 43 tests

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -777,6 +777,38 @@ class TestListDatasetsArgs:
             assert args.profile == 'client-a'
 
 
+class TestDiscoveryMutualExclusivity:
+    """Test that discovery commands are mutually exclusive"""
+
+    def test_list_dataviews_and_connections_rejected(self):
+        """Test that --list-dataviews and --list-connections cannot be combined"""
+        test_args = ['cja_sdr_generator.py', '--list-dataviews', '--list-connections']
+        with patch.object(sys, 'argv', test_args):
+            with pytest.raises(SystemExit):
+                parse_arguments()
+
+    def test_list_dataviews_and_datasets_rejected(self):
+        """Test that --list-dataviews and --list-datasets cannot be combined"""
+        test_args = ['cja_sdr_generator.py', '--list-dataviews', '--list-datasets']
+        with patch.object(sys, 'argv', test_args):
+            with pytest.raises(SystemExit):
+                parse_arguments()
+
+    def test_list_connections_and_datasets_rejected(self):
+        """Test that --list-connections and --list-datasets cannot be combined"""
+        test_args = ['cja_sdr_generator.py', '--list-connections', '--list-datasets']
+        with patch.object(sys, 'argv', test_args):
+            with pytest.raises(SystemExit):
+                parse_arguments()
+
+    def test_all_three_rejected(self):
+        """Test that all three discovery flags cannot be combined"""
+        test_args = ['cja_sdr_generator.py', '--list-dataviews', '--list-connections', '--list-datasets']
+        with patch.object(sys, 'argv', test_args):
+            with pytest.raises(SystemExit):
+                parse_arguments()
+
+
 class TestExtractDatasetInfo:
     """Test _extract_dataset_info() helper"""
 

--- a/tests/test_ux_features.py
+++ b/tests/test_ux_features.py
@@ -337,10 +337,10 @@ class TestCombinedFeatures:
 class TestVersionUpdated:
     """Test that version is correct"""
 
-    def test_version_is_3_2_0(self):
-        """Test that version is 3.2.0"""
+    def test_version_is_3_2_1(self):
+        """Test that version is 3.2.1"""
         from cja_auto_sdr.generator import __version__
-        assert __version__ == "3.2.0"
+        assert __version__ == "3.2.1"
 
 
 class TestFormatAutoDetection:


### PR DESCRIPTION
## Summary

- Adds `--list-connections` command that lists all accessible CJA connections with their datasets (single API call via `getConnections`)
- Adds `--list-datasets` command that lists all data views with their backing connections and underlying datasets (joins data views → connections via `parentDataGroupId`)
- Both commands support `--format table|json|csv`, `--output`, and `--profile` options, following the established `--list-dataviews` pattern
- Discovery commands (`--list-dataviews`, `--list-connections`, `--list-datasets`) are mutually exclusive via argparse
- Refactors all list commands to share `_run_list_command()` boilerplate (profile resolution, CJA config, banner display, error handling)
- Adds `_extract_dataset_info()` helper for resilient parsing of dataset objects from the API
- Uses `csv.writer` instead of manual escaping for CSV output
- Machine-readable errors (JSON/CSV modes) now route to stderr
- Handles NaN `parentDataGroupId` values from DataFrame-backed API responses
- Bumps version to v3.2.1

Closes #4

## Test plan

- [x] 44 new tests added (1,275 total, all passing): arg parsing, mutual exclusivity, `_extract_dataset_info()` unit tests, mock-based integration tests for both functions, file output, parent dir creation, empty results, config failures
- [x] Manual: `cja_auto_sdr --list-connections` — lists connections with datasets in table format
- [x] Manual: `cja_auto_sdr --list-connections --format json` — JSON output
- [x] Manual: `cja_auto_sdr --list-datasets` — lists data views with connections + datasets
- [x] Manual: `cja_auto_sdr --list-datasets --format csv --output datasets.csv` — CSV file output
- [x] Inspect `dataSets` field structure from a real API response to validate/adjust the helper