### PR TITLE
fix: harden parallel cache, credentials, diff, and inventory edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Snapshot timestamp normalization**: Snapshot retention now normalizes timestamps consistently for age-based pruning
 - **Inventory parsing hardening**: Calculated metrics, derived fields, and segments inventory parsers now handle mixed API payload shapes (missing keys, unexpected types) without crashing
 - **Stale metadata recommendations**: Restored stale metadata recommendation output in relevant contexts
+- **Parallel validation cache bleed**: `_run_optimized_validation` used a shared-list slice to collect issues for caching; under concurrent execution two threads could capture each other's issues. Replaced with a per-call `local_issues` list so cache writes are isolated
+- **Environment credential strict validation**: `CredentialResolver` now applies strict validation to environment credentials, preventing malformed values (e.g. invalid org ID, too-short secrets) from being silently accepted — falls back to config file instead
+- **Diff false-positive on list ordering**: Inventory list fields (`functions_used`, `metric_references`, `segment_references`, `dimension_references`, `tags`) are now compared order-insensitively, eliminating false modifications when the API returns elements in a different order
+- **Snapshot version upgrade for empty inventories**: `DataViewSnapshot` now upgrades to v2.0 when inventory fields are explicitly present but empty (`[]`), not only when truthy
+- **`format_iso_date` non-string input**: Handles non-string API payload values (int, dict, list) by coercing to string instead of raising `TypeError`
+- **Org report description recommendation denominator**: Missing-description threshold now excludes errored data view fetches from the denominator, preventing inflated thresholds that suppressed valid recommendations
 
 ### Security
 - **HTML diff output escaping**: Added `html.escape()` to all diff HTML output — `diff.id`, `diff.name`, metadata names/IDs, and summary table headers were previously inserted as raw HTML
@@ -45,7 +51,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added inventory parsing tests for calculated metrics, derived fields, and segments with mixed API payloads
 - Added output format tests for HTML severity row styling
 - Added org report vectorized analyzer tests
-- **1,679 tests** (1,677 passing, 2 skipped) — up from 1,668
+- Added parallel validation cache isolation test with interleaving coverage
+- Added strict credential validation and resolver fallback tests
+- Added diff order-insensitive list comparison test for inventory fields
+- Added snapshot v2.0 upgrade test for empty inventory arrays
+- Added `format_iso_date` non-string input test
+- Added org report description recommendation denominator test
+- **1,686 tests** (1,684 passing, 2 skipped) — up from 1,668
 
 ## [3.2.2] - 2026-02-08
 

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (1,679+ tests)
+├── tests/                     # Test suite (1,686+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/docs/DIFF_COMPARISON.md
+++ b/docs/DIFF_COMPARISON.md
@@ -1456,7 +1456,7 @@ The diff comparison feature includes comprehensive unit tests in `tests/test_dif
 | `TestAutoSnapshotCLIArguments` | 10 | --auto-snapshot, --snapshot-dir, --keep-last |
 | `TestGetMostRecentSnapshot` | 5 | Most recent snapshot lookup, filtering |
 
-**Total: 167 tests**
+**Total: 169 tests**
 
 ### Running Tests
 

--- a/src/cja_auto_sdr/core/credentials.py
+++ b/src/cja_auto_sdr/core/credentials.py
@@ -285,11 +285,11 @@ class CredentialResolver:
         creds = loader.load(self.logger)
 
         if creds:
-            is_valid, _ = validate_credentials(creds, self.logger, strict=False, source="environment")
+            is_valid, _ = validate_credentials(creds, self.logger, strict=True, source="environment")
             if is_valid:
                 self.logger.info("Using credentials from environment variables")
                 return creds, "environment"
-            self.logger.debug("Environment credentials incomplete, trying next source")
+            self.logger.debug("Environment credentials invalid, trying next source")
 
         return None, ""
 

--- a/src/cja_auto_sdr/diff/models.py
+++ b/src/cja_auto_sdr/diff/models.py
@@ -332,8 +332,9 @@ class DataViewSnapshot:
                 "metrics_count": len(self.metrics) if self.metrics else 0,
                 "dimensions_count": len(self.dimensions) if self.dimensions else 0,
             }
-        # Auto-upgrade version if inventory data is present
-        if any([self.calculated_metrics_inventory, self.segments_inventory]):
+        # Auto-upgrade version when inventory fields are explicitly included,
+        # even when those arrays are empty.
+        if self.calculated_metrics_inventory is not None or self.segments_inventory is not None:
             self.snapshot_version = "2.0"
 
     @property

--- a/src/cja_auto_sdr/inventory/utils.py
+++ b/src/cja_auto_sdr/inventory/utils.py
@@ -26,7 +26,7 @@ __version__ = "1.0.0"
 # ==================== DATE FORMATTING ====================
 
 
-def format_iso_date(iso_date: str) -> str:
+def format_iso_date(iso_date: Any) -> str:
     """Format ISO date string to readable format (YYYY-MM-DD HH:MM).
 
     Args:
@@ -35,16 +35,20 @@ def format_iso_date(iso_date: str) -> str:
     Returns:
         Formatted date string or "-" if invalid/empty
     """
-    if not iso_date:
+    if iso_date is None:
+        return "-"
+    value = iso_date if isinstance(iso_date, str) else str(iso_date)
+    value = value.strip()
+    if not value:
         return "-"
     try:
         # Handle various ISO formats including timezone
-        if "T" in iso_date:
-            dt = datetime.fromisoformat(iso_date.replace("Z", "+00:00"))
+        if "T" in value:
+            dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
             return dt.strftime("%Y-%m-%d %H:%M")
-        return iso_date[:10]  # Just the date part
+        return value[:10]  # Just the date part
     except ValueError, TypeError:
-        return iso_date[:19] if len(iso_date) > 19 else iso_date
+        return value[:19] if len(value) > 19 else value
 
 
 # ==================== OWNER/TAGS EXTRACTION ====================

--- a/src/cja_auto_sdr/org/analyzer.py
+++ b/src/cja_auto_sdr/org/analyzer.py
@@ -1298,8 +1298,13 @@ class OrgComponentAnalyzer:
                     pass
 
             # Missing descriptions
-            no_desc_count = len([s for s in summaries if not s.error and not s.has_description])
-            if no_desc_count > 0 and no_desc_count >= len(summaries) * 0.3:
+            successful_summaries = [s for s in summaries if not s.error]
+            no_desc_count = len([s for s in successful_summaries if not s.has_description])
+            if (
+                successful_summaries
+                and no_desc_count > 0
+                and no_desc_count >= len(successful_summaries) * 0.3
+            ):
                 recommendations.append(
                     {
                         "type": "missing_descriptions",

--- a/src/cja_auto_sdr/org/analyzer.py
+++ b/src/cja_auto_sdr/org/analyzer.py
@@ -1300,11 +1300,7 @@ class OrgComponentAnalyzer:
             # Missing descriptions
             successful_summaries = [s for s in summaries if not s.error]
             no_desc_count = len([s for s in successful_summaries if not s.has_description])
-            if (
-                successful_summaries
-                and no_desc_count > 0
-                and no_desc_count >= len(successful_summaries) * 0.3
-            ):
+            if successful_summaries and no_desc_count > 0 and no_desc_count >= len(successful_summaries) * 0.3:
                 recommendations.append(
                     {
                         "type": "missing_descriptions",

--- a/tests/README.md
+++ b/tests/README.md
@@ -52,20 +52,20 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 1,679 comprehensive tests**
+**Total: 1,686 comprehensive tests**
 
 ### Test Count Breakdown
 
 | Test File | Tests | Coverage Area |
 |-----------|-------|---------------|
-| `test_diff_comparison.py` | 167 | Data view diff comparison feature with inventory support |
+| `test_diff_comparison.py` | 169 | Data view diff comparison feature with inventory support |
 | `test_ux_features.py` | 123 | UX features: --open, --stats, --output, --list-dataviews formats, inventory validation, inventory summary, include-all-inventory |
-| `test_org_report.py` | 171 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
+| `test_org_report.py` | 172 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
 | `test_org_report_integration.py` | 17 | Org-wide analysis integration tests: end-to-end flows, caching, filtering, governance |
 | `test_cli.py` | 234 | Command-line interface and argument parsing |
 | `test_profiles.py` | 48 | Multi-organization profile support |
 | `test_derived_inventory.py` | 46 | Derived fields inventory feature |
-| `test_inventory_utils.py` | 46 | Inventory utilities and helpers |
+| `test_inventory_utils.py` | 47 | Inventory utilities and helpers |
 | `test_segments_inventory.py` | 43 | Segments inventory feature |
 | `test_edge_cases.py` | 39 | Edge cases, configuration dataclasses, custom exceptions |
 | `test_calculated_metrics_inventory.py` | 38 | Calculated metrics inventory feature |
@@ -86,18 +86,18 @@ tests/
 | `test_name_resolution.py` | 20 | Data view name to ID resolution |
 | `test_shared_cache.py` | 17 | Shared validation cache |
 | `test_logging_optimization.py` | 15 | Logging performance optimizations |
-| `test_env_credentials.py` | 13 | Environment variable credentials |
+| `test_env_credentials.py` | 15 | Environment variable credentials |
 | `test_dry_run.py` | 12 | Dry-run mode functionality |
 | `test_early_exit.py` | 11 | Early exit optimizations |
 | `test_data_quality.py` | 10 | Data quality validation logic |
-| `test_parallel_validation.py` | 8 | Parallel validation operations |
+| `test_parallel_validation.py` | 9 | Parallel validation operations |
 | `test_discovery_formatters.py` | 27 | Shared discovery formatters, WorkerArgs dataclass, _exit_error, BANNER_WIDTH |
 | `test_output_content_validation.py` | 26 | Output format content validation (CSV, JSON, HTML, Excel, Markdown roundtrip) |
 | `test_malformed_api_responses.py` | 19 | Negative tests for malformed/unexpected API responses |
 | `test_main_entry_points.py` | 19 | main() and _main_impl() entry points, dispatch, run_state, run summary |
 | `test_quality_policy_and_run_summary.py` | 57 | Quality policy functions and run summary/status inference |
 | `test_e2e_integration.py` | 16 | End-to-end integration tests with real pipeline, mocked API boundary |
-| **Total** | **1,679** | **Collected via pytest --collect-only** |
+| **Total** | **1,686** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -501,8 +501,8 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (1,679 tests total)
-- [x] Org-wide analysis tests (test_org_report.py) - 171 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
+- [x] Comprehensive test coverage (1,686 tests total)
+- [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 48 tests
 - [x] API worker auto-tuning tests (test_api_tuning.py) - 23 tests
@@ -511,9 +511,9 @@ Check for drift (CI-friendly):
 - [x] Calculated metrics inventory tests (test_calculated_metrics_inventory.py) - 38 tests
 - [x] Segments inventory tests (test_segments_inventory.py) - 43 tests
 - [x] Derived fields inventory tests (test_derived_inventory.py) - 46 tests
-- [x] Inventory utilities tests (test_inventory_utils.py) - 46 tests
+- [x] Inventory utilities tests (test_inventory_utils.py) - 47 tests
 - [x] Git integration tests (test_git_integration.py) - 36 tests
-- [x] Inventory diff support in snapshot comparisons (test_diff_comparison.py) - 167 tests
+- [x] Inventory diff support in snapshot comparisons (test_diff_comparison.py) - 169 tests
 - [x] Inventory summary and include-all-inventory tests (test_ux_features.py) - 123 tests
 - [x] Parallel validation tests (test_parallel_validation.py)
 - [x] Validation caching tests (test_validation_cache.py)
@@ -529,7 +529,7 @@ Check for drift (CI-friendly):
 - [x] Excel formatting tests (test_excel_formatting.py)
 - [x] CJA initialization tests (test_cja_initialization.py)
 - [x] Name resolution tests (test_name_resolution.py)
-- [x] Data view diff comparison tests (test_diff_comparison.py) - 167 tests covering snapshots, comparison logic, output formats, CLI arguments, name resolution
+- [x] Data view diff comparison tests (test_diff_comparison.py) - 169 tests covering snapshots, comparison logic, output formats, CLI arguments, name resolution
 - [x] Edge case tests (test_edge_cases.py) - 39 tests covering custom exceptions, configuration dataclasses, OutputWriter Protocol, boundary conditions
 
 ## Future Enhancements

--- a/tests/test_inventory_utils.py
+++ b/tests/test_inventory_utils.py
@@ -44,6 +44,12 @@ class TestFormatIsoDate:
         result = format_iso_date("invalid-date-string-with-lots-of-text")
         assert result == "invalid-da"  # First 10 characters
 
+    def test_non_string_values_do_not_raise(self):
+        """Non-string API payload values should be handled safely."""
+        assert format_iso_date(123) == "123"
+        assert format_iso_date({"a": 1}) == "{'a': 1}"
+        assert format_iso_date(["x"]) == "['x']"
+
 
 class TestExtractOwner:
     """Tests for extract_owner function."""


### PR DESCRIPTION
## Summary
- **Parallel validation cache bleed**: replaced shared-list slice with per-call `local_issues` list so cache writes are thread-isolated
- **Environment credential strict validation**: `CredentialResolver` now rejects malformed env credentials and falls back to config file
- **Diff false-positive on list ordering**: inventory list fields (`functions_used`, `tags`, `metric_references`, etc.) compared order-insensitively
- **Snapshot version upgrade**: `DataViewSnapshot` upgrades to v2.0 for explicitly empty inventory arrays (`[]`), not only truthy ones
- **`format_iso_date` non-string input**: coerces non-string API values instead of raising `TypeError`
- **Org report description recommendation**: denominator excludes errored data view fetches

Part of v3.2.3 patch. 1,686 tests (1,684 passing, 2 skipped).

## Test plan
- [x] All 1,686 tests pass (`uv run pytest tests/`)
- [x] New parallel cache isolation test with `SlowIssueChecker` interleaving
- [x] New strict credential validation + resolver fallback tests
- [x] New diff order-insensitive list comparison test
- [x] New snapshot v2.0 upgrade test for empty inventories
- [x] New `format_iso_date` non-string input test
- [x] New org report description recommendation denominator test