### PR TITLE
fix: harden org-report output context and stdout handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Data view cache isolation by credential context**: Data view name-resolution cache keys now include credential/profile context, preventing stale cache reuse across different profiles using the same config path
 - **Org-report sample bound validation**: `--sample` now requires values of at least `1` with fast validation in both CLI argument handling and analyzer execution
 - **Strict profile import validation**: Non-interactive `--profile-import` now enforces strict credential format checks and reports full validation issues before writing profile config
+- **Org-report recommendation output fidelity**: Recommendation context is now normalized and preserved across HTML, Markdown, JSON, CSV, and Excel outputs, including data view pair details and non-primitive context values
+- **Org-report stdout preflight validation**: Unsupported `--org-report --output -` format combinations and unknown formats are now rejected before org analysis starts, preventing expensive fail-late execution
 
 ### Tests
 - Added `test_e2e_integration.py` — 16 end-to-end integration tests that mock only the API boundary and exercise the full pipeline (output writers, DQ checker, special character handling)
@@ -58,7 +60,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `--org-report --sample` negative value rejection in both CLI and analyzer paths
   - Strict non-interactive profile import rejection for invalid credential formats
   - Retry config guards for negative env values and invalid delay windows
-- **1,529 tests** (1,527 passing, 2 skipped) — up from 1,431
+  - Org-report recommendation context/serialization coverage across HTML, Markdown, JSON, CSV, and Excel outputs
+  - Org-report stdout/output-format preflight validation (including fail-fast no-analysis assertions)
+- **1,539 tests** (1,537 passing, 2 skipped) — up from 1,431
 
 ### Changed
 - Removed `.python-version` from repo; `requires-python` in `pyproject.toml` is sufficient

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (1,529+ tests)
+├── tests/                     # Test suite (1,538+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (1,538+ tests)
+├── tests/                     # Test suite (1,539+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -10804,6 +10804,119 @@ def write_org_report_comparison_console(comparison: OrgReportComparison, quiet: 
     print()
 
 
+def _normalize_recommendation_severity(severity: Any) -> str:
+    """Normalize recommendation severity to supported output classes."""
+    value = str(severity or "low").strip().lower()
+    return value if value in {"high", "medium", "low"} else "low"
+
+
+def _format_recommendation_context_entries(rec: dict[str, Any]) -> list[tuple[str, str]]:
+    """Build human-readable recommendation context entries for output renderers."""
+
+    def _fmt_data_view(name: Any, dv_id: Any) -> str:
+        name_text = str(name).strip() if name is not None else ""
+        id_text = str(dv_id).strip() if dv_id is not None else ""
+        if name_text and id_text:
+            return f"{name_text} ({id_text})"
+        return name_text or id_text
+
+    context_entries: list[tuple[str, str]] = []
+
+    data_view_text = _fmt_data_view(rec.get("data_view_name"), rec.get("data_view"))
+    if data_view_text:
+        context_entries.append(("Data View", data_view_text))
+
+    pair_left = _fmt_data_view(rec.get("data_view_1_name"), rec.get("data_view_1"))
+    pair_right = _fmt_data_view(rec.get("data_view_2_name"), rec.get("data_view_2"))
+    if pair_left or pair_right:
+        if pair_left and pair_right:
+            context_entries.append(("Pair", f"{pair_left} ↔ {pair_right}"))
+        else:
+            context_entries.append(("Pair", pair_left or pair_right))
+
+    similarity = rec.get("similarity")
+    if isinstance(similarity, (int, float)) and not isinstance(similarity, bool):
+        context_entries.append(("Similarity", f"{similarity * 100:.1f}%"))
+
+    for label, key in (
+        ("Isolated Count", "isolated_count"),
+        ("Derived Count", "derived_count"),
+        ("Total Count", "total_count"),
+        ("Count", "count"),
+        ("Drift Count", "drift_count"),
+    ):
+        if key in rec and rec.get(key) is not None:
+            context_entries.append((label, str(rec.get(key))))
+
+    ratio = rec.get("ratio")
+    if isinstance(ratio, (int, float)) and not isinstance(ratio, bool):
+        context_entries.append(("Ratio", f"{ratio * 100:.1f}%"))
+
+    modified = rec.get("modified")
+    if modified:
+        context_entries.append(("Last Modified", str(modified)))
+
+    return context_entries
+
+
+def _normalize_recommendation_for_json(raw_rec: Any) -> dict[str, Any]:
+    """Normalize recommendation payload for JSON serialization and output parity."""
+    rec = dict(raw_rec) if isinstance(raw_rec, dict) else {"type": "unknown", "reason": str(raw_rec)}
+    rec["severity"] = _normalize_recommendation_severity(rec.get("severity", "low"))
+    context_entries = _format_recommendation_context_entries(rec)
+    if context_entries:
+        rec["context"] = [{"label": label, "value": value} for label, value in context_entries]
+    # Ensure output is JSON-serializable even if recommendations include odd values.
+    normalized = json.loads(json.dumps(rec, ensure_ascii=False, default=str))
+    return normalized if isinstance(normalized, dict) else {"type": "unknown", "reason": str(normalized)}
+
+
+def _flatten_recommendation_for_tabular(rec: dict[str, Any]) -> dict[str, Any]:
+    """Flatten recommendation fields for CSV/Excel exports with full context columns."""
+    known_keys = {
+        "type",
+        "severity",
+        "reason",
+        "data_view",
+        "data_view_name",
+        "data_view_1",
+        "data_view_1_name",
+        "data_view_2",
+        "data_view_2_name",
+        "similarity",
+        "isolated_count",
+        "derived_count",
+        "total_count",
+        "ratio",
+        "count",
+        "drift_count",
+        "modified",
+        "context",
+    }
+    extra_details = {k: v for k, v in rec.items() if k not in known_keys}
+
+    return {
+        "Type": rec.get("type", ""),
+        "Severity": _normalize_recommendation_severity(rec.get("severity", "low")),
+        "Description": rec.get("reason", ""),
+        "Data View ID": rec.get("data_view", ""),
+        "Data View Name": rec.get("data_view_name", ""),
+        "Data View 1 ID": rec.get("data_view_1", ""),
+        "Data View 1 Name": rec.get("data_view_1_name", ""),
+        "Data View 2 ID": rec.get("data_view_2", ""),
+        "Data View 2 Name": rec.get("data_view_2_name", ""),
+        "Similarity": rec.get("similarity", ""),
+        "Isolated Count": rec.get("isolated_count", ""),
+        "Derived Count": rec.get("derived_count", ""),
+        "Total Count": rec.get("total_count", ""),
+        "Ratio": rec.get("ratio", ""),
+        "Count": rec.get("count", ""),
+        "Drift Count": rec.get("drift_count", ""),
+        "Modified": rec.get("modified", ""),
+        "Extra Details": json.dumps(extra_details, sort_keys=True, default=str) if extra_details else "",
+    }
+
+
 def build_org_report_json_data(result: OrgReportResult) -> dict[str, Any]:
     """Build org report JSON payload."""
     effective_overlap_threshold = min(result.parameters.overlap_threshold, 0.9)
@@ -10940,7 +11053,7 @@ def build_org_report_json_data(result: OrgReportResult) -> dict[str, Any]:
         ]
         if result.clusters
         else None,
-        "recommendations": result.recommendations,
+        "recommendations": [_normalize_recommendation_for_json(rec) for rec in result.recommendations],
         # New features
         "governance_violations": result.governance_violations,
         "thresholds_exceeded": result.thresholds_exceeded,
@@ -11293,19 +11406,7 @@ def write_org_report_excel(
         # Sheet 6: Recommendations
         if result.recommendations:
             rec_data = [
-                {
-                    "Type": rec.get("type", ""),
-                    "Severity": rec.get("severity", ""),
-                    "Description": rec.get("reason", ""),
-                    "Data View": rec.get("data_view", rec.get("data_view_1", "")),
-                    "Details": json.dumps(
-                        {
-                            k: v
-                            for k, v in rec.items()
-                            if k not in ["type", "severity", "reason", "data_view", "data_view_1"]
-                        }
-                    ),
-                }
+                _flatten_recommendation_for_tabular(_normalize_recommendation_for_json(rec))
                 for rec in result.recommendations
             ]
             rec_df = pd.DataFrame(rec_data)
@@ -11313,7 +11414,9 @@ def write_org_report_excel(
             worksheet = writer.sheets["Recommendations"]
             worksheet.set_column("A:B", 20)
             worksheet.set_column("C:C", 60)
-            worksheet.set_column("D:E", 25)
+            worksheet.set_column("D:I", 24)
+            worksheet.set_column("J:Q", 14)
+            worksheet.set_column("R:R", 40)
 
     logger.info(f"Excel report written to {file_path}")
     return str(file_path)
@@ -11506,18 +11609,20 @@ def write_org_report_markdown(
         lines.append("## Recommendations")
         lines.append("")
 
-        for i, rec in enumerate(result.recommendations, 1):
+        for i, raw_rec in enumerate(result.recommendations, 1):
+            rec = _normalize_recommendation_for_json(raw_rec)
             severity = rec.get("severity", "low")
             severity_badge = {"high": "🔴", "medium": "🟡", "low": "🔵"}.get(severity, "⚪")
-            lines.append(f"### {i}. {severity_badge} {rec.get('type', 'Unknown').replace('_', ' ').title()}")
+            rec_type = str(rec.get("type", "Unknown")).replace("_", " ").title()
+            lines.append(f"### {i}. {severity_badge} {rec_type}")
             lines.append("")
-            lines.append(rec.get("reason", "No details provided."))
+            reason = str(rec.get("reason", "No details provided.")).replace("|", "\\|").replace("`", "\\`")
+            lines.append(reason)
             lines.append("")
 
-            if rec.get("data_view"):
-                lines.append(f"- **Data View:** {rec.get('data_view_name', '')} (`{rec.get('data_view')}`)")
-            if rec.get("data_view_1"):
-                lines.append(f"- **Pair:** {rec.get('data_view_1_name', '')} ↔ {rec.get('data_view_2_name', '')}")
+            for label, value in _format_recommendation_context_entries(rec):
+                value_text = str(value).replace("|", "\\|").replace("`", "\\`")
+                lines.append(f"- **{label}:** {value_text}")
             lines.append("")
 
     # Footer
@@ -11661,6 +11766,8 @@ def write_org_report_html(
         .recommendation {{ padding: 1rem; border-left: 4px solid var(--primary); margin: 1rem 0; background: #f8f9fa; }}
         .recommendation.high {{ border-color: var(--danger); }}
         .recommendation.medium {{ border-color: var(--warning); }}
+        .rec-context {{ margin: 0.6rem 0 0 1.2rem; color: var(--text-secondary); }}
+        .rec-context li {{ margin: 0.2rem 0; }}
     </style>
 </head>
 <body>
@@ -11823,13 +11930,24 @@ def write_org_report_html(
         html_out += """
         <h2>Recommendations</h2>
 """
-        for rec in result.recommendations:
+        for raw_rec in result.recommendations:
+            rec = _normalize_recommendation_for_json(raw_rec)
             severity = rec.get("severity", "low")
-            rec_type = html.escape(rec.get("type", "Unknown").replace("_", " ").title())
+            rec_type = html.escape(str(rec.get("type", "Unknown")).replace("_", " ").title())
             rec_reason = html.escape(rec.get("reason", "No details provided."))
+            context_entries = _format_recommendation_context_entries(rec)
+            context_html = ""
+            if context_entries:
+                context_html = '            <ul class="rec-context">\n'
+                for label, value in context_entries:
+                    label_escaped = html.escape(str(label))
+                    value_escaped = html.escape(str(value))
+                    context_html += f"                <li><strong>{label_escaped}:</strong> {value_escaped}</li>\n"
+                context_html += "            </ul>\n"
             html_out += f"""        <div class="recommendation {severity}">
             <strong><span class="badge badge-{severity}">{severity.upper()}</span> {rec_type}</strong>
             <p>{rec_reason}</p>
+{context_html}
         </div>
 """
 
@@ -12023,13 +12141,7 @@ def write_org_report_csv(
     # 6. Recommendations CSV (if any)
     if result.recommendations:
         rec_data = [
-            {
-                "Type": rec.get("type", ""),
-                "Severity": rec.get("severity", ""),
-                "Description": rec.get("reason", ""),
-                "Data View": rec.get("data_view", rec.get("data_view_1", "")),
-                "Data View Name": rec.get("data_view_name", rec.get("data_view_1_name", "")),
-            }
+            _flatten_recommendation_for_tabular(_normalize_recommendation_for_json(rec))
             for rec in result.recommendations
         ]
         rec_df = pd.DataFrame(rec_data)
@@ -12133,6 +12245,14 @@ def run_org_report(
 
         # Generate output based on format
         output_path_obj = Path(output_path) if output_path and not output_to_stdout else None
+
+        if output_to_stdout and output_format not in {"json", "console", None}:
+            _status_print(
+                ConsoleColors.error(
+                    "ERROR: --output stdout is only supported for --format json in org-report mode."
+                )
+            )
+            return False, False
 
         # Handle org-stats mode (Feature 2) - minimal output
         if org_config.org_stats_only:

--- a/tests/README.md
+++ b/tests/README.md
@@ -51,7 +51,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 1,529 comprehensive tests**
+**Total: 1,538 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -59,7 +59,7 @@ tests/
 |-----------|-------|---------------|
 | `test_diff_comparison.py` | 162 | Data view diff comparison feature with inventory support |
 | `test_ux_features.py` | 123 | UX features: --open, --stats, --output, --list-dataviews formats, inventory validation, inventory summary, include-all-inventory |
-| `test_org_report.py` | 147 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
+| `test_org_report.py` | 156 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
 | `test_org_report_integration.py` | 17 | Org-wide analysis integration tests: end-to-end flows, caching, filtering, governance |
 | `test_cli.py` | 233 | Command-line interface and argument parsing |
 | `test_profiles.py` | 48 | Multi-organization profile support |
@@ -95,7 +95,7 @@ tests/
 | `test_malformed_api_responses.py` | 19 | Negative tests for malformed/unexpected API responses |
 | `test_main_entry_points.py` | 19 | main() and _main_impl() entry points, dispatch, run_state, run summary |
 | `test_e2e_integration.py` | 16 | End-to-end integration tests with real pipeline, mocked API boundary |
-| **Total** | **1,529** | **Collected via pytest --collect-only** |
+| **Total** | **1,538** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -499,8 +499,8 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (1,529 tests total)
-- [x] Org-wide analysis tests (test_org_report.py) - 147 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
+- [x] Comprehensive test coverage (1,538 tests total)
+- [x] Org-wide analysis tests (test_org_report.py) - 156 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 48 tests
 - [x] API worker auto-tuning tests (test_api_tuning.py) - 23 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -51,7 +51,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 1,538 comprehensive tests**
+**Total: 1,539 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -59,7 +59,7 @@ tests/
 |-----------|-------|---------------|
 | `test_diff_comparison.py` | 162 | Data view diff comparison feature with inventory support |
 | `test_ux_features.py` | 123 | UX features: --open, --stats, --output, --list-dataviews formats, inventory validation, inventory summary, include-all-inventory |
-| `test_org_report.py` | 156 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
+| `test_org_report.py` | 157 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
 | `test_org_report_integration.py` | 17 | Org-wide analysis integration tests: end-to-end flows, caching, filtering, governance |
 | `test_cli.py` | 233 | Command-line interface and argument parsing |
 | `test_profiles.py` | 48 | Multi-organization profile support |
@@ -95,7 +95,7 @@ tests/
 | `test_malformed_api_responses.py` | 19 | Negative tests for malformed/unexpected API responses |
 | `test_main_entry_points.py` | 19 | main() and _main_impl() entry points, dispatch, run_state, run summary |
 | `test_e2e_integration.py` | 16 | End-to-end integration tests with real pipeline, mocked API boundary |
-| **Total** | **1,538** | **Collected via pytest --collect-only** |
+| **Total** | **1,539** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -499,8 +499,8 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (1,538 tests total)
-- [x] Org-wide analysis tests (test_org_report.py) - 156 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
+- [x] Comprehensive test coverage (1,539 tests total)
+- [x] Org-wide analysis tests (test_org_report.py) - 157 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 48 tests
 - [x] API worker auto-tuning tests (test_api_tuning.py) - 23 tests

--- a/tests/test_org_report.py
+++ b/tests/test_org_report.py
@@ -2298,7 +2298,9 @@ class TestOrgReportOutputHandling:
     def test_csv_output_to_stdout_errors(self, sample_result, capsys):
         """CSV org-report should error on stdout since it writes multiple files."""
         with (
-            patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "ok", {"org_id": "org_123"})),
+            patch(
+                "cja_auto_sdr.generator.configure_cjapy", return_value=(True, "ok", {"org_id": "org_123"})
+            ) as mock_configure,
             patch("cja_auto_sdr.generator.cjapy.CJA", return_value=Mock()),
             patch("cja_auto_sdr.generator.OrgComponentAnalyzer") as mock_analyzer,
         ):
@@ -2317,11 +2319,15 @@ class TestOrgReportOutputHandling:
             assert success is False
             captured = capsys.readouterr()
             assert "only supported for --format json" in captured.out
+            mock_configure.assert_not_called()
+            mock_analyzer.assert_not_called()
 
     def test_markdown_output_to_stdout_errors(self, sample_result, capsys):
         """Markdown org-report should fail fast when stdout is requested."""
         with (
-            patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "ok", {"org_id": "org_123"})),
+            patch(
+                "cja_auto_sdr.generator.configure_cjapy", return_value=(True, "ok", {"org_id": "org_123"})
+            ) as mock_configure,
             patch("cja_auto_sdr.generator.cjapy.CJA", return_value=Mock()),
             patch("cja_auto_sdr.generator.OrgComponentAnalyzer") as mock_analyzer,
         ):
@@ -2340,11 +2346,15 @@ class TestOrgReportOutputHandling:
             assert success is False
             captured = capsys.readouterr()
             assert "only supported for --format json" in captured.out
+            mock_configure.assert_not_called()
+            mock_analyzer.assert_not_called()
 
     def test_alias_output_to_stdout_errors(self, sample_result, capsys):
         """Format aliases should fail fast when stdout is requested."""
         with (
-            patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "ok", {"org_id": "org_123"})),
+            patch(
+                "cja_auto_sdr.generator.configure_cjapy", return_value=(True, "ok", {"org_id": "org_123"})
+            ) as mock_configure,
             patch("cja_auto_sdr.generator.cjapy.CJA", return_value=Mock()),
             patch("cja_auto_sdr.generator.OrgComponentAnalyzer") as mock_analyzer,
         ):
@@ -2363,11 +2373,15 @@ class TestOrgReportOutputHandling:
             assert success is False
             captured = capsys.readouterr()
             assert "only supported for --format json" in captured.out
+            mock_configure.assert_not_called()
+            mock_analyzer.assert_not_called()
 
     def test_all_output_to_stdout_errors(self, sample_result, capsys):
         """--format all should fail fast when stdout is requested."""
         with (
-            patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "ok", {"org_id": "org_123"})),
+            patch(
+                "cja_auto_sdr.generator.configure_cjapy", return_value=(True, "ok", {"org_id": "org_123"})
+            ) as mock_configure,
             patch("cja_auto_sdr.generator.cjapy.CJA", return_value=Mock()),
             patch("cja_auto_sdr.generator.OrgComponentAnalyzer") as mock_analyzer,
         ):
@@ -2386,6 +2400,35 @@ class TestOrgReportOutputHandling:
             assert success is False
             captured = capsys.readouterr()
             assert "only supported for --format json" in captured.out
+            mock_configure.assert_not_called()
+            mock_analyzer.assert_not_called()
+
+    def test_unknown_format_fails_before_analysis(self, sample_result, capsys):
+        """Unknown org-report format should fail before any API/configuration work."""
+        with (
+            patch(
+                "cja_auto_sdr.generator.configure_cjapy", return_value=(True, "ok", {"org_id": "org_123"})
+            ) as mock_configure,
+            patch("cja_auto_sdr.generator.cjapy.CJA", return_value=Mock()),
+            patch("cja_auto_sdr.generator.OrgComponentAnalyzer") as mock_analyzer,
+        ):
+            mock_analyzer.return_value.run_analysis.return_value = sample_result
+
+            success, _ = run_org_report(
+                config_file="config.json",
+                output_format="not-a-format",
+                output_path=None,
+                output_dir=".",
+                org_config=OrgReportConfig(),
+                profile=None,
+                quiet=True,
+            )
+
+            assert success is False
+            captured = capsys.readouterr()
+            assert "Unknown format" in captured.out
+            mock_configure.assert_not_called()
+            mock_analyzer.assert_not_called()
 
 
 # ==================== NEW FEATURE TESTS ====================


### PR DESCRIPTION
## Summary
- add recommendation context parity across org-report outputs (HTML, Markdown, JSON, CSV, Excel)
- normalize recommendation payloads for JSON serialization and include structured context metadata
- fail fast when org-report uses non-JSON formats with --output stdout
- retain synced test-count docs after added regressions

## Tests
- PYTHONPATH=src uv run pytest -q -rs
- PYTHONPATH=src uv run pytest -q tests/test_org_report.py tests/test_output_formats.py tests/test_output_content_validation.py -q
- uv run ruff check src/cja_auto_sdr/generator.py tests/test_org_report.py
