### PR TITLE
fix: harden inventory parsing against unexpected API payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.5] - 2026-02-13
+
+### Fixed
+- **Inventory parsing hardening**: All three inventory parsers (derived fields, segments, calculated metrics) now handle unexpected API payload shapes — non-dict list entries, non-string func/name/context values, dict-shaped args, non-list operands/preds/checkpoints, non-finite split indexes, and non-string delimiters/patterns — without crashing
+- **Datetime metadata preservation**: `pd.Timestamp` values in created/modified fields are now coerced via `isoformat()` instead of being silently dropped to empty strings
+- **Split index coercion**: Non-finite float indexes (`NaN`, `Inf`, `-Inf`) in derived field split definitions now fall back to the default index instead of raising `OverflowError`
+
+### Changed
+- **Centralized normalization helpers**: Extracted `normalize_func_name`, `coerce_scalar_text`, and `coerce_display_text` into `inventory/utils.py` so all three builders share identical coercion logic, eliminating implementation drift
+
+### Tests
+- Added edge-case tests for non-dict payloads, non-string func names, non-list operands/preds, dict-shaped args, non-finite split indexes, non-string delimiters/patterns/datasets, non-dict branch items, datetime metadata preservation, and timestamp description coercion
+- **1,739 tests** (1,737 passing, 2 skipped) — up from 1,712
+
 ## [3.2.4] - 2026-02-13
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (1,714+ tests)
+├── tests/                     # Test suite (1,724+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (1,735+ tests)
+├── tests/                     # Test suite (1,738+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (1,738+ tests)
+├── tests/                     # Test suite (1,739+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (1,724+ tests)
+├── tests/                     # Test suite (1,735+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -203,7 +203,7 @@ This command:
 
 ```bash
 $ uv run cja_auto_sdr --version
-cja_auto_sdr 3.2.4
+cja_auto_sdr 3.2.5
 ```
 
 > **Important:** All commands in this guide assume you're in the `cja_auto_sdr` directory. If you see "command not found", make sure you're in the right directory and have run `uv sync`.

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Quick Reference Card
 
-Single-page command cheat sheet for CJA SDR Generator v3.2.4.
+Single-page command cheat sheet for CJA SDR Generator v3.2.5.
 
 ## Four Main Modes
 

--- a/src/cja_auto_sdr/core/version.py
+++ b/src/cja_auto_sdr/core/version.py
@@ -1,3 +1,3 @@
 """Version information for CJA Auto SDR."""
 
-__version__ = "3.2.4"
+__version__ = "3.2.5"

--- a/src/cja_auto_sdr/inventory/calculated_metrics.py
+++ b/src/cja_auto_sdr/inventory/calculated_metrics.py
@@ -27,11 +27,14 @@ import pandas as pd
 
 from cja_auto_sdr.inventory.utils import (
     BatchProcessingStats,
+    coerce_display_text,
+    coerce_scalar_text,
     extract_owner,
     extract_short_name,
     extract_tags,
     format_iso_date,
     normalize_api_response,
+    normalize_func_name,
     validate_required_id,
 )
 
@@ -569,41 +572,15 @@ class CalculatedMetricsInventoryBuilder:
 
     def _normalize_func_name(self, value: Any) -> str:
         """Normalize function names to comparable string keys."""
-        if isinstance(value, str):
-            return value.strip()
-        return ""
+        return normalize_func_name(value)
 
     def _coerce_scalar_text(self, value: Any) -> str:
         """Convert scalar values to text while ignoring null/object payloads."""
-        if value is None:
-            return ""
-        if isinstance(value, str):
-            return value.strip()
-
-        try:
-            is_na = pd.isna(value)
-            if isinstance(is_na, bool) and is_na:
-                return ""
-        except TypeError, ValueError:
-            pass
-
-        if hasattr(value, "isoformat"):
-            try:
-                iso_value = value.isoformat()
-                if iso_value is None:
-                    return ""
-                return str(iso_value).strip()
-            except TypeError, ValueError:
-                pass
-
-        if pd.api.types.is_scalar(value):
-            return str(value).strip()
-        return ""
+        return coerce_scalar_text(value)
 
     def _coerce_display_text(self, value: Any, fallback: str = "") -> str:
         """Normalize text values for summaries/dataclass fields."""
-        normalized = self._coerce_scalar_text(value)
-        return normalized if normalized else fallback
+        return coerce_display_text(value, fallback=fallback)
 
     def _normalize_reference_value(self, value: Any) -> str:
         """Normalize IDs and reference values from mixed payload shapes."""

--- a/src/cja_auto_sdr/inventory/calculated_metrics.py
+++ b/src/cja_auto_sdr/inventory/calculated_metrics.py
@@ -419,6 +419,9 @@ class CalculatedMetricsInventoryBuilder:
             # Process each metric with tracking
             stats = BatchProcessingStats(logger=self.logger)
             for metric_data in metrics_list:
+                if not isinstance(metric_data, dict):
+                    stats.record_skip("unexpected metric payload type", str(type(metric_data)))
+                    continue
                 summary = self._process_metric(metric_data, stats)
                 if summary:
                     inventory.metrics.append(summary)
@@ -452,11 +455,13 @@ class CalculatedMetricsInventoryBuilder:
                 stats.record_skip("missing ID", metric_data.get("name", "Unknown"))
             return None
 
-        metric_name = metric_data.get("name", "Unknown")
-        description = metric_data.get("description", "")
+        metric_name = self._coerce_display_text(metric_data.get("name", "Unknown"), fallback="Unknown")
+        description = self._coerce_display_text(metric_data.get("description", ""), fallback="")
 
         # Extract owner info using shared utility
         owner, owner_id = extract_owner(metric_data.get("owner", {}))
+        owner = self._coerce_display_text(owner, fallback="")
+        owner_id = self._coerce_display_text(owner_id, fallback="")
 
         # Get definition
         definition = metric_data.get("definition", {})
@@ -509,8 +514,8 @@ class CalculatedMetricsInventoryBuilder:
         tags = extract_tags(metric_data.get("tags", []))
 
         # Extract timestamps
-        created = metric_data.get("created", metric_data.get("createdDate", ""))
-        modified = metric_data.get("modified", metric_data.get("modifiedDate", ""))
+        created = self._coerce_display_text(metric_data.get("created", metric_data.get("createdDate", "")), fallback="")
+        modified = self._coerce_display_text(metric_data.get("modified", metric_data.get("modifiedDate", "")), fallback="")
 
         # Extract sharing info
         shares_data = metric_data.get("shares", [])
@@ -518,14 +523,17 @@ class CalculatedMetricsInventoryBuilder:
         shared_to_count = len(shares)
 
         # Extract data view association
-        data_view_id = metric_data.get("dataId", metric_data.get("rsid", ""))
-        site_title = metric_data.get("siteTitle", "")
+        data_view_id = self._coerce_display_text(metric_data.get("dataId", metric_data.get("rsid", "")), fallback="")
+        site_title = self._coerce_display_text(metric_data.get("siteTitle", ""), fallback="")
 
         # Generate formula summary
         formula_summary = self._generate_formula_summary(formula, parsed)
 
         # Serialize definition to JSON string for full fidelity
-        definition_json_str = json.dumps(definition, separators=(",", ":"))
+        try:
+            definition_json_str = json.dumps(definition, separators=(",", ":"))
+        except (TypeError, ValueError):
+            definition_json_str = json.dumps(str(definition))
 
         return CalculatedMetricSummary(
             metric_id=metric_id,
@@ -557,6 +565,66 @@ class CalculatedMetricsInventoryBuilder:
             definition_json=definition_json_str,
         )
 
+    def _normalize_func_name(self, value: Any) -> str:
+        """Normalize function names to comparable string keys."""
+        if isinstance(value, str):
+            return value.strip()
+        return ""
+
+    def _coerce_scalar_text(self, value: Any) -> str:
+        """Convert scalar values to text while ignoring null/object payloads."""
+        if value is None:
+            return ""
+        if isinstance(value, str):
+            return value.strip()
+
+        try:
+            is_na = pd.isna(value)
+            if isinstance(is_na, bool) and is_na:
+                return ""
+        except (TypeError, ValueError):
+            pass
+
+        if hasattr(value, "isoformat"):
+            try:
+                iso_value = value.isoformat()
+                if iso_value is None:
+                    return ""
+                return str(iso_value).strip()
+            except (TypeError, ValueError):
+                pass
+
+        if pd.api.types.is_scalar(value):
+            return str(value).strip()
+        return ""
+
+    def _coerce_display_text(self, value: Any, fallback: str = "") -> str:
+        """Normalize text values for summaries/dataclass fields."""
+        normalized = self._coerce_scalar_text(value)
+        return normalized if normalized else fallback
+
+    def _normalize_reference_value(self, value: Any) -> str:
+        """Normalize IDs and reference values from mixed payload shapes."""
+        if value is None:
+            return ""
+        if isinstance(value, (list, tuple)):
+            for item in value:
+                candidate = self._normalize_reference_value(item)
+                if candidate:
+                    return candidate
+            return ""
+        if isinstance(value, dict):
+            for key in ("segment_id", "id", "name", "metric", "value", "val"):
+                if key in value:
+                    candidate = self._normalize_reference_value(value.get(key))
+                    if candidate:
+                        return candidate
+            return ""
+        normalized = extract_short_name(value)
+        if normalized.lower() in {"", "nan", "none", "null"}:
+            return ""
+        return normalized
+
     def _parse_formula(self, formula: Any, depth: int = 0) -> dict[str, Any]:
         """
         Recursively parse a formula and extract all relevant data.
@@ -584,7 +652,7 @@ class CalculatedMetricsInventoryBuilder:
 
             max_nesting = max(max_nesting, current_depth)
 
-            func = node.get("func", "")
+            func = self._normalize_func_name(node.get("func", ""))
             if func:
                 functions_internal.add(func)
 
@@ -613,17 +681,15 @@ class CalculatedMetricsInventoryBuilder:
 
                 # Extract metric references
                 if func == "metric":
-                    metric_name = node.get("name", "")
-                    if metric_name:
-                        # Clean up metric name using shared utility
-                        clean_name = extract_short_name(metric_name)
+                    clean_name = self._normalize_reference_value(node.get("name", ""))
+                    if clean_name:
                         metric_refs.add(clean_name)
 
                 # Extract segment references
                 if func == "segment":
-                    segment_id = node.get("segment_id", node.get("id", ""))
-                    if segment_id:
-                        segment_refs.add(segment_id)
+                    clean_segment = self._normalize_reference_value(node.get("segment_id", node.get("id", "")))
+                    if clean_segment:
+                        segment_refs.add(clean_segment)
 
             # Traverse child nodes
             for key in [
@@ -811,11 +877,10 @@ class CalculatedMetricsInventoryBuilder:
             return "Segmented metric"
 
         if func == "metric":
-            name = actual_formula.get("name", "")
-            if not isinstance(name, str):
-                name = str(name)
-            clean_name = name.split("/")[-1] if "/" in name else name
-            return f"= {clean_name}"
+            clean_name = self._normalize_reference_value(actual_formula.get("name", ""))
+            if clean_name:
+                return f"= {clean_name}"
+            return "Metric reference"
 
         if func in ("col-sum", "col-max", "col-min", "col-mean", "col-count"):
             op_name = func.replace("col-", "").upper()
@@ -905,10 +970,7 @@ class CalculatedMetricsInventoryBuilder:
         func = node.get("func", "")
 
         if func == "metric":
-            name = node.get("name", "")
-            if not isinstance(name, str):
-                name = str(name)
-            return name.split("/")[-1] if "/" in name else name
+            return self._normalize_reference_value(node.get("name", ""))
 
         if func == "number":
             val = node.get("val", "")
@@ -1083,19 +1145,20 @@ class CalculatedMetricsInventoryBuilder:
 
         return ""
 
-    def _get_short_id(self, full_id: str) -> str:
+    def _get_short_id(self, full_id: Any) -> str:
         """Get a shortened version of an ID for display."""
-        if not full_id:
+        normalized_id = self._normalize_reference_value(full_id)
+        if not normalized_id:
             return ""
         # Handle IDs like "s300000000_1234567890abcdef" -> show last part
-        if "_" in full_id:
-            parts = full_id.split("_")
+        if "_" in normalized_id:
+            parts = normalized_id.split("_")
             if len(parts[-1]) > 8:
                 return parts[-1][:8] + "..."
             return parts[-1]
-        if len(full_id) > 12:
-            return full_id[:12] + "..."
-        return full_id
+        if len(normalized_id) > 12:
+            return normalized_id[:12] + "..."
+        return normalized_id
 
     def _get_reference_name(self, node: dict[str, Any]) -> str:
         """Extract a human-readable name from a formula node."""
@@ -1105,10 +1168,7 @@ class CalculatedMetricsInventoryBuilder:
         func = node.get("func", "")
 
         if func == "metric":
-            name = node.get("name", "")
-            if not isinstance(name, str):
-                name = str(name)
-            return name.split("/")[-1] if "/" in name else name
+            return self._normalize_reference_value(node.get("name", ""))
 
         if func == "number":
             val = node.get("val", "")

--- a/src/cja_auto_sdr/inventory/calculated_metrics.py
+++ b/src/cja_auto_sdr/inventory/calculated_metrics.py
@@ -812,6 +812,8 @@ class CalculatedMetricsInventoryBuilder:
 
         if func == "metric":
             name = actual_formula.get("name", "")
+            if not isinstance(name, str):
+                name = str(name)
             clean_name = name.split("/")[-1] if "/" in name else name
             return f"= {clean_name}"
 
@@ -904,6 +906,8 @@ class CalculatedMetricsInventoryBuilder:
 
         if func == "metric":
             name = node.get("name", "")
+            if not isinstance(name, str):
+                name = str(name)
             return name.split("/")[-1] if "/" in name else name
 
         if func == "number":
@@ -940,7 +944,7 @@ class CalculatedMetricsInventoryBuilder:
                     expr = self._build_formula_expression(node[key], max_depth - 1)
                     if expr:
                         operands.append(expr)
-            if "operands" in node:
+            if "operands" in node and isinstance(node["operands"], list):
                 for op in node["operands"]:
                     expr = self._build_formula_expression(op, max_depth - 1)
                     if expr:
@@ -1027,7 +1031,7 @@ class CalculatedMetricsInventoryBuilder:
                 name = self._get_reference_name(formula[key])
                 if name:
                     operands.append(name)
-        if "operands" in formula:
+        if "operands" in formula and isinstance(formula["operands"], list):
             for op in formula["operands"]:
                 name = self._get_reference_name(op)
                 if name:
@@ -1102,6 +1106,8 @@ class CalculatedMetricsInventoryBuilder:
 
         if func == "metric":
             name = node.get("name", "")
+            if not isinstance(name, str):
+                name = str(name)
             return name.split("/")[-1] if "/" in name else name
 
         if func == "number":

--- a/src/cja_auto_sdr/inventory/calculated_metrics.py
+++ b/src/cja_auto_sdr/inventory/calculated_metrics.py
@@ -515,7 +515,9 @@ class CalculatedMetricsInventoryBuilder:
 
         # Extract timestamps
         created = self._coerce_display_text(metric_data.get("created", metric_data.get("createdDate", "")), fallback="")
-        modified = self._coerce_display_text(metric_data.get("modified", metric_data.get("modifiedDate", "")), fallback="")
+        modified = self._coerce_display_text(
+            metric_data.get("modified", metric_data.get("modifiedDate", "")), fallback=""
+        )
 
         # Extract sharing info
         shares_data = metric_data.get("shares", [])
@@ -532,7 +534,7 @@ class CalculatedMetricsInventoryBuilder:
         # Serialize definition to JSON string for full fidelity
         try:
             definition_json_str = json.dumps(definition, separators=(",", ":"))
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             definition_json_str = json.dumps(str(definition))
 
         return CalculatedMetricSummary(
@@ -582,7 +584,7 @@ class CalculatedMetricsInventoryBuilder:
             is_na = pd.isna(value)
             if isinstance(is_na, bool) and is_na:
                 return ""
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             pass
 
         if hasattr(value, "isoformat"):
@@ -591,7 +593,7 @@ class CalculatedMetricsInventoryBuilder:
                 if iso_value is None:
                     return ""
                 return str(iso_value).strip()
-            except (TypeError, ValueError):
+            except TypeError, ValueError:
                 pass
 
         if pd.api.types.is_scalar(value):

--- a/src/cja_auto_sdr/inventory/derived_fields.py
+++ b/src/cja_auto_sdr/inventory/derived_fields.py
@@ -370,7 +370,7 @@ class DerivedFieldInventoryBuilder:
                 is_na = bool(is_na.all()) if len(is_na) > 0 else True
             else:
                 is_na = bool(is_na)
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             is_na = field_def_str is None
 
         if is_na or field_def_str in ("NaN", "", "null", None):

--- a/src/cja_auto_sdr/inventory/derived_fields.py
+++ b/src/cja_auto_sdr/inventory/derived_fields.py
@@ -370,7 +370,7 @@ class DerivedFieldInventoryBuilder:
                 is_na = bool(is_na.all()) if len(is_na) > 0 else True
             else:
                 is_na = bool(is_na)
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             is_na = field_def_str is None
 
         if is_na or field_def_str in ("NaN", "", "null", None):
@@ -670,6 +670,8 @@ class DerivedFieldInventoryBuilder:
             string_outputs = 0
 
             for branch in branches:
+                if not isinstance(branch, dict):
+                    continue
                 map_to = branch.get("map-to")
                 if isinstance(map_to, (int, float)):
                     numeric_outputs += 1
@@ -1149,7 +1151,7 @@ class DerivedFieldInventoryBuilder:
                 value_field = mapping.get("value-field", "")
                 dataset = mapping.get("dataset", "")
                 if key_field and value_field:
-                    dataset_name = dataset.split("/")[-1] if dataset else "lookup"
+                    dataset_name = dataset.split("/")[-1] if isinstance(dataset, str) and dataset else "lookup"
                     return f"Lookup: {self._get_field_short_name(key_field)} → {self._get_field_short_name(value_field)} from {dataset_name}"
                 if key_field:
                     return f"Lookup by {self._get_field_short_name(key_field)}"
@@ -1167,7 +1169,7 @@ class DerivedFieldInventoryBuilder:
 
             # Find the input field
             args = func_obj.get("args", [])
-            if args and isinstance(args[0], dict):
+            if isinstance(args, list) and args and isinstance(args[0], dict):
                 input_field = self._get_field_short_name(args[0].get("id", ""))
 
             component_names = {
@@ -1207,10 +1209,12 @@ class DerivedFieldInventoryBuilder:
 
             delimiter = func_obj.get("delimiter", "")
             args = func_obj.get("args", [])
+            if not isinstance(args, list):
+                args = []
             field_count = len([a for a in args if isinstance(a, dict) and a.get("func") == "raw-field"])
 
             if delimiter:
-                delim_desc = f'"{delimiter}"' if delimiter.strip() else "(space)"
+                delim_desc = f'"{delimiter}"' if str(delimiter).strip() else "(space)"
                 if field_count > 0:
                     return f"Concat {field_count} fields with {delim_desc}"
                 return f"Concatenate with {delim_desc}"
@@ -1226,8 +1230,8 @@ class DerivedFieldInventoryBuilder:
             if func_obj.get("func") != "regex-replace":
                 continue
 
-            pattern = func_obj.get("pattern", "")
-            replacement = func_obj.get("replacement", "")
+            pattern = str(func_obj.get("pattern", ""))
+            replacement = str(func_obj.get("replacement", ""))
 
             if pattern:
                 short_pattern = pattern[:25] + "..." if len(pattern) > 25 else pattern
@@ -1250,7 +1254,7 @@ class DerivedFieldInventoryBuilder:
 
             args = func_obj.get("args", [])
             field_name = ""
-            if args and isinstance(args[0], dict):
+            if isinstance(args, list) and args and isinstance(args[0], dict):
                 field_name = self._get_field_short_name(args[0].get("id", ""))
 
             if field_name:
@@ -1271,7 +1275,7 @@ class DerivedFieldInventoryBuilder:
             scope = func_obj.get("scope", "")  # session, person, etc.
             args = func_obj.get("args", [])
             field_name = ""
-            if args and isinstance(args[0], dict):
+            if isinstance(args, list) and args and isinstance(args[0], dict):
                 field_name = self._get_field_short_name(args[0].get("id", ""))
 
             if field_name and scope:
@@ -1302,7 +1306,7 @@ class DerivedFieldInventoryBuilder:
 
             args = func_obj.get("args", [])
             field_name = ""
-            if args and isinstance(args[0], dict):
+            if isinstance(args, list) and args and isinstance(args[0], dict):
                 field_name = self._get_field_short_name(args[0].get("id", ""))
 
             delim_desc = f'"{delimiter}"' if delimiter else "delimiter"
@@ -1342,7 +1346,7 @@ class DerivedFieldInventoryBuilder:
 
             # Find the input field from args or referenced label
             args = func_obj.get("args", [])
-            if args and isinstance(args[0], dict):
+            if isinstance(args, list) and args and isinstance(args[0], dict):
                 input_field = self._get_field_short_name(args[0].get("id", ""))
             elif field_ref:
                 input_field = field_ref
@@ -1365,7 +1369,7 @@ class DerivedFieldInventoryBuilder:
             input_field = ""
 
             args = func_obj.get("args", [])
-            if args and isinstance(args[0], dict):
+            if isinstance(args, list) and args and isinstance(args[0], dict):
                 input_field = self._get_field_short_name(args[0].get("id", ""))
             elif field_ref:
                 input_field = field_ref
@@ -1388,7 +1392,7 @@ class DerivedFieldInventoryBuilder:
             input_field = ""
 
             args = func_obj.get("args", [])
-            if args and isinstance(args[0], dict):
+            if isinstance(args, list) and args and isinstance(args[0], dict):
                 input_field = self._get_field_short_name(args[0].get("id", ""))
             elif field_ref:
                 input_field = field_ref
@@ -1412,7 +1416,7 @@ class DerivedFieldInventoryBuilder:
             input_field = ""
 
             args = func_obj.get("args", [])
-            if args and isinstance(args[0], dict):
+            if isinstance(args, list) and args and isinstance(args[0], dict):
                 input_field = self._get_field_short_name(args[0].get("id", ""))
             elif field_ref:
                 input_field = field_ref
@@ -1438,7 +1442,7 @@ class DerivedFieldInventoryBuilder:
             input_field = ""
 
             args = func_obj.get("args", [])
-            if args and isinstance(args[0], dict):
+            if isinstance(args, list) and args and isinstance(args[0], dict):
                 input_field = self._get_field_short_name(args[0].get("id", ""))
             elif field_ref:
                 input_field = field_ref
@@ -1471,7 +1475,7 @@ class DerivedFieldInventoryBuilder:
             input_field = ""
 
             args = func_obj.get("args", [])
-            if args and isinstance(args[0], dict):
+            if isinstance(args, list) and args and isinstance(args[0], dict):
                 input_field = self._get_field_short_name(args[0].get("id", ""))
             elif field_ref:
                 input_field = field_ref

--- a/src/cja_auto_sdr/inventory/derived_fields.py
+++ b/src/cja_auto_sdr/inventory/derived_fields.py
@@ -30,7 +30,10 @@ import pandas as pd
 
 from cja_auto_sdr.inventory.utils import (
     BatchProcessingStats,
+    coerce_display_text,
+    coerce_scalar_text,
     extract_short_name,
+    normalize_func_name,
     validate_required_id,
 )
 
@@ -575,9 +578,7 @@ class DerivedFieldInventoryBuilder:
 
     def _normalize_func_name(self, value: Any) -> str:
         """Normalize function names to strings suitable for comparisons/lookup keys."""
-        if isinstance(value, str):
-            return value.strip()
-        return ""
+        return normalize_func_name(value)
 
     def _normalize_source_type(self, value: Any) -> str:
         """Normalize sourceFieldType values from scalar/list-like payloads."""
@@ -597,23 +598,11 @@ class DerivedFieldInventoryBuilder:
 
     def _coerce_scalar_text(self, value: Any) -> str:
         """Convert scalar values to display text while ignoring null/object payloads."""
-        if value is None:
-            return ""
-        if isinstance(value, str):
-            return value.strip()
-        if isinstance(value, (int, float, bool)):
-            try:
-                if bool(pd.isna(value)):
-                    return ""
-            except TypeError, ValueError:
-                pass
-            return str(value).strip()
-        return ""
+        return coerce_scalar_text(value)
 
     def _coerce_display_text(self, value: Any, fallback: str = "") -> str:
         """Normalize display text with a fallback for null/unsupported value shapes."""
-        normalized = self._coerce_scalar_text(value)
-        return normalized if normalized else fallback
+        return coerce_display_text(value, fallback=fallback)
 
     def _coerce_int_index(self, value: Any, default: int = 0) -> int:
         """Safely coerce split indexes to integers without raising on malformed values."""

--- a/src/cja_auto_sdr/inventory/derived_fields.py
+++ b/src/cja_auto_sdr/inventory/derived_fields.py
@@ -590,7 +590,7 @@ class DerivedFieldInventoryBuilder:
         if hasattr(value, "tolist") and not isinstance(value, dict):
             try:
                 return self._normalize_source_type(value.tolist())
-            except (TypeError, ValueError):
+            except TypeError, ValueError:
                 return ""
         return ""
 

--- a/src/cja_auto_sdr/inventory/segments.py
+++ b/src/cja_auto_sdr/inventory/segments.py
@@ -471,8 +471,12 @@ class SegmentsInventoryBuilder:
         tags = extract_tags(segment_data.get("tags", []))
 
         # Extract timestamps
-        created = self._coerce_display_text(segment_data.get("created", segment_data.get("createdDate", "")), fallback="")
-        modified = self._coerce_display_text(segment_data.get("modified", segment_data.get("modifiedDate", "")), fallback="")
+        created = self._coerce_display_text(
+            segment_data.get("created", segment_data.get("createdDate", "")), fallback=""
+        )
+        modified = self._coerce_display_text(
+            segment_data.get("modified", segment_data.get("modifiedDate", "")), fallback=""
+        )
 
         # Extract sharing info
         shares_data = segment_data.get("shares", [])
@@ -489,7 +493,7 @@ class SegmentsInventoryBuilder:
         # Serialize definition to JSON string for full fidelity
         try:
             definition_json_str = json.dumps(definition, separators=(",", ":"))
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             definition_json_str = json.dumps(str(definition))
 
         return SegmentSummary(
@@ -539,7 +543,7 @@ class SegmentsInventoryBuilder:
             is_na = pd.isna(value)
             if isinstance(is_na, bool) and is_na:
                 return ""
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             pass
 
         if hasattr(value, "isoformat"):
@@ -548,7 +552,7 @@ class SegmentsInventoryBuilder:
                 if iso_value is None:
                     return ""
                 return str(iso_value).strip()
-            except (TypeError, ValueError):
+            except TypeError, ValueError:
                 pass
 
         if pd.api.types.is_scalar(value):

--- a/src/cja_auto_sdr/inventory/segments.py
+++ b/src/cja_auto_sdr/inventory/segments.py
@@ -602,7 +602,7 @@ class SegmentsInventoryBuilder:
 
             # Extract container type (context)
             context = node.get("context", "")
-            if context and not container_type:
+            if context and isinstance(context, str) and not container_type:
                 container_type = context.lower()
 
             # Extract dimension references using shared utility
@@ -808,7 +808,7 @@ class SegmentsInventoryBuilder:
         # Handle logical operators
         if func == "and":
             preds = node.get("preds", [])
-            if preds:
+            if isinstance(preds, list) and preds:
                 parts = []
                 for p in preds[:3]:  # Limit to 3 for readability
                     desc = self._describe_definition(p, max_depth - 1)
@@ -820,7 +820,7 @@ class SegmentsInventoryBuilder:
 
         if func == "or":
             preds = node.get("preds", [])
-            if preds:
+            if isinstance(preds, list) and preds:
                 parts = []
                 for p in preds[:3]:
                     desc = self._describe_definition(p, max_depth - 1)

--- a/src/cja_auto_sdr/inventory/segments.py
+++ b/src/cja_auto_sdr/inventory/segments.py
@@ -26,11 +26,14 @@ import pandas as pd
 
 from cja_auto_sdr.inventory.utils import (
     BatchProcessingStats,
+    coerce_display_text,
+    coerce_scalar_text,
     extract_owner,
     extract_short_name,
     extract_tags,
     format_iso_date,
     normalize_api_response,
+    normalize_func_name,
     validate_required_id,
 )
 
@@ -528,41 +531,15 @@ class SegmentsInventoryBuilder:
 
     def _normalize_func_name(self, value: Any) -> str:
         """Normalize function names to comparable string keys."""
-        if isinstance(value, str):
-            return value.strip()
-        return ""
+        return normalize_func_name(value)
 
     def _coerce_scalar_text(self, value: Any) -> str:
         """Convert scalar values to text while ignoring null/object payloads."""
-        if value is None:
-            return ""
-        if isinstance(value, str):
-            return value.strip()
-
-        try:
-            is_na = pd.isna(value)
-            if isinstance(is_na, bool) and is_na:
-                return ""
-        except TypeError, ValueError:
-            pass
-
-        if hasattr(value, "isoformat"):
-            try:
-                iso_value = value.isoformat()
-                if iso_value is None:
-                    return ""
-                return str(iso_value).strip()
-            except TypeError, ValueError:
-                pass
-
-        if pd.api.types.is_scalar(value):
-            return str(value).strip()
-        return ""
+        return coerce_scalar_text(value)
 
     def _coerce_display_text(self, value: Any, fallback: str = "") -> str:
         """Normalize text values for summaries/dataclass fields."""
-        normalized = self._coerce_scalar_text(value)
-        return normalized if normalized else fallback
+        return coerce_display_text(value, fallback=fallback)
 
     def _normalize_reference_value(self, value: Any) -> str:
         """Normalize variable API reference payloads (string/dict/etc.) into a short ID."""

--- a/tests/README.md
+++ b/tests/README.md
@@ -52,7 +52,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 1,735 comprehensive tests**
+**Total: 1,738 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -64,7 +64,7 @@ tests/
 | `test_org_report_integration.py` | 17 | Org-wide analysis integration tests: end-to-end flows, caching, filtering, governance |
 | `test_cli.py` | 235 | Command-line interface and argument parsing |
 | `test_profiles.py` | 48 | Multi-organization profile support |
-| `test_derived_inventory.py` | 58 | Derived fields inventory feature |
+| `test_derived_inventory.py` | 61 | Derived fields inventory feature |
 | `test_inventory_utils.py` | 47 | Inventory utilities and helpers |
 | `test_segments_inventory.py` | 48 | Segments inventory feature |
 | `test_edge_cases.py` | 39 | Edge cases, configuration dataclasses, custom exceptions |
@@ -97,7 +97,7 @@ tests/
 | `test_main_entry_points.py` | 19 | main() and _main_impl() entry points, dispatch, run_state, run summary |
 | `test_quality_policy_and_run_summary.py` | 57 | Quality policy functions and run summary/status inference |
 | `test_e2e_integration.py` | 16 | End-to-end integration tests with real pipeline, mocked API boundary |
-| **Total** | **1,735** | **Collected via pytest --collect-only** |
+| **Total** | **1,738** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -501,7 +501,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (1,735 tests total)
+- [x] Comprehensive test coverage (1,738 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 48 tests
@@ -510,7 +510,7 @@ Check for drift (CI-friendly):
 - [x] Shared validation cache tests (test_shared_cache.py) - 17 tests
 - [x] Calculated metrics inventory tests (test_calculated_metrics_inventory.py) - 44 tests
 - [x] Segments inventory tests (test_segments_inventory.py) - 48 tests
-- [x] Derived fields inventory tests (test_derived_inventory.py) - 58 tests
+- [x] Derived fields inventory tests (test_derived_inventory.py) - 61 tests
 - [x] Inventory utilities tests (test_inventory_utils.py) - 47 tests
 - [x] Git integration tests (test_git_integration.py) - 36 tests
 - [x] Inventory diff support in snapshot comparisons (test_diff_comparison.py) - 169 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -64,15 +64,15 @@ tests/
 | `test_org_report_integration.py` | 17 | Org-wide analysis integration tests: end-to-end flows, caching, filtering, governance |
 | `test_cli.py` | 235 | Command-line interface and argument parsing |
 | `test_profiles.py` | 48 | Multi-organization profile support |
-| `test_derived_inventory.py` | 47 | Derived fields inventory feature |
+| `test_derived_inventory.py` | 54 | Derived fields inventory feature |
 | `test_inventory_utils.py` | 47 | Inventory utilities and helpers |
-| `test_segments_inventory.py` | 43 | Segments inventory feature |
+| `test_segments_inventory.py` | 45 | Segments inventory feature |
 | `test_edge_cases.py` | 39 | Edge cases, configuration dataclasses, custom exceptions |
-| `test_calculated_metrics_inventory.py` | 38 | Calculated metrics inventory feature |
+| `test_calculated_metrics_inventory.py` | 40 | Calculated metrics inventory feature |
 | `test_git_integration.py` | 36 | Git integration, snapshot management, inventory snapshots |
 | `test_output_formats.py` | 37 | CSV, JSON, HTML, Markdown output generation |
 | `test_cja_initialization.py` | 35 | CJA connection and configuration validation |
-| `test_utils.py` | 49 | Utility functions and helpers |
+| `test_utils.py` | 50 | Utility functions and helpers |
 | `test_excel_formatting.py` | 25 | Excel sheet formatting and styling |
 | `test_parallel_api_fetcher.py` | 25 | Parallel API data fetching |
 | `test_api_tuning.py` | 23 | API worker auto-tuning |
@@ -508,9 +508,9 @@ Check for drift (CI-friendly):
 - [x] API worker auto-tuning tests (test_api_tuning.py) - 23 tests
 - [x] Circuit breaker pattern tests (test_circuit_breaker.py) - 22 tests
 - [x] Shared validation cache tests (test_shared_cache.py) - 17 tests
-- [x] Calculated metrics inventory tests (test_calculated_metrics_inventory.py) - 38 tests
-- [x] Segments inventory tests (test_segments_inventory.py) - 43 tests
-- [x] Derived fields inventory tests (test_derived_inventory.py) - 47 tests
+- [x] Calculated metrics inventory tests (test_calculated_metrics_inventory.py) - 40 tests
+- [x] Segments inventory tests (test_segments_inventory.py) - 45 tests
+- [x] Derived fields inventory tests (test_derived_inventory.py) - 54 tests
 - [x] Inventory utilities tests (test_inventory_utils.py) - 47 tests
 - [x] Git integration tests (test_git_integration.py) - 36 tests
 - [x] Inventory diff support in snapshot comparisons (test_diff_comparison.py) - 169 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -52,7 +52,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 1,714 comprehensive tests**
+**Total: 1,724 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -97,7 +97,7 @@ tests/
 | `test_main_entry_points.py` | 19 | main() and _main_impl() entry points, dispatch, run_state, run summary |
 | `test_quality_policy_and_run_summary.py` | 57 | Quality policy functions and run summary/status inference |
 | `test_e2e_integration.py` | 16 | End-to-end integration tests with real pipeline, mocked API boundary |
-| **Total** | **1,714** | **Collected via pytest --collect-only** |
+| **Total** | **1,724** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -501,7 +501,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (1,714 tests total)
+- [x] Comprehensive test coverage (1,724 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 48 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -52,7 +52,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 1,738 comprehensive tests**
+**Total: 1,739 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -64,7 +64,7 @@ tests/
 | `test_org_report_integration.py` | 17 | Org-wide analysis integration tests: end-to-end flows, caching, filtering, governance |
 | `test_cli.py` | 235 | Command-line interface and argument parsing |
 | `test_profiles.py` | 48 | Multi-organization profile support |
-| `test_derived_inventory.py` | 61 | Derived fields inventory feature |
+| `test_derived_inventory.py` | 62 | Derived fields inventory feature |
 | `test_inventory_utils.py` | 47 | Inventory utilities and helpers |
 | `test_segments_inventory.py` | 48 | Segments inventory feature |
 | `test_edge_cases.py` | 39 | Edge cases, configuration dataclasses, custom exceptions |
@@ -97,7 +97,7 @@ tests/
 | `test_main_entry_points.py` | 19 | main() and _main_impl() entry points, dispatch, run_state, run summary |
 | `test_quality_policy_and_run_summary.py` | 57 | Quality policy functions and run summary/status inference |
 | `test_e2e_integration.py` | 16 | End-to-end integration tests with real pipeline, mocked API boundary |
-| **Total** | **1,738** | **Collected via pytest --collect-only** |
+| **Total** | **1,739** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -501,7 +501,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (1,738 tests total)
+- [x] Comprehensive test coverage (1,739 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 48 tests
@@ -510,7 +510,7 @@ Check for drift (CI-friendly):
 - [x] Shared validation cache tests (test_shared_cache.py) - 17 tests
 - [x] Calculated metrics inventory tests (test_calculated_metrics_inventory.py) - 44 tests
 - [x] Segments inventory tests (test_segments_inventory.py) - 48 tests
-- [x] Derived fields inventory tests (test_derived_inventory.py) - 61 tests
+- [x] Derived fields inventory tests (test_derived_inventory.py) - 62 tests
 - [x] Inventory utilities tests (test_inventory_utils.py) - 47 tests
 - [x] Git integration tests (test_git_integration.py) - 36 tests
 - [x] Inventory diff support in snapshot comparisons (test_diff_comparison.py) - 169 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -52,7 +52,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 1,724 comprehensive tests**
+**Total: 1,735 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -64,11 +64,11 @@ tests/
 | `test_org_report_integration.py` | 17 | Org-wide analysis integration tests: end-to-end flows, caching, filtering, governance |
 | `test_cli.py` | 235 | Command-line interface and argument parsing |
 | `test_profiles.py` | 48 | Multi-organization profile support |
-| `test_derived_inventory.py` | 54 | Derived fields inventory feature |
+| `test_derived_inventory.py` | 58 | Derived fields inventory feature |
 | `test_inventory_utils.py` | 47 | Inventory utilities and helpers |
-| `test_segments_inventory.py` | 45 | Segments inventory feature |
+| `test_segments_inventory.py` | 48 | Segments inventory feature |
 | `test_edge_cases.py` | 39 | Edge cases, configuration dataclasses, custom exceptions |
-| `test_calculated_metrics_inventory.py` | 40 | Calculated metrics inventory feature |
+| `test_calculated_metrics_inventory.py` | 44 | Calculated metrics inventory feature |
 | `test_git_integration.py` | 36 | Git integration, snapshot management, inventory snapshots |
 | `test_output_formats.py` | 37 | CSV, JSON, HTML, Markdown output generation |
 | `test_cja_initialization.py` | 35 | CJA connection and configuration validation |
@@ -97,7 +97,7 @@ tests/
 | `test_main_entry_points.py` | 19 | main() and _main_impl() entry points, dispatch, run_state, run summary |
 | `test_quality_policy_and_run_summary.py` | 57 | Quality policy functions and run summary/status inference |
 | `test_e2e_integration.py` | 16 | End-to-end integration tests with real pipeline, mocked API boundary |
-| **Total** | **1,724** | **Collected via pytest --collect-only** |
+| **Total** | **1,735** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -501,16 +501,16 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (1,724 tests total)
+- [x] Comprehensive test coverage (1,735 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 48 tests
 - [x] API worker auto-tuning tests (test_api_tuning.py) - 23 tests
 - [x] Circuit breaker pattern tests (test_circuit_breaker.py) - 22 tests
 - [x] Shared validation cache tests (test_shared_cache.py) - 17 tests
-- [x] Calculated metrics inventory tests (test_calculated_metrics_inventory.py) - 40 tests
-- [x] Segments inventory tests (test_segments_inventory.py) - 45 tests
-- [x] Derived fields inventory tests (test_derived_inventory.py) - 54 tests
+- [x] Calculated metrics inventory tests (test_calculated_metrics_inventory.py) - 44 tests
+- [x] Segments inventory tests (test_segments_inventory.py) - 48 tests
+- [x] Derived fields inventory tests (test_derived_inventory.py) - 58 tests
 - [x] Inventory utilities tests (test_inventory_utils.py) - 47 tests
 - [x] Git integration tests (test_git_integration.py) - 36 tests
 - [x] Inventory diff support in snapshot comparisons (test_diff_comparison.py) - 169 tests

--- a/tests/test_calculated_metrics_inventory.py
+++ b/tests/test_calculated_metrics_inventory.py
@@ -638,6 +638,91 @@ class TestEdgeCases:
 
         assert inventory.total_calculated_metrics == 1
 
+    def test_non_dict_metric_payloads_are_skipped(self):
+        """Unexpected list entries from the API should be skipped safely."""
+        valid_metric = {
+            "id": "cm_valid",
+            "name": "Valid Metric",
+            "description": "",
+            "definition": {"func": "calc-metric", "formula": {"func": "metric", "name": "metrics/revenue"}},
+        }
+        mock_cja = Mock()
+        mock_cja.getCalculatedMetrics.return_value = ["bad_payload", valid_metric]
+
+        builder = CalculatedMetricsInventoryBuilder()
+        inventory = builder.build(mock_cja, "dv_test", "Test")
+
+        assert inventory.total_calculated_metrics == 1
+        assert inventory.metrics[0].metric_id == "cm_valid"
+
+    def test_dict_shaped_segment_id_is_normalized(self):
+        """Segment IDs provided as objects should still be extracted safely."""
+        metric = {
+            "id": "cm_segment_obj",
+            "name": "Segment Object Metric",
+            "description": "",
+            "definition": {
+                "func": "calc-metric",
+                "formula": {
+                    "func": "segment",
+                    "segment_id": {"id": "segments/s_mobile_visitors"},
+                    "metric": {"func": "metric", "name": "metrics/orders"},
+                },
+            },
+        }
+        mock_cja = Mock()
+        mock_cja.getCalculatedMetrics.return_value = [metric]
+
+        builder = CalculatedMetricsInventoryBuilder()
+        inventory = builder.build(mock_cja, "dv_test", "Test")
+
+        assert inventory.total_calculated_metrics == 1
+        assert "s_mobile_visitors" in inventory.metrics[0].segment_references
+
+    def test_non_string_func_name_does_not_crash(self):
+        """Unhashable/non-string func values should be ignored safely."""
+        metric = {
+            "id": "cm_bad_func",
+            "name": "Bad Func",
+            "description": "",
+            "definition": {
+                "func": "calc-metric",
+                "formula": {"func": {"bad": "metric"}, "name": "metrics/revenue"},
+            },
+        }
+        mock_cja = Mock()
+        mock_cja.getCalculatedMetrics.return_value = [metric]
+
+        builder = CalculatedMetricsInventoryBuilder()
+        inventory = builder.build(mock_cja, "dv_test", "Test")
+
+        assert inventory.total_calculated_metrics == 1
+
+    def test_timestamp_metadata_is_preserved(self):
+        """Datetime-like created/modified values should not be dropped."""
+        metric = {
+            "id": "cm_timestamps",
+            "name": "Timestamp Metric",
+            "description": "",
+            "created": pd.Timestamp("2025-01-15T10:30:00Z"),
+            "modified": pd.Timestamp("2025-01-16T11:45:00Z"),
+            "definition": {"func": "calc-metric", "formula": {"func": "metric", "name": "metrics/revenue"}},
+        }
+        mock_cja = Mock()
+        mock_cja.getCalculatedMetrics.return_value = [metric]
+
+        builder = CalculatedMetricsInventoryBuilder()
+        inventory = builder.build(mock_cja, "dv_test", "Test")
+
+        assert inventory.total_calculated_metrics == 1
+        assert inventory.metrics[0].created != ""
+        assert inventory.metrics[0].modified != ""
+        df = inventory.get_dataframe()
+        assert df.iloc[0]["created"] != "-"
+        assert df.iloc[0]["modified"] != "-"
+        assert "2025-01-15" in str(df.iloc[0]["created"])
+        assert "2025-01-16" in str(df.iloc[0]["modified"])
+
 
 # ==================== DATA CLASS TESTS ====================
 

--- a/tests/test_calculated_metrics_inventory.py
+++ b/tests/test_calculated_metrics_inventory.py
@@ -597,6 +597,47 @@ class TestEdgeCases:
         assert inventory.total_calculated_metrics == 1
         assert inventory.metrics[0].formula_summary == "1.0"
 
+    def test_non_string_metric_name_does_not_crash(self):
+        """Non-string metric name should not crash name.split('/')."""
+        metric = {
+            "id": "cm_name",
+            "name": "Non String Name",
+            "description": "",
+            "definition": {
+                "func": "calc-metric",
+                "formula": {"func": "metric", "name": 123},
+            },
+        }
+        mock_cja = Mock()
+        mock_cja.getCalculatedMetrics.return_value = [metric]
+
+        builder = CalculatedMetricsInventoryBuilder()
+        inventory = builder.build(mock_cja, "dv_test", "Test")
+
+        assert inventory.total_calculated_metrics == 1
+
+    def test_non_list_operands_does_not_crash(self):
+        """Non-list operands value should not crash iteration."""
+        metric = {
+            "id": "cm_ops",
+            "name": "Non List Operands",
+            "description": "",
+            "definition": {
+                "func": "calc-metric",
+                "formula": {
+                    "func": "add",
+                    "operands": "not_a_list",
+                },
+            },
+        }
+        mock_cja = Mock()
+        mock_cja.getCalculatedMetrics.return_value = [metric]
+
+        builder = CalculatedMetricsInventoryBuilder()
+        inventory = builder.build(mock_cja, "dv_test", "Test")
+
+        assert inventory.total_calculated_metrics == 1
+
 
 # ==================== DATA CLASS TESTS ====================
 

--- a/tests/test_derived_inventory.py
+++ b/tests/test_derived_inventory.py
@@ -1315,6 +1315,27 @@ class TestDescriptionExtraction:
 
         assert inventory.fields[0].description == ""
 
+    def test_timestamp_description_handled(self):
+        """Datetime-like descriptions should be preserved via scalar coercion."""
+        df = pd.DataFrame(
+            [
+                {
+                    "id": "metrics/test",
+                    "name": "Test Metric",
+                    "description": pd.Timestamp("2025-01-15T10:30:00Z"),
+                    "sourceFieldType": "derived",
+                    "fieldDefinition": json.dumps([{"func": "raw-field", "id": "test", "label": "test"}]),
+                    "dataSetType": "event",
+                }
+            ]
+        )
+
+        builder = DerivedFieldInventoryBuilder()
+        inventory = builder.build(df, pd.DataFrame(), "dv_test", "Test")
+
+        assert inventory.fields[0].description != ""
+        assert "2025-01-15" in inventory.fields[0].description
+
     def test_description_in_dataframe(self):
         """Test that description column appears in DataFrame output"""
         df = pd.DataFrame(

--- a/tests/test_output_content_validation.py
+++ b/tests/test_output_content_validation.py
@@ -38,7 +38,7 @@ def rich_data_dict():
         "Metadata": pd.DataFrame(
             {
                 "Property": ["Generated At", "Data View ID", "Tool Version", "Total Metrics"],
-                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.2.4", 3],
+                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.2.5", 3],
             }
         ),
         "Data Quality": pd.DataFrame(
@@ -104,7 +104,7 @@ def rich_metadata_dict():
         "Generated At": "2025-01-15 10:30:00 PST",
         "Data View ID": "dv_content_test",
         "Data View Name": "Test DataView",
-        "Tool Version": "3.2.4",
+        "Tool Version": "3.2.5",
         "Metrics Count": "3",
         "Dimensions Count": "4",
     }
@@ -224,7 +224,7 @@ class TestJSONContentValidation:
             data = json.load(f)
 
         assert data["metadata"]["Data View ID"] == "dv_content_test"
-        assert data["metadata"]["Tool Version"] == "3.2.4"
+        assert data["metadata"]["Tool Version"] == "3.2.5"
 
 
 # ===================================================================

--- a/tests/test_segments_inventory.py
+++ b/tests/test_segments_inventory.py
@@ -656,6 +656,45 @@ class TestEdgeCases:
         assert "s_reference" in inventory.segments[0].other_segment_references
         assert "pageurl" in inventory.segments[0].dimension_references
 
+    def test_non_string_context_does_not_crash(self):
+        """Non-string context value should not crash parsing."""
+        segment = {
+            "id": "s_ctx",
+            "name": "Non String Context",
+            "description": "",
+            "definition": {
+                "func": "container",
+                "context": 123,
+                "pred": {"func": "exists", "dimension": "variables/pageurl"},
+            },
+        }
+        mock_cja = Mock()
+        mock_cja.getFilters.return_value = [segment]
+
+        builder = SegmentsInventoryBuilder()
+        inventory = builder.build(mock_cja, "dv_test", "Test")
+
+        assert inventory.total_segments == 1
+
+    def test_non_list_preds_does_not_crash(self):
+        """Non-list preds value should not crash describe_definition."""
+        segment = {
+            "id": "s_preds",
+            "name": "Non List Preds",
+            "description": "",
+            "definition": {
+                "func": "and",
+                "preds": "not_a_list",
+            },
+        }
+        mock_cja = Mock()
+        mock_cja.getFilters.return_value = [segment]
+
+        builder = SegmentsInventoryBuilder()
+        inventory = builder.build(mock_cja, "dv_test", "Test")
+
+        assert inventory.total_segments == 1
+
 
 # ==================== DATA CLASS TESTS ====================
 

--- a/tests/test_segments_inventory.py
+++ b/tests/test_segments_inventory.py
@@ -695,6 +695,76 @@ class TestEdgeCases:
 
         assert inventory.total_segments == 1
 
+    def test_non_dict_segment_payloads_are_skipped(self):
+        """Unexpected list entries from the API should be skipped safely."""
+        valid_segment = {
+            "id": "s_valid",
+            "name": "Valid Segment",
+            "description": "",
+            "definition": {
+                "func": "container",
+                "context": "hits",
+                "pred": {"func": "exists", "dimension": "variables/pageurl"},
+            },
+        }
+        mock_cja = Mock()
+        mock_cja.getFilters.return_value = ["bad_payload", valid_segment]
+
+        builder = SegmentsInventoryBuilder()
+        inventory = builder.build(mock_cja, "dv_test", "Test")
+
+        assert inventory.total_segments == 1
+        assert inventory.segments[0].segment_id == "s_valid"
+
+    def test_non_string_func_values_do_not_crash(self):
+        """Unhashable/non-string func values should not break parser traversal."""
+        segment = {
+            "id": "s_bad_func",
+            "name": "Bad Func",
+            "description": "",
+            "definition": {
+                "func": {"name": "container"},
+                "context": "hits",
+                "pred": {"func": "exists", "dimension": "variables/pageurl"},
+            },
+        }
+        mock_cja = Mock()
+        mock_cja.getFilters.return_value = [segment]
+
+        builder = SegmentsInventoryBuilder()
+        inventory = builder.build(mock_cja, "dv_test", "Test")
+
+        assert inventory.total_segments == 1
+
+    def test_timestamp_metadata_is_preserved(self):
+        """Datetime-like created/modified values should not be dropped."""
+        segment = {
+            "id": "s_timestamps",
+            "name": "Timestamp Segment",
+            "description": "",
+            "created": pd.Timestamp("2025-01-15T10:30:00Z"),
+            "modified": pd.Timestamp("2025-01-16T11:45:00Z"),
+            "definition": {
+                "func": "container",
+                "context": "hits",
+                "pred": {"func": "exists", "dimension": "variables/pageurl"},
+            },
+        }
+        mock_cja = Mock()
+        mock_cja.getFilters.return_value = [segment]
+
+        builder = SegmentsInventoryBuilder()
+        inventory = builder.build(mock_cja, "dv_test", "Test")
+
+        assert inventory.total_segments == 1
+        assert inventory.segments[0].created != ""
+        assert inventory.segments[0].modified != ""
+        df = inventory.get_dataframe()
+        assert df.iloc[0]["created"] != "-"
+        assert df.iloc[0]["modified"] != "-"
+        assert "2025-01-15" in str(df.iloc[0]["created"])
+        assert "2025-01-16" in str(df.iloc[0]["modified"])
+
 
 # ==================== DATA CLASS TESTS ====================
 

--- a/tests/test_ux_features.py
+++ b/tests/test_ux_features.py
@@ -344,11 +344,11 @@ class TestCombinedFeatures:
 class TestVersionUpdated:
     """Test that version is correct"""
 
-    def test_version_is_3_2_4(self):
-        """Test that version is 3.2.4"""
+    def test_version_is_3_2_5(self):
+        """Test that version is 3.2.5"""
         from cja_auto_sdr.generator import __version__
 
-        assert __version__ == "3.2.4"
+        assert __version__ == "3.2.5"
 
 
 class TestFormatAutoDetection:


### PR DESCRIPTION
## Summary
- hardens inventory parsing paths (derived fields, segments, calculated metrics) against malformed API payload shapes
- centralizes shared normalization logic in src/cja_auto_sdr/inventory/utils.py (normalize_func_name, coerce_scalar_text, coerce_display_text) to reduce drift across builders
- preserves consistent scalar coercion behavior across all three inventory builders, including datetime-like values
- safely handles non-finite split indexes in derived field split summaries (NaN and Infinity fallback to default index)
- adds regression coverage for non-finite split indexes and datetime-like description coercion
- syncs repository test-count metadata (now 1,739 total tests)

## Test plan
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- PYTHONPATH=src uv run pytest -q tests/test_derived_inventory.py tests/test_segments_inventory.py tests/test_calculated_metrics_inventory.py tests/test_inventory_utils.py
- uv run python scripts/update_test_counts.py --check
