### PR TITLE
v3.2.1: add quality gating/reporting, CI summaries, and validation hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Dataset Discovery** - List all data views with their backing connections and datasets using `--list-datasets`
 - **Permissions Fallback** - When the API service account lacks product-admin privileges, both commands gracefully fall back to deriving connection IDs from data views instead of failing
 - **Mutually Exclusive Discovery** - `--list-dataviews`, `--list-connections`, and `--list-datasets` are now mutually exclusive at the CLI level
+- **CI Quality Gates & Reports** - Added quality policy exits via `--fail-on-quality` and standalone issue exports via `--quality-report`
+- **GitHub Step Summaries** - Added automatic Markdown summaries for diff, quality, and org-report output in GitHub Actions
+- **Snapshot Auto-Prune Defaults** - Added default retention behavior for `--auto-prune` with explicit-flag precedence
 
 ### Added
 
@@ -28,6 +31,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### CLI Improvements
 - Discovery commands (`--list-dataviews`, `--list-connections`, `--list-datasets`) are now mutually exclusive via argparse `add_mutually_exclusive_group()`
+
+#### CI, Quality & Snapshot Controls
+- Added global ANSI color controls across all output paths via `--no-color`, `NO_COLOR`, and `FORCE_COLOR`
+- Added `--fail-on-quality SEVERITY` for SDR mode to return exit code `2` when quality thresholds are exceeded
+- Added standalone quality issues reporting with `--quality-report json|csv` (file or stdout)
+- Added automatic GitHub Actions step summaries for diff, quality, and org-report output when `GITHUB_STEP_SUMMARY` is set
+- Added `--auto-prune` defaults for diff auto-snapshot flows (`--keep-last 20` + `--keep-since 30d` when retention flags are omitted)
+
+### Fixed
+- Rejected unsupported quality gate combinations: `--fail-on-quality` now errors outside SDR mode and when combined with `--skip-validation`
+- Corrected quality-report failure semantics: processing failures now still exit `1` even with `--continue-on-error`, and write failures are reported as clean CLI errors instead of uncaught tracebacks
+- Corrected GitHub quality summaries to include failed and successful data views in processed counts
+- Corrected diff GitHub summary totals to include inventory-only changes (calculated metrics and segments)
+- Corrected auto-prune retention precedence: explicit values are preserved, including `--keep-last 0`, `--keep-last=0`, `--keep-since 90d`, and `--keep-since=90d`
+- Corrected empty CSV quality reports to emit a stable header row for zero-issue runs
 
 ### Testing
 - Added tests for `--list-connections` table, JSON, CSV output and no-results handling

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ A **Solution Design Reference** is the essential documentation that bridges your
 | | Snapshot Support | Save and compare against baseline snapshots for change tracking |
 | | Snapshot-to-Snapshot | Compare two snapshot files directly without API calls |
 | | Auto-Snapshot on Diff | Automatically save timestamped snapshots during comparisons for audit trails |
-| | CI/CD Integration | Exit codes for pipeline automation (2=changes found, 3=threshold exceeded) |
+| | CI/CD Integration | Policy exit codes for automation (2=policy threshold exceeded, 3=diff warn threshold exceeded) |
+| | GitHub Actions Step Summary | Automatically writes Markdown summaries to `GITHUB_STEP_SUMMARY` when available |
 | | Smart Name Resolution | Fuzzy matching suggestions for typos, interactive disambiguation for duplicates |
 | **Git Integration** | Version-Controlled Snapshots | Save SDR snapshots in Git-friendly format with auto-commit |
 | | Audit Trail | Full history of every Data View configuration change |
@@ -68,7 +69,7 @@ A **Solution Design Reference** is the essential documentation that bridges your
 | | Connection & Dataset Discovery | `--list-connections` and `--list-datasets` for infrastructure inventory |
 | | Machine-Readable Discovery | `--list-dataviews --format json` for scripting integration |
 | | Dry-Run Mode | Test configuration without generating reports |
-| | Color-Coded Output | Green/yellow/red console feedback for instant status |
+| | Color-Coded Output | Global color controls via `--no-color`, `NO_COLOR`, and `FORCE_COLOR` |
 | | Enhanced Error Messages | Contextual error messages with actionable fix suggestions |
 | | Comprehensive Logging | Timestamped logs with rotation for audit trails |
 
@@ -235,6 +236,8 @@ cja_auto_sdr "Production Analytics"
 | Include calculated metrics | `cja_auto_sdr dv_12345 --include-calculated` |
 | Include all inventories | `cja_auto_sdr dv_12345 --include-all-inventory` |
 | Inventory-only output | `cja_auto_sdr dv_12345 --include-segments --inventory-only` |
+| Fail on quality issues >= HIGH | `cja_auto_sdr dv_12345 --fail-on-quality HIGH` |
+| Standalone quality report | `cja_auto_sdr dv_12345 --quality-report json --output -` |
 | **Output Formats** | |
 | Export as Excel (default) | `cja_auto_sdr dv_12345 --format excel` |
 | Export as CSV | `cja_auto_sdr dv_12345 --format csv` |
@@ -262,6 +265,7 @@ cja_auto_sdr "Production Analytics"
 | Compare two snapshots | `cja_auto_sdr --compare-snapshots ./old.json ./new.json` |
 | Auto-save snapshots | `cja_auto_sdr --diff dv_1 dv_2 --auto-snapshot` |
 | With retention policy | `cja_auto_sdr --diff dv_1 dv_2 --auto-snapshot --keep-last 10` |
+| Auto-prune snapshots (defaults) | `cja_auto_sdr --diff dv_1 dv_2 --auto-snapshot --auto-prune` |
 | **Inventory Diff** (same data view over time) | |
 | Snapshot with inventory | `cja_auto_sdr dv_12345 --snapshot ./baseline.json --include-calculated --include-segments` |
 | Compare with inventory | `cja_auto_sdr dv_12345 --diff-snapshot ./baseline.json --include-calculated` |

--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md   # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md # Org-wide report guide
 │   └── ...                  # Additional guides
-├── tests/                   # Test suite (1,320+ tests)
+├── tests/                   # Test suite (1,345+ tests)
 ├── sample_outputs/          # Example output files
 │   ├── excel/               # Sample Excel SDR
 │   ├── csv/                 # Sample CSV output

--- a/docs/DIFF_COMPARISON.md
+++ b/docs/DIFF_COMPARISON.md
@@ -10,6 +10,7 @@ The diff comparison feature allows you to:
 - **Compare inventory items** in snapshot diffs for the same data view (calculated metrics, segments)
 - **Generate diff reports** in all supported output formats
 - **Integrate with CI/CD pipelines** using exit codes
+- **Publish GitHub Actions summaries** automatically via `GITHUB_STEP_SUMMARY`
 
 ## How Comparison Works
 
@@ -568,6 +569,15 @@ cja_auto_sdr --diff dv_12345 dv_67890 --auto-snapshot --snapshot-dir ./history
 # With retention policy (keep only last 10 snapshots per data view)
 cja_auto_sdr --diff dv_12345 dv_67890 --auto-snapshot --keep-last 10
 
+# Time-based retention (delete snapshots older than 30 days)
+cja_auto_sdr --diff dv_12345 dv_67890 --auto-snapshot --keep-since 30d
+
+# Auto-prune defaults (when both retention flags are omitted)
+cja_auto_sdr --diff dv_12345 dv_67890 --auto-snapshot --auto-prune
+
+# Explicit retention values (space or --arg=value form) override defaults
+cja_auto_sdr --diff dv_12345 dv_67890 --auto-snapshot --auto-prune --keep-last=0
+
 # Works with diff-snapshot too (saves current state)
 cja_auto_sdr dv_12345 --diff-snapshot ./baseline.json --auto-snapshot
 ```
@@ -581,6 +591,9 @@ cja_auto_sdr dv_12345 --diff-snapshot ./baseline.json --auto-snapshot
 **Retention Policy:**
 - `--keep-last 0` (default): Keep all snapshots forever
 - `--keep-last N`: Keep only the N most recent snapshots per data view
+- `--keep-since PERIOD`: Delete snapshots older than `7d`, `2w`, `1m`, or numeric days (for example `30`)
+- `--auto-prune`: Applies defaults `--keep-last 20` + `--keep-since 30d` only when both retention flags are omitted
+- Explicit retention in either form always takes precedence (`--keep-last N` / `--keep-last=N`, `--keep-since PERIOD` / `--keep-since=PERIOD`)
 - Old snapshots are deleted automatically after new ones are saved
 
 ## Smart Name Resolution
@@ -635,7 +648,7 @@ To minimize API calls during name resolution, data view listings are cached for 
 | `--dimensions-only` | Only compare dimensions (exclude metrics). |
 | `--extended-fields` | Include extended fields (attribution, format, bucketing, etc.). |
 | `--side-by-side` | Show side-by-side comparison view for modified items. |
-| `--no-color` | Disable ANSI color codes in diff console output. |
+| `--no-color` | Disable ANSI color codes in console output (global). |
 | `--quiet-diff` | Suppress output, only return exit code (0=no changes, 2=changes, 3=threshold). |
 | `--reverse-diff` | Swap source and target comparison direction. |
 | `--warn-threshold PERCENT` | Exit with code 3 if change percentage exceeds threshold. |
@@ -644,8 +657,10 @@ To minimize API calls during name resolution, data view listings are cached for 
 | `--diff-output FILE` | Write diff output directly to file instead of stdout. |
 | `--format-pr-comment` | Output in GitHub/GitLab PR comment format with collapsible details. |
 | `--auto-snapshot` | Automatically save snapshots during diff for audit trail. |
+| `--auto-prune` | With `--auto-snapshot`, apply default retention (`--keep-last 20` and `--keep-since 30d`) only when both retention flags are omitted. |
 | `--snapshot-dir DIR` | Directory for auto-saved snapshots (default: ./snapshots). |
 | `--keep-last N` | Retention: keep only last N snapshots per data view (0 = keep all). |
+| `--keep-since PERIOD` | Date-based retention: delete snapshots older than PERIOD (`7d`, `2w`, `1m`, `30`). |
 
 ## Output Formats
 
@@ -826,7 +841,7 @@ In detailed output, changes are marked with symbols:
 
 The summary appears in all output formats with slight variations:
 
-- **Console**: Colored symbols and percentages with ANSI codes (use `--no-color` to disable)
+- **Console**: Colored symbols and percentages with ANSI codes (disable with `--no-color` or `NO_COLOR`; force with `FORCE_COLOR`)
 - **Markdown**: Plain text table suitable for documentation and PR comments
 - **HTML**: Styled table with color-coded cells
 - **Excel**: Dedicated Summary sheet with formatted columns
@@ -930,6 +945,8 @@ The diff command uses exit codes for CI/CD integration:
 | 2 | Success, differences found |
 | 3 | Threshold exceeded (`--warn-threshold` triggered) |
 
+> **Note:** Exit code `2` is used globally for policy threshold failures. In diff mode, it means differences were found.
+
 ### Example: GitHub Actions
 
 ```yaml
@@ -941,6 +958,8 @@ The diff command uses exit codes for CI/CD integration:
       exit 1  # Fail the build
     fi
 ```
+
+If running in GitHub Actions, CJA Auto SDR also appends a Markdown diff summary automatically when `GITHUB_STEP_SUMMARY` is present. The summary total includes metrics, dimensions, calculated metrics, and segment inventory changes.
 
 ### Example: Pre-deployment Validation
 

--- a/docs/DIFF_COMPARISON.md
+++ b/docs/DIFF_COMPARISON.md
@@ -1457,7 +1457,7 @@ The diff comparison feature includes comprehensive unit tests in `tests/test_dif
 | `TestAutoSnapshotCLIArguments` | 10 | --auto-snapshot, --snapshot-dir, --keep-last |
 | `TestGetMostRecentSnapshot` | 5 | Most recent snapshot lookup, filtering |
 
-**Total: 159 tests**
+**Total: 162 tests**
 
 ### Running Tests
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -91,10 +91,10 @@ uv run cja_auto_sdr --sample-config
 |-----------|---------|---------------|
 | `0` | Success | Command completed successfully (diff: no changes found) |
 | `1` | General Error | Configuration errors, missing arguments, validation failures |
-| `2` | Diff: Changes Found | Diff comparison succeeded but differences were detected |
+| `2` | Policy Threshold Exceeded | Diff changes found, quality gate failed (`--fail-on-quality`), or org governance threshold failed (`--fail-on-threshold`) |
 | `3` | Diff: Threshold Exceeded | Changes exceeded `--warn-threshold` percentage |
 
-**Diff-specific exit codes** are designed for CI/CD integration:
+**Policy-aware exit codes** are designed for CI/CD integration:
 
 ```bash
 # Check exit code after diff
@@ -102,7 +102,7 @@ cja_auto_sdr --diff dv_12345 dv_67890 --quiet-diff
 case $? in
   0) echo "No differences found" ;;
   1) echo "Error occurred" ;;
-  2) echo "Differences detected (review needed)" ;;
+  2) echo "Policy threshold exceeded (review needed)" ;;
   3) echo "Too many changes (threshold exceeded)" ;;
 esac
 ```
@@ -844,6 +844,8 @@ ERROR - Failed to save auto-snapshot: ./snapshots/DataView_dv_123_20260118.json
 **Symptoms:** Old snapshots accumulate even with `--keep-last N` set.
 
 **Cause:** Retention applies per data view, not globally. If you have 10 data views, `--keep-last 5` keeps 5 snapshots *per data view* (up to 50 total).
+
+**Tip:** If you want retention applied automatically on every diff run, use `--auto-prune` with `--auto-snapshot` (defaults to `--keep-last 20` and `--keep-since 30d` unless explicit retention flags are provided).
 
 **Verification:**
 ```bash
@@ -2327,7 +2329,7 @@ For detailed org-wide analysis troubleshooting, see the [Troubleshooting section
 | "scipy not available" with `--cluster` | Optional dependency not installed | Install with: `uv pip install 'cja-auto-sdr[clustering]'` |
 | Cache not working | Cache directory permissions | Check `~/.cja_auto_sdr/cache/` (macOS/Linux) or `%USERPROFILE%\.cja_auto_sdr\cache\` (Windows) is writable |
 | `--owner-summary` shows nothing | Missing metadata | Add `--include-metadata` flag |
-| Exit code 2 unexpectedly | Governance threshold exceeded | Check `--duplicate-threshold` and `--isolated-threshold` values |
+| Exit code 2 unexpectedly in `--org-report` | Governance threshold exceeded | Check `--duplicate-threshold` and `--isolated-threshold` values |
 | "Another --org-report is already running" | Concurrent run prevention | Wait for other run to finish, or check if a previous run crashed (lock auto-expires after 1 hour) |
 
 ### Clustering Issues

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -210,7 +210,7 @@ done
 
 Integrate diff comparison into CI/CD pipelines to catch unexpected changes:
 - Automated detection of configuration drift
-- Exit codes for pipeline integration (0=no changes, 2=changes found, 3=threshold exceeded)
+- Exit codes for pipeline integration (0=pass, 2=policy threshold exceeded, 3=diff warning threshold exceeded)
 - PR comments with change summaries
 - Fail builds when critical changes exceed thresholds
 
@@ -219,7 +219,7 @@ Integrate diff comparison into CI/CD pipelines to catch unexpected changes:
 ```bash
 # Basic CI/CD drift check (exit code 2 if differences found)
 cja_auto_sdr --diff dv_12345 dv_67890 --quiet-diff
-echo "Exit code: $?"  # 0=identical, 2=different
+echo "Exit code: $?"  # 0=identical, 2=different, 3=warn-threshold exceeded
 
 # Fail build if changes exceed 5%
 cja_auto_sdr --diff dv_12345 dv_67890 --warn-threshold 5 --quiet-diff

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -6275,8 +6275,7 @@ Requirements:
         type=str.upper,
         choices=list(QUALITY_SEVERITY_ORDER),
         metavar="SEVERITY",
-        help="Exit with code 2 when quality issues at or above SEVERITY are found "
-        "(CRITICAL, HIGH, MEDIUM, LOW, INFO)",
+        help="Exit with code 2 when quality issues at or above SEVERITY are found (CRITICAL, HIGH, MEDIUM, LOW, INFO)",
     )
 
     parser.add_argument(
@@ -13547,9 +13546,7 @@ def main():
         )
         if not args.quiet:
             print(
-                ConsoleColors.error(
-                    f"QUALITY GATE FAILED: Found issues at or above {fail_on_quality} severity."
-                ),
+                ConsoleColors.error(f"QUALITY GATE FAILED: Found issues at or above {fail_on_quality} severity."),
                 file=sys.stderr,
             )
             for severity in QUALITY_SEVERITY_ORDER:

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -12023,7 +12023,7 @@ def main():
     keep_last_specified = _cli_option_specified("--keep-last")
     keep_since_specified = _cli_option_specified("--keep-since")
 
-    non_sdr_modes_for_quality_gate = (
+    non_sdr_modes_for_quality_options = (
         getattr(args, "diff", False)
         or getattr(args, "snapshot", None)
         or getattr(args, "diff_snapshot", None)
@@ -12036,6 +12036,7 @@ def main():
         or getattr(args, "list_datasets", False)
         or getattr(args, "validate_config", False)
         or getattr(args, "config_status", False)
+        or getattr(args, "config_json", False)
         or getattr(args, "sample_config", False)
         or getattr(args, "exit_codes", False)
         or getattr(args, "profile_list", False)
@@ -12043,11 +12044,11 @@ def main():
         or getattr(args, "profile_test", None)
         or getattr(args, "profile_show", None)
         or getattr(args, "git_init", False)
-        or getattr(args, "compare_org_report", None)
+        or getattr(args, "org_compare_report", None)
         or getattr(args, "stats", False)
         or getattr(args, "dry_run", False)
     )
-    if getattr(args, "fail_on_quality", None) and non_sdr_modes_for_quality_gate:
+    if getattr(args, "fail_on_quality", None) and non_sdr_modes_for_quality_options:
         _exit_error("--fail-on-quality is only supported in SDR generation mode")
 
     if getattr(args, "auto_prune", False) and not getattr(args, "auto_snapshot", False):
@@ -12056,15 +12057,7 @@ def main():
         _exit_error("--fail-on-quality cannot be used with --skip-validation")
     if getattr(args, "quality_report", None) and args.skip_validation:
         _exit_error("--quality-report cannot be used with --skip-validation")
-    if getattr(args, "quality_report", None) and (
-        getattr(args, "diff", False)
-        or getattr(args, "snapshot", None)
-        or getattr(args, "diff_snapshot", None)
-        or getattr(args, "compare_with_prev", False)
-        or getattr(args, "compare_snapshots", None)
-        or getattr(args, "org_report", False)
-        or getattr(args, "inventory_summary", False)
-    ):
+    if getattr(args, "quality_report", None) and non_sdr_modes_for_quality_options:
         _exit_error("--quality-report is only supported in SDR generation mode")
 
     # Propagate retry config via env vars so both the current process

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -506,7 +506,7 @@ def build_quality_step_summary(results: list[ProcessingResult]) -> str:
     return "\n".join(lines)
 
 
-def build_diff_step_summary(diff_result: "DiffResult") -> str:
+def build_diff_step_summary(diff_result: DiffResult) -> str:
     """Build markdown summary table for diff output."""
     summary = diff_result.summary
     total_changes = summary.total_changes + summary.calc_metrics_changed + summary.segments_changed
@@ -531,23 +531,19 @@ def build_diff_step_summary(diff_result: "DiffResult") -> str:
 
     if summary.source_calc_metrics_count > 0 or summary.target_calc_metrics_count > 0:
         lines.append(
-            (
-                f"| Calc Metrics | {summary.source_calc_metrics_count} | {summary.target_calc_metrics_count} | "
-                f"{summary.calc_metrics_added} | {summary.calc_metrics_removed} | {summary.calc_metrics_modified} | {summary.calc_metrics_unchanged} |"
-            )
+            f"| Calc Metrics | {summary.source_calc_metrics_count} | {summary.target_calc_metrics_count} | "
+            f"{summary.calc_metrics_added} | {summary.calc_metrics_removed} | {summary.calc_metrics_modified} | {summary.calc_metrics_unchanged} |"
         )
     if summary.source_segments_count > 0 or summary.target_segments_count > 0:
         lines.append(
-            (
-                f"| Segments | {summary.source_segments_count} | {summary.target_segments_count} | "
-                f"{summary.segments_added} | {summary.segments_removed} | {summary.segments_modified} | {summary.segments_unchanged} |"
-            )
+            f"| Segments | {summary.source_segments_count} | {summary.target_segments_count} | "
+            f"{summary.segments_added} | {summary.segments_removed} | {summary.segments_modified} | {summary.segments_unchanged} |"
         )
 
     return "\n".join(lines)
 
 
-def build_org_step_summary(result: "OrgReportResult") -> str:
+def build_org_step_summary(result: OrgReportResult) -> str:
     """Build markdown summary table for org-report output."""
     dist = result.distribution
     lines = [
@@ -2629,11 +2625,11 @@ def _format_side_by_side(
 
     # Pre-compute all display strings
     field_displays = []
-    for field, (old_val, new_val) in diff.changed_fields.items():
+    for field_name, (old_val, new_val) in diff.changed_fields.items():
         old_str = _format_diff_value(old_val, truncate=False)
         new_str = _format_diff_value(new_val, truncate=False)
-        old_display = f"{field}: {old_str}"
-        new_display = f"{field}: {new_str}"
+        old_display = f"{field_name}: {old_str}"
+        new_display = f"{field_name}: {new_str}"
         field_displays.append((old_display, new_display))
 
     # Calculate column width: expand to fit content but cap at max_col_width
@@ -3302,7 +3298,7 @@ def _format_markdown_side_by_side(diff: ComponentDiff, source_label: str, target
     lines.append(f"| Field | {source_label} | {target_label} |")
     lines.append("| --- | --- | --- |")
 
-    for field, (old_val, new_val) in diff.changed_fields.items():
+    for field_name, (old_val, new_val) in diff.changed_fields.items():
         old_formatted = _format_diff_value(old_val, truncate=False)
         new_formatted = _format_diff_value(new_val, truncate=False)
         # Use italic for empty values in markdown
@@ -3315,7 +3311,7 @@ def _format_markdown_side_by_side(diff: ComponentDiff, source_label: str, target
         if len(new_str) > 50:
             new_str = new_str[:47] + "..."
 
-        lines.append(f"| `{field}` | {old_str} | {new_str} |")
+        lines.append(f"| `{field_name}` | {old_str} | {new_str} |")
 
     lines.append("")
     return lines
@@ -8745,23 +8741,23 @@ def validate_config_only(config_file: str = "config.json", profile: str | None =
 
         print()
         print("  Credential status:")
-        for field in required_fields:
-            if creds.get(field):
-                value = creds[field]
-                if field in ["secret", "client_id"]:
+        for field_name in required_fields:
+            if creds.get(field_name):
+                value = creds[field_name]
+                if field_name in ["secret", "client_id"]:
                     masked = value[:4] + "****" + value[-4:] if len(value) > 8 else "****"
                 else:
                     masked = value
-                print(f"    ✓ {field}: {masked}")
+                print(f"    ✓ {field_name}: {masked}")
             else:
-                print(f"    ✗ {field}: not set (required)")
-                missing.append(field)
+                print(f"    ✗ {field_name}: not set (required)")
+                missing.append(field_name)
 
-        for field in optional_fields:
-            if creds.get(field):
-                print(f"    ✓ {field}: {creds[field]}")
+        for field_name in optional_fields:
+            if creds.get(field_name):
+                print(f"    ✓ {field_name}: {creds[field_name]}")
             else:
-                print(f"    - {field}: not set (optional)")
+                print(f"    - {field_name}: not set (optional)")
 
         print()
         if missing:

--- a/tests/README.md
+++ b/tests/README.md
@@ -39,17 +39,17 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 1,320 comprehensive tests**
+**Total: 1,345 comprehensive tests**
 
 ### Test Count Breakdown
 
 | Test File | Tests | Coverage Area |
 |-----------|-------|---------------|
-| `test_diff_comparison.py` | 159 | Data view diff comparison feature with inventory support |
-| `test_ux_features.py` | 116 | UX features: --open, --stats, --output, --list-dataviews formats, inventory validation, inventory summary, include-all-inventory |
+| `test_diff_comparison.py` | 162 | Data view diff comparison feature with inventory support |
+| `test_ux_features.py` | 119 | UX features: --open, --stats, --output, --list-dataviews formats, inventory validation, inventory summary, include-all-inventory |
 | `test_org_report.py` | 144 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
 | `test_org_report_integration.py` | 17 | Org-wide analysis integration tests: end-to-end flows, caching, filtering, governance |
-| `test_cli.py` | 141 | Command-line interface and argument parsing |
+| `test_cli.py` | 160 | Command-line interface and argument parsing |
 | `test_profiles.py` | 43 | Multi-organization profile support |
 | `test_derived_inventory.py` | 43 | Derived fields inventory feature |
 | `test_inventory_utils.py` | 41 | Inventory utilities and helpers |
@@ -79,7 +79,7 @@ tests/
 | `test_data_quality.py` | 10 | Data quality validation logic |
 | `test_parallel_validation.py` | 8 | Parallel validation operations |
 | `test_discovery_formatters.py` | 23 | Shared discovery formatters, WorkerArgs dataclass, _exit_error, BANNER_WIDTH |
-| **Total** | **1,320** | **Collected via pytest --collect-only** |
+| **Total** | **1,345** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -483,7 +483,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (1,320 tests total)
+- [x] Comprehensive test coverage (1,345 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 144 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 43 tests
@@ -495,8 +495,8 @@ Check for drift (CI-friendly):
 - [x] Derived fields inventory tests (test_derived_inventory.py) - 43 tests
 - [x] Inventory utilities tests (test_inventory_utils.py) - 41 tests
 - [x] Git integration tests (test_git_integration.py) - 33 tests
-- [x] Inventory diff support in snapshot comparisons (test_diff_comparison.py) - 159 tests
-- [x] Inventory summary and include-all-inventory tests (test_ux_features.py) - 116 tests
+- [x] Inventory diff support in snapshot comparisons (test_diff_comparison.py) - 162 tests
+- [x] Inventory summary and include-all-inventory tests (test_ux_features.py) - 119 tests
 - [x] Parallel validation tests (test_parallel_validation.py)
 - [x] Validation caching tests (test_validation_cache.py)
 - [x] Early exit optimization tests (test_early_exit.py)
@@ -511,7 +511,7 @@ Check for drift (CI-friendly):
 - [x] Excel formatting tests (test_excel_formatting.py)
 - [x] CJA initialization tests (test_cja_initialization.py)
 - [x] Name resolution tests (test_name_resolution.py)
-- [x] Data view diff comparison tests (test_diff_comparison.py) - 159 tests covering snapshots, comparison logic, output formats, CLI arguments, name resolution
+- [x] Data view diff comparison tests (test_diff_comparison.py) - 162 tests covering snapshots, comparison logic, output formats, CLI arguments, name resolution
 - [x] Edge case tests (test_edge_cases.py) - 39 tests covering custom exceptions, configuration dataclasses, OutputWriter Protocol, boundary conditions
 
 ## Future Enhancements

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -629,6 +629,18 @@ class TestQualityGateAndReport:
 
         assert exc_info.value.code == 1
 
+    @patch("cja_auto_sdr.generator.show_config_status")
+    def test_fail_on_quality_rejects_non_sdr_config_json_mode(self, mock_show_config_status):
+        """Quality gate should fail fast for --config-json (non-SDR mode)."""
+        from cja_auto_sdr.generator import main
+
+        with patch.object(sys, "argv", ["cja_auto_sdr", "--config-json", "--fail-on-quality", "HIGH"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 1
+        mock_show_config_status.assert_not_called()
+
     @patch("cja_auto_sdr.generator.handle_diff_command")
     def test_fail_on_quality_rejects_non_sdr_diff_mode(self, mock_handle_diff):
         """Quality gate should fail fast in non-SDR modes instead of being silently ignored."""
@@ -640,6 +652,18 @@ class TestQualityGateAndReport:
 
         assert exc_info.value.code == 1
         mock_handle_diff.assert_not_called()
+
+    @patch("cja_auto_sdr.generator.generate_sample_config")
+    def test_quality_report_rejects_non_sdr_sample_config_mode(self, mock_generate_sample_config):
+        """Quality report should fail fast for sample-config mode instead of being ignored."""
+        from cja_auto_sdr.generator import main
+
+        with patch.object(sys, "argv", ["cja_auto_sdr", "--sample-config", "--quality-report", "json"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 1
+        mock_generate_sample_config.assert_not_called()
 
     @patch("cja_auto_sdr.generator.write_quality_report_output")
     @patch("cja_auto_sdr.generator.process_single_dataview")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -292,6 +292,20 @@ class TestUXImprovements:
             assert args.max_issues == 5
             assert args.skip_validation is True
 
+    def test_fail_on_quality_flag(self):
+        """Test parsing with --fail-on-quality flag (case-insensitive input)."""
+        test_args = ["cja_sdr_generator.py", "--fail-on-quality", "high", "dv_12345"]
+        with patch.object(sys, "argv", test_args):
+            args = parse_arguments()
+            assert args.fail_on_quality == "HIGH"
+
+    def test_quality_report_flag(self):
+        """Test parsing with --quality-report flag."""
+        test_args = ["cja_sdr_generator.py", "--quality-report", "json", "dv_12345"]
+        with patch.object(sys, "argv", test_args):
+            args = parse_arguments()
+            assert args.quality_report == "json"
+
 
 class TestProcessingResult:
     """Test ProcessingResult dataclass"""
@@ -538,6 +552,405 @@ class TestConsoleScriptEntryPoints:
         )
         assert result.returncode == 0
         assert __version__ in result.stdout
+
+
+class TestQualityGateAndReport:
+    """Tests for quality gate/report behavior in main()."""
+
+    @patch("cja_auto_sdr.generator.process_single_dataview")
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    def test_fail_on_quality_exits_with_code_2(self, mock_resolve, mock_process):
+        """Exit code should be 2 when threshold severity issues are found."""
+        from cja_auto_sdr.generator import ProcessingResult, main
+
+        mock_resolve.return_value = (["dv_test"], {})
+        mock_process.return_value = ProcessingResult(
+            data_view_id="dv_test",
+            data_view_name="Test View",
+            success=True,
+            duration=0.1,
+            metrics_count=1,
+            dimensions_count=1,
+            dq_issues_count=1,
+            dq_issues=[{"Severity": "HIGH", "Issue": "Duplicate component"}],
+            dq_severity_counts={"HIGH": 1},
+        )
+
+        with patch.object(sys, "argv", ["cja_auto_sdr", "dv_test", "--fail-on-quality", "HIGH"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 2
+
+    @patch("cja_auto_sdr.generator.write_quality_report_output")
+    @patch("cja_auto_sdr.generator.process_single_dataview")
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    def test_quality_report_mode_uses_standalone_writer(self, mock_resolve, mock_process, mock_write_report):
+        """Quality report mode should bypass SDR files and emit standalone report."""
+        from cja_auto_sdr.generator import ProcessingResult, main
+
+        mock_resolve.return_value = (["dv_test"], {})
+        mock_write_report.return_value = "stdout"
+        mock_process.return_value = ProcessingResult(
+            data_view_id="dv_test",
+            data_view_name="Test View",
+            success=True,
+            duration=0.1,
+            dq_issues_count=1,
+            dq_issues=[{"Severity": "LOW", "Issue": "Missing description"}],
+            dq_severity_counts={"LOW": 1},
+        )
+
+        with patch.object(sys, "argv", ["cja_auto_sdr", "dv_test", "--quality-report", "json", "--output", "-"]):
+            main()
+
+        assert mock_process.call_args.kwargs["quality_report_only"] is True
+        mock_write_report.assert_called_once()
+
+    def test_quality_report_rejects_skip_validation(self):
+        """Quality report mode should reject --skip-validation."""
+        from cja_auto_sdr.generator import main
+
+        with patch.object(
+            sys, "argv", ["cja_auto_sdr", "dv_test", "--quality-report", "json", "--skip-validation"]
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 1
+
+    def test_fail_on_quality_rejects_skip_validation(self):
+        """Quality gate should reject --skip-validation to avoid silent policy bypass."""
+        from cja_auto_sdr.generator import main
+
+        with patch.object(sys, "argv", ["cja_auto_sdr", "dv_test", "--fail-on-quality", "HIGH", "--skip-validation"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 1
+
+    @patch("cja_auto_sdr.generator.handle_diff_command")
+    def test_fail_on_quality_rejects_non_sdr_diff_mode(self, mock_handle_diff):
+        """Quality gate should fail fast in non-SDR modes instead of being silently ignored."""
+        from cja_auto_sdr.generator import main
+
+        with patch.object(sys, "argv", ["cja_auto_sdr", "--diff", "dv_a", "dv_b", "--fail-on-quality", "HIGH"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 1
+        mock_handle_diff.assert_not_called()
+
+    @patch("cja_auto_sdr.generator.write_quality_report_output")
+    @patch("cja_auto_sdr.generator.process_single_dataview")
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    def test_quality_report_continue_on_error_still_exits_1_on_processing_failure(
+        self, mock_resolve, mock_process, mock_write_report
+    ):
+        """--continue-on-error should continue processing but still fail on processing errors."""
+        from cja_auto_sdr.generator import ProcessingResult, main
+
+        mock_resolve.return_value = (["dv_fail", "dv_ok"], {})
+        mock_write_report.return_value = "stdout"
+        mock_process.side_effect = [
+            ProcessingResult(
+                data_view_id="dv_fail",
+                data_view_name="Failing View",
+                success=False,
+                duration=0.1,
+                error_message="mock failure",
+            ),
+            ProcessingResult(
+                data_view_id="dv_ok",
+                data_view_name="Healthy View",
+                success=True,
+                duration=0.1,
+                dq_issues_count=1,
+                dq_issues=[{"Severity": "LOW", "Issue": "Minor"}],
+                dq_severity_counts={"LOW": 1},
+            ),
+        ]
+
+        with patch.object(
+            sys,
+            "argv",
+            ["cja_auto_sdr", "dv_fail", "dv_ok", "--quality-report", "json", "--output", "-", "--continue-on-error"],
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 1
+        mock_write_report.assert_called_once()
+
+    @patch("cja_auto_sdr.generator.write_quality_report_output")
+    @patch("cja_auto_sdr.generator.append_github_step_summary")
+    @patch("cja_auto_sdr.generator.build_quality_step_summary")
+    @patch("cja_auto_sdr.generator.process_single_dataview")
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    def test_quality_report_summary_includes_failed_and_successful_results(
+        self,
+        mock_resolve,
+        mock_process,
+        mock_build_summary,
+        mock_append_summary,
+        mock_write_report,
+    ):
+        """GitHub quality summary should include all processed data views."""
+        from cja_auto_sdr.generator import ProcessingResult, main
+
+        mock_resolve.return_value = (["dv_fail", "dv_ok"], {})
+        mock_build_summary.return_value = "summary"
+        mock_append_summary.return_value = True
+        mock_write_report.return_value = "stdout"
+        mock_process.side_effect = [
+            ProcessingResult(
+                data_view_id="dv_fail",
+                data_view_name="Failing View",
+                success=False,
+                duration=0.1,
+                error_message="mock failure",
+            ),
+            ProcessingResult(
+                data_view_id="dv_ok",
+                data_view_name="Healthy View",
+                success=True,
+                duration=0.1,
+                dq_issues_count=1,
+                dq_issues=[{"Severity": "LOW", "Issue": "Minor"}],
+                dq_severity_counts={"LOW": 1},
+            ),
+        ]
+
+        with patch.object(
+            sys,
+            "argv",
+            ["cja_auto_sdr", "dv_fail", "dv_ok", "--quality-report", "json", "--output", "-", "--continue-on-error"],
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 1
+        mock_build_summary.assert_called_once()
+        summary_results = mock_build_summary.call_args.args[0]
+        assert [r.data_view_id for r in summary_results] == ["dv_fail", "dv_ok"]
+        assert summary_results[0].success is False
+        assert summary_results[1].success is True
+
+    @patch("cja_auto_sdr.generator.write_quality_report_output", side_effect=OSError("permission denied"))
+    @patch("cja_auto_sdr.generator.process_single_dataview")
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    def test_quality_report_write_error_exits_cleanly_with_code_1(
+        self, mock_resolve, mock_process, mock_write_report, capsys
+    ):
+        """Quality report write failures should be handled with a clean exit code 1."""
+        from cja_auto_sdr.generator import ProcessingResult, main
+
+        mock_resolve.return_value = (["dv_ok"], {})
+        mock_process.return_value = ProcessingResult(
+            data_view_id="dv_ok",
+            data_view_name="Healthy View",
+            success=True,
+            duration=0.1,
+            dq_issues_count=0,
+            dq_issues=[],
+            dq_severity_counts={},
+        )
+
+        with patch.object(
+            sys, "argv", ["cja_auto_sdr", "dv_ok", "--quality-report", "json", "--output", "report.json"]
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "Failed to write quality report" in captured.err
+        mock_write_report.assert_called_once()
+
+    def test_quality_report_csv_empty_writes_header_row(self, tmp_path):
+        """CSV quality reports should include headers even when there are no issues."""
+        from cja_auto_sdr.generator import write_quality_report_output
+
+        output_path = tmp_path / "quality_report.csv"
+        write_quality_report_output([], report_format="csv", output=str(output_path), output_dir=tmp_path)
+
+        header = output_path.read_text(encoding="utf-8").splitlines()[0]
+        assert header == "Data View ID,Data View Name,Severity,Category,Type,Item Name,Issue,Details"
+
+    @patch("cja_auto_sdr.generator.BatchProcessor")
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    def test_batch_failures_take_precedence_over_quality_gate_with_continue_on_error(
+        self, mock_resolve, mock_batch_cls
+    ):
+        """Batch processing failures should keep exit code 1 precedence over quality gate exit 2."""
+        from cja_auto_sdr.generator import ProcessingResult, main
+
+        mock_resolve.return_value = (["dv_fail", "dv_ok"], {})
+        mock_batch = mock_batch_cls.return_value
+        mock_batch.process_batch.return_value = {
+            "successful": [
+                ProcessingResult(
+                    data_view_id="dv_ok",
+                    data_view_name="Healthy View",
+                    success=True,
+                    duration=0.1,
+                    dq_issues_count=1,
+                    dq_issues=[{"Severity": "HIGH", "Issue": "Threshold issue"}],
+                    dq_severity_counts={"HIGH": 1},
+                )
+            ],
+            "failed": [
+                ProcessingResult(
+                    data_view_id="dv_fail",
+                    data_view_name="Failing View",
+                    success=False,
+                    duration=0.1,
+                    error_message="mock failure",
+                )
+            ],
+            "total": 2,
+            "total_duration": 0.2,
+        }
+
+        with patch.object(
+            sys,
+            "argv",
+            ["cja_auto_sdr", "dv_fail", "dv_ok", "--continue-on-error", "--fail-on-quality", "HIGH"],
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 1
+
+    @patch("cja_auto_sdr.generator.append_github_step_summary")
+    @patch("cja_auto_sdr.generator.build_quality_step_summary")
+    @patch("cja_auto_sdr.generator.BatchProcessor")
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    def test_batch_summary_includes_failed_views_in_standard_mode(
+        self,
+        mock_resolve,
+        mock_batch_cls,
+        mock_build_summary,
+        mock_append_summary,
+    ):
+        """Quality summary should include failed views in normal SDR batch mode."""
+        from cja_auto_sdr.generator import ProcessingResult, main
+
+        mock_resolve.return_value = (["dv_fail", "dv_ok"], {})
+        mock_build_summary.return_value = "summary"
+        mock_append_summary.return_value = True
+        mock_batch = mock_batch_cls.return_value
+        mock_batch.process_batch.return_value = {
+            "successful": [
+                ProcessingResult(
+                    data_view_id="dv_ok",
+                    data_view_name="Healthy View",
+                    success=True,
+                    duration=0.1,
+                    dq_issues_count=0,
+                    dq_issues=[],
+                    dq_severity_counts={},
+                )
+            ],
+            "failed": [
+                ProcessingResult(
+                    data_view_id="dv_fail",
+                    data_view_name="Failing View",
+                    success=False,
+                    duration=0.1,
+                    error_message="mock failure",
+                )
+            ],
+            "total": 2,
+            "total_duration": 0.2,
+        }
+
+        with patch.object(sys, "argv", ["cja_auto_sdr", "dv_fail", "dv_ok", "--continue-on-error"]):
+            main()
+
+        mock_build_summary.assert_called_once()
+        summary_results = mock_build_summary.call_args.args[0]
+        assert len(summary_results) == 2
+        assert {result.data_view_id for result in summary_results} == {"dv_fail", "dv_ok"}
+        assert any(not result.success for result in summary_results)
+
+    def test_auto_prune_requires_auto_snapshot(self):
+        """--auto-prune should fail fast without --auto-snapshot."""
+        from cja_auto_sdr.generator import main
+
+        with patch.object(sys, "argv", ["cja_auto_sdr", "--diff", "dv_a", "dv_b", "--auto-prune"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 1
+
+    def test_auto_prune_defaults_apply_only_when_retention_flags_omitted(self):
+        """Auto-prune defaults should only apply when neither retention flag is provided."""
+        from cja_auto_sdr.generator import (
+            DEFAULT_AUTO_PRUNE_KEEP_LAST,
+            DEFAULT_AUTO_PRUNE_KEEP_SINCE,
+            resolve_auto_prune_retention,
+        )
+
+        keep_last, keep_since = resolve_auto_prune_retention(
+            keep_last=0,
+            keep_since=None,
+            auto_prune=True,
+            keep_last_specified=False,
+            keep_since_specified=False,
+        )
+        assert keep_last == DEFAULT_AUTO_PRUNE_KEEP_LAST
+        assert keep_since == DEFAULT_AUTO_PRUNE_KEEP_SINCE
+
+        keep_last, keep_since = resolve_auto_prune_retention(
+            keep_last=0,
+            keep_since=None,
+            auto_prune=True,
+            keep_last_specified=True,
+            keep_since_specified=False,
+        )
+        assert keep_last == 0
+        assert keep_since is None
+
+    @patch("cja_auto_sdr.generator.handle_diff_command")
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    def test_keep_last_equals_syntax_counts_as_explicit_for_auto_prune(self, mock_resolve, mock_handle_diff):
+        """--keep-last=0 should be treated as explicitly provided retention."""
+        from cja_auto_sdr.generator import main
+
+        mock_resolve.side_effect = [(["dv_a"], {}), (["dv_b"], {})]
+        mock_handle_diff.return_value = (True, False, None)
+
+        with patch.object(
+            sys, "argv", ["cja_auto_sdr", "--diff", "dv_a", "dv_b", "--auto-snapshot", "--auto-prune", "--keep-last=0"]
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 0
+        assert mock_handle_diff.call_args.kwargs["keep_last_specified"] is True
+        assert mock_handle_diff.call_args.kwargs["keep_since_specified"] is False
+
+    @patch("cja_auto_sdr.generator.handle_diff_command")
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    def test_keep_since_equals_syntax_counts_as_explicit_for_auto_prune(self, mock_resolve, mock_handle_diff):
+        """--keep-since=90d should be treated as explicitly provided retention."""
+        from cja_auto_sdr.generator import main
+
+        mock_resolve.side_effect = [(["dv_a"], {}), (["dv_b"], {})]
+        mock_handle_diff.return_value = (True, False, None)
+
+        with patch.object(
+            sys,
+            "argv",
+            ["cja_auto_sdr", "--diff", "dv_a", "dv_b", "--auto-snapshot", "--auto-prune", "--keep-since=90d"],
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 0
+        assert mock_handle_diff.call_args.kwargs["keep_last_specified"] is False
+        assert mock_handle_diff.call_args.kwargs["keep_since_specified"] is True
 
 
 class TestRetryArguments:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -611,9 +611,7 @@ class TestQualityGateAndReport:
         """Quality report mode should reject --skip-validation."""
         from cja_auto_sdr.generator import main
 
-        with patch.object(
-            sys, "argv", ["cja_auto_sdr", "dv_test", "--quality-report", "json", "--skip-validation"]
-        ):
+        with patch.object(sys, "argv", ["cja_auto_sdr", "dv_test", "--quality-report", "json", "--skip-validation"]):
             with pytest.raises(SystemExit) as exc_info:
                 main()
 

--- a/tests/test_process_single_dataview.py
+++ b/tests/test_process_single_dataview.py
@@ -698,6 +698,7 @@ class TestProcessSingleDataviewWorker:
             include_segments_inventory=False,
             inventory_only=False,
             inventory_order=None,
+            quality_report_only=False,
         )
 
 

--- a/tests/test_ux_features.py
+++ b/tests/test_ux_features.py
@@ -524,6 +524,36 @@ class TestConsoleColorsTheme:
         result = ConsoleColors.diff_modified("test")
         assert "test" in result
 
+    def test_no_color_env_disables_colors(self):
+        """Test NO_COLOR environment variable disables ANSI colors."""
+        from cja_auto_sdr.generator import ConsoleColors
+
+        original_state = ConsoleColors.is_enabled()
+        with patch.dict("os.environ", {"NO_COLOR": "1"}, clear=False):
+            ConsoleColors.configure()
+            assert ConsoleColors.is_enabled() is False
+        ConsoleColors.set_enabled(original_state)
+
+    def test_force_color_env_enables_colors(self):
+        """Test FORCE_COLOR environment variable enables ANSI colors."""
+        from cja_auto_sdr.generator import ConsoleColors
+
+        original_state = ConsoleColors.is_enabled()
+        with patch.dict("os.environ", {"FORCE_COLOR": "1"}, clear=False):
+            ConsoleColors.configure()
+            assert ConsoleColors.is_enabled() is True
+        ConsoleColors.set_enabled(original_state)
+
+    def test_no_color_flag_overrides_force_color(self):
+        """Test --no-color policy overrides FORCE_COLOR."""
+        from cja_auto_sdr.generator import ConsoleColors
+
+        original_state = ConsoleColors.is_enabled()
+        with patch.dict("os.environ", {"FORCE_COLOR": "1"}, clear=False):
+            ConsoleColors.configure(no_color=True)
+            assert ConsoleColors.is_enabled() is False
+        ConsoleColors.set_enabled(original_state)
+
 
 class TestInteractiveFlag:
     """Tests for --interactive flag"""


### PR DESCRIPTION
## Summary
This PR completes the v3.2.1 CLI/CI enhancement set and follow-up hardening for quality/report workflows.

## Changes
- Added global ANSI color controls across output paths via `--no-color`, `NO_COLOR`, and `FORCE_COLOR`.
- Added quality policy gating with `--fail-on-quality SEVERITY` (exit code `2` on threshold breach).
- Added standalone quality export with `--quality-report json|csv` (including stdout output).
- Added GitHub Actions step summary output when `GITHUB_STEP_SUMMARY` is set.
- Added `--auto-prune` default retention behavior for diff auto-snapshot runs (`--keep-last 20` + `--keep-since 30d`).
- Fixed retention precedence so explicit flags are preserved, including `--keep-last 0`, `--keep-last=0`, `--keep-since 90d`, and `--keep-since=90d`.
- Fixed quality-report behavior with `--continue-on-error` so processing failures still return exit code `1`.
- Fixed quality-report write-path handling to return a clean CLI error (no uncaught traceback) on output failures.
- Fixed empty CSV quality reports to emit a stable header row when there are zero issues.
- Fixed quality step summary counts to include both successful and failed data views.
- Fixed diff step summary totals to include inventory-only changes (calculated metrics and segments).
- Hardened validation so `--fail-on-quality` is rejected in non-SDR modes, including `--config-json`.
- Hardened validation so `--quality-report` is rejected in non-SDR modes, including `--sample-config`, discovery commands, config commands, and profile commands.
- Enforced that `--fail-on-quality` and `--quality-report` cannot be combined with `--skip-validation`.

## Documentation
Updated:
- `CHANGELOG.md` (entries folded into v3.2.1)
- `README.md`
- `docs/CLI_REFERENCE.md`
- `docs/DIFF_COMPARISON.md`
- `docs/QUICK_REFERENCE.md`
- `docs/TROUBLESHOOTING.md`
- `docs/USE_CASES.md`

## Testing
- `PYTHONPATH=src uv run pytest -q tests/test_cli.py` (`160 passed`)
- `PYTHONPATH=src uv run pytest -q tests/test_diff_comparison.py tests/test_ux_features.py tests/test_process_single_dataview.py` (`298 passed, 1 skipped`)
