### PR TITLE
Fix --list-connections and --list-datasets for non-admin accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md   # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md # Org-wide report guide
 │   └── ...                  # Additional guides
-├── tests/                   # Test suite (1,275+ tests)
+├── tests/                   # Test suite (1,280+ tests)
 ├── sample_outputs/          # Example output files
 │   ├── excel/               # Sample Excel SDR
 │   ├── csv/                 # Sample CSV output

--- a/tests/README.md
+++ b/tests/README.md
@@ -39,7 +39,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 1,275 comprehensive tests**
+**Total: 1,280 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -49,7 +49,7 @@ tests/
 | `test_ux_features.py` | 116 | UX features: --open, --stats, --output, --list-dataviews formats, inventory validation, inventory summary, include-all-inventory |
 | `test_org_report.py` | 144 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
 | `test_org_report_integration.py` | 17 | Org-wide analysis integration tests: end-to-end flows, caching, filtering, governance |
-| `test_cli.py` | 120 | Command-line interface and argument parsing |
+| `test_cli.py` | 125 | Command-line interface and argument parsing |
 | `test_profiles.py` | 43 | Multi-organization profile support |
 | `test_derived_inventory.py` | 43 | Derived fields inventory feature |
 | `test_inventory_utils.py` | 41 | Inventory utilities and helpers |
@@ -78,7 +78,7 @@ tests/
 | `test_early_exit.py` | 11 | Early exit optimizations |
 | `test_data_quality.py` | 10 | Data quality validation logic |
 | `test_parallel_validation.py` | 8 | Parallel validation operations |
-| **Total** | **1,275** | **Collected via pytest --collect-only** |
+| **Total** | **1,280** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -482,7 +482,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (1,275 tests total)
+- [x] Comprehensive test coverage (1,280 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 144 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 43 tests


### PR DESCRIPTION
## Summary
- **Problem**: `GET /connections` API requires product-admin privileges. Without it, `getConnections()` silently returns `[]`, causing `--list-connections` to show "No connections found" and `--list-datasets` to show "Connection: Unknown" / "Datasets: (none)" — even though connections exist.
- **Fix**: Both commands now detect the permissions gap by checking whether data views reference connections via `parentDataGroupId`. When they do, a warning is shown and connection IDs are derived from data views.
- **Output changes**: JSON/CSV include a `warning` field and `null` connection names; table mode shows a human-readable warning and connection IDs only (no "Unknown", no "(none)").

## Test plan
- [x] 5 new tests covering all fallback paths (table/JSON/CSV for connections, table/JSON for datasets)
- [x] Updated 3 existing empty-state tests to mock `getDataViews` for the "genuinely empty" path
- [x] Updated `test_list_datasets_unknown_connection` assertion (`'Unknown'` → `None`)
- [x] Full suite passes: 1,280 tests (1,279 passed, 1 skipped)
- [x] Test counts updated in README.md and tests/README.md