### PR TITLE
Refactor discovery formatting and replace worker tuple with dataclass

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md   # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md # Org-wide report guide
 │   └── ...                  # Additional guides
-├── tests/                   # Test suite (1,296+ tests)
+├── tests/                   # Test suite (1,319+ tests)
 ├── sample_outputs/          # Example output files
 │   ├── excel/               # Sample Excel SDR
 │   ├── csv/                 # Sample CSV output

--- a/src/cja_auto_sdr/core/constants.py
+++ b/src/cja_auto_sdr/core/constants.py
@@ -35,6 +35,11 @@ EXTENSION_TO_FORMAT: Dict[str, str] = {
     '.markdown': 'markdown',
 }
 
+# ==================== DISPLAY CONSTANTS ====================
+
+# Width of banner separator lines (used across CLI output)
+BANNER_WIDTH: int = 60
+
 # ==================== WORKER LIMITS ====================
 
 # Worker thread/process limits

--- a/tests/README.md
+++ b/tests/README.md
@@ -49,7 +49,7 @@ tests/
 | `test_ux_features.py` | 116 | UX features: --open, --stats, --output, --list-dataviews formats, inventory validation, inventory summary, include-all-inventory |
 | `test_org_report.py` | 144 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
 | `test_org_report_integration.py` | 17 | Org-wide analysis integration tests: end-to-end flows, caching, filtering, governance |
-| `test_cli.py` | 137 | Command-line interface and argument parsing |
+| `test_cli.py` | 141 | Command-line interface and argument parsing |
 | `test_profiles.py` | 43 | Multi-organization profile support |
 | `test_derived_inventory.py` | 43 | Derived fields inventory feature |
 | `test_inventory_utils.py` | 41 | Inventory utilities and helpers |

--- a/tests/README.md
+++ b/tests/README.md
@@ -39,7 +39,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 1,296 comprehensive tests**
+**Total: 1,319 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -78,7 +78,8 @@ tests/
 | `test_early_exit.py` | 11 | Early exit optimizations |
 | `test_data_quality.py` | 10 | Data quality validation logic |
 | `test_parallel_validation.py` | 8 | Parallel validation operations |
-| **Total** | **1,296** | **Collected via pytest --collect-only** |
+| `test_discovery_formatters.py` | 23 | Shared discovery formatters, WorkerArgs dataclass, _exit_error, BANNER_WIDTH |
+| **Total** | **1,319** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -482,7 +483,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (1,296 tests total)
+- [x] Comprehensive test coverage (1,319 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 144 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 43 tests

--- a/tests/test_batch_processor.py
+++ b/tests/test_batch_processor.py
@@ -10,7 +10,7 @@ import tempfile
 # Add parent directory to path for imports
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from cja_auto_sdr.generator import BatchProcessor, ProcessingResult
+from cja_auto_sdr.generator import BatchProcessor, ProcessingResult, WorkerArgs
 from cja_auto_sdr.core.exceptions import OutputError
 
 
@@ -525,11 +525,12 @@ class TestBatchProcessorWorkerArgs:
             )
             processor.process_batch(["dv_test_12345"])
 
-        # Verify args were passed
+        # Verify args were passed as WorkerArgs
         assert len(submitted_args) == 1
         args = submitted_args[0]
-        assert args[0] == "dv_test_12345"  # data_view_id
-        assert args[1] == mock_config_file  # config_file
+        assert isinstance(args, WorkerArgs)
+        assert args.data_view_id == "dv_test_12345"
+        assert args.config_file == mock_config_file
 
 
 class TestBatchProcessorEdgeCases:

--- a/tests/test_discovery_formatters.py
+++ b/tests/test_discovery_formatters.py
@@ -1,0 +1,232 @@
+"""Tests for shared discovery command formatting helpers."""
+import json
+import pytest
+
+from cja_auto_sdr.generator import (
+    _format_as_json,
+    _format_as_csv,
+    _format_as_table,
+    WorkerArgs,
+    _exit_error,
+)
+from cja_auto_sdr.core.constants import BANNER_WIDTH
+
+
+# ==================== _format_as_json ====================
+
+
+class TestFormatAsJson:
+    """Tests for _format_as_json helper."""
+
+    def test_basic_payload(self):
+        """Produces valid JSON with indent=2."""
+        payload = {"items": [{"id": "a"}], "count": 1}
+        result = _format_as_json(payload)
+        assert json.loads(result) == payload
+        # Check indentation
+        assert '  "items"' in result
+
+    def test_empty_list(self):
+        """Empty list payload serializes correctly."""
+        payload = {"items": [], "count": 0}
+        result = _format_as_json(payload)
+        assert json.loads(result) == payload
+
+    def test_unicode_values(self):
+        """Unicode characters are preserved."""
+        payload = {"name": "Données françaises"}
+        result = _format_as_json(payload)
+        parsed = json.loads(result)
+        assert parsed["name"] == "Données françaises"
+
+    def test_nested_dict(self):
+        """Nested dicts are serialized."""
+        payload = {"a": {"b": {"c": 1}}}
+        result = _format_as_json(payload)
+        assert json.loads(result)["a"]["b"]["c"] == 1
+
+
+# ==================== _format_as_csv ====================
+
+
+class TestFormatAsCsv:
+    """Tests for _format_as_csv helper."""
+
+    def test_basic_rows(self):
+        """Produces CSV with header and data rows."""
+        cols = ['id', 'name']
+        rows = [{'id': '1', 'name': 'Alice'}, {'id': '2', 'name': 'Bob'}]
+        result = _format_as_csv(cols, rows)
+        lines = result.strip().split('\n')
+        assert lines[0] == 'id,name'
+        assert lines[1] == '1,Alice'
+        assert lines[2] == '2,Bob'
+
+    def test_empty_rows(self):
+        """Empty row list produces header only."""
+        result = _format_as_csv(['a', 'b'], [])
+        assert result.strip() == 'a,b'
+
+    def test_missing_keys(self):
+        """Missing keys default to empty string."""
+        result = _format_as_csv(['id', 'name'], [{'id': '1'}])
+        lines = result.strip().split('\n')
+        assert lines[1] == '1,'
+
+    def test_values_with_commas(self):
+        """Values containing commas are properly quoted."""
+        result = _format_as_csv(['name'], [{'name': 'Last, First'}])
+        lines = result.strip().split('\n')
+        assert '"Last, First"' in lines[1]
+
+    def test_unicode_values(self):
+        """Unicode values in CSV."""
+        result = _format_as_csv(['name'], [{'name': 'données'}])
+        assert 'données' in result
+
+    def test_newline_terminator(self):
+        """Each row ends with \\n, not \\r\\n."""
+        result = _format_as_csv(['a'], [{'a': '1'}])
+        assert '\r\n' not in result
+
+
+# ==================== _format_as_table ====================
+
+
+class TestFormatAsTable:
+    """Tests for _format_as_table helper."""
+
+    def test_basic_table(self):
+        """Produces a table with header, separator, and data."""
+        items = [{'id': 'abc', 'name': 'Test'}]
+        result = _format_as_table("Found 1 item(s):", items, ['id', 'name'])
+        assert "Found 1 item(s):" in result
+        assert "Id" in result  # default title-cased label
+        assert "Name" in result
+        assert "abc" in result
+        assert "Test" in result
+        # Should contain a dash separator line
+        assert '---' in result
+
+    def test_custom_labels(self):
+        """Custom col_labels override defaults."""
+        items = [{'x': '1'}]
+        result = _format_as_table("Header:", items, ['x'], col_labels=['Custom'])
+        assert "Custom" in result
+        assert "X" not in result  # default label not used
+
+    def test_column_width_adapts(self):
+        """Columns are wide enough for the longest value."""
+        items = [{'id': 'short'}, {'id': 'a_very_long_value_here'}]
+        result = _format_as_table("Header:", items, ['id'])
+        lines = result.split('\n')
+        # Find the data lines — they should all be consistently wide
+        data_lines = [l for l in lines if 'a_very_long_value_here' in l]
+        assert len(data_lines) == 1
+
+    def test_empty_items(self):
+        """Empty items list produces header but no data rows."""
+        result = _format_as_table("No items:", [], ['id', 'name'])
+        assert "No items:" in result
+        # Still has column labels and separator
+        assert "Id" in result
+        assert '---' in result
+
+    def test_missing_keys_in_items(self):
+        """Items with missing keys show empty string."""
+        items = [{'id': '1'}]
+        result = _format_as_table("Header:", items, ['id', 'name'])
+        assert '1' in result
+
+    def test_leading_trailing_blank_lines(self):
+        """Result starts and ends with blank lines for spacing."""
+        items = [{'a': '1'}]
+        result = _format_as_table("H:", items, ['a'])
+        assert result.startswith('\n')
+
+
+# ==================== WorkerArgs ====================
+
+
+class TestWorkerArgs:
+    """Tests for WorkerArgs dataclass."""
+
+    def test_required_field(self):
+        """data_view_id is required."""
+        wa = WorkerArgs(data_view_id="dv_123")
+        assert wa.data_view_id == "dv_123"
+
+    def test_defaults(self):
+        """All optional fields have sensible defaults."""
+        wa = WorkerArgs(data_view_id="dv_123")
+        assert wa.config_file == "config.json"
+        assert wa.output_dir == "."
+        assert wa.log_level == "INFO"
+        assert wa.output_format == "excel"
+        assert wa.enable_cache is False
+        assert wa.cache_size == 1000
+        assert wa.cache_ttl == 3600
+        assert wa.quiet is False
+        assert wa.skip_validation is False
+        assert wa.max_issues == 0
+        assert wa.profile is None
+        assert wa.shared_cache is None
+        assert wa.inventory_only is False
+        assert wa.inventory_order is None
+
+    def test_custom_values(self):
+        """Custom values are stored correctly."""
+        wa = WorkerArgs(
+            data_view_id="dv_456",
+            config_file="/path/to/config.json",
+            output_format="json",
+            enable_cache=True,
+            cache_size=500,
+            profile="staging",
+            inventory_only=True,
+            inventory_order="alpha",
+        )
+        assert wa.data_view_id == "dv_456"
+        assert wa.config_file == "/path/to/config.json"
+        assert wa.output_format == "json"
+        assert wa.enable_cache is True
+        assert wa.cache_size == 500
+        assert wa.profile == "staging"
+        assert wa.inventory_only is True
+        assert wa.inventory_order == "alpha"
+
+    def test_missing_required_field_raises(self):
+        """Omitting data_view_id raises TypeError."""
+        with pytest.raises(TypeError):
+            WorkerArgs()
+
+
+# ==================== _exit_error ====================
+
+
+class TestExitError:
+    """Tests for _exit_error helper."""
+
+    def test_prints_error_and_exits(self, capsys):
+        """Should print to stderr and exit with code 1."""
+        with pytest.raises(SystemExit) as exc_info:
+            _exit_error("something went wrong")
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "something went wrong" in captured.err
+        assert "ERROR:" in captured.err
+
+
+# ==================== BANNER_WIDTH ====================
+
+
+class TestBannerWidth:
+    """Tests for BANNER_WIDTH constant."""
+
+    def test_value(self):
+        """BANNER_WIDTH is 60."""
+        assert BANNER_WIDTH == 60
+
+    def test_type(self):
+        """BANNER_WIDTH is an int."""
+        assert isinstance(BANNER_WIDTH, int)

--- a/tests/test_process_single_dataview.py
+++ b/tests/test_process_single_dataview.py
@@ -15,7 +15,8 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from cja_auto_sdr.generator import (
     process_single_dataview,
     process_single_dataview_worker,
-    ProcessingResult
+    ProcessingResult,
+    WorkerArgs,
 )
 
 
@@ -552,24 +553,10 @@ class TestProcessSingleDataviewWorker:
         )
         mock_process.return_value = expected_result
 
-        args = (
-            "dv_test_12345",  # data_view_id
-            "config.json",   # config_file
-            "/output",       # output_dir
-            "INFO",          # log_level
-            "text",          # log_format
-            "excel",         # output_format
-            False,           # enable_cache
-            1000,            # cache_size
-            3600,            # cache_ttl
-            False,           # quiet
-            False,           # skip_validation
-            0,               # max_issues
-            False,           # clear_cache
-            False,           # show_timings
-            False,           # metrics_only
-            False,           # dimensions_only
-            None             # profile
+        args = WorkerArgs(
+            data_view_id="dv_test_12345",
+            config_file="config.json",
+            output_dir="/output",
         )
 
         result = process_single_dataview_worker(args)
@@ -578,9 +565,10 @@ class TestProcessSingleDataviewWorker:
         mock_process.assert_called_once_with(
             "dv_test_12345", "config.json", "/output", "INFO", "text", "excel",
             False, 1000, 3600, False, False, 0, False, False, False, False,
-            profile=None, shared_cache=None, api_tuning_config=None, circuit_breaker_config=None,
+            profile=None, shared_cache=None,
+            api_tuning_config=None, circuit_breaker_config=None,
             include_derived_inventory=False, include_calculated_metrics=False,
-            include_segments_inventory=False, inventory_only=False, inventory_order=None
+            include_segments_inventory=False, inventory_only=False, inventory_order=None,
         )
 
 


### PR DESCRIPTION
## Summary

- **BANNER_WIDTH constant**: Added `BANNER_WIDTH = 60` to `constants.py` and replaced all 127 inline `"=" * 60` occurrences in `generator.py` with `"=" * BANNER_WIDTH`
- **`_exit_error()` helper**: Extracted a small helper to deduplicate the 8-repetition validation error-exit pattern in `main()`, reducing ~25 lines of boilerplate to ~10
- **`WorkerArgs` dataclass**: Replaced the opaque 25-element worker tuple with a named `WorkerArgs` dataclass, eliminating the 8-branch `len(args)` backward-compatibility dispatch in `process_single_dataview_worker`
- **Shared discovery formatters**: Added `_format_as_json`, `_format_as_csv`, and `_format_as_table` helpers and refactored `_fetch_dataviews`, `_fetch_connections`, and `_fetch_datasets` to use them instead of inline formatting
- **23 new tests** covering formatters, WorkerArgs, `_exit_error`, and `BANNER_WIDTH`; test count updated to 1,319

## Test plan

- [x] Full test suite passes: 1,318 passed, 1 skipped (1,319 collected)
- [x] New formatter tests cover JSON, CSV, table output with edge cases (empty lists, unicode, missing keys)
- [x] WorkerArgs tests verify required field, defaults, and custom values
- [x] Existing discovery command tests still pass (output is functionally identical)
- [x] Existing batch processor tests updated and passing with WorkerArgs
- [x] Test count validation test passes