### PR TITLE
Fix --include-all-inventory in snapshot/diff modes and sync docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A **Solution Design Reference** is the essential documentation that bridges your
 
 1. **Connects** to your CJA instance via the Adobe API
 2. **Extracts** all metrics, dimensions, and configuration from your Data View(s)
-3. **Validates** data quality with 8+ automated checks (duplicates, missing fields, null values)
+3. **Validates** data quality with core automated checks (duplicates, required fields, null values, missing descriptions, empty datasets, invalid IDs)
 4. **Generates** formatted documentation with color-coded quality indicators
 
 ### Key Features
@@ -29,14 +29,14 @@ A **Solution Design Reference** is the essential documentation that bridges your
 | | Validation Caching | 50-90% faster on repeated runs with intelligent result caching |
 | | Optimized Validation | Single-pass DataFrame scanning (30-50% faster) |
 | | Configurable Workers | Scale from 1-256 parallel workers based on your infrastructure |
-| **Quality** | 8+ Validation Checks | Detect duplicates, missing fields, null values, invalid IDs |
+| **Quality** | Core Validation Checks | Detect duplicates, missing fields, null values, invalid IDs, and empty datasets |
 | | Severity Classification | CRITICAL, HIGH, MEDIUM, LOW with color-coded Excel formatting |
 | | Quality Dashboard | Dedicated sheet with filtering, sorting, and actionable insights |
 | **Output** | Multiple Formats | Excel, CSV, JSON, HTML, Markdown—or generate all at once |
 | | Professional Excel | Up to 8 formatted sheets with conditional formatting, frozen headers, auto-filtering |
-| | Segments Inventory | Document segment filters, complexity, and references with `--include-segments` (SDR + Diff) |
+| | Segments Inventory | Document segment filters, complexity, and references with `--include-segments` (SDR + Snapshot Diff) |
 | | Derived Field Inventory | Document derived field logic, complexity, and dependencies with `--include-derived` (SDR only) |
-| | Calculated Metrics Inventory | Document calculated metric formulas and references with `--include-calculated` (SDR + Diff) |
+| | Calculated Metrics Inventory | Document calculated metric formulas and references with `--include-calculated` (SDR + Snapshot Diff) |
 | | Inventory-Only Mode | Generate only inventory sheets without standard SDR with `--inventory-only` |
 | | Stdout Support | Pipe JSON/CSV output directly to other tools with `--output -` |
 | | Auto-Open Files | Open generated files immediately with `--open` flag |
@@ -145,7 +145,7 @@ uv run cja_auto_sdr --sample-config
 # Edit config.json with your credentials
 ```
 
-> **Note:** The configuration file must be named `config.json` and placed in the project root directory.
+> **Note:** By default, the tool reads `./config.json` from your current working directory. Use `--config-file /path/to/config.json` to load a file from a different location or filename.
 
 ```json
 {
@@ -267,7 +267,7 @@ cja_auto_sdr "Production Analytics"
 | With retention policy | `cja_auto_sdr --diff dv_1 dv_2 --auto-snapshot --keep-last 10` |
 | Auto-prune snapshots (defaults) | `cja_auto_sdr --diff dv_1 dv_2 --auto-snapshot --auto-prune` |
 | **Inventory Diff** (same data view over time) | |
-| Snapshot with inventory | `cja_auto_sdr dv_12345 --snapshot ./baseline.json --include-calculated --include-segments` |
+| Snapshot with inventory | `cja_auto_sdr dv_12345 --snapshot ./baseline.json --include-all-inventory` |
 | Compare with inventory | `cja_auto_sdr dv_12345 --diff-snapshot ./baseline.json --include-calculated` |
 | Full inventory diff | `cja_auto_sdr dv_12345 --diff-snapshot ./baseline.json --include-calculated --include-segments` |
 | **Git Integration** | |
@@ -361,7 +361,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md   # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md # Org-wide report guide
 │   └── ...                  # Additional guides
-├── tests/                   # Test suite (1,347+ tests)
+├── tests/                   # Test suite (1,351+ tests)
 ├── sample_outputs/          # Example output files
 │   ├── excel/               # Sample Excel SDR
 │   ├── csv/                 # Sample CSV output

--- a/docs/CALCULATED_METRICS_INVENTORY.md
+++ b/docs/CALCULATED_METRICS_INVENTORY.md
@@ -137,7 +137,7 @@ Adds a "Calculated Metrics" sheet to the SDR workbook, sorted by complexity scor
 **Sheet Order:**
 1. Metadata
 2. Data Quality
-3. DataView
+3. DataView Details
 4. Metrics
 5. Dimensions
 6. Derived Fields (if `--include-derived`)

--- a/docs/DATA_QUALITY.md
+++ b/docs/DATA_QUALITY.md
@@ -4,7 +4,7 @@ Comprehensive guide to the automated data quality checks performed by the CJA SD
 
 ## Overview
 
-The generator performs 8+ automated validation checks on your CJA components, identifying issues before they impact your analytics. Each issue is classified by severity and includes actionable recommendations.
+The generator performs six core automated validation checks on your CJA components, identifying issues before they impact your analytics. Each issue is classified by severity and includes actionable recommendations.
 
 ## Validation Checks
 
@@ -68,25 +68,16 @@ The generator performs 8+ automated validation checks on your CJA components, id
 | Impact | Components cannot be referenced properly in reports |
 | Example | ID field is empty or contains invalid characters |
 
-### 7. Field Existence Validation
+### No-Issue Summary Row
 
-**What it checks**: Verifies expected columns are present in API response.
-
-| Aspect | Details |
-|--------|---------|
-| Severity | CRITICAL |
-| Impact | May indicate API changes or permissions issues |
-| Example | Expected "attribution" field missing from response |
-
-### 8. Data Completeness
-
-**What it checks**: Overall assessment of data quality across all checks.
+When no issues are detected, the report includes an informational summary row:
 
 | Aspect | Details |
 |--------|---------|
-| Severity | Multiple levels |
-| Impact | Varies by specific issue |
-| Example | 15% of components missing descriptions |
+| Severity | INFO |
+| Category | Data Quality |
+| Issue | No data quality issues detected |
+| Details | All validation checks passed successfully |
 
 ## Severity Levels
 
@@ -118,13 +109,20 @@ The generator performs 8+ automated validation checks on your CJA components, id
 - Examples: Missing descriptions
 - **Action**: Address during maintenance windows
 
+### INFO (Green Background)
+
+- **Informational status**
+- Indicates validation passed with no issues found
+- Example: "No data quality issues detected"
+- **Action**: No remediation required
+
 ## Understanding the Data Quality Sheet
 
 The Excel output includes a dedicated "Data Quality" sheet with these columns:
 
 | Column | Description |
 |--------|-------------|
-| Severity | Issue severity level (CRITICAL, HIGH, MEDIUM, LOW) |
+| Severity | Issue severity level (CRITICAL, HIGH, MEDIUM, LOW, INFO) |
 | Category | Type of issue (Duplicates, Missing Fields, etc.) |
 | Type | Whether it affects Metrics or Dimensions |
 | Item Name | Specific component(s) affected |

--- a/docs/DERIVED_FIELDS_INVENTORY.md
+++ b/docs/DERIVED_FIELDS_INVENTORY.md
@@ -135,7 +135,7 @@ Adds a "Derived Fields" sheet to the SDR workbook, sorted by complexity score (h
 **Sheet Order:**
 1. Metadata
 2. Data Quality
-3. DataView
+3. DataView Details
 4. Metrics
 5. Dimensions
 6. Derived Fields (if `--include-derived`)

--- a/docs/DIFF_COMPARISON.md
+++ b/docs/DIFF_COMPARISON.md
@@ -643,7 +643,7 @@ To minimize API calls during name resolution, data view listings are cached for 
 | `--summary` | Show summary statistics only (no detailed changes). |
 | `--ignore-fields FIELDS` | Comma-separated fields to ignore during comparison. |
 | `--diff-labels A B` | Custom labels for source and target sides. |
-| `--show-only TYPES` | Filter by change type: added, removed, modified (comma-separated). |
+| `--show-only TYPES` | Filter by change type: added, removed, modified, unchanged (comma-separated). |
 | `--metrics-only` | Only compare metrics (exclude dimensions). |
 | `--dimensions-only` | Only compare dimensions (exclude metrics). |
 | `--extended-fields` | Include extended fields (attribution, format, bucketing, etc.). |
@@ -882,7 +882,7 @@ Basic snapshot without inventory data:
 
 ### Version 2.0 (With Inventory)
 
-When created with `--include-calculated`, `--include-segments`, or `--include-all-inventory`:
+When created with `--include-calculated` and/or `--include-segments`:
 
 ```json
 {
@@ -1233,11 +1233,7 @@ For reliable cross-DV comparison of calculated metrics or segments, manual revie
 When creating a snapshot, include inventory flags to capture that data:
 
 ```bash
-# Create snapshot with all supported inventories (shorthand)
-# Note: --include-all-inventory auto-excludes --include-derived in snapshot mode
-cja_auto_sdr dv_12345 --snapshot ./baseline.json --include-all-inventory
-
-# Create snapshot with calculated metrics and segments inventory (longhand)
+# Create snapshot with calculated metrics and segments inventory
 cja_auto_sdr dv_12345 --snapshot ./baseline.json \
   --include-calculated --include-segments
 
@@ -1247,16 +1243,13 @@ cja_auto_sdr dv_12345 --snapshot ./baseline.json --include-calculated
 
 Snapshots with inventory data use version 2.0 format and include the inventory arrays.
 
-> **Note:** `--include-derived` is not supported with `--snapshot`. Derived fields inventory is only available in SDR generation mode. Derived field changes are captured in the standard Metrics/Dimensions diff. The `--include-all-inventory` flag uses smart mode detection and automatically excludes derived fields when in snapshot mode.
+> **Note:** `--include-derived` is not supported with `--snapshot`. Derived fields inventory is only available in SDR generation mode. Derived field changes are captured in the standard Metrics/Dimensions diff. `--include-all-inventory` uses smart mode detection in snapshot/diff workflows and automatically enables only `--include-calculated` + `--include-segments`.
 
 ### Comparing Snapshots with Inventory
 
 When comparing against a snapshot, request the same inventory types that were captured:
 
 ```bash
-# Compare with all inventory types (shorthand, auto-excludes derived)
-cja_auto_sdr dv_12345 --diff-snapshot ./baseline.json --include-all-inventory
-
 # Compare with calculated metrics inventory
 cja_auto_sdr dv_12345 --diff-snapshot ./baseline.json --include-calculated
 
@@ -1265,7 +1258,11 @@ cja_auto_sdr dv_12345 --diff-snapshot ./baseline.json \
   --include-calculated --include-segments
 
 # Compare two snapshot files directly
-cja_auto_sdr --compare-snapshots ./before.json ./after.json --include-all-inventory
+cja_auto_sdr --compare-snapshots ./before.json ./after.json \
+  --include-calculated --include-segments
+
+# Snapshot/diff shorthand (auto-excludes derived)
+cja_auto_sdr dv_12345 --diff-snapshot ./baseline.json --include-all-inventory
 ```
 
 ### Inventory Validation

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -272,7 +272,7 @@ See `.env.example` for a complete template.
 
 ### Option 2: Configuration File
 
-Create a `config.json` file in the project root directory:
+Create a `config.json` file in your current working directory (default path), or pass `--config-file` to use a different location:
 
 ```bash
 # Copy the example template

--- a/docs/INVENTORY_OVERVIEW.md
+++ b/docs/INVENTORY_OVERVIEW.md
@@ -11,13 +11,13 @@ Component inventories provide comprehensive documentation of CJA analytics compo
 | [Calculated Metrics](./CALCULATED_METRICS_INVENTORY.md) | `--include-calculated` | CJA API (`getCalculatedMetrics`) | Yes (same DV only)† |
 | [Segments](./SEGMENTS_INVENTORY.md) | `--include-segments` | CJA API (`getFilters`) | Yes (same DV only)† |
 | [Derived Fields](./DERIVED_FIELDS_INVENTORY.md) | `--include-derived` | Data View components | No* |
-| **All Inventories** | `--include-all-inventory` | All sources | Smart** |
+| **All Inventories** | `--include-all-inventory` | All sources | Yes (smart mode)‡ |
 
 > *Derived fields appear in standard Metrics/Dimensions SDR output, so changes are captured in the standard diff. The inventory provides additional logic analysis not available elsewhere.
 >
 > †**Same Data View Only:** Inventory diff is only supported for snapshot comparisons of the **same data view** over time (`--diff-snapshot`, `--compare-snapshots`, `--compare-with-prev`). Cross-data-view comparison (`--diff dv_A dv_B`) does not support inventory options because calculated metric and segment IDs are data-view-scoped and cannot be reliably matched across different data views.
 >
-> **Smart mode detection: `--include-all-inventory` enables all three inventories for SDR generation, but automatically excludes `--include-derived` when in snapshot/diff mode (since derived fields don't support diff).
+> ‡**Smart mode detection:** `--include-all-inventory` enables all three inventories in SDR mode, and enables only calculated metrics + segments in snapshot/diff modes (derived fields are excluded).
 
 ## When to Use Each Inventory
 
@@ -240,16 +240,13 @@ Track changes to calculated metrics and segments over time. See [Diff Comparison
 ```bash
 # Create baseline snapshot
 cja_auto_sdr dv_12345 \
-    --include-calculated \
-    --include-segments \
-    --format json \
-    --output baseline_$(date +%Y%m%d).json
+    --snapshot baseline_$(date +%Y%m%d).json \
+    --include-all-inventory
 
 # Later: compare against baseline
 cja_auto_sdr dv_12345 \
     --diff-snapshot baseline_20260101.json \
-    --include-calculated \
-    --include-segments
+    --include-all-inventory
 ```
 
 This reveals:

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -185,7 +185,7 @@ uv sync
 Resolved 15 packages in 0.5s
 Downloaded 15 packages in 2.3s
 Installed 15 packages in 0.8s
- + cjapy==0.2.4.post2
+ + cjapy==0.2.4.post3
  + pandas==2.3.3
  + xlsxwriter==3.2.9
  + tqdm==4.66.0
@@ -203,7 +203,7 @@ This command:
 
 ```bash
 $ uv run cja_auto_sdr --version
-cja_auto_sdr 3.2.0
+cja_auto_sdr 3.2.1
 ```
 
 > **Important:** All commands in this guide assume you're in the `cja_auto_sdr` directory. If you see "command not found", make sure you're in the right directory and have run `uv sync`.
@@ -244,7 +244,7 @@ You have two options for configuring credentials:
 
 ### Option A: Configuration File (Quickest)
 
-Create a file named `config.json` in the project root directory:
+Create a `config.json` file in your current working directory (default path), or use `--config-file` to point to a different location:
 
 ```bash
 # Copy the example template (recommended)
@@ -507,7 +507,7 @@ Extracting dimensions... ━━━━━━━━━━━━━━━━━━�
 ============================================================
 RUNNING DATA QUALITY VALIDATION
 ============================================================
-Running 8 validation checks...
+Running validation checks...
 ✓ Duplicate ID check: PASSED
 ✓ Missing name check: PASSED (2 warnings)
 ✓ Null value check: PASSED
@@ -519,7 +519,7 @@ GENERATING EXCEL REPORT
 Creating workbook...
 Writing Metadata sheet...
 Writing Data Quality sheet...
-Writing DataView sheet...
+Writing DataView Details sheet...
 Writing Metrics sheet (145 metrics)...
 Writing Dimensions sheet (287 dimensions)...
 Applying formatting...
@@ -581,7 +581,7 @@ Results of automated validation checks:
 | Column | Description |
 |--------|-------------|
 | Severity | CRITICAL, HIGH, MEDIUM, LOW, or INFO |
-| Category | Type of check (Duplicates, Naming, etc.) |
+| Category | Type of check (Duplicates, Missing Fields, etc.) |
 | Type | Component type (Metrics, Dimensions) |
 | Item Name | Name of the affected component |
 | Issue | Description of the problem |
@@ -734,7 +734,7 @@ Keep the [Quick Reference Card](QUICK_REFERENCE.md) handy for common commands an
 Error: Configuration file 'config.json' not found
 ```
 
-**Solution:** Ensure `config.json` exists in the project root directory, not in a subdirectory.
+**Solution:** Ensure your config file exists at the path you're using. By default this is `./config.json` in your current directory, or pass an explicit path with `--config-file`.
 
 ```bash
 ls config.json

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -194,7 +194,7 @@ cja_auto_sdr --org-report --sample 50
 # Reproducible sample with seed
 cja_auto_sdr --org-report --sample 50 --sample-seed 42
 
-# Stratified sampling by owner
+# Stratified sampling by data view name prefix
 cja_auto_sdr --org-report --sample 50 --sample-stratified
 
 # --- Trending & Comparison ---
@@ -272,11 +272,13 @@ cja_auto_sdr --list-dataviews  # Uses client-a
 | `--include-segments` | Add segments inventory sheet/section | SDR + Snapshot Diff |
 | `--include-derived` | Add derived field inventory sheet/section | SDR only |
 | `--include-calculated` | Add calculated metrics inventory sheet/section | SDR + Snapshot Diff |
-| `--include-all-inventory` | Enable all inventory options (smart mode detection) | SDR + Snapshot Diff |
+| `--include-all-inventory` | Enable all inventory options (smart mode: auto-excludes derived in snapshot/diff modes) | SDR + Snapshot Diff |
 | `--inventory-only` | Output only inventory sheets (requires `--include-*`) | SDR only |
 | `--inventory-summary` | Quick stats without full output (requires `--include-*`) | SDR only |
 
 > **Note:** `--include-derived` is for SDR generation only. Derived fields are already included in the standard metrics/dimensions output, so changes are captured in the Metrics/Dimensions diff.
+>
+> **Snapshot/Diff inventory:** `--include-all-inventory` automatically enables `--include-segments` and `--include-calculated`, and excludes `--include-derived`.
 
 ### Diff-Specific Options
 
@@ -392,11 +394,12 @@ cja_auto_sdr dv_12345 --include-segments --inventory-summary --format json
 
 # --- Inventory Diff (same data view over time) ---
 
-# Create snapshot with inventory
-cja_auto_sdr dv_12345 --snapshot ./baseline.json --include-calculated --include-segments
+# Create snapshot with inventory (smart shorthand)
+cja_auto_sdr dv_12345 --snapshot ./baseline.json --include-all-inventory
+# Equivalent to: --include-calculated --include-segments
 
-# Compare against snapshot with inventory
-cja_auto_sdr dv_12345 --diff-snapshot ./baseline.json --include-calculated --include-segments
+# Compare against snapshot with inventory (same behavior)
+cja_auto_sdr dv_12345 --diff-snapshot ./baseline.json --include-all-inventory
 ```
 
 ## Environment Variables
@@ -448,7 +451,7 @@ See [CONFIGURATION.md](CONFIGURATION.md) for detailed setup of `config.json` and
 **Excel Sheet Order:**
 1. Metadata
 2. Data Quality
-3. DataView
+3. DataView Details
 4. Metrics
 5. Dimensions
 6. Segments (if `--include-segments`)

--- a/docs/SEGMENTS_INVENTORY.md
+++ b/docs/SEGMENTS_INVENTORY.md
@@ -28,7 +28,7 @@ cja_auto_sdr dv_12345 --include-segments --include-calculated --inventory-only
 | Option | Description |
 |--------|-------------|
 | `--include-segments` | Include segments inventory in SDR output. Adds a "Segments" sheet/section with complexity scores, definition summaries, and dimension/metric references. |
-| `--inventory-only` | Output only inventory sheets (Segments, Calculated Metrics, Derived Fields). Skips standard SDR sheets (Metadata, Data Quality, DataView, Metrics, Dimensions). Requires at least one `--include-*` flag. |
+| `--inventory-only` | Output only inventory sheets (Segments, Calculated Metrics, Derived Fields). Skips standard SDR sheets (Metadata, Data Quality, DataView Details, Metrics, Dimensions). Requires at least one `--include-*` flag. |
 
 ## Output Columns
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1400,7 +1400,7 @@ The inventory features (`--include-segments`, `--include-calculated`, `--include
 
 ### Using --include-all-inventory
 
-The `--include-all-inventory` flag is a shorthand that enables all inventory types with **smart mode detection**:
+The `--include-all-inventory` flag uses smart mode detection:
 
 ```bash
 # Shorthand for all inventories (SDR mode)
@@ -1410,7 +1410,7 @@ cja_auto_sdr dv_12345 --include-all-inventory
 cja_auto_sdr dv_12345 --include-segments --include-calculated --include-derived
 ```
 
-**Smart mode detection:** When used with snapshot or diff modes, `--include-all-inventory` automatically excludes `--include-derived` (since derived fields don't support diff):
+When used with snapshot/diff modes, it automatically excludes `--include-derived`:
 
 ```bash
 # In snapshot mode, --include-all-inventory enables only segments and calculated metrics

--- a/tests/README.md
+++ b/tests/README.md
@@ -39,14 +39,14 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 1,347 comprehensive tests**
+**Total: 1,351 comprehensive tests**
 
 ### Test Count Breakdown
 
 | Test File | Tests | Coverage Area |
 |-----------|-------|---------------|
 | `test_diff_comparison.py` | 162 | Data view diff comparison feature with inventory support |
-| `test_ux_features.py` | 119 | UX features: --open, --stats, --output, --list-dataviews formats, inventory validation, inventory summary, include-all-inventory |
+| `test_ux_features.py` | 123 | UX features: --open, --stats, --output, --list-dataviews formats, inventory validation, inventory summary, include-all-inventory |
 | `test_org_report.py` | 144 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
 | `test_org_report_integration.py` | 17 | Org-wide analysis integration tests: end-to-end flows, caching, filtering, governance |
 | `test_cli.py` | 160 | Command-line interface and argument parsing |
@@ -79,7 +79,7 @@ tests/
 | `test_data_quality.py` | 10 | Data quality validation logic |
 | `test_parallel_validation.py` | 8 | Parallel validation operations |
 | `test_discovery_formatters.py` | 23 | Shared discovery formatters, WorkerArgs dataclass, _exit_error, BANNER_WIDTH |
-| **Total** | **1,347** | **Collected via pytest --collect-only** |
+| **Total** | **1,351** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -483,7 +483,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (1,347 tests total)
+- [x] Comprehensive test coverage (1,351 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 144 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 43 tests
@@ -496,7 +496,7 @@ Check for drift (CI-friendly):
 - [x] Inventory utilities tests (test_inventory_utils.py) - 41 tests
 - [x] Git integration tests (test_git_integration.py) - 33 tests
 - [x] Inventory diff support in snapshot comparisons (test_diff_comparison.py) - 162 tests
-- [x] Inventory summary and include-all-inventory tests (test_ux_features.py) - 119 tests
+- [x] Inventory summary and include-all-inventory tests (test_ux_features.py) - 123 tests
 - [x] Parallel validation tests (test_parallel_validation.py)
 - [x] Validation caching tests (test_validation_cache.py)
 - [x] Early exit optimization tests (test_early_exit.py)


### PR DESCRIPTION
## Summary
This PR fixes `--include-all-inventory` so it works correctly in snapshot-based workflows and updates docs to match actual behavior.

## What Changed
- Fixed CLI dispatch ordering so `--include-all-inventory` is expanded **before** snapshot/diff handlers run.
- Added smart-mode handling for inventory expansion:
  - SDR mode: enables `--include-segments`, `--include-calculated`, `--include-derived`
  - Snapshot/diff modes (`--snapshot`, `--diff-snapshot`, `--compare-snapshots`, `--compare-with-prev`): enables only `--include-segments` + `--include-calculated`
- Updated `--include-all-inventory` help text in CLI parser for clarity.
- Added regression tests to confirm expanded flags are passed to:
  - `handle_snapshot_command`
  - `handle_diff_snapshot_command`
  - `handle_compare_snapshots_command`
  - `--compare-with-prev` path
- Updated documentation examples and references to reflect the fixed smart-mode behavior.
- Refreshed test-count docs via `scripts/update_test_counts.py`.

## Why
Previously, `--include-all-inventory` was expanded after early snapshot/diff dispatch paths, so those modes did not receive the expected inventory flags.

## Validation
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run python scripts/update_test_counts.py --check`
- `uv run pytest tests/ -v --tb=short --cov=cja_auto_sdr --cov-report=term`

## Notes
- Derived fields remain SDR-only for diff behavior; snapshot/diff flows intentionally exclude `--include-derived`.
