### PR TITLE
fix: harden CI workflows and remove dead code

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,11 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v5
         with:
-          python-version: "3.14.x"
-      - name: Install uv
-        run: pip install uv
+          python-version: "3.14"
       - name: Sync dependencies
         run: uv sync --dev
       - name: Ruff check

--- a/.github/workflows/test-counts.yml
+++ b/.github/workflows/test-counts.yml
@@ -12,12 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v5
         with:
-          python-version: "3.14.x"
-      - name: Install uv
-        run: pip install uv
+          python-version: "3.14"
       - name: Sync dependencies
         run: uv sync --dev
       - name: Verify test counts are up to date
-        run: .venv/bin/python scripts/update_test_counts.py --check
+        run: uv run python scripts/update_test_counts.py --check

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,11 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v5
         with:
-          python-version: "3.14.x"
-      - name: Install uv
-        run: pip install uv
+          python-version: "3.14"
       - name: Sync dependencies
         run: uv sync --dev
       - name: Run tests with coverage

--- a/src/cja_auto_sdr/api/resilience.py
+++ b/src/cja_auto_sdr/api/resilience.py
@@ -712,7 +712,6 @@ def retry_with_backoff(
         @functools.wraps(func)
         def wrapper(*args, **kwargs) -> Any:
             _logger = logger or logging.getLogger(__name__)
-            last_exception = None
 
             for attempt in range(_max_retries + 1):  # +1 for initial attempt
                 try:
@@ -722,8 +721,6 @@ def retry_with_backoff(
                         _logger.info(f"✓ {func.__name__} succeeded on attempt {attempt + 1}/{_max_retries + 1}")
                     return result
                 except _retryable_exceptions as e:
-                    last_exception = e
-
                     if attempt == _max_retries:
                         _logger.error(f"All {_max_retries + 1} attempts failed for {func.__name__}")
 
@@ -759,10 +756,6 @@ def retry_with_backoff(
                     # Non-retryable exception, raise immediately
                     _logger.error(f"{func.__name__} failed with non-retryable error: {e!s}")
                     raise
-
-            # Should not reach here, but just in case
-            if last_exception:
-                raise last_exception
 
         return wrapper
 


### PR DESCRIPTION
## Summary

- **CI workflows**: Replace `actions/setup-python` + `pip install uv` with `astral-sh/setup-uv@v5` in all 3 workflows (tests, lint, test-counts) for built-in caching and the recommended setup path
- **test-counts.yml**: Fix hardcoded `.venv/bin/python` → `uv run python` so the check actually runs in CI
- **resilience.py**: Remove unreachable dead code and unused `last_exception` variable in `retry_with_backoff` — the retry loop always exits via `return` (success), `raise` (exhausted retries), or `raise` (non-retryable exception)

## Test plan

- [x] `ruff check src/ tests/` — all checks passed
- [x] `ruff format --check src/ tests/` — 99 files already formatted
- [x] `pytest tests/ -v --tb=short` — 1319 passed, 1 skipped