### PR TITLE
fix: restore failing CI checks (ruff format + test-count sync)

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (1,511+ tests)
+├── tests/                     # Test suite (1,522+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/src/cja_auto_sdr/api/resilience.py
+++ b/src/cja_auto_sdr/api/resilience.py
@@ -24,7 +24,7 @@ def _parse_env_numeric(value: str | None, cast: Callable[[str], Any]) -> Any | N
         return None
     try:
         return cast(value)
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         return None
 
 
@@ -60,8 +60,7 @@ def _effective_retry_config() -> dict[str, Any]:
         cfg["max_delay"] = parsed_max_delay
     elif "RETRY_MAX_DELAY" in os.environ:
         logger.warning(
-            f"Ignoring invalid RETRY_MAX_DELAY={os.environ.get('RETRY_MAX_DELAY')!r}; "
-            f"using default {cfg['max_delay']}"
+            f"Ignoring invalid RETRY_MAX_DELAY={os.environ.get('RETRY_MAX_DELAY')!r}; using default {cfg['max_delay']}"
         )
 
     return cfg

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -6220,7 +6220,9 @@ class BatchProcessor:
             # Process with ProcessPoolExecutor for true parallelism
             with ProcessPoolExecutor(max_workers=self.workers) as executor:
                 # Submit all tasks
-                future_to_dv = {executor.submit(process_single_dataview_worker, wa): wa.data_view_id for wa in worker_args}
+                future_to_dv = {
+                    executor.submit(process_single_dataview_worker, wa): wa.data_view_id for wa in worker_args
+                }
 
                 # Collect results as they complete with progress bar
                 with tqdm(
@@ -6611,7 +6613,7 @@ def _safe_env_number(env_var: str, default: int | float, cast: Callable[[str], i
         return default
     try:
         return cast(raw)
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         return default
 
 
@@ -15148,7 +15150,9 @@ def main():
     exit_code = 0
 
     redirect_stdout_for_run_summary = run_state.get("run_summary_output") in ("-", "stdout")
-    run_context = contextlib.redirect_stdout(sys.stderr) if redirect_stdout_for_run_summary else contextlib.nullcontext()
+    run_context = (
+        contextlib.redirect_stdout(sys.stderr) if redirect_stdout_for_run_summary else contextlib.nullcontext()
+    )
 
     try:
         with run_context:

--- a/tests/README.md
+++ b/tests/README.md
@@ -51,7 +51,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 1,511 comprehensive tests**
+**Total: 1,522 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -59,16 +59,16 @@ tests/
 |-----------|-------|---------------|
 | `test_diff_comparison.py` | 162 | Data view diff comparison feature with inventory support |
 | `test_ux_features.py` | 123 | UX features: --open, --stats, --output, --list-dataviews formats, inventory validation, inventory summary, include-all-inventory |
-| `test_org_report.py` | 144 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
+| `test_org_report.py` | 146 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
 | `test_org_report_integration.py` | 17 | Org-wide analysis integration tests: end-to-end flows, caching, filtering, governance |
-| `test_cli.py` | 229 | Command-line interface and argument parsing |
+| `test_cli.py` | 232 | Command-line interface and argument parsing |
 | `test_profiles.py` | 47 | Multi-organization profile support |
 | `test_derived_inventory.py` | 43 | Derived fields inventory feature |
 | `test_inventory_utils.py` | 41 | Inventory utilities and helpers |
 | `test_segments_inventory.py` | 41 | Segments inventory feature |
 | `test_edge_cases.py` | 39 | Edge cases, configuration dataclasses, custom exceptions |
 | `test_calculated_metrics_inventory.py` | 36 | Calculated metrics inventory feature |
-| `test_git_integration.py` | 33 | Git integration, snapshot management, inventory snapshots |
+| `test_git_integration.py` | 36 | Git integration, snapshot management, inventory snapshots |
 | `test_output_formats.py` | 36 | CSV, JSON, HTML, Markdown output generation |
 | `test_cja_initialization.py` | 33 | CJA connection and configuration validation |
 | `test_utils.py` | 27 | Utility functions and helpers |
@@ -77,8 +77,8 @@ tests/
 | `test_api_tuning.py` | 23 | API worker auto-tuning |
 | `test_error_messages.py` | 23 | Enhanced error messages and guidance |
 | `test_circuit_breaker.py` | 22 | Circuit breaker pattern |
-| `test_retry.py` | 21 | Retry with exponential backoff |
-| `test_batch_processor.py` | 20 | Batch processing of multiple data views |
+| `test_retry.py` | 22 | Retry with exponential backoff |
+| `test_batch_processor.py` | 22 | Batch processing of multiple data views |
 | `test_validation_cache.py` | 19 | Validation result caching |
 | `test_process_single_dataview.py` | 20 | End-to-end single data view processing |
 | `test_optimized_validation.py` | 16 | Optimized data quality validation |
@@ -95,7 +95,7 @@ tests/
 | `test_malformed_api_responses.py` | 19 | Negative tests for malformed/unexpected API responses |
 | `test_main_entry_points.py` | 19 | main() and _main_impl() entry points, dispatch, run_state, run summary |
 | `test_e2e_integration.py` | 16 | End-to-end integration tests with real pipeline, mocked API boundary |
-| **Total** | **1,511** | **Collected via pytest --collect-only** |
+| **Total** | **1,522** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -499,8 +499,8 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (1,511 tests total)
-- [x] Org-wide analysis tests (test_org_report.py) - 144 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
+- [x] Comprehensive test coverage (1,522 tests total)
+- [x] Org-wide analysis tests (test_org_report.py) - 146 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 47 tests
 - [x] API worker auto-tuning tests (test_api_tuning.py) - 23 tests
@@ -510,7 +510,7 @@ Check for drift (CI-friendly):
 - [x] Segments inventory tests (test_segments_inventory.py) - 41 tests
 - [x] Derived fields inventory tests (test_derived_inventory.py) - 43 tests
 - [x] Inventory utilities tests (test_inventory_utils.py) - 41 tests
-- [x] Git integration tests (test_git_integration.py) - 33 tests
+- [x] Git integration tests (test_git_integration.py) - 36 tests
 - [x] Inventory diff support in snapshot comparisons (test_diff_comparison.py) - 162 tests
 - [x] Inventory summary and include-all-inventory tests (test_ux_features.py) - 123 tests
 - [x] Parallel validation tests (test_parallel_validation.py)

--- a/tests/test_batch_processor.py
+++ b/tests/test_batch_processor.py
@@ -313,7 +313,9 @@ class TestBatchProcessorProcessBatch:
         mock_executor.return_value = mock_executor_instance
 
         with patch("cja_auto_sdr.generator.as_completed", return_value=[mock_future]):
-            processor = BatchProcessor(config_file=mock_config_file, output_dir=temp_output_dir, continue_on_error=False)
+            processor = BatchProcessor(
+                config_file=mock_config_file, output_dir=temp_output_dir, continue_on_error=False
+            )
             processor.process_batch(["dv_test_12345"])
 
         mock_future.cancel.assert_called()


### PR DESCRIPTION
## Summary\n- run ruff formatter on files flagged by CI\n- sync generated test count docs using scripts/update_test_counts.py\n- no behavioral code changes; formatting + documentation/test-metadata only\n\n## Validation\n- uv run ruff check src/ tests/\n- uv run ruff format --check src/ tests/\n- uv run python scripts/update_test_counts.py --check\n- uv run pytest -q tests/test_cli.py -k "run_summary and subprocess"\n- uv run pytest tests/ -v --tb=short --cov=cja_auto_sdr --cov-report=term