### PR TITLE
fix: patch v3.2.2 defects and add regression tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,10 +34,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Git init false-success path**: `git_init_snapshot_repo()` now checks and propagates `git add` / `git commit` failures instead of reporting initialization success when either command fails
 - **Org-report lock liveness**: `OrgReportLock._is_process_running()` now treats `PermissionError`/EPERM as process-alive to avoid stale-lock takeover of active runs
 - **Main entrypoint global side effects**: Removed global `sys.exit` monkeypatching in `main()` while preserving `--run-summary-json stdout` JSON-only output behavior
-- **Retry env parsing hard-failures**: Invalid `MAX_RETRIES` / `RETRY_BASE_DELAY` / `RETRY_MAX_DELAY` values now safely fall back to defaults in both CLI parsing and runtime retry configuration
+- **Retry env parsing and backoff bounds**: Invalid, negative, or non-finite `MAX_RETRIES` / `RETRY_BASE_DELAY` / `RETRY_MAX_DELAY` values now safely fall back to defaults, and invalid delay windows are clamped to prevent negative sleep durations or skipped retries
 - **Batch early-stop cleanup**: Batch processor now cancels remaining futures on exception stop paths and guarantees shared-cache shutdown via `finally`
 - **Org cache observability**: `OrgReportCache` now logs warnings on cache load/save failures instead of silently swallowing I/O errors
 - **Snapshot diff guidance typo**: Corrected invalid remediation command shown for missing inventory snapshot data (removed nonexistent `--sdr` flag)
+- **Data view cache isolation by credential context**: Data view name-resolution cache keys now include credential/profile context, preventing stale cache reuse across different profiles using the same config path
+- **Org-report sample bound validation**: `--sample` now requires values of at least `1` with fast validation in both CLI argument handling and analyzer execution
+- **Strict profile import validation**: Non-interactive `--profile-import` now enforces strict credential format checks and reports full validation issues before writing profile config
 
 ### Tests
 - Added `test_e2e_integration.py` — 16 end-to-end integration tests that mock only the API boundary and exercise the full pipeline (output writers, DQ checker, special character handling)
@@ -51,7 +54,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Org cache save warning visibility
   - Invalid retry env var fallback behavior (CLI + runtime)
   - Batch cancellation/shutdown behavior on exception and interrupt paths
-- **1,522 tests** (1,520 passing, 2 skipped) — up from 1,431
+  - Data view cache isolation by credential context during name resolution
+  - `--org-report --sample` negative value rejection in both CLI and analyzer paths
+  - Strict non-interactive profile import rejection for invalid credential formats
+  - Retry config guards for negative env values and invalid delay windows
+- **1,529 tests** (1,527 passing, 2 skipped) — up from 1,431
 
 ### Changed
 - Removed `.python-version` from repo; `requires-python` in `pyproject.toml` is sufficient

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (1,522+ tests)
+├── tests/                     # Test suite (1,529+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/src/cja_auto_sdr/org/analyzer.py
+++ b/src/cja_auto_sdr/org/analyzer.py
@@ -330,6 +330,9 @@ class OrgComponentAnalyzer:
         Returns:
             Tuple of (data_view_list, is_sampled, total_available_count)
         """
+        if self.config.sample_size is not None and self.config.sample_size < 1:
+            raise ValueError("--sample must be at least 1")
+
         try:
             all_data_views = self.cja.getDataViews()
         except Exception as e:

--- a/tests/README.md
+++ b/tests/README.md
@@ -51,7 +51,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 1,522 comprehensive tests**
+**Total: 1,529 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -59,10 +59,10 @@ tests/
 |-----------|-------|---------------|
 | `test_diff_comparison.py` | 162 | Data view diff comparison feature with inventory support |
 | `test_ux_features.py` | 123 | UX features: --open, --stats, --output, --list-dataviews formats, inventory validation, inventory summary, include-all-inventory |
-| `test_org_report.py` | 146 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
+| `test_org_report.py` | 147 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
 | `test_org_report_integration.py` | 17 | Org-wide analysis integration tests: end-to-end flows, caching, filtering, governance |
-| `test_cli.py` | 232 | Command-line interface and argument parsing |
-| `test_profiles.py` | 47 | Multi-organization profile support |
+| `test_cli.py` | 233 | Command-line interface and argument parsing |
+| `test_profiles.py` | 48 | Multi-organization profile support |
 | `test_derived_inventory.py` | 43 | Derived fields inventory feature |
 | `test_inventory_utils.py` | 41 | Inventory utilities and helpers |
 | `test_segments_inventory.py` | 41 | Segments inventory feature |
@@ -77,12 +77,12 @@ tests/
 | `test_api_tuning.py` | 23 | API worker auto-tuning |
 | `test_error_messages.py` | 23 | Enhanced error messages and guidance |
 | `test_circuit_breaker.py` | 22 | Circuit breaker pattern |
-| `test_retry.py` | 22 | Retry with exponential backoff |
+| `test_retry.py` | 25 | Retry with exponential backoff |
 | `test_batch_processor.py` | 22 | Batch processing of multiple data views |
 | `test_validation_cache.py` | 19 | Validation result caching |
 | `test_process_single_dataview.py` | 20 | End-to-end single data view processing |
 | `test_optimized_validation.py` | 16 | Optimized data quality validation |
-| `test_name_resolution.py` | 19 | Data view name to ID resolution |
+| `test_name_resolution.py` | 20 | Data view name to ID resolution |
 | `test_shared_cache.py` | 16 | Shared validation cache |
 | `test_logging_optimization.py` | 15 | Logging performance optimizations |
 | `test_env_credentials.py` | 13 | Environment variable credentials |
@@ -95,7 +95,7 @@ tests/
 | `test_malformed_api_responses.py` | 19 | Negative tests for malformed/unexpected API responses |
 | `test_main_entry_points.py` | 19 | main() and _main_impl() entry points, dispatch, run_state, run summary |
 | `test_e2e_integration.py` | 16 | End-to-end integration tests with real pipeline, mocked API boundary |
-| **Total** | **1,522** | **Collected via pytest --collect-only** |
+| **Total** | **1,529** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -499,10 +499,10 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (1,522 tests total)
-- [x] Org-wide analysis tests (test_org_report.py) - 146 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
+- [x] Comprehensive test coverage (1,529 tests total)
+- [x] Org-wide analysis tests (test_org_report.py) - 147 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
-- [x] Profile management tests (test_profiles.py) - 47 tests
+- [x] Profile management tests (test_profiles.py) - 48 tests
 - [x] API worker auto-tuning tests (test_api_tuning.py) - 23 tests
 - [x] Circuit breaker pattern tests (test_circuit_breaker.py) - 22 tests
 - [x] Shared validation cache tests (test_shared_cache.py) - 16 tests

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3446,6 +3446,22 @@ class TestRunModeInference:
         assert _infer_run_mode(args) == expected_mode
 
 
+class TestOrgReportArgumentValidation:
+    """Tests for org-report-specific numeric validation in main()."""
+
+    @patch("cja_auto_sdr.generator.run_org_report")
+    def test_org_report_rejects_negative_sample_size(self, mock_run_org_report):
+        """--sample should fail fast for negative values before org-report execution."""
+        from cja_auto_sdr.generator import main
+
+        with patch.object(sys, "argv", ["cja_auto_sdr", "--org-report", "--sample", "-1"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 1
+        mock_run_org_report.assert_not_called()
+
+
 class TestProfileImportCLI:
     """Tests for non-interactive --profile-import CLI flow."""
 

--- a/tests/test_org_report.py
+++ b/tests/test_org_report.py
@@ -1372,6 +1372,16 @@ class TestSampling:
         assert len(result) == 3
         assert is_sampled is False
 
+    def test_negative_sample_size_rejected(self, mock_cja, mock_logger):
+        """Sample size must be positive to avoid random.sample runtime errors."""
+        mock_cja.getDataViews.return_value = pd.DataFrame([{"id": f"dv_{i}", "name": f"DV {i}"} for i in range(3)])
+
+        config = OrgReportConfig(sample_size=-1, sample_seed=42)
+        analyzer = OrgComponentAnalyzer(mock_cja, config, mock_logger)
+
+        with pytest.raises(ValueError, match="--sample must be at least 1"):
+            analyzer._list_and_filter_data_views()
+
 
 class TestOrgReportCache:
     """Test OrgReportCache functionality"""

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -534,6 +534,27 @@ class TestProfileImport:
         assert result is False
         assert json.loads(existing_config.read_text())["org_id"] == "existing@AdobeOrg"
 
+    def test_import_profile_non_interactive_rejects_invalid_credential_format(self, tmp_path):
+        """Import should fail when credentials fail strict format validation."""
+        source = tmp_path / "credentials.json"
+        source.write_text(
+            json.dumps(
+                {
+                    "org_id": "not_adobe_org",
+                    "client_id": "1234567890abcdef1234567890abcdef",
+                    "secret": "abcdefghijklmnop1234567890",
+                    "scopes": "openid,AdobeID",
+                }
+            )
+        )
+
+        profile_dir = tmp_path / "orgs" / "client-a"
+        with patch("cja_auto_sdr.generator.get_profile_path", return_value=profile_dir):
+            result = import_profile_non_interactive("client-a", source)
+
+        assert result is False
+        assert not (profile_dir / "config.json").exists()
+
 
 class TestProfileExceptions:
     """Test profile exception classes"""


### PR DESCRIPTION
## Summary
- harden retry env parsing to ignore negative/non-finite values and clamp invalid delay windows
- isolate dataview cache by credential context (profile/source/credential fingerprint)
- reject invalid org-report sample sizes (--sample < 1) in CLI and analyzer
- enforce strict validation in non-interactive profile import and surface full validation issues
- sync documented test counts used by CI (README.md, tests/README.md)

## Tests
- PYTHONPATH=src uv run pytest -q -rs (1527 passed, 2 skipped)
- uv run python scripts/update_test_counts.py --check
