### PR TITLE
fix: code quality, safety, and CI improvements

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,5 +18,5 @@ jobs:
         run: pip install uv
       - name: Sync dependencies
         run: uv sync --dev
-      - name: Run tests
-        run: uv run pytest tests/ -v --tb=short
+      - name: Run tests with coverage
+        run: uv run pytest tests/ -v --tb=short --cov=cja_auto_sdr --cov-report=term

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ clustering = [
 dev = [
     "pytest>=8.3.4",
     "pytest-cov>=4.1.0",
+    "ruff>=0.9.0",
 ]
 env = [
     "python-dotenv>=1.0.0",
@@ -84,7 +85,7 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"src/cja_auto_sdr/generator.py" = ["E", "W", "F401", "B", "SIM", "RUF", "UP"]  # F401: intentional re-exports for backward compat
+"src/cja_auto_sdr/generator.py" = ["F401", "E402", "RUF001", "RUF003", "SIM115"]  # F401: re-exports; E402: optional imports; RUF001/3: intentional Unicode symbols; SIM115: NamedTemporaryFile with delete=False
 "tests/**" = ["B", "SIM", "RUF012"]
 
 [tool.ruff.lint.isort]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1657,13 +1657,14 @@ class TestEmitOutputPager:
             patch("sys.stdout") as mock_stdout,
             patch("os.get_terminal_size", return_value=os.terminal_size((80, 24))),
             patch.dict(os.environ, {"PAGER": "less"}),
+            patch("shutil.which", return_value="/usr/bin/less"),
             patch("subprocess.Popen", return_value=mock_proc) as mock_popen,
         ):
             mock_stdout.isatty.return_value = True
             _emit_output(long_text, None, False)
 
         mock_popen.assert_called_once_with(["less", "-R"], stdin=subprocess.PIPE)
-        mock_proc.communicate.assert_called_once_with(long_text.rstrip("\n").encode())
+        mock_proc.communicate.assert_called_once_with(long_text.rstrip("\n").encode(), timeout=300)
 
     def test_no_pager_when_output_fits_terminal(self):
         """Test that _emit_output prints normally when output fits in terminal"""
@@ -1720,6 +1721,7 @@ class TestEmitOutputPager:
             patch("sys.stdout") as mock_stdout,
             patch("os.get_terminal_size", return_value=os.terminal_size((80, 24))),
             patch.dict(os.environ, {"PAGER": "more"}),
+            patch("shutil.which", return_value="/usr/bin/more"),
             patch("subprocess.Popen", return_value=mock_proc) as mock_popen,
         ):
             mock_stdout.isatty.return_value = True
@@ -1734,6 +1736,7 @@ class TestEmitOutputPager:
         with (
             patch("sys.stdout") as mock_stdout,
             patch("os.get_terminal_size", return_value=os.terminal_size((80, 24))),
+            patch("shutil.which", return_value="/usr/bin/less"),
             patch("subprocess.Popen", side_effect=FileNotFoundError),
         ):
             mock_stdout.isatty.return_value = True

--- a/uv.lock
+++ b/uv.lock
@@ -99,6 +99,7 @@ completion = [
 dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "ruff" },
 ]
 env = [
     { name = "python-dotenv" },
@@ -127,6 +128,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
     { name = "python-dotenv", marker = "extra == 'env'", specifier = ">=1.0.0" },
     { name = "python-dotenv", marker = "extra == 'full'", specifier = ">=1.0.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9.0" },
     { name = "scipy", marker = "extra == 'clustering'", specifier = ">=1.14.0" },
     { name = "scipy", marker = "extra == 'full'", specifier = ">=1.14.0" },
     { name = "tqdm", specifier = ">=4.66.0" },


### PR DESCRIPTION
## Summary

- **Parenthesize 16 multi-exception `except` clauses** — `except X, Y:` → `except (X, Y):` for PEP 8 compliance and clarity (functionally equivalent in 3.14 but non-standard)
- **Harden pager subprocess** — validate `$PAGER` with `shutil.which()` before spawning, add 300s timeout, fix `UnboundLocalError` when `Popen` itself fails
- **Narrow getpass fallback** — replace bare `except Exception` with `(ImportError, GetPassWarning)`
- **Eliminate global dict mutation** — `main()` no longer mutates `DEFAULT_RETRY_CONFIG`; CLI retry overrides now propagate via env vars, read by new `_effective_retry_config()` helper in `resilience.py`
- **Tighten ruff linting for generator.py** — enable E/W/UP/B/SIM/RUF rules (previously all blanket-disabled), auto-fix 250+ violations: typing modernization (`Dict` → `dict`, `Optional[X]` → `X | None`), unused loop variables, f-string conversions, `raise ... from e`, implicit `Optional`
- **Add code coverage to CI** — `--cov=cja_auto_sdr --cov-report=term` in test workflow
- **Sync dev dependencies** — add `ruff>=0.9.0` to `[project.optional-dependencies].dev`

## Test plan

- [x] Full test suite passes (1319 passed, 1 skipped)
- [x] `ruff check` and `ruff format --check` pass on src/ and tests/
- [x] Documented test count unchanged (1,320)
- [ ] CI workflows pass on PR (lint + tests + test-counts)