### PR TITLE
v3.2.7: Internal consistency, lazy-forwarding tests, ruff expansion

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Sync dependencies
         run: uv sync --dev
       - name: Run tests with coverage
-        run: uv run pytest tests/ -v --tb=short --cov=cja_auto_sdr --cov-report=term --cov-fail-under=74
+        run: uv run pytest tests/ -v --tb=short --cov=cja_auto_sdr --cov-report=term --cov-fail-under=80
 
   run-summary-contract:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Sync dependencies
         run: uv sync --dev
       - name: Run tests with coverage
-        run: uv run pytest tests/ -v --tb=short --cov=cja_auto_sdr --cov-report=term --cov-fail-under=73
+        run: uv run pytest tests/ -v --tb=short --cov=cja_auto_sdr --cov-report=term --cov-fail-under=74
 
   run-summary-contract:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **Lazy-forwarding standardization**: Converted 4 hand-rolled `__getattr__` implementations (`cli/`, `git/`, `data/`, `output/`) to use the centralized `make_getattr()` helper from `core/lazy.py`, narrowing open `hasattr()` catch-alls to explicit name lists
 - **Phantom export cleanup**: Removed 4 stale lazy exports (`DiffChange`, `format_output`, `OUTPUT_FORMATS`, `generate_output_files`) that referenced symbols never defined in `generator.py`
+- **Compatibility note**: The removed lazy exports were stale placeholders and not functional public APIs; supported import paths are unchanged
 
 ### Added
 - **Ruff rule expansion**: Enabled ISC (implicit string concat), TID (tidy imports), A (builtins), PLE (pylint errors), RSE (unnecessary parens on raise), PLW (pylint warnings) — 6 new rule sets with targeted suppressions
-- **CI coverage threshold**: Raised `--cov-fail-under` from 73% to 74%
+- **CI coverage threshold**: Raised `--cov-fail-under` from 75% to 80%
 
 ### Fixed
 - **Documentation accuracy**: Corrected output filename patterns in `QUICK_REFERENCE.md` from `SDR_<name>_<date>` to actual `CJA_DataView_<Name>_<ID>_SDR` pattern; updated `PERFORMANCE.md` stale version reference

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Ruff rule expansion**: Enabled ISC (implicit string concat), TID (tidy imports), A (builtins), PLE (pylint errors), RSE (unnecessary parens on raise), PLW (pylint warnings) — 6 new rule sets with targeted suppressions
-- **CI coverage threshold**: Raised `--cov-fail-under` from 75% to 80%
+- **CI coverage threshold**: Raised `--cov-fail-under` from 73% to 80%
 
 ### Fixed
 - **Documentation accuracy**: Corrected output filename patterns in `QUICK_REFERENCE.md` from `SDR_<name>_<date>` to actual `CJA_DataView_<Name>_<ID>_SDR` pattern; updated `PERFORMANCE.md` stale version reference

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.7] - 2026-02-15
+
+### Changed
+- **Lazy-forwarding standardization**: Converted 4 hand-rolled `__getattr__` implementations (`cli/`, `git/`, `data/`, `output/`) to use the centralized `make_getattr()` helper from `core/lazy.py`, narrowing open `hasattr()` catch-alls to explicit name lists
+- **Phantom export cleanup**: Removed 4 stale lazy exports (`DiffChange`, `format_output`, `OUTPUT_FORMATS`, `generate_output_files`) that referenced symbols never defined in `generator.py`
+
+### Added
+- **Ruff rule expansion**: Enabled ISC (implicit string concat), TID (tidy imports), A (builtins), PLE (pylint errors), RSE (unnecessary parens on raise), PLW (pylint warnings) — 6 new rule sets with targeted suppressions
+- **CI coverage threshold**: Raised `--cov-fail-under` from 73% to 74%
+
+### Fixed
+- **Documentation accuracy**: Corrected output filename patterns in `QUICK_REFERENCE.md` from `SDR_<name>_<date>` to actual `CJA_DataView_<Name>_<ID>_SDR` pattern; updated `PERFORMANCE.md` stale version reference
+- **PLW3301**: Flattened 5 nested `max()` calls to use star-unpacking
+- **RSE102**: Removed unnecessary parentheses on 2 bare `raise` statements
+
+### Tests
+- Added 55 tests in `test_lazy_forwarding.py`:
+  - 9 direct unit tests for `core/lazy.py` `make_getattr()` helper (target module, mapping, error cases, iterable types)
+  - 34 parametrized positive tests across all 12 lazy-forwarding modules
+  - 12 negative tests verifying `AttributeError` for unknown attributes
+
 ## [3.2.6] - 2026-02-14
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,16 @@
+# Project Notes for Claude
+
+## Python Version
+
+This project requires **Python 3.14+**. This is intentional and correct - Python 3.14 exists and is the minimum supported version for this project.
+
+## Project Overview
+
+CJA SDR Generator - A tool for generating Solution Design Reference (SDR) documentation from Adobe Customer Journey Analytics data views.
+
+## Key Details
+
+- Package manager: uv
+- Entry point: `cja_auto_sdr` command (via pyproject.toml scripts)
+- Current version: v3.2.7
+- Main script: `generator.py`

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (2,706+ tests)
+├── tests/                     # Test suite (2,758+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (2,651+ tests)
+├── tests/                     # Test suite (2,706+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -408,10 +408,10 @@ See which configuration source is being used:
 cja_auto_sdr --config-status
 # Shows: configuration source, all fields (masked), and validation status
 
-# Or with verbose output during a command
-cja_auto_sdr --list-dataviews --verbose
-# Output shows: "Using credentials from environment variables" or
-#              "Using credentials from config.json"
+# Or with debug logging during a command
+cja_auto_sdr --list-dataviews --log-level DEBUG
+# Output includes credential source details, such as
+# "Using credentials from environment variables" or "Using credentials from config.json"
 ```
 
 ---
@@ -707,11 +707,11 @@ jobs:
 ```bash
 # Pass environment variables at runtime
 docker run -e ORG_ID -e CLIENT_ID -e SECRET -e SCOPES \
-  cja-sdr-generator "My Data View" --format excel
+  cja_auto_sdr "My Data View" --format excel
 
 # Or use an env file
 docker run --env-file .env.production \
-  cja-sdr-generator "My Data View" --format excel
+  cja_auto_sdr "My Data View" --format excel
 ```
 
 ---
@@ -889,8 +889,8 @@ cja_auto_sdr --validate-config
 # Dry run (validate + simulate)
 cja_auto_sdr --dry-run
 
-# Verbose mode (see credential source)
-cja_auto_sdr --list-dataviews --verbose
+# Debug logging (see credential source)
+cja_auto_sdr --list-dataviews --log-level DEBUG
 
 # Test connection
 cja_auto_sdr --list-dataviews

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -913,7 +913,7 @@ cja_auto_sdr --list-dataviews --log-level DEBUG
 At launch, the tool logs a diagnostic line containing the tool version, Python version, platform, active log level, and inferred run mode (batch, single, or discovery). This appears automatically at `INFO` level and is useful for troubleshooting environment issues in CI/CD logs or support requests:
 
 ```text
-CJA SDR Generator v3.2.6 | Python 3.14.2 | darwin | log_level=INFO | mode=single
+CJA SDR Generator v3.2.7 | Python 3.14.2 | darwin | log_level=INFO | mode=single
 ```
 
 ### Structured JSON Logging

--- a/docs/OUTPUT_FORMATS.md
+++ b/docs/OUTPUT_FORMATS.md
@@ -1,6 +1,6 @@
 # Output Format Flexibility
 
-Version 3.2 supports multiple output formats beyond Excel, providing flexible integration options for different use cases including SDR generation, diff comparison, and org-wide analysis.
+The tool supports multiple output formats beyond Excel, providing flexible integration options for SDR generation, diff comparison, and org-wide analysis.
 
 ## Supported Formats
 
@@ -26,7 +26,7 @@ Version 3.2 supports multiple output formats beyond Excel, providing flexible in
 | Console | ✗ | ✓ (default) | ✓ (default) |
 | All | ✓ | ✓ | ✓ |
 
-### Format Aliases (v3.2.0)
+### Format Aliases (introduced in v3.2.0)
 
 For convenience, format aliases provide shortcuts to common format combinations:
 
@@ -109,7 +109,7 @@ cja_auto_sdr dv_12345 --stats --format csv --output stats.csv
 **Default format** - Professional formatted workbook with color-coding and styling.
 
 **Output:**
-- Single file: `CJA_DataView_{name}_SDR.xlsx`
+- Single file: `CJA_DataView_{name}_{id}_SDR.xlsx`
 - Multiple sheets (in order):
   1. Metadata
   2. Data Quality (color-coded by severity)
@@ -172,7 +172,7 @@ cja_auto_sdr dv_12345 --format csv
 
 # Then in Python:
 import pandas as pd
-metrics = pd.read_csv('CJA_DataView_myview_SDR_csv/metrics.csv')
+metrics = pd.read_csv('CJA_DataView_myview_dv_12345_SDR_csv/metrics.csv')
 # Perform custom analysis...
 ```
 
@@ -191,7 +191,7 @@ metrics = pd.read_csv('CJA_DataView_myview_SDR_csv/metrics.csv')
     "Generated At": "2024-01-01 12:00:00",
     "Data View ID": "dv_12345",
     "Data View Name": "My Data View",
-    "Tool Version": "3.0",
+    "Tool Version": "3.2.7",
     "Metrics Count": "150",
     "Dimensions Count": "75"
   },
@@ -249,11 +249,11 @@ metrics = pd.read_csv('CJA_DataView_myview_SDR_csv/metrics.csv')
 # 1. API Integration
 curl -X POST https://api.example.com/dataviews \
   -H "Content-Type: application/json" \
-  -d @CJA_DataView_myview_SDR.json
+  -d @CJA_DataView_myview_dv_12345_SDR.json
 
 # 2. Python Processing
 import json
-with open('CJA_DataView_myview_SDR.json') as f:
+with open('CJA_DataView_myview_dv_12345_SDR.json') as f:
     data = json.load(f)
     metrics = data['metrics']
     for metric in metrics:
@@ -261,7 +261,7 @@ with open('CJA_DataView_myview_SDR.json') as f:
 
 # 3. JavaScript/Node.js
 const fs = require('fs');
-const data = JSON.parse(fs.readFileSync('CJA_DataView_myview_SDR.json'));
+const data = JSON.parse(fs.readFileSync('CJA_DataView_myview_dv_12345_SDR.json'));
 console.log(`Metrics: ${data.metrics.length}`);
 ```
 
@@ -308,11 +308,11 @@ console.log(`Metrics: ${data.metrics.length}`);
 ```bash
 # Generate HTML and open in browser
 cja_auto_sdr dv_12345 --format html
-open CJA_DataView_myview_SDR.html  # macOS
+open CJA_DataView_myview_dv_12345_SDR.html  # macOS
 # or
-xdg-open CJA_DataView_myview_SDR.html  # Linux
+xdg-open CJA_DataView_myview_dv_12345_SDR.html  # Linux
 # or
-start CJA_DataView_myview_SDR.html  # Windows
+start CJA_DataView_myview_dv_12345_SDR.html  # Windows
 ```
 
 ---
@@ -379,10 +379,10 @@ start CJA_DataView_myview_SDR.html  # Windows
 cja_auto_sdr dv_12345 --format markdown
 
 # View in terminal
-cat CJA_DataView_myview_SDR.md
+cat CJA_DataView_myview_dv_12345_SDR.md
 
 # Convert to PDF with pandoc (if installed)
-pandoc CJA_DataView_myview_SDR.md -o report.pdf
+pandoc CJA_DataView_myview_dv_12345_SDR.md -o report.pdf
 ```
 
 ---
@@ -392,11 +392,11 @@ pandoc CJA_DataView_myview_SDR.md -o report.pdf
 Generate all output formats in a single run for complete documentation packages.
 
 **Output (SDR mode):**
-- `CJA_DataView_{name}_SDR.xlsx` (Excel)
-- `CJA_DataView_{name}_SDR_csv/` (CSV directory)
-- `CJA_DataView_{name}_SDR.json` (JSON)
-- `CJA_DataView_{name}_SDR.html` (HTML)
-- `CJA_DataView_{name}_SDR.md` (Markdown)
+- `CJA_DataView_{name}_{id}_SDR.xlsx` (Excel)
+- `CJA_DataView_{name}_{id}_SDR_csv/` (CSV directory)
+- `CJA_DataView_{name}_{id}_SDR.json` (JSON)
+- `CJA_DataView_{name}_{id}_SDR.html` (HTML)
+- `CJA_DataView_{name}_{id}_SDR.md` (Markdown)
 
 **Output (diff/org-wide modes):**
 - All file formats above, plus console output displayed in terminal
@@ -456,7 +456,7 @@ subprocess.run([
 ])
 
 # Load and send to API
-with open('CJA_DataView_myview_SDR.json') as f:
+with open('CJA_DataView_myview_dv_12345_SDR.json') as f:
     data = json.load(f)
 
 response = requests.post(
@@ -484,7 +484,7 @@ subprocess.run([
 ])
 
 # Load and process
-csv_dir = 'CJA_DataView_myview_SDR_csv'
+csv_dir = 'CJA_DataView_myview_dv_12345_SDR_csv'
 metrics = pd.read_csv(f'{csv_dir}/metrics.csv')
 dimensions = pd.read_csv(f'{csv_dir}/dimensions.csv')
 quality = pd.read_csv(f'{csv_dir}/data_quality.csv')
@@ -724,7 +724,7 @@ Output format flexibility provides:
 
 ---
 
-## Org-Wide Analysis Output (v3.2.0)
+## Org-Wide Analysis Output (introduced in v3.2.0)
 
 The org-wide analysis mode (`--org-report`) generates specialized output showing component distribution across all data views.
 
@@ -747,7 +747,7 @@ Output includes:
 cja_auto_sdr --org-report --format excel
 
 # Quick stats only (minimal output)
-cja_auto_sdr --org-report --stats-only
+cja_auto_sdr --org-report --org-stats
 
 # All formats for comprehensive documentation
 cja_auto_sdr --org-report --format all --output-dir ./reports

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -2,7 +2,7 @@
 
 Technical details and optimization options for the CJA SDR Generator.
 
-> **Note:** Performance benchmarks in this guide were measured with v3.1.0. Actual performance may vary based on network conditions, API rate limits, and data view size.
+> **Note:** Performance benchmarks in this guide were originally measured with v3.1.0 and remain representative. Features added in v3.2.x (circuit breaker, API auto-tuning, shared validation cache) may improve performance further. Actual results vary based on network conditions, API rate limits, and data view size.
 
 ## Performance Overview
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -413,7 +413,7 @@ For log aggregation systems (Splunk, ELK, CloudWatch), use structured JSON loggi
 cja_auto_sdr dv_12345 --log-format json
 
 # Output format (one JSON object per line):
-{"timestamp": "2026-01-23T15:11:50", "level": "INFO", "logger": "cja_sdr_generator", "message": "Processing data view", "module": "cja_sdr_generator", "function": "process_single_dataview", "line": 6683}
+{"timestamp": "2026-01-23T15:11:50", "level": "INFO", "logger": "cja_auto_sdr.generator", "message": "Processing data view", "module": "generator", "function": "process_single_dataview", "line": 6683}
 ```
 
 **Benefits:**

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -203,7 +203,7 @@ This command:
 
 ```bash
 $ uv run cja_auto_sdr --version
-cja_auto_sdr 3.2.6
+cja_auto_sdr 3.2.7
 ```
 
 > **Important:** All commands in this guide assume you're in the `cja_auto_sdr` directory. If you see "command not found", make sure you're in the right directory and have run `uv sync`.

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Quick Reference Card
 
-Single-page command cheat sheet for CJA SDR Generator v3.2.6.
+Single-page command cheat sheet for CJA SDR Generator v3.2.7.
 
 ## Four Main Modes
 

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -476,11 +476,11 @@ See [CONFIGURATION.md](CONFIGURATION.md) for detailed setup of `config.json` and
 
 | Format | File Pattern | Description |
 |--------|--------------|-------------|
-| Excel | `SDR_<name>_<date>.xlsx` | Full report with Data Quality sheet |
-| CSV | `SDR_<name>_<date>.csv` | Flat component list |
-| JSON | `SDR_<name>_<date>.json` | Machine-readable format |
-| HTML | `SDR_<name>_<date>.html` | Browser-viewable report |
-| Markdown | `SDR_<name>_<date>.md` | Documentation-ready format |
+| Excel | `CJA_DataView_<Name>_<ID>_SDR.xlsx` | Full report with Data Quality sheet |
+| CSV | `CJA_DataView_<Name>_<ID>_SDR_csv/` | Directory with per-sheet CSV files |
+| JSON | `CJA_DataView_<Name>_<ID>_SDR.json` | Machine-readable format |
+| HTML | `CJA_DataView_<Name>_<ID>_SDR.html` | Browser-viewable report |
+| Markdown | `CJA_DataView_<Name>_<ID>_SDR.md` | Documentation-ready format |
 
 **Excel Sheet Order:**
 1. Metadata

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -292,7 +292,7 @@ or
 Exception: OAuth response missing required fields. Response: {"error": "invalid_scope", "error_description": "..."}
 ```
 
-**Cause:** The OAuth token request to Adobe's authentication server failed. As of v3.1.0 (cjapy 0.2.4-3), you now receive the actual OAuth error response, making it much easier to diagnose credential issues.
+**Cause:** The OAuth token request to Adobe's authentication server failed. As of v3.1.0 (cjapy 0.2.4.post3), you now receive the actual OAuth error response, making it much easier to diagnose credential issues.
 
 **Common OAuth error responses and solutions:**
 
@@ -1731,7 +1731,7 @@ uv run cja_auto_sdr dv_1 dv_2 dv_3 --workers 2 --retry-base-delay 1.5
 
 ## Dependency Issues
 
-> **Recommended cjapy version:** v3.2.0 requires cjapy 0.2.4-3 or later for improved OAuth error handling. Users on older versions may see confusing errors when authentication fails. Upgrade with: `uv add --upgrade cjapy`
+> **Recommended cjapy version:** v3.2.7 requires cjapy 0.2.4.post3 or later for improved OAuth error handling. Users on older versions may see confusing errors when authentication fails. Upgrade with: `uv add --upgrade cjapy`
 
 ### Module Not Found
 
@@ -1853,7 +1853,7 @@ python -m pip install --upgrade pip
 pip install numpy>=2.2.0
 
 # Install other dependencies
-pip install cjapy>=0.2.4.post2 pandas>=2.3.3 xlsxwriter>=3.2.9 tqdm>=4.66.0
+pip install cjapy>=0.2.4.post3 pandas>=2.3.3 xlsxwriter>=3.2.9 tqdm>=4.66.0
 
 # Verify numpy works
 python -c "import numpy; print(numpy.__version__)"
@@ -2126,7 +2126,7 @@ uv run cja_auto_sdr dv_12345 --log-level DEBUG --log-format json
 
 **JSON output format:**
 ```json
-{"timestamp": "2026-01-23T15:11:50", "level": "INFO", "logger": "cja_sdr_generator", "message": "Processing data view", "module": "cja_sdr_generator", "function": "process_single_dataview", "line": 6683}
+{"timestamp": "2026-01-23T15:11:50", "level": "INFO", "logger": "cja_auto_sdr.generator", "message": "Processing data view", "module": "generator", "function": "process_single_dataview", "line": 6683}
 ```
 
 **Benefits:**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,21 +95,30 @@ select = [
     "C4",   # flake8-comprehensions
     "PT",   # flake8-pytest-style
     "PIE",  # flake8-pie
+    "ISC",  # implicit string concatenation
+    "TID",  # tidy imports
+    "A",    # flake8-builtins
+    "PLE",  # pylint errors
+    "RSE",  # unnecessary parens on raise
+    "PLW",  # pylint warnings
 ]
 ignore = [
-    "E501",   # line too long (handled by formatter)
-    "SIM108", # ternary operator (readability preference)
-    "S101",   # assert (used in tests and src invariant checks)
-    "S311",   # random (used for retry jitter, not crypto)
-    "S603",   # subprocess call (legitimate CLI tool usage)
-    "S606",   # os.startfile (legitimate CLI tool usage)
-    "S607",   # partial executable path (legitimate CLI tool usage)
-    "PT011",  # pytest.raises too broad (matching messages makes tests brittle)
-    "PT012",  # multiline pytest.raises block (common with context managers)
+    "E501",    # line too long (handled by formatter)
+    "SIM108",  # ternary operator (readability preference)
+    "S101",    # assert (used in tests and src invariant checks)
+    "S311",    # random (used for retry jitter, not crypto)
+    "S603",    # subprocess call (legitimate CLI tool usage)
+    "S606",    # os.startfile (legitimate CLI tool usage)
+    "S607",    # partial executable path (legitimate CLI tool usage)
+    "PT011",   # pytest.raises too broad (matching messages makes tests brittle)
+    "PT012",   # multiline pytest.raises block (common with context managers)
+    "PLW1510", # subprocess.run without check (intentional in git helpers)
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"src/cja_auto_sdr/generator.py" = ["F401", "E402", "RUF001", "RUF003", "SIM115", "S105"]  # F401: re-exports; E402: optional imports; RUF001/3: intentional Unicode symbols; SIM115: NamedTemporaryFile with delete=False; S105: token_name false positive
+"src/cja_auto_sdr/generator.py" = ["F401", "E402", "RUF001", "RUF003", "SIM115", "S105", "PLW2901"]  # F401: re-exports; E402: optional imports; RUF001/3: intentional Unicode symbols; SIM115: NamedTemporaryFile with delete=False; S105: token_name false positive; PLW2901: line=line.strip() pattern
+"src/cja_auto_sdr/core/credentials.py" = ["PLW2901"]  # line=line.strip() pattern
+"src/cja_auto_sdr/core/logging.py" = ["PLW0603"]      # legitimate global state for logging init
 "src/cja_auto_sdr/api/*.py" = ["F822"]       # lazy forwarding modules (resolved via __getattr__)
 "src/cja_auto_sdr/cli/*.py" = ["F822"]       # lazy forwarding modules
 "src/cja_auto_sdr/core/profiles.py" = ["F822"]  # lazy forwarding module

--- a/scripts/check_version_sync.py
+++ b/scripts/check_version_sync.py
@@ -47,6 +47,11 @@ VERSION_LOCATIONS: list[tuple[str, str, str]] = [
         "Quickstart Guide version output",
     ),
     (
+        "docs/CONFIGURATION.md",
+        r"CJA SDR Generator v(\d+\.\d+\.\d+)",
+        "Configuration startup diagnostics version example",
+    ),
+    (
         "tests/test_ux_features.py",
         r'assert __version__ == "(\d+\.\d+\.\d+)"',
         "UX features version assertion",

--- a/src/cja_auto_sdr/cli/__init__.py
+++ b/src/cja_auto_sdr/cli/__init__.py
@@ -27,10 +27,6 @@ __all__ = [
 ]
 
 
-def __getattr__(name):
-    """Lazy import from generator for backwards compatibility."""
-    from cja_auto_sdr import generator
+from cja_auto_sdr.core.lazy import make_getattr
 
-    if hasattr(generator, name):
-        return getattr(generator, name)
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+__getattr__ = make_getattr(__name__, __all__, target_module="cja_auto_sdr.generator")

--- a/src/cja_auto_sdr/core/version.py
+++ b/src/cja_auto_sdr/core/version.py
@@ -1,3 +1,3 @@
 """Version information for CJA Auto SDR."""
 
-__version__ = "3.2.6"
+__version__ = "3.2.7"

--- a/src/cja_auto_sdr/data/__init__.py
+++ b/src/cja_auto_sdr/data/__init__.py
@@ -15,13 +15,13 @@ Example usage:
 # Deferred imports to avoid circular import with generator.py
 # Will be populated when code is fully extracted
 
-__all__ = []
+from cja_auto_sdr.core.lazy import make_getattr
+
+__all__: list[str] = []
 
 _LAZY_EXPORTS = [
     "ProcessingResult",
     "DiffSummary",
 ]
-
-from cja_auto_sdr.core.lazy import make_getattr
 
 __getattr__ = make_getattr(__name__, _LAZY_EXPORTS, target_module="cja_auto_sdr.generator")

--- a/src/cja_auto_sdr/data/__init__.py
+++ b/src/cja_auto_sdr/data/__init__.py
@@ -17,21 +17,12 @@ Example usage:
 
 __all__ = []
 
-
-_ALLOWED_GENERATOR_IMPORTS = {
+_LAZY_EXPORTS = [
     "ProcessingResult",
     "DiffSummary",
     "DiffChange",
-}
+]
 
+from cja_auto_sdr.core.lazy import make_getattr
 
-def __getattr__(name):
-    """Lazy import from generator for backwards compatibility.
-
-    Only exposes explicitly declared names to prevent accidental coupling.
-    """
-    if name in _ALLOWED_GENERATOR_IMPORTS:
-        from cja_auto_sdr import generator
-
-        return getattr(generator, name)
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+__getattr__ = make_getattr(__name__, _LAZY_EXPORTS, target_module="cja_auto_sdr.generator")

--- a/src/cja_auto_sdr/data/__init__.py
+++ b/src/cja_auto_sdr/data/__init__.py
@@ -20,7 +20,6 @@ __all__ = []
 _LAZY_EXPORTS = [
     "ProcessingResult",
     "DiffSummary",
-    "DiffChange",
 ]
 
 from cja_auto_sdr.core.lazy import make_getattr

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -9260,9 +9260,9 @@ def interactive_select_dataviews(config_file: str = "config.json", profile: str 
 
         # Calculate column widths
         num_width = len(str(len(display_data))) + 2
-        max_id_width = max(len("ID"), max(len(item["id"]) for item in display_data)) + 2
-        max_name_width = max(len("Name"), max(len(item["name"]) for item in display_data)) + 2
-        max_owner_width = max(len("Owner"), max(len(item["owner"]) for item in display_data)) + 2
+        max_id_width = max(len("ID"), *(len(item["id"]) for item in display_data)) + 2
+        max_name_width = max(len("Name"), *(len(item["name"]) for item in display_data)) + 2
+        max_owner_width = max(len("Owner"), *(len(item["owner"]) for item in display_data)) + 2
 
         total_width = num_width + max_id_width + max_name_width + max_owner_width
 
@@ -9576,7 +9576,7 @@ def interactive_wizard(config_file: str = "config.json", profile: str | None = N
                         try:
                             range_parts = part.split("-")
                             if len(range_parts) != 2:
-                                raise ValueError()
+                                raise ValueError
                             start, end = int(range_parts[0]), int(range_parts[1])
                             if start > end:
                                 start, end = end, start
@@ -10240,8 +10240,8 @@ def show_stats(
             # Table format
             if stats_data:
                 # Calculate column widths
-                max_id_width = max(len("ID"), max(len(s["id"]) for s in stats_data)) + 2
-                max_name_width = min(40, max(len("Name"), max(len(s["name"]) for s in stats_data)) + 2)
+                max_id_width = max(len("ID"), *(len(s["id"]) for s in stats_data)) + 2
+                max_name_width = min(40, max(len("Name"), *(len(s["name"]) for s in stats_data)) + 2)
 
                 # Print header
                 header = (

--- a/src/cja_auto_sdr/git/__init__.py
+++ b/src/cja_auto_sdr/git/__init__.py
@@ -19,10 +19,6 @@ __all__ = [
 ]
 
 
-def __getattr__(name):
-    """Lazy import from generator for backwards compatibility."""
-    from cja_auto_sdr import generator
+from cja_auto_sdr.core.lazy import make_getattr
 
-    if hasattr(generator, name):
-        return getattr(generator, name)
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+__getattr__ = make_getattr(__name__, __all__, target_module="cja_auto_sdr.generator")

--- a/src/cja_auto_sdr/output/__init__.py
+++ b/src/cja_auto_sdr/output/__init__.py
@@ -25,20 +25,12 @@ __all__ = [
 ]
 
 
-_ALLOWED_GENERATOR_IMPORTS = {
+_LAZY_EXPORTS = [
     "format_output",
     "generate_output_files",
     "OUTPUT_FORMATS",
-}
+]
 
+from cja_auto_sdr.core.lazy import make_getattr
 
-def __getattr__(name):
-    """Lazy import from generator for backwards compatibility.
-
-    Only exposes explicitly declared names to prevent accidental coupling.
-    """
-    if name in _ALLOWED_GENERATOR_IMPORTS:
-        from cja_auto_sdr import generator
-
-        return getattr(generator, name)
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+__getattr__ = make_getattr(__name__, _LAZY_EXPORTS, target_module="cja_auto_sdr.generator")

--- a/src/cja_auto_sdr/output/__init__.py
+++ b/src/cja_auto_sdr/output/__init__.py
@@ -23,14 +23,3 @@ __all__ = [
     "write_json_output",
     "write_markdown_output",
 ]
-
-
-_LAZY_EXPORTS = [
-    "format_output",
-    "generate_output_files",
-    "OUTPUT_FORMATS",
-]
-
-from cja_auto_sdr.core.lazy import make_getattr
-
-__getattr__ = make_getattr(__name__, _LAZY_EXPORTS, target_module="cja_auto_sdr.generator")

--- a/tests/README.md
+++ b/tests/README.md
@@ -59,10 +59,11 @@ tests/
 ├── test_logging_redaction.py        # Logging and sensitive data redaction tests
 ├── test_config_dataclasses.py       # Config dataclasses and constants tests
 ├── test_lock_manager.py             # Lock manager tests
+├── test_lazy_forwarding.py          # Lazy-forwarding infrastructure tests
 └── README.md                        # This file
 ```
 
-**Total: 2,651 comprehensive tests**
+**Total: 2,706 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -117,7 +118,8 @@ tests/
 | `test_logging_redaction.py` | 136 | Logging, sensitive data redaction, JSON formatter |
 | `test_config_dataclasses.py` | 88 | Config dataclasses and constants functions |
 | `test_lock_manager.py` | 48 | Lock manager acquire/release/heartbeat lifecycle |
-| **Total** | **2,651** | **Collected via pytest --collect-only** |
+| `test_lazy_forwarding.py` | 55 | Lazy-forwarding infrastructure and make_getattr() |
+| **Total** | **2,706** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -521,7 +523,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (2,651 tests total)
+- [x] Comprehensive test coverage (2,706 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 48 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -63,7 +63,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 2,706 comprehensive tests**
+**Total: 2,758 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -118,8 +118,8 @@ tests/
 | `test_logging_redaction.py` | 136 | Logging, sensitive data redaction, JSON formatter |
 | `test_config_dataclasses.py` | 88 | Config dataclasses and constants functions |
 | `test_lock_manager.py` | 48 | Lock manager acquire/release/heartbeat lifecycle |
-| `test_lazy_forwarding.py` | 55 | Lazy-forwarding infrastructure and make_getattr() |
-| **Total** | **2,706** | **Collected via pytest --collect-only** |
+| `test_lazy_forwarding.py` | 71 | Lazy-forwarding infrastructure and make_getattr() |
+| **Total** | **2,758** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -523,7 +523,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (2,706 tests total)
+- [x] Comprehensive test coverage (2,758 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 48 tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -205,8 +205,7 @@ def rich_org_report_result():
     }
 
     stale_components = [
-        {"pattern": "deprecated_prefix", "name": f"old_metric_{i}", "component_id": f"metric/old/{i}"}
-        for i in range(6)
+        {"pattern": "deprecated_prefix", "name": f"old_metric_{i}", "component_id": f"metric/old/{i}"} for i in range(6)
     ]
     stale_components.extend(
         [{"pattern": "legacy_suffix", "name": f"segment_{i}_old", "component_id": f"segment/old/{i}"} for i in range(3)]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,256 @@ from unittest.mock import Mock
 import pandas as pd
 import pytest
 
+from cja_auto_sdr.org.models import (
+    ComponentDistribution,
+    ComponentInfo,
+    DataViewCluster,
+    DataViewSummary,
+    OrgReportConfig,
+    OrgReportResult,
+    SimilarityPair,
+)
+
+
+@pytest.fixture
+def rich_org_report_result():
+    """Create a comprehensive org report result used by renderer and CLI tests."""
+    config = OrgReportConfig(
+        core_threshold=0.5,
+        include_metadata=True,
+        overlap_threshold=0.95,
+        summary_only=False,
+        include_component_types=True,
+        include_drift=True,
+    )
+
+    summaries = [
+        DataViewSummary(
+            data_view_id="dv_001",
+            data_view_name="Primary Business Data View With A Long Name",
+            metric_ids={"metric/core/1", "metric/common/1", "metric/limited/1"},
+            dimension_ids={"dimension/core/1", "dimension/common/1"},
+            metric_count=3,
+            dimension_count=2,
+            standard_metric_count=2,
+            derived_metric_count=1,
+            standard_dimension_count=1,
+            derived_dimension_count=1,
+            owner="Alice",
+            owner_id="owner_1",
+            created="2026-01-01T00:00:00+00:00",
+            modified="2026-02-15T10:00:00+00:00",
+            has_description=True,
+        ),
+        DataViewSummary(
+            data_view_id="dv_002",
+            data_view_name="Secondary Data View",
+            metric_count=0,
+            dimension_count=0,
+            error="permission denied",
+            status="error",
+        ),
+        DataViewSummary(
+            data_view_id="dv_003",
+            data_view_name="Tertiary Data View",
+            metric_ids={"metric/core/2", "metric/isolated/1"},
+            dimension_ids={"dimension/isolated/1"},
+            metric_count=2,
+            dimension_count=1,
+            standard_metric_count=1,
+            derived_metric_count=1,
+            standard_dimension_count=1,
+            derived_dimension_count=0,
+            owner="Carol",
+            owner_id="owner_3",
+            created="2026-01-03T00:00:00+00:00",
+            modified="2026-02-15T11:00:00+00:00",
+        ),
+    ]
+
+    distribution = ComponentDistribution(
+        core_metrics=["metric/core/1", "metric/core/2"],
+        core_dimensions=["dimension/core/1"],
+        common_metrics=["metric/common/1"],
+        common_dimensions=["dimension/common/1"],
+        limited_metrics=["metric/limited/1"],
+        limited_dimensions=["dimension/limited/1"],
+        isolated_metrics=["metric/isolated/1"],
+        isolated_dimensions=["dimension/isolated/1"],
+    )
+
+    component_index = {
+        "metric/core/1": ComponentInfo(
+            component_id="metric/core/1",
+            component_type="metric",
+            name="Core Metric One",
+            data_views={"dv_001", "dv_003"},
+        ),
+        "metric/core/2": ComponentInfo(
+            component_id="metric/core/2",
+            component_type="metric",
+            name="Core Metric Two",
+            data_views={"dv_001", "dv_003"},
+        ),
+        "metric/common/1": ComponentInfo(
+            component_id="metric/common/1",
+            component_type="metric",
+            name="Common Metric",
+            data_views={"dv_001", "dv_002"},
+        ),
+        "metric/limited/1": ComponentInfo(
+            component_id="metric/limited/1",
+            component_type="metric",
+            name="Limited Metric",
+            data_views={"dv_001", "dv_002"},
+        ),
+        "metric/isolated/1": ComponentInfo(
+            component_id="metric/isolated/1",
+            component_type="metric",
+            name="Isolated Metric",
+            data_views={"dv_003"},
+        ),
+        "dimension/core/1": ComponentInfo(
+            component_id="dimension/core/1",
+            component_type="dimension",
+            name="Core Dimension",
+            data_views={"dv_001", "dv_003"},
+        ),
+        "dimension/common/1": ComponentInfo(
+            component_id="dimension/common/1",
+            component_type="dimension",
+            name="Common Dimension",
+            data_views={"dv_001", "dv_002"},
+        ),
+        "dimension/limited/1": ComponentInfo(
+            component_id="dimension/limited/1",
+            component_type="dimension",
+            name="Limited Dimension",
+            data_views={"dv_001", "dv_002"},
+        ),
+        "dimension/isolated/1": ComponentInfo(
+            component_id="dimension/isolated/1",
+            component_type="dimension",
+            name="Isolated Dimension",
+            data_views={"dv_003"},
+        ),
+    }
+
+    similarity_pairs = [
+        SimilarityPair(
+            dv1_id="dv_001",
+            dv1_name="Primary Business Data View With A Very Long Name",
+            dv2_id="dv_003",
+            dv2_name="Tertiary Data View Also Quite Long",
+            jaccard_similarity=0.93,
+            shared_count=15,
+            union_count=18,
+            only_in_dv1=["metric/limited/1", "dimension/common/1", "metric/common/1", "metric/x"],
+            only_in_dv2=["metric/isolated/1", "dimension/isolated/1", "dimension/y", "metric/z"],
+            only_in_dv1_names={
+                "metric/limited/1": "Limited Metric",
+                "dimension/common/1": "Common Dimension",
+            },
+            only_in_dv2_names={
+                "metric/isolated/1": "Isolated Metric",
+                "dimension/isolated/1": "Isolated Dimension",
+            },
+        )
+    ]
+    similarity_pairs.extend(
+        [
+            SimilarityPair(
+                dv1_id=f"dv_{i:03d}",
+                dv1_name=f"Data View {i}",
+                dv2_id=f"dv_{i + 1:03d}",
+                dv2_name=f"Data View {i + 1}",
+                jaccard_similarity=0.90,
+                shared_count=20,
+                union_count=22,
+            )
+            for i in range(10, 31)
+        ]
+    )
+
+    clusters = [
+        DataViewCluster(
+            cluster_id=i,
+            cluster_name=f"Cluster {i}",
+            data_view_ids=[f"dv_{i:03d}", f"dv_{i + 100:03d}", f"dv_{i + 200:03d}", f"dv_{i + 300:03d}"],
+            data_view_names=[
+                f"Data View {i}",
+                f"Data View {i + 100}",
+                f"Data View {i + 200}",
+                f"Data View {i + 300}",
+            ],
+            cohesion_score=0.78,
+        )
+        for i in range(1, 12)
+    ]
+
+    owner_data = {
+        f"Owner {i}": {
+            "data_view_count": i,
+            "total_metrics": i * 10,
+            "total_dimensions": i * 5,
+            "avg_components_per_dv": float(i * 3),
+        }
+        for i in range(1, 18)
+    }
+
+    stale_components = [
+        {"pattern": "deprecated_prefix", "name": f"old_metric_{i}", "component_id": f"metric/old/{i}"}
+        for i in range(6)
+    ]
+    stale_components.extend(
+        [{"pattern": "legacy_suffix", "name": f"segment_{i}_old", "component_id": f"segment/old/{i}"} for i in range(3)]
+    )
+
+    recommendations = [
+        {
+            "severity": "high",
+            "reason": "A data view has many isolated components",
+            "data_view": "dv_001",
+            "data_view_name": "Primary Business Data View",
+        },
+        {
+            "severity": "medium",
+            "reason": "Two data views are highly similar",
+            "data_view_1": "dv_001",
+            "data_view_1_name": "Primary Business Data View",
+            "data_view_2": "dv_003",
+            "data_view_2_name": "Tertiary Data View",
+        },
+    ]
+
+    return OrgReportResult(
+        timestamp="2026-02-16T12:00:00+00:00",
+        org_id="test_org@AdobeOrg",
+        parameters=config,
+        data_view_summaries=summaries,
+        component_index=component_index,
+        distribution=distribution,
+        similarity_pairs=similarity_pairs,
+        recommendations=recommendations,
+        duration=12.34,
+        clusters=clusters,
+        is_sampled=True,
+        total_available_data_views=25,
+        governance_violations=[
+            {"message": "Duplicate threshold exceeded", "threshold": 5, "actual": 11},
+        ],
+        naming_audit={
+            "case_styles": {"snake_case": 9, "camelCase": 4, "UPPER_CASE": 2},
+            "total_components": 15,
+            "recommendations": [{"severity": "medium", "message": "Prefer snake_case for new components"}],
+        },
+        owner_summary={
+            "by_owner": owner_data,
+            "owners_sorted_by_dv_count": list(owner_data.keys()),
+        },
+        stale_components=stale_components,
+    )
+
 
 @pytest.fixture
 def mock_config_file(tmp_path):

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -248,7 +248,7 @@ class TestCircuitBreakerOpen:
     def test_cannot_catch_as_cjasdr_error(self):
         with pytest.raises(CircuitBreakerOpen):
             try:
-                raise CircuitBreakerOpen()
+                raise CircuitBreakerOpen
             except CJASDRError:
                 pytest.fail("should not be caught as CJASDRError")
 

--- a/tests/test_generator_interactive_and_console.py
+++ b/tests/test_generator_interactive_and_console.py
@@ -296,20 +296,28 @@ def test_run_org_report_reports_alias_and_individual_format_branches(tmp_path: P
 
     with ExitStack() as stack:
         stack.enter_context(
-            patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "mock", {"org_id": "test_org@AdobeOrg"}))
+            patch(
+                "cja_auto_sdr.generator.configure_cjapy", return_value=(True, "mock", {"org_id": "test_org@AdobeOrg"})
+            )
         )
         mock_cjapy = stack.enter_context(patch("cja_auto_sdr.generator.cjapy"))
         mock_analyzer_cls = stack.enter_context(patch("cja_auto_sdr.generator.OrgComponentAnalyzer"))
         stack.enter_context(patch("cja_auto_sdr.generator.write_org_report_console", return_value=None))
-        stack.enter_context(patch("cja_auto_sdr.generator.write_org_report_json", return_value=str(tmp_path / "report.json")))
+        stack.enter_context(
+            patch("cja_auto_sdr.generator.write_org_report_json", return_value=str(tmp_path / "report.json"))
+        )
         stack.enter_context(
             patch("cja_auto_sdr.generator.write_org_report_excel", return_value=str(tmp_path / "report.xlsx"))
         )
         stack.enter_context(
             patch("cja_auto_sdr.generator.write_org_report_markdown", return_value=str(tmp_path / "report.md"))
         )
-        stack.enter_context(patch("cja_auto_sdr.generator.write_org_report_html", return_value=str(tmp_path / "report.html")))
-        stack.enter_context(patch("cja_auto_sdr.generator.write_org_report_csv", return_value=str(tmp_path / "report_csv")))
+        stack.enter_context(
+            patch("cja_auto_sdr.generator.write_org_report_html", return_value=str(tmp_path / "report.html"))
+        )
+        stack.enter_context(
+            patch("cja_auto_sdr.generator.write_org_report_csv", return_value=str(tmp_path / "report_csv"))
+        )
         stack.enter_context(patch("cja_auto_sdr.generator.build_org_step_summary", return_value="summary"))
         stack.enter_context(patch("cja_auto_sdr.generator.append_github_step_summary"))
 
@@ -470,7 +478,9 @@ def test_run_org_report_org_stats_json_stdout_branch(tmp_path: Path, capsys, ric
     assert '"report_type": "org_analysis"' in stdout
 
 
-def test_org_report_renderers_core_min_count_and_unnamed_component_branches(tmp_path: Path, capsys, rich_org_report_result):
+def test_org_report_renderers_core_min_count_and_unnamed_component_branches(
+    tmp_path: Path, capsys, rich_org_report_result
+):
     result = rich_org_report_result
     result.parameters.core_min_count = 3
 

--- a/tests/test_generator_interactive_and_console.py
+++ b/tests/test_generator_interactive_and_console.py
@@ -1,0 +1,912 @@
+"""Coverage-focused tests for interactive and org-report console helpers."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+from cja_auto_sdr import generator
+from cja_auto_sdr.org.models import (
+    ComponentDistribution,
+    ComponentInfo,
+    DataViewCluster,
+    DataViewSummary,
+    OrgReportComparison,
+    OrgReportConfig,
+    OrgReportResult,
+    SimilarityPair,
+)
+
+
+def _mock_data_views() -> list[dict[str, object]]:
+    return [
+        {"id": "dv_001", "name": "Marketing DV", "owner": {"name": "Alice"}},
+        {"id": "dv_002", "name": "Product DV", "owner": {"name": "Bob"}},
+        {"id": "dv_003", "name": "Finance DV", "owner": {"name": "Carol"}},
+    ]
+
+
+def _build_rich_result() -> OrgReportResult:
+    config = OrgReportConfig(
+        core_threshold=0.5,
+        include_metadata=True,
+        overlap_threshold=0.95,
+        summary_only=False,
+        include_component_types=True,
+        include_drift=True,
+    )
+
+    summaries = [
+        DataViewSummary(
+            data_view_id="dv_001",
+            data_view_name="Primary Business Data View With A Long Name",
+            metric_ids={"metric/core/1", "metric/common/1", "metric/limited/1"},
+            dimension_ids={"dimension/core/1", "dimension/common/1"},
+            metric_count=3,
+            dimension_count=2,
+            standard_metric_count=2,
+            derived_metric_count=1,
+            standard_dimension_count=1,
+            derived_dimension_count=1,
+            owner="Alice",
+            owner_id="owner_1",
+            created="2026-01-01T00:00:00+00:00",
+            modified="2026-02-15T10:00:00+00:00",
+            has_description=True,
+        ),
+        DataViewSummary(
+            data_view_id="dv_002",
+            data_view_name="Secondary Data View",
+            metric_count=0,
+            dimension_count=0,
+            error="permission denied",
+            status="error",
+        ),
+        DataViewSummary(
+            data_view_id="dv_003",
+            data_view_name="Tertiary Data View",
+            metric_ids={"metric/core/2", "metric/isolated/1"},
+            dimension_ids={"dimension/isolated/1"},
+            metric_count=2,
+            dimension_count=1,
+            standard_metric_count=1,
+            derived_metric_count=1,
+            standard_dimension_count=1,
+            derived_dimension_count=0,
+            owner="Carol",
+            owner_id="owner_3",
+            created="2026-01-03T00:00:00+00:00",
+            modified="2026-02-15T11:00:00+00:00",
+        ),
+    ]
+
+    distribution = ComponentDistribution(
+        core_metrics=["metric/core/1", "metric/core/2"],
+        core_dimensions=["dimension/core/1"],
+        common_metrics=["metric/common/1"],
+        common_dimensions=["dimension/common/1"],
+        limited_metrics=["metric/limited/1"],
+        limited_dimensions=["dimension/limited/1"],
+        isolated_metrics=["metric/isolated/1"],
+        isolated_dimensions=["dimension/isolated/1"],
+    )
+
+    component_index = {
+        "metric/core/1": ComponentInfo(
+            component_id="metric/core/1",
+            component_type="metric",
+            name="Core Metric One",
+            data_views={"dv_001", "dv_003"},
+        ),
+        "metric/core/2": ComponentInfo(
+            component_id="metric/core/2",
+            component_type="metric",
+            name="Core Metric Two",
+            data_views={"dv_001", "dv_003"},
+        ),
+        "metric/common/1": ComponentInfo(
+            component_id="metric/common/1",
+            component_type="metric",
+            name="Common Metric",
+            data_views={"dv_001", "dv_002"},
+        ),
+        "metric/limited/1": ComponentInfo(
+            component_id="metric/limited/1",
+            component_type="metric",
+            name="Limited Metric",
+            data_views={"dv_001", "dv_002"},
+        ),
+        "metric/isolated/1": ComponentInfo(
+            component_id="metric/isolated/1",
+            component_type="metric",
+            name="Isolated Metric",
+            data_views={"dv_003"},
+        ),
+        "dimension/core/1": ComponentInfo(
+            component_id="dimension/core/1",
+            component_type="dimension",
+            name="Core Dimension",
+            data_views={"dv_001", "dv_003"},
+        ),
+        "dimension/common/1": ComponentInfo(
+            component_id="dimension/common/1",
+            component_type="dimension",
+            name="Common Dimension",
+            data_views={"dv_001", "dv_002"},
+        ),
+        "dimension/limited/1": ComponentInfo(
+            component_id="dimension/limited/1",
+            component_type="dimension",
+            name="Limited Dimension",
+            data_views={"dv_001", "dv_002"},
+        ),
+        "dimension/isolated/1": ComponentInfo(
+            component_id="dimension/isolated/1",
+            component_type="dimension",
+            name="Isolated Dimension",
+            data_views={"dv_003"},
+        ),
+    }
+
+    similarity_pairs = [
+        SimilarityPair(
+            dv1_id="dv_001",
+            dv1_name="Primary Business Data View With A Very Long Name",
+            dv2_id="dv_003",
+            dv2_name="Tertiary Data View Also Quite Long",
+            jaccard_similarity=0.93,
+            shared_count=15,
+            union_count=18,
+            only_in_dv1=["metric/limited/1", "dimension/common/1", "metric/common/1", "metric/x"],
+            only_in_dv2=["metric/isolated/1", "dimension/isolated/1", "dimension/y", "metric/z"],
+            only_in_dv1_names={
+                "metric/limited/1": "Limited Metric",
+                "dimension/common/1": "Common Dimension",
+            },
+            only_in_dv2_names={
+                "metric/isolated/1": "Isolated Metric",
+                "dimension/isolated/1": "Isolated Dimension",
+            },
+        )
+    ]
+    similarity_pairs.extend(
+        [
+            SimilarityPair(
+                dv1_id=f"dv_{i:03d}",
+                dv1_name=f"Data View {i}",
+                dv2_id=f"dv_{i + 1:03d}",
+                dv2_name=f"Data View {i + 1}",
+                jaccard_similarity=0.90,
+                shared_count=20,
+                union_count=22,
+            )
+            for i in range(10, 31)
+        ]
+    )
+
+    clusters = [
+        DataViewCluster(
+            cluster_id=i,
+            cluster_name=f"Cluster {i}",
+            data_view_ids=[f"dv_{i:03d}", f"dv_{i + 100:03d}", f"dv_{i + 200:03d}", f"dv_{i + 300:03d}"],
+            data_view_names=[
+                f"Data View {i}",
+                f"Data View {i + 100}",
+                f"Data View {i + 200}",
+                f"Data View {i + 300}",
+            ],
+            cohesion_score=0.78,
+        )
+        for i in range(1, 12)
+    ]
+
+    owner_data = {
+        f"Owner {i}": {
+            "data_view_count": i,
+            "total_metrics": i * 10,
+            "total_dimensions": i * 5,
+            "avg_components_per_dv": float(i * 3),
+        }
+        for i in range(1, 18)
+    }
+
+    stale_components = [
+        {"pattern": "deprecated_prefix", "name": f"old_metric_{i}", "component_id": f"metric/old/{i}"}
+        for i in range(6)
+    ]
+    stale_components.extend(
+        [{"pattern": "legacy_suffix", "name": f"segment_{i}_old", "component_id": f"segment/old/{i}"} for i in range(3)]
+    )
+
+    recommendations = [
+        {
+            "severity": "high",
+            "reason": "A data view has many isolated components",
+            "data_view": "dv_001",
+            "data_view_name": "Primary Business Data View",
+        },
+        {
+            "severity": "medium",
+            "reason": "Two data views are highly similar",
+            "data_view_1": "dv_001",
+            "data_view_1_name": "Primary Business Data View",
+            "data_view_2": "dv_003",
+            "data_view_2_name": "Tertiary Data View",
+        },
+    ]
+
+    return OrgReportResult(
+        timestamp="2026-02-16T12:00:00+00:00",
+        org_id="test_org@AdobeOrg",
+        parameters=config,
+        data_view_summaries=summaries,
+        component_index=component_index,
+        distribution=distribution,
+        similarity_pairs=similarity_pairs,
+        recommendations=recommendations,
+        duration=12.34,
+        clusters=clusters,
+        is_sampled=True,
+        total_available_data_views=25,
+        governance_violations=[
+            {"message": "Duplicate threshold exceeded", "threshold": 5, "actual": 11},
+        ],
+        naming_audit={
+            "case_styles": {"snake_case": 9, "camelCase": 4, "UPPER_CASE": 2},
+            "total_components": 15,
+            "recommendations": [{"severity": "medium", "message": "Prefer snake_case for new components"}],
+        },
+        owner_summary={
+            "by_owner": owner_data,
+            "owners_sorted_by_dv_count": list(owner_data.keys()),
+        },
+        stale_components=stale_components,
+    )
+
+
+@patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "mock", None))
+@patch("cja_auto_sdr.generator.cjapy")
+def test_interactive_select_dataviews_retries_and_parses_ranges(mock_cjapy: Mock, _mock_config: Mock):
+    mock_cja = Mock()
+    mock_cja.getDataViews.return_value = _mock_data_views()
+    mock_cjapy.CJA.return_value = mock_cja
+
+    with patch("builtins.input", side_effect=["", "1-a", "10", "1,2-3"]):
+        selected = generator.interactive_select_dataviews(profile="dev")
+
+    assert selected == ["dv_001", "dv_002", "dv_003"]
+
+
+@patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "mock", None))
+@patch("cja_auto_sdr.generator.cjapy")
+def test_interactive_select_dataviews_cancelled(mock_cjapy: Mock, _mock_config: Mock):
+    mock_cja = Mock()
+    mock_cja.getDataViews.return_value = _mock_data_views()
+    mock_cjapy.CJA.return_value = mock_cja
+
+    with patch("builtins.input", side_effect=["q"]):
+        assert generator.interactive_select_dataviews(profile="dev") == []
+
+
+@patch("cja_auto_sdr.generator.configure_cjapy", return_value=(False, "bad credentials", None))
+def test_interactive_select_dataviews_config_failure(_mock_config: Mock):
+    assert generator.interactive_select_dataviews(config_file="bad.json") == []
+
+
+@patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "mock", None))
+@patch("cja_auto_sdr.generator.cjapy")
+def test_interactive_wizard_full_flow_with_retries(mock_cjapy: Mock, _mock_config: Mock):
+    mock_cja = Mock()
+    mock_cja.getDataViews.return_value = _mock_data_views()
+    mock_cjapy.CJA.return_value = mock_cja
+
+    user_inputs = [
+        "",
+        "2-1,5",
+        "1,2",
+        "99",
+        "",
+        "maybe",
+        "y",
+        "n",
+        "",
+        "",
+    ]
+    with patch("builtins.input", side_effect=user_inputs):
+        result = generator.interactive_wizard(profile="dev")
+
+    assert result is not None
+    assert result.data_view_ids == ["dv_001", "dv_002"]
+    assert result.output_format == "excel"
+    assert result.include_segments is True
+    assert result.include_calculated is False
+    assert result.include_derived is False
+
+
+@patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "mock", None))
+@patch("cja_auto_sdr.generator.cjapy")
+def test_interactive_wizard_cancelled_at_confirmation(mock_cjapy: Mock, _mock_config: Mock):
+    mock_cja = Mock()
+    mock_cja.getDataViews.return_value = _mock_data_views()
+    mock_cjapy.CJA.return_value = mock_cja
+
+    user_inputs = ["1", "1", "n", "n", "n", "n"]
+    with patch("builtins.input", side_effect=user_inputs):
+        assert generator.interactive_wizard(profile="dev") is None
+
+
+@patch("cja_auto_sdr.generator.configure_cjapy", return_value=(False, "bad credentials", None))
+def test_interactive_wizard_config_failure(_mock_config: Mock):
+    assert generator.interactive_wizard(config_file="bad.json") is None
+
+
+def test_write_org_report_console_renders_all_major_sections(capsys):
+    result = _build_rich_result()
+    generator.write_org_report_console(result, result.parameters, quiet=False)
+    output = capsys.readouterr().out
+
+    assert "ORG-WIDE COMPONENT ANALYSIS REPORT" in output
+    assert "[SAMPLED]" in output
+    assert "DATA VIEWS" in output
+    assert "COMPONENT SUMMARY" in output
+    assert "HIGH OVERLAP PAIRS" in output
+    assert "DATA VIEW CLUSTERS" in output
+    assert "GOVERNANCE VIOLATIONS" in output
+    assert "OWNER SUMMARY" in output
+    assert "NAMING AUDIT" in output
+    assert "STALE COMPONENTS" in output
+    assert "RECOMMENDATIONS" in output
+
+
+def test_write_org_report_stats_and_comparison_consoles(capsys):
+    result = _build_rich_result()
+    generator.write_org_report_stats_only(result, quiet=False)
+
+    comparison = OrgReportComparison(
+        current_timestamp="2026-02-16T12:00:00+00:00",
+        previous_timestamp="2026-02-01T12:00:00+00:00",
+        data_views_added=["dv_new_1", "dv_new_2", "dv_new_3", "dv_new_4", "dv_new_5", "dv_new_6"],
+        data_views_removed=["dv_old_1", "dv_old_2", "dv_old_3", "dv_old_4", "dv_old_5", "dv_old_6"],
+        data_views_added_names=["New 1", "New 2", "New 3", "New 4", "New 5", "New 6"],
+        data_views_removed_names=["Old 1", "Old 2", "Old 3", "Old 4", "Old 5", "Old 6"],
+        new_high_similarity_pairs=[{"dv1_id": "dv_a", "dv2_id": "dv_b"}],
+        resolved_pairs=[{"dv1_id": "dv_x", "dv2_id": "dv_y"}],
+        summary={"data_views_delta": 5, "components_delta": -3, "core_delta": 2, "isolated_delta": 0},
+    )
+    generator.write_org_report_comparison_console(comparison, quiet=False)
+    output = capsys.readouterr().out
+
+    assert "ORG STATS" in output
+    assert "ORG REPORT COMPARISON (TRENDING)" in output
+    assert "Data Views Added" in output
+    assert "Resolved High-Similarity Pairs" in output
+
+
+def test_write_org_report_file_outputs_all_formats(tmp_path: Path):
+    result = _build_rich_result()
+    logger = logging.getLogger("test_org_report_outputs")
+
+    json_path = generator.write_org_report_json(result, tmp_path / "org_report", str(tmp_path), logger)
+    excel_path = generator.write_org_report_excel(result, tmp_path / "org_report", str(tmp_path), logger)
+    markdown_path = generator.write_org_report_markdown(result, tmp_path / "org_report", str(tmp_path), logger)
+    html_path = generator.write_org_report_html(result, tmp_path / "org_report", str(tmp_path), logger)
+    csv_dir = generator.write_org_report_csv(result, tmp_path / "org_report.csv", str(tmp_path), logger)
+
+    assert Path(json_path).exists()
+    assert Path(excel_path).exists()
+    assert Path(markdown_path).exists()
+    assert Path(html_path).exists()
+    assert Path(csv_dir).is_dir()
+    assert (Path(csv_dir) / "org_report_summary.csv").exists()
+    assert (Path(csv_dir) / "org_report_data_views.csv").exists()
+    assert (Path(csv_dir) / "org_report_components.csv").exists()
+    assert (Path(csv_dir) / "org_report_distribution.csv").exists()
+    assert (Path(csv_dir) / "org_report_similarity.csv").exists()
+    assert (Path(csv_dir) / "org_report_recommendations.csv").exists()
+
+
+def test_org_report_branches_for_core_min_count_and_quiet_modes(capsys):
+    result = _build_rich_result()
+    result.parameters.core_min_count = 2
+    result.is_sampled = False
+
+    comparison = OrgReportComparison(
+        current_timestamp="2026-02-16T12:00:00+00:00",
+        previous_timestamp="2026-02-15T12:00:00+00:00",
+        summary={"data_views_delta": 0, "components_delta": 0, "core_delta": 0, "isolated_delta": 0},
+    )
+
+    generator.write_org_report_console(result, result.parameters, quiet=False)
+    out = capsys.readouterr().out
+    assert "Core (in >=2 DVs)" in out
+    assert "Data Views Analyzed: 2 / 3" in out
+
+    generator.write_org_report_stats_only(result, quiet=True)
+    generator.write_org_report_comparison_console(comparison, quiet=True)
+
+
+def test_run_org_report_all_formats_branch(tmp_path: Path):
+    result = _build_rich_result()
+    result.thresholds_exceeded = True
+    result.governance_violations = [{"message": "threshold exceeded"}]
+    org_config = OrgReportConfig(fail_on_threshold=True)
+
+    with (
+        patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "mock", {"org_id": "test_org@AdobeOrg"})),
+        patch("cja_auto_sdr.generator.cjapy") as mock_cjapy,
+        patch("cja_auto_sdr.generator.OrgComponentAnalyzer") as mock_analyzer_cls,
+        patch("cja_auto_sdr.generator.write_org_report_console") as mock_console,
+        patch("cja_auto_sdr.generator.write_org_report_json", return_value=str(tmp_path / "report.json")) as mock_json,
+        patch(
+            "cja_auto_sdr.generator.write_org_report_excel", return_value=str(tmp_path / "report.xlsx")
+        ) as mock_excel,
+        patch(
+            "cja_auto_sdr.generator.write_org_report_markdown", return_value=str(tmp_path / "report.md")
+        ) as mock_markdown,
+        patch("cja_auto_sdr.generator.write_org_report_html", return_value=str(tmp_path / "report.html")) as mock_html,
+        patch("cja_auto_sdr.generator.write_org_report_csv", return_value=str(tmp_path / "report_csv")) as mock_csv,
+        patch("cja_auto_sdr.generator.build_org_step_summary", return_value="summary"),
+        patch("cja_auto_sdr.generator.append_github_step_summary") as mock_append_summary,
+    ):
+        mock_cjapy.CJA.return_value = Mock()
+        mock_analyzer = Mock()
+        mock_analyzer.run_analysis.return_value = result
+        mock_analyzer_cls.return_value = mock_analyzer
+
+        success, thresholds_exceeded = generator.run_org_report(
+            config_file="config.json",
+            output_format="all",
+            output_path=str(tmp_path / "org_output"),
+            output_dir=str(tmp_path),
+            org_config=org_config,
+            profile="dev",
+            quiet=False,
+        )
+
+    assert success is True
+    assert thresholds_exceeded is True
+    mock_console.assert_called_once()
+    mock_json.assert_called_once()
+    mock_excel.assert_called_once()
+    mock_markdown.assert_called_once()
+    mock_html.assert_called_once()
+    mock_csv.assert_called_once()
+    mock_append_summary.assert_called_once()
+
+
+def test_run_org_report_stats_only_and_csv_stdout_guard(tmp_path: Path):
+    result = _build_rich_result()
+
+    stats_config = OrgReportConfig(org_stats_only=True)
+    with (
+        patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "mock", {"org_id": "test_org@AdobeOrg"})),
+        patch("cja_auto_sdr.generator.cjapy") as mock_cjapy,
+        patch("cja_auto_sdr.generator.OrgComponentAnalyzer") as mock_analyzer_cls,
+        patch("cja_auto_sdr.generator.write_org_report_stats_only") as mock_stats_only,
+        patch("cja_auto_sdr.generator.write_org_report_json", return_value=str(tmp_path / "stats.json")) as mock_json,
+        patch("cja_auto_sdr.generator.build_org_step_summary", return_value="summary"),
+        patch("cja_auto_sdr.generator.append_github_step_summary"),
+    ):
+        mock_cjapy.CJA.return_value = Mock()
+        mock_analyzer = Mock()
+        mock_analyzer.run_analysis.return_value = result
+        mock_analyzer_cls.return_value = mock_analyzer
+
+        success, thresholds_exceeded = generator.run_org_report(
+            config_file="config.json",
+            output_format="json",
+            output_path=str(tmp_path / "org_stats"),
+            output_dir=str(tmp_path),
+            org_config=stats_config,
+            profile=None,
+            quiet=False,
+        )
+
+    assert success is True
+    assert thresholds_exceeded is False
+    mock_stats_only.assert_called_once()
+    mock_json.assert_called_once()
+
+    csv_config = OrgReportConfig()
+    with (
+        patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "mock", {"org_id": "test_org@AdobeOrg"})),
+        patch("cja_auto_sdr.generator.cjapy") as mock_cjapy,
+        patch("cja_auto_sdr.generator.OrgComponentAnalyzer") as mock_analyzer_cls,
+        patch("cja_auto_sdr.generator.build_org_step_summary", return_value="summary"),
+        patch("cja_auto_sdr.generator.append_github_step_summary"),
+    ):
+        mock_cjapy.CJA.return_value = Mock()
+        mock_analyzer = Mock()
+        mock_analyzer.run_analysis.return_value = result
+        mock_analyzer_cls.return_value = mock_analyzer
+
+        success, thresholds_exceeded = generator.run_org_report(
+            config_file="config.json",
+            output_format="csv",
+            output_path="stdout",
+            output_dir=str(tmp_path),
+            org_config=csv_config,
+            quiet=False,
+        )
+
+    assert success is False
+    assert thresholds_exceeded is False
+
+
+def test_run_org_report_reports_alias_and_individual_format_branches(tmp_path: Path):
+    result = _build_rich_result()
+    base_output = tmp_path / "org_report_out"
+    common_patches = (
+        patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "mock", {"org_id": "test_org@AdobeOrg"})),
+        patch("cja_auto_sdr.generator.cjapy"),
+        patch("cja_auto_sdr.generator.OrgComponentAnalyzer"),
+        patch("cja_auto_sdr.generator.write_org_report_console", return_value=None),
+        patch("cja_auto_sdr.generator.write_org_report_json", return_value=str(tmp_path / "report.json")),
+        patch("cja_auto_sdr.generator.write_org_report_excel", return_value=str(tmp_path / "report.xlsx")),
+        patch("cja_auto_sdr.generator.write_org_report_markdown", return_value=str(tmp_path / "report.md")),
+        patch("cja_auto_sdr.generator.write_org_report_html", return_value=str(tmp_path / "report.html")),
+        patch("cja_auto_sdr.generator.write_org_report_csv", return_value=str(tmp_path / "report_csv")),
+        patch("cja_auto_sdr.generator.build_org_step_summary", return_value="summary"),
+        patch("cja_auto_sdr.generator.append_github_step_summary"),
+    )
+
+    with (
+        common_patches[0] as _cfg,
+        common_patches[1] as mock_cjapy,
+        common_patches[2] as mock_analyzer_cls,
+        common_patches[3],
+        common_patches[4],
+        common_patches[5],
+        common_patches[6],
+        common_patches[7],
+        common_patches[8],
+        common_patches[9],
+        common_patches[10],
+    ):
+        mock_cjapy.CJA.return_value = Mock()
+        analyzer = Mock()
+        analyzer.run_analysis.return_value = result
+        mock_analyzer_cls.return_value = analyzer
+
+        # Alias branch
+        ok, exceeded = generator.run_org_report(
+            config_file="config.json",
+            output_format="reports",
+            output_path=str(base_output),
+            output_dir=str(tmp_path),
+            org_config=OrgReportConfig(),
+            quiet=False,
+        )
+        assert ok is True
+        assert exceeded is False
+
+        # Single-format branches
+        for fmt in ("console", "json", "excel", "markdown", "html", "csv"):
+            ok, exceeded = generator.run_org_report(
+                config_file="config.json",
+                output_format=fmt,
+                output_path=str(base_output),
+                output_dir=str(tmp_path),
+                org_config=OrgReportConfig(),
+                quiet=False,
+            )
+            assert ok is True
+            assert exceeded is False
+
+
+def test_run_org_report_cache_and_comparison_error_paths(tmp_path: Path):
+    result = _build_rich_result()
+    config = OrgReportConfig(use_cache=True, compare_org_report="missing_previous.json")
+
+    with (
+        patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "mock", {"org_id": "test_org@AdobeOrg"})),
+        patch("cja_auto_sdr.generator.cjapy") as mock_cjapy,
+        patch("cja_auto_sdr.generator.OrgReportCache") as mock_cache_cls,
+        patch("cja_auto_sdr.generator.OrgComponentAnalyzer") as mock_analyzer_cls,
+        patch("cja_auto_sdr.generator.compare_org_reports", side_effect=FileNotFoundError),
+        patch("cja_auto_sdr.generator.write_org_report_console"),
+        patch("cja_auto_sdr.generator.build_org_step_summary", return_value="summary"),
+        patch("cja_auto_sdr.generator.append_github_step_summary"),
+    ):
+        mock_cjapy.CJA.return_value = Mock()
+        cache = Mock()
+        cache.get_stats.return_value = {"entries": 3}
+        mock_cache_cls.return_value = cache
+
+        analyzer = Mock()
+        analyzer.run_analysis.return_value = result
+        mock_analyzer_cls.return_value = analyzer
+
+        ok, exceeded = generator.run_org_report(
+            config_file="config.json",
+            output_format="console",
+            output_path=None,
+            output_dir=str(tmp_path),
+            org_config=config,
+            quiet=False,
+        )
+
+    assert ok is True
+    assert exceeded is False
+
+
+def test_run_org_report_failure_paths(tmp_path: Path):
+    with patch("cja_auto_sdr.generator.configure_cjapy", return_value=(False, "bad credentials", None)):
+        ok, exceeded = generator.run_org_report(
+            config_file="config.json",
+            output_format="console",
+            output_path=None,
+            output_dir=str(tmp_path),
+            org_config=OrgReportConfig(),
+            quiet=False,
+        )
+    assert ok is False
+    assert exceeded is False
+
+    empty_result = _build_rich_result()
+    empty_result.data_view_summaries = []
+    with (
+        patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "mock", {"org_id": "test_org@AdobeOrg"})),
+        patch("cja_auto_sdr.generator.cjapy") as mock_cjapy,
+        patch("cja_auto_sdr.generator.OrgComponentAnalyzer") as mock_analyzer_cls,
+    ):
+        mock_cjapy.CJA.return_value = Mock()
+        analyzer = Mock()
+        analyzer.run_analysis.return_value = empty_result
+        mock_analyzer_cls.return_value = analyzer
+
+        ok, exceeded = generator.run_org_report(
+            config_file="config.json",
+            output_format="console",
+            output_path=None,
+            output_dir=str(tmp_path),
+            org_config=OrgReportConfig(),
+            quiet=False,
+        )
+    assert ok is False
+    assert exceeded is False
+
+    with (
+        patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "mock", {"org_id": "test_org@AdobeOrg"})),
+        patch("cja_auto_sdr.generator.cjapy") as mock_cjapy,
+        patch("cja_auto_sdr.generator.OrgComponentAnalyzer") as mock_analyzer_cls,
+    ):
+        mock_cjapy.CJA.return_value = Mock()
+        analyzer = Mock()
+        analyzer.run_analysis.side_effect = RuntimeError("analysis failed")
+        mock_analyzer_cls.return_value = analyzer
+
+        ok, exceeded = generator.run_org_report(
+            config_file="config.json",
+            output_format="console",
+            output_path=None,
+            output_dir=str(tmp_path),
+            org_config=OrgReportConfig(),
+            quiet=False,
+        )
+    assert ok is False
+    assert exceeded is False
+
+
+def test_run_org_report_org_stats_json_stdout_branch(tmp_path: Path, capsys):
+    result = _build_rich_result()
+    config = OrgReportConfig(org_stats_only=True)
+
+    with (
+        patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "mock", {"org_id": "test_org@AdobeOrg"})),
+        patch("cja_auto_sdr.generator.cjapy") as mock_cjapy,
+        patch("cja_auto_sdr.generator.OrgComponentAnalyzer") as mock_analyzer_cls,
+        patch("cja_auto_sdr.generator.write_org_report_stats_only"),
+        patch("cja_auto_sdr.generator.build_org_step_summary", return_value="summary"),
+        patch("cja_auto_sdr.generator.append_github_step_summary"),
+    ):
+        mock_cjapy.CJA.return_value = Mock()
+        analyzer = Mock()
+        analyzer.run_analysis.return_value = result
+        mock_analyzer_cls.return_value = analyzer
+
+        ok, exceeded = generator.run_org_report(
+            config_file="config.json",
+            output_format="json",
+            output_path="stdout",
+            output_dir=str(tmp_path),
+            org_config=config,
+            quiet=False,
+        )
+
+    stdout = capsys.readouterr().out
+    assert ok is True
+    assert exceeded is False
+    assert '"report_type": "org_analysis"' in stdout
+
+
+def test_org_report_renderers_core_min_count_and_unnamed_component_branches(tmp_path: Path, capsys):
+    result = _build_rich_result()
+    result.parameters.core_min_count = 3
+
+    # Force markdown/html/console branches that depend on unnamed components and large core lists.
+    # This exercises the "more rows" truncation and no-name formatting paths.
+    result.distribution.core_metrics = [f"metric/core_extra/{i}" for i in range(25)]
+    result.distribution.core_dimensions = [f"dimension/core_extra/{i}" for i in range(25)]
+    result.similarity_pairs = []
+
+    for comp_id in result.distribution.core_metrics:
+        result.component_index[comp_id] = ComponentInfo(
+            component_id=comp_id,
+            component_type="metric",
+            name=None,
+            data_views={"dv_001", "dv_003"},
+        )
+    for comp_id in result.distribution.core_dimensions:
+        result.component_index[comp_id] = ComponentInfo(
+            component_id=comp_id,
+            component_type="dimension",
+            name=None,
+            data_views={"dv_001", "dv_003"},
+        )
+
+    logger = logging.getLogger("test_org_report_renderer_branches")
+    md_path = generator.write_org_report_markdown(result, tmp_path / "core_min", str(tmp_path), logger)
+    html_path = generator.write_org_report_html(result, tmp_path / "core_min_html", str(tmp_path), logger)
+    generator.write_org_report_console(result, result.parameters, quiet=False)
+    output = capsys.readouterr().out
+
+    assert Path(md_path).exists()
+    assert Path(html_path).exists()
+    assert "Core (in >=3 DVs)" in output
+
+
+def test_run_org_report_defensive_unsupported_format_fallback(tmp_path: Path):
+    result = _build_rich_result()
+    with (
+        patch("cja_auto_sdr.generator._validate_org_report_output_request", return_value=True),
+        patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "mock", {"org_id": "test_org@AdobeOrg"})),
+        patch("cja_auto_sdr.generator.cjapy") as mock_cjapy,
+        patch("cja_auto_sdr.generator.OrgComponentAnalyzer") as mock_analyzer_cls,
+    ):
+        mock_cjapy.CJA.return_value = Mock()
+        analyzer = Mock()
+        analyzer.run_analysis.return_value = result
+        mock_analyzer_cls.return_value = analyzer
+
+        ok, exceeded = generator.run_org_report(
+            config_file="config.json",
+            output_format="unsupported_internal_mode",
+            output_path=None,
+            output_dir=str(tmp_path),
+            org_config=OrgReportConfig(),
+            quiet=False,
+        )
+
+    assert ok is False
+    assert exceeded is False
+
+
+def test_run_org_report_data_alias_and_internal_csv_stdout_branch(tmp_path: Path):
+    result = _build_rich_result()
+    with (
+        patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "mock", {"org_id": "test_org@AdobeOrg"})),
+        patch("cja_auto_sdr.generator.cjapy") as mock_cjapy,
+        patch("cja_auto_sdr.generator.OrgComponentAnalyzer") as mock_analyzer_cls,
+        patch("cja_auto_sdr.generator.write_org_report_json", return_value=str(tmp_path / "report.json")) as mock_json,
+        patch("cja_auto_sdr.generator.write_org_report_csv", return_value=str(tmp_path / "report_csv")) as mock_csv,
+        patch("cja_auto_sdr.generator.build_org_step_summary", return_value="summary"),
+        patch("cja_auto_sdr.generator.append_github_step_summary"),
+    ):
+        mock_cjapy.CJA.return_value = Mock()
+        analyzer = Mock()
+        analyzer.run_analysis.return_value = result
+        mock_analyzer_cls.return_value = analyzer
+
+        ok, exceeded = generator.run_org_report(
+            config_file="config.json",
+            output_format="data",
+            output_path=str(tmp_path / "org_data"),
+            output_dir=str(tmp_path),
+            org_config=OrgReportConfig(),
+            quiet=False,
+        )
+    assert ok is True
+    assert exceeded is False
+    mock_json.assert_called()
+    mock_csv.assert_called()
+
+    # Internal defensive CSV-stdout branch (normally blocked by upfront validation).
+    with (
+        patch("cja_auto_sdr.generator._validate_org_report_output_request", return_value=True),
+        patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "mock", {"org_id": "test_org@AdobeOrg"})),
+        patch("cja_auto_sdr.generator.cjapy") as mock_cjapy,
+        patch("cja_auto_sdr.generator.OrgComponentAnalyzer") as mock_analyzer_cls,
+    ):
+        mock_cjapy.CJA.return_value = Mock()
+        analyzer = Mock()
+        analyzer.run_analysis.return_value = result
+        mock_analyzer_cls.return_value = analyzer
+        ok, exceeded = generator.run_org_report(
+            config_file="config.json",
+            output_format="csv",
+            output_path="stdout",
+            output_dir=str(tmp_path),
+            org_config=OrgReportConfig(),
+            quiet=False,
+        )
+    assert ok is False
+    assert exceeded is False
+
+
+def test_run_org_report_file_not_found_and_keyboard_interrupt_paths(tmp_path: Path):
+    with patch("cja_auto_sdr.generator.configure_cjapy", side_effect=FileNotFoundError):
+        ok, exceeded = generator.run_org_report(
+            config_file="missing.json",
+            output_format="console",
+            output_path=None,
+            output_dir=str(tmp_path),
+            org_config=OrgReportConfig(),
+            quiet=False,
+        )
+    assert ok is False
+    assert exceeded is False
+
+    with (
+        patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "mock", {"org_id": "test_org@AdobeOrg"})),
+        patch("cja_auto_sdr.generator.cjapy") as mock_cjapy,
+        patch("cja_auto_sdr.generator.OrgComponentAnalyzer") as mock_analyzer_cls,
+    ):
+        mock_cjapy.CJA.return_value = Mock()
+        analyzer = Mock()
+        analyzer.run_analysis.side_effect = KeyboardInterrupt
+        mock_analyzer_cls.return_value = analyzer
+        with pytest.raises(KeyboardInterrupt):
+            generator.run_org_report(
+                config_file="config.json",
+                output_format="console",
+                output_path=None,
+                output_dir=str(tmp_path),
+                org_config=OrgReportConfig(),
+                quiet=False,
+            )
+
+
+def test_recommendation_context_and_normalization_helpers():
+    rec = {
+        "data_view_name": "Primary",
+        "data_view": "dv_1",
+        "data_view_1_name": "Left",
+        "data_view_1": "dv_left",
+        "similarity": 0.88,
+        "isolated_count": 4,
+        "derived_count": 2,
+        "total_count": 10,
+        "count": 5,
+        "drift_count": 1,
+        "ratio": 0.4,
+        "modified": "2026-02-10T00:00:00+00:00",
+    }
+    entries = generator._format_recommendation_context_entries(rec)
+    assert ("Data View", "Primary (dv_1)") in entries
+    assert ("Pair", "Left (dv_left)") in entries
+    assert ("Similarity", "88.0%") in entries
+    assert ("Isolated Count", "4") in entries
+    assert ("Derived Count", "2") in entries
+    assert ("Total Count", "10") in entries
+    assert ("Count", "5") in entries
+    assert ("Drift Count", "1") in entries
+    assert ("Ratio", "40.0%") in entries
+    assert ("Last Modified", "2026-02-10T00:00:00+00:00") in entries
+
+    assert generator._normalize_recommendation_severity("HIGH") == "high"
+    assert generator._normalize_recommendation_severity("unexpected") == "low"
+
+    normalized = generator._normalize_recommendation_for_json("raw text recommendation")
+    assert normalized["type"] == "unknown"
+    assert normalized["severity"] == "low"
+    assert "raw text recommendation" in normalized["reason"]
+
+    flattened = generator._flatten_recommendation_for_tabular(
+        {"type": "naming", "severity": "MEDIUM", "reason": "Use one style", "custom_field": {"x": 1}}
+    )
+    assert flattened["Severity"] == "medium"
+    assert "custom_field" in flattened["Extra Details"]

--- a/tests/test_generator_interactive_and_console.py
+++ b/tests/test_generator_interactive_and_console.py
@@ -3,22 +3,14 @@
 from __future__ import annotations
 
 import logging
+from contextlib import ExitStack
 from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
 
 from cja_auto_sdr import generator
-from cja_auto_sdr.org.models import (
-    ComponentDistribution,
-    ComponentInfo,
-    DataViewCluster,
-    DataViewSummary,
-    OrgReportComparison,
-    OrgReportConfig,
-    OrgReportResult,
-    SimilarityPair,
-)
+from cja_auto_sdr.org.models import ComponentInfo, OrgReportComparison, OrgReportConfig
 
 
 def _mock_data_views() -> list[dict[str, object]]:
@@ -27,243 +19,6 @@ def _mock_data_views() -> list[dict[str, object]]:
         {"id": "dv_002", "name": "Product DV", "owner": {"name": "Bob"}},
         {"id": "dv_003", "name": "Finance DV", "owner": {"name": "Carol"}},
     ]
-
-
-def _build_rich_result() -> OrgReportResult:
-    config = OrgReportConfig(
-        core_threshold=0.5,
-        include_metadata=True,
-        overlap_threshold=0.95,
-        summary_only=False,
-        include_component_types=True,
-        include_drift=True,
-    )
-
-    summaries = [
-        DataViewSummary(
-            data_view_id="dv_001",
-            data_view_name="Primary Business Data View With A Long Name",
-            metric_ids={"metric/core/1", "metric/common/1", "metric/limited/1"},
-            dimension_ids={"dimension/core/1", "dimension/common/1"},
-            metric_count=3,
-            dimension_count=2,
-            standard_metric_count=2,
-            derived_metric_count=1,
-            standard_dimension_count=1,
-            derived_dimension_count=1,
-            owner="Alice",
-            owner_id="owner_1",
-            created="2026-01-01T00:00:00+00:00",
-            modified="2026-02-15T10:00:00+00:00",
-            has_description=True,
-        ),
-        DataViewSummary(
-            data_view_id="dv_002",
-            data_view_name="Secondary Data View",
-            metric_count=0,
-            dimension_count=0,
-            error="permission denied",
-            status="error",
-        ),
-        DataViewSummary(
-            data_view_id="dv_003",
-            data_view_name="Tertiary Data View",
-            metric_ids={"metric/core/2", "metric/isolated/1"},
-            dimension_ids={"dimension/isolated/1"},
-            metric_count=2,
-            dimension_count=1,
-            standard_metric_count=1,
-            derived_metric_count=1,
-            standard_dimension_count=1,
-            derived_dimension_count=0,
-            owner="Carol",
-            owner_id="owner_3",
-            created="2026-01-03T00:00:00+00:00",
-            modified="2026-02-15T11:00:00+00:00",
-        ),
-    ]
-
-    distribution = ComponentDistribution(
-        core_metrics=["metric/core/1", "metric/core/2"],
-        core_dimensions=["dimension/core/1"],
-        common_metrics=["metric/common/1"],
-        common_dimensions=["dimension/common/1"],
-        limited_metrics=["metric/limited/1"],
-        limited_dimensions=["dimension/limited/1"],
-        isolated_metrics=["metric/isolated/1"],
-        isolated_dimensions=["dimension/isolated/1"],
-    )
-
-    component_index = {
-        "metric/core/1": ComponentInfo(
-            component_id="metric/core/1",
-            component_type="metric",
-            name="Core Metric One",
-            data_views={"dv_001", "dv_003"},
-        ),
-        "metric/core/2": ComponentInfo(
-            component_id="metric/core/2",
-            component_type="metric",
-            name="Core Metric Two",
-            data_views={"dv_001", "dv_003"},
-        ),
-        "metric/common/1": ComponentInfo(
-            component_id="metric/common/1",
-            component_type="metric",
-            name="Common Metric",
-            data_views={"dv_001", "dv_002"},
-        ),
-        "metric/limited/1": ComponentInfo(
-            component_id="metric/limited/1",
-            component_type="metric",
-            name="Limited Metric",
-            data_views={"dv_001", "dv_002"},
-        ),
-        "metric/isolated/1": ComponentInfo(
-            component_id="metric/isolated/1",
-            component_type="metric",
-            name="Isolated Metric",
-            data_views={"dv_003"},
-        ),
-        "dimension/core/1": ComponentInfo(
-            component_id="dimension/core/1",
-            component_type="dimension",
-            name="Core Dimension",
-            data_views={"dv_001", "dv_003"},
-        ),
-        "dimension/common/1": ComponentInfo(
-            component_id="dimension/common/1",
-            component_type="dimension",
-            name="Common Dimension",
-            data_views={"dv_001", "dv_002"},
-        ),
-        "dimension/limited/1": ComponentInfo(
-            component_id="dimension/limited/1",
-            component_type="dimension",
-            name="Limited Dimension",
-            data_views={"dv_001", "dv_002"},
-        ),
-        "dimension/isolated/1": ComponentInfo(
-            component_id="dimension/isolated/1",
-            component_type="dimension",
-            name="Isolated Dimension",
-            data_views={"dv_003"},
-        ),
-    }
-
-    similarity_pairs = [
-        SimilarityPair(
-            dv1_id="dv_001",
-            dv1_name="Primary Business Data View With A Very Long Name",
-            dv2_id="dv_003",
-            dv2_name="Tertiary Data View Also Quite Long",
-            jaccard_similarity=0.93,
-            shared_count=15,
-            union_count=18,
-            only_in_dv1=["metric/limited/1", "dimension/common/1", "metric/common/1", "metric/x"],
-            only_in_dv2=["metric/isolated/1", "dimension/isolated/1", "dimension/y", "metric/z"],
-            only_in_dv1_names={
-                "metric/limited/1": "Limited Metric",
-                "dimension/common/1": "Common Dimension",
-            },
-            only_in_dv2_names={
-                "metric/isolated/1": "Isolated Metric",
-                "dimension/isolated/1": "Isolated Dimension",
-            },
-        )
-    ]
-    similarity_pairs.extend(
-        [
-            SimilarityPair(
-                dv1_id=f"dv_{i:03d}",
-                dv1_name=f"Data View {i}",
-                dv2_id=f"dv_{i + 1:03d}",
-                dv2_name=f"Data View {i + 1}",
-                jaccard_similarity=0.90,
-                shared_count=20,
-                union_count=22,
-            )
-            for i in range(10, 31)
-        ]
-    )
-
-    clusters = [
-        DataViewCluster(
-            cluster_id=i,
-            cluster_name=f"Cluster {i}",
-            data_view_ids=[f"dv_{i:03d}", f"dv_{i + 100:03d}", f"dv_{i + 200:03d}", f"dv_{i + 300:03d}"],
-            data_view_names=[
-                f"Data View {i}",
-                f"Data View {i + 100}",
-                f"Data View {i + 200}",
-                f"Data View {i + 300}",
-            ],
-            cohesion_score=0.78,
-        )
-        for i in range(1, 12)
-    ]
-
-    owner_data = {
-        f"Owner {i}": {
-            "data_view_count": i,
-            "total_metrics": i * 10,
-            "total_dimensions": i * 5,
-            "avg_components_per_dv": float(i * 3),
-        }
-        for i in range(1, 18)
-    }
-
-    stale_components = [
-        {"pattern": "deprecated_prefix", "name": f"old_metric_{i}", "component_id": f"metric/old/{i}"} for i in range(6)
-    ]
-    stale_components.extend(
-        [{"pattern": "legacy_suffix", "name": f"segment_{i}_old", "component_id": f"segment/old/{i}"} for i in range(3)]
-    )
-
-    recommendations = [
-        {
-            "severity": "high",
-            "reason": "A data view has many isolated components",
-            "data_view": "dv_001",
-            "data_view_name": "Primary Business Data View",
-        },
-        {
-            "severity": "medium",
-            "reason": "Two data views are highly similar",
-            "data_view_1": "dv_001",
-            "data_view_1_name": "Primary Business Data View",
-            "data_view_2": "dv_003",
-            "data_view_2_name": "Tertiary Data View",
-        },
-    ]
-
-    return OrgReportResult(
-        timestamp="2026-02-16T12:00:00+00:00",
-        org_id="test_org@AdobeOrg",
-        parameters=config,
-        data_view_summaries=summaries,
-        component_index=component_index,
-        distribution=distribution,
-        similarity_pairs=similarity_pairs,
-        recommendations=recommendations,
-        duration=12.34,
-        clusters=clusters,
-        is_sampled=True,
-        total_available_data_views=25,
-        governance_violations=[
-            {"message": "Duplicate threshold exceeded", "threshold": 5, "actual": 11},
-        ],
-        naming_audit={
-            "case_styles": {"snake_case": 9, "camelCase": 4, "UPPER_CASE": 2},
-            "total_components": 15,
-            "recommendations": [{"severity": "medium", "message": "Prefer snake_case for new components"}],
-        },
-        owner_summary={
-            "by_owner": owner_data,
-            "owners_sorted_by_dv_count": list(owner_data.keys()),
-        },
-        stale_components=stale_components,
-    )
 
 
 @patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "mock", None))
@@ -342,8 +97,8 @@ def test_interactive_wizard_config_failure(_mock_config: Mock):
     assert generator.interactive_wizard(config_file="bad.json") is None
 
 
-def test_write_org_report_console_renders_all_major_sections(capsys):
-    result = _build_rich_result()
+def test_write_org_report_console_renders_all_major_sections(capsys, rich_org_report_result):
+    result = rich_org_report_result
     generator.write_org_report_console(result, result.parameters, quiet=False)
     output = capsys.readouterr().out
 
@@ -360,8 +115,8 @@ def test_write_org_report_console_renders_all_major_sections(capsys):
     assert "RECOMMENDATIONS" in output
 
 
-def test_write_org_report_stats_and_comparison_consoles(capsys):
-    result = _build_rich_result()
+def test_write_org_report_stats_and_comparison_consoles(capsys, rich_org_report_result):
+    result = rich_org_report_result
     generator.write_org_report_stats_only(result, quiet=False)
 
     comparison = OrgReportComparison(
@@ -384,8 +139,8 @@ def test_write_org_report_stats_and_comparison_consoles(capsys):
     assert "Resolved High-Similarity Pairs" in output
 
 
-def test_write_org_report_file_outputs_all_formats(tmp_path: Path):
-    result = _build_rich_result()
+def test_write_org_report_file_outputs_all_formats(tmp_path: Path, rich_org_report_result):
+    result = rich_org_report_result
     logger = logging.getLogger("test_org_report_outputs")
 
     json_path = generator.write_org_report_json(result, tmp_path / "org_report", str(tmp_path), logger)
@@ -407,8 +162,8 @@ def test_write_org_report_file_outputs_all_formats(tmp_path: Path):
     assert (Path(csv_dir) / "org_report_recommendations.csv").exists()
 
 
-def test_org_report_branches_for_core_min_count_and_quiet_modes(capsys):
-    result = _build_rich_result()
+def test_org_report_branches_for_core_min_count_and_quiet_modes(capsys, rich_org_report_result):
+    result = rich_org_report_result
     result.parameters.core_min_count = 2
     result.is_sampled = False
 
@@ -427,8 +182,8 @@ def test_org_report_branches_for_core_min_count_and_quiet_modes(capsys):
     generator.write_org_report_comparison_console(comparison, quiet=True)
 
 
-def test_run_org_report_all_formats_branch(tmp_path: Path):
-    result = _build_rich_result()
+def test_run_org_report_all_formats_branch(tmp_path: Path, rich_org_report_result):
+    result = rich_org_report_result
     result.thresholds_exceeded = True
     result.governance_violations = [{"message": "threshold exceeded"}]
     org_config = OrgReportConfig(fail_on_threshold=True)
@@ -476,8 +231,8 @@ def test_run_org_report_all_formats_branch(tmp_path: Path):
     mock_append_summary.assert_called_once()
 
 
-def test_run_org_report_stats_only_and_csv_stdout_guard(tmp_path: Path):
-    result = _build_rich_result()
+def test_run_org_report_stats_only_and_csv_stdout_guard(tmp_path: Path, rich_org_report_result):
+    result = rich_org_report_result
 
     stats_config = OrgReportConfig(org_stats_only=True)
     with (
@@ -535,36 +290,29 @@ def test_run_org_report_stats_only_and_csv_stdout_guard(tmp_path: Path):
     assert thresholds_exceeded is False
 
 
-def test_run_org_report_reports_alias_and_individual_format_branches(tmp_path: Path):
-    result = _build_rich_result()
+def test_run_org_report_reports_alias_and_individual_format_branches(tmp_path: Path, rich_org_report_result):
+    result = rich_org_report_result
     base_output = tmp_path / "org_report_out"
-    common_patches = (
-        patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "mock", {"org_id": "test_org@AdobeOrg"})),
-        patch("cja_auto_sdr.generator.cjapy"),
-        patch("cja_auto_sdr.generator.OrgComponentAnalyzer"),
-        patch("cja_auto_sdr.generator.write_org_report_console", return_value=None),
-        patch("cja_auto_sdr.generator.write_org_report_json", return_value=str(tmp_path / "report.json")),
-        patch("cja_auto_sdr.generator.write_org_report_excel", return_value=str(tmp_path / "report.xlsx")),
-        patch("cja_auto_sdr.generator.write_org_report_markdown", return_value=str(tmp_path / "report.md")),
-        patch("cja_auto_sdr.generator.write_org_report_html", return_value=str(tmp_path / "report.html")),
-        patch("cja_auto_sdr.generator.write_org_report_csv", return_value=str(tmp_path / "report_csv")),
-        patch("cja_auto_sdr.generator.build_org_step_summary", return_value="summary"),
-        patch("cja_auto_sdr.generator.append_github_step_summary"),
-    )
 
-    with (
-        common_patches[0] as _cfg,
-        common_patches[1] as mock_cjapy,
-        common_patches[2] as mock_analyzer_cls,
-        common_patches[3],
-        common_patches[4],
-        common_patches[5],
-        common_patches[6],
-        common_patches[7],
-        common_patches[8],
-        common_patches[9],
-        common_patches[10],
-    ):
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "mock", {"org_id": "test_org@AdobeOrg"}))
+        )
+        mock_cjapy = stack.enter_context(patch("cja_auto_sdr.generator.cjapy"))
+        mock_analyzer_cls = stack.enter_context(patch("cja_auto_sdr.generator.OrgComponentAnalyzer"))
+        stack.enter_context(patch("cja_auto_sdr.generator.write_org_report_console", return_value=None))
+        stack.enter_context(patch("cja_auto_sdr.generator.write_org_report_json", return_value=str(tmp_path / "report.json")))
+        stack.enter_context(
+            patch("cja_auto_sdr.generator.write_org_report_excel", return_value=str(tmp_path / "report.xlsx"))
+        )
+        stack.enter_context(
+            patch("cja_auto_sdr.generator.write_org_report_markdown", return_value=str(tmp_path / "report.md"))
+        )
+        stack.enter_context(patch("cja_auto_sdr.generator.write_org_report_html", return_value=str(tmp_path / "report.html")))
+        stack.enter_context(patch("cja_auto_sdr.generator.write_org_report_csv", return_value=str(tmp_path / "report_csv")))
+        stack.enter_context(patch("cja_auto_sdr.generator.build_org_step_summary", return_value="summary"))
+        stack.enter_context(patch("cja_auto_sdr.generator.append_github_step_summary"))
+
         mock_cjapy.CJA.return_value = Mock()
         analyzer = Mock()
         analyzer.run_analysis.return_value = result
@@ -596,8 +344,8 @@ def test_run_org_report_reports_alias_and_individual_format_branches(tmp_path: P
             assert exceeded is False
 
 
-def test_run_org_report_cache_and_comparison_error_paths(tmp_path: Path):
-    result = _build_rich_result()
+def test_run_org_report_cache_and_comparison_error_paths(tmp_path: Path, rich_org_report_result):
+    result = rich_org_report_result
     config = OrgReportConfig(use_cache=True, compare_org_report="missing_previous.json")
 
     with (
@@ -632,7 +380,7 @@ def test_run_org_report_cache_and_comparison_error_paths(tmp_path: Path):
     assert exceeded is False
 
 
-def test_run_org_report_failure_paths(tmp_path: Path):
+def test_run_org_report_failure_paths(tmp_path: Path, rich_org_report_result):
     with patch("cja_auto_sdr.generator.configure_cjapy", return_value=(False, "bad credentials", None)):
         ok, exceeded = generator.run_org_report(
             config_file="config.json",
@@ -645,7 +393,7 @@ def test_run_org_report_failure_paths(tmp_path: Path):
     assert ok is False
     assert exceeded is False
 
-    empty_result = _build_rich_result()
+    empty_result = rich_org_report_result
     empty_result.data_view_summaries = []
     with (
         patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "mock", {"org_id": "test_org@AdobeOrg"})),
@@ -690,8 +438,8 @@ def test_run_org_report_failure_paths(tmp_path: Path):
     assert exceeded is False
 
 
-def test_run_org_report_org_stats_json_stdout_branch(tmp_path: Path, capsys):
-    result = _build_rich_result()
+def test_run_org_report_org_stats_json_stdout_branch(tmp_path: Path, capsys, rich_org_report_result):
+    result = rich_org_report_result
     config = OrgReportConfig(org_stats_only=True)
 
     with (
@@ -722,8 +470,8 @@ def test_run_org_report_org_stats_json_stdout_branch(tmp_path: Path, capsys):
     assert '"report_type": "org_analysis"' in stdout
 
 
-def test_org_report_renderers_core_min_count_and_unnamed_component_branches(tmp_path: Path, capsys):
-    result = _build_rich_result()
+def test_org_report_renderers_core_min_count_and_unnamed_component_branches(tmp_path: Path, capsys, rich_org_report_result):
+    result = rich_org_report_result
     result.parameters.core_min_count = 3
 
     # Force markdown/html/console branches that depend on unnamed components and large core lists.
@@ -758,8 +506,8 @@ def test_org_report_renderers_core_min_count_and_unnamed_component_branches(tmp_
     assert "Core (in >=3 DVs)" in output
 
 
-def test_run_org_report_defensive_unsupported_format_fallback(tmp_path: Path):
-    result = _build_rich_result()
+def test_run_org_report_defensive_unsupported_format_fallback(tmp_path: Path, rich_org_report_result):
+    result = rich_org_report_result
     with (
         patch("cja_auto_sdr.generator._validate_org_report_output_request", return_value=True),
         patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "mock", {"org_id": "test_org@AdobeOrg"})),
@@ -784,8 +532,8 @@ def test_run_org_report_defensive_unsupported_format_fallback(tmp_path: Path):
     assert exceeded is False
 
 
-def test_run_org_report_data_alias_and_internal_csv_stdout_branch(tmp_path: Path):
-    result = _build_rich_result()
+def test_run_org_report_data_alias_and_internal_csv_stdout_branch(tmp_path: Path, rich_org_report_result):
+    result = rich_org_report_result
     with (
         patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "mock", {"org_id": "test_org@AdobeOrg"})),
         patch("cja_auto_sdr.generator.cjapy") as mock_cjapy,

--- a/tests/test_generator_interactive_and_console.py
+++ b/tests/test_generator_interactive_and_console.py
@@ -214,8 +214,7 @@ def _build_rich_result() -> OrgReportResult:
     }
 
     stale_components = [
-        {"pattern": "deprecated_prefix", "name": f"old_metric_{i}", "component_id": f"metric/old/{i}"}
-        for i in range(6)
+        {"pattern": "deprecated_prefix", "name": f"old_metric_{i}", "component_id": f"metric/old/{i}"} for i in range(6)
     ]
     stale_components.extend(
         [{"pattern": "legacy_suffix", "name": f"segment_{i}_old", "component_id": f"segment/old/{i}"} for i in range(3)]

--- a/tests/test_lazy_forwarding.py
+++ b/tests/test_lazy_forwarding.py
@@ -1,0 +1,208 @@
+"""Tests for lazy-forwarding infrastructure and all modules using make_getattr().
+
+Covers:
+- Direct unit tests for core/lazy.py make_getattr() helper
+- Positive tests: lazy-forwarded attributes resolve correctly
+- Negative tests: unknown attributes raise AttributeError
+"""
+
+import importlib
+
+import pytest
+
+from cja_auto_sdr.core.lazy import make_getattr
+
+
+# ---------------------------------------------------------------------------
+# Section 1: Direct unit tests for make_getattr()
+# ---------------------------------------------------------------------------
+
+
+class TestMakeGetattr:
+    """Unit tests for the make_getattr() factory function itself."""
+
+    def test_resolves_from_target_module(self):
+        """make_getattr resolves an attribute from a single target module."""
+        getter = make_getattr(
+            "test_module",
+            ["__version__"],
+            target_module="cja_auto_sdr.core.version",
+        )
+        result = getter("__version__")
+        assert isinstance(result, str)
+        assert "." in result  # version string like "3.2.7"
+
+    def test_raises_attribute_error_for_unknown_name(self):
+        """make_getattr raises AttributeError for names not in export list."""
+        getter = make_getattr(
+            "test_module",
+            ["__version__"],
+            target_module="cja_auto_sdr.core.version",
+        )
+        with pytest.raises(AttributeError, match="test_module"):
+            getter("nonexistent_attribute_xyz")
+
+    def test_raises_value_error_without_target_or_mapping(self):
+        """make_getattr raises ValueError when neither target_module nor mapping given."""
+        with pytest.raises(ValueError, match="target_module or mapping is required"):
+            make_getattr("test_module", ["some_name"])
+
+    def test_works_with_explicit_mapping(self):
+        """make_getattr resolves using explicit name-to-module mapping."""
+        getter = make_getattr(
+            "test_module",
+            ["__version__", "CircuitState"],
+            mapping={
+                "__version__": "cja_auto_sdr.core.version",
+                "CircuitState": "cja_auto_sdr.core.config",
+            },
+        )
+        version = getter("__version__")
+        assert isinstance(version, str)
+
+        circuit_state = getter("CircuitState")
+        assert hasattr(circuit_state, "CLOSED")
+
+    def test_mapping_overrides_target_module(self):
+        """When both mapping and target_module given, mapping takes precedence."""
+        getter = make_getattr(
+            "test_module",
+            ["CircuitState"],
+            target_module="cja_auto_sdr.core.version",  # wrong module
+            mapping={"CircuitState": "cja_auto_sdr.core.config"},  # correct module
+        )
+        result = getter("CircuitState")
+        assert hasattr(result, "CLOSED")
+
+    def test_export_names_accepts_list(self):
+        """make_getattr accepts a list for export_names."""
+        getter = make_getattr(
+            "test_module",
+            ["__version__"],
+            target_module="cja_auto_sdr.core.version",
+        )
+        assert callable(getter)
+
+    def test_export_names_accepts_set(self):
+        """make_getattr accepts a set for export_names."""
+        getter = make_getattr(
+            "test_module",
+            {"__version__"},
+            target_module="cja_auto_sdr.core.version",
+        )
+        result = getter("__version__")
+        assert isinstance(result, str)
+
+    def test_export_names_accepts_tuple(self):
+        """make_getattr accepts a tuple for export_names."""
+        getter = make_getattr(
+            "test_module",
+            ("__version__",),
+            target_module="cja_auto_sdr.core.version",
+        )
+        result = getter("__version__")
+        assert isinstance(result, str)
+
+    def test_error_message_includes_module_name(self):
+        """AttributeError message includes the module name for diagnostics."""
+        getter = make_getattr(
+            "my.custom.module",
+            ["x"],
+            target_module="cja_auto_sdr.core.version",
+        )
+        with pytest.raises(AttributeError, match="my.custom.module"):
+            getter("unknown")
+
+
+# ---------------------------------------------------------------------------
+# Section 2: Parametrized tests for all forwarding modules
+# ---------------------------------------------------------------------------
+
+# Each tuple: (module_path, attribute_name)
+# We pick one or two representative attributes per module to keep tests fast.
+
+POSITIVE_CASES = [
+    # Root package -> generator
+    ("cja_auto_sdr", "__version__"),
+    ("cja_auto_sdr", "main"),
+    # core -> various submodules (lazy)
+    ("cja_auto_sdr.core", "JSONFormatter"),
+    ("cja_auto_sdr.core", "setup_logging"),
+    ("cja_auto_sdr.core", "PerformanceTracker"),
+    ("cja_auto_sdr.core", "ConfigValidator"),
+    ("cja_auto_sdr.core", "CredentialResolver"),
+    ("cja_auto_sdr.core", "LockManager"),
+    ("cja_auto_sdr.core", "get_profiles_dir"),
+    # core/profiles -> generator
+    ("cja_auto_sdr.core.profiles", "get_profiles_dir"),
+    ("cja_auto_sdr.core.profiles", "resolve_active_profile"),
+    ("cja_auto_sdr.core.profiles", "validate_profile_name"),
+    # api -> various submodules
+    ("cja_auto_sdr.api", "configure_cjapy"),
+    ("cja_auto_sdr.api", "initialize_cja"),
+    ("cja_auto_sdr.api", "validate_data_view"),
+    ("cja_auto_sdr.api", "ParallelAPIFetcher"),
+    ("cja_auto_sdr.api", "ValidationCache"),
+    ("cja_auto_sdr.api", "SharedValidationCache"),
+    ("cja_auto_sdr.api", "APIWorkerTuner"),
+    # cli -> generator
+    ("cja_auto_sdr.cli", "main"),
+    ("cja_auto_sdr.cli", "parse_arguments"),
+    # cli/commands -> generator
+    ("cja_auto_sdr.cli.commands", "generate_sample_config"),
+    ("cja_auto_sdr.cli.commands", "list_dataviews"),
+    ("cja_auto_sdr.cli.commands", "show_config_status"),
+    ("cja_auto_sdr.cli.commands", "validate_config_only"),
+    # data -> generator
+    ("cja_auto_sdr.data", "ProcessingResult"),
+    ("cja_auto_sdr.data", "DiffSummary"),
+    # git -> generator (via diff.git)
+    ("cja_auto_sdr.git", "is_git_repository"),
+    ("cja_auto_sdr.git", "generate_git_commit_message"),
+    # diff -> diff.writers
+    ("cja_auto_sdr.diff", "write_diff_output"),
+    ("cja_auto_sdr.diff", "write_diff_json_output"),
+    ("cja_auto_sdr.diff", "write_diff_excel_output"),
+    # org -> org.analyzer
+    ("cja_auto_sdr.org", "OrgComponentAnalyzer"),
+    # inventory -> inventory.summary
+    ("cja_auto_sdr.inventory", "display_inventory_summary"),
+]
+
+
+@pytest.mark.parametrize(
+    ("module_path", "attr_name"),
+    POSITIVE_CASES,
+    ids=[f"{m}.{a}" for m, a in POSITIVE_CASES],
+)
+def test_lazy_forward_resolves(module_path, attr_name):
+    """Verify that each lazy-forwarded attribute resolves to a real object."""
+    mod = importlib.import_module(module_path)
+    result = getattr(mod, attr_name)
+    assert result is not None
+
+
+# Negative cases: each module should raise AttributeError for unknown attrs.
+
+NEGATIVE_MODULES = [
+    "cja_auto_sdr",
+    "cja_auto_sdr.core",
+    "cja_auto_sdr.core.profiles",
+    "cja_auto_sdr.api",
+    "cja_auto_sdr.cli",
+    "cja_auto_sdr.cli.commands",
+    "cja_auto_sdr.data",
+    "cja_auto_sdr.output",
+    "cja_auto_sdr.git",
+    "cja_auto_sdr.diff",
+    "cja_auto_sdr.org",
+    "cja_auto_sdr.inventory",
+]
+
+
+@pytest.mark.parametrize("module_path", NEGATIVE_MODULES, ids=NEGATIVE_MODULES)
+def test_lazy_forward_rejects_unknown(module_path):
+    """Verify that unknown attributes raise AttributeError, not silently resolve."""
+    mod = importlib.import_module(module_path)
+    with pytest.raises(AttributeError):
+        getattr(mod, "__nonexistent_test_attr_xyz__")

--- a/tests/test_lazy_forwarding.py
+++ b/tests/test_lazy_forwarding.py
@@ -166,6 +166,17 @@ POSITIVE_CASES = [
     ("cja_auto_sdr.org", "OrgComponentAnalyzer"),
     # inventory -> inventory.summary
     ("cja_auto_sdr.inventory", "display_inventory_summary"),
+    # pipeline package + modules -> generator
+    ("cja_auto_sdr.pipeline", "BatchProcessor"),
+    ("cja_auto_sdr.pipeline", "ProcessingResult"),
+    ("cja_auto_sdr.pipeline", "process_single_dataview"),
+    ("cja_auto_sdr.pipeline", "process_single_dataview_worker"),
+    ("cja_auto_sdr.pipeline", "run_dry_run"),
+    ("cja_auto_sdr.pipeline.batch", "BatchProcessor"),
+    ("cja_auto_sdr.pipeline.dry_run", "run_dry_run"),
+    ("cja_auto_sdr.pipeline.models", "ProcessingResult"),
+    ("cja_auto_sdr.pipeline.single", "process_single_dataview"),
+    ("cja_auto_sdr.pipeline.workers", "process_single_dataview_worker"),
 ]
 
 
@@ -196,6 +207,12 @@ NEGATIVE_MODULES = [
     "cja_auto_sdr.diff",
     "cja_auto_sdr.org",
     "cja_auto_sdr.inventory",
+    "cja_auto_sdr.pipeline",
+    "cja_auto_sdr.pipeline.batch",
+    "cja_auto_sdr.pipeline.dry_run",
+    "cja_auto_sdr.pipeline.models",
+    "cja_auto_sdr.pipeline.single",
+    "cja_auto_sdr.pipeline.workers",
 ]
 
 

--- a/tests/test_lazy_forwarding.py
+++ b/tests/test_lazy_forwarding.py
@@ -12,7 +12,6 @@ import pytest
 
 from cja_auto_sdr.core.lazy import make_getattr
 
-
 # ---------------------------------------------------------------------------
 # Section 1: Direct unit tests for make_getattr()
 # ---------------------------------------------------------------------------
@@ -110,7 +109,7 @@ class TestMakeGetattr:
             ["x"],
             target_module="cja_auto_sdr.core.version",
         )
-        with pytest.raises(AttributeError, match="my.custom.module"):
+        with pytest.raises(AttributeError, match=r"my\.custom\.module"):
             getter("unknown")
 
 

--- a/tests/test_org_cache_branches.py
+++ b/tests/test_org_cache_branches.py
@@ -1,0 +1,182 @@
+"""Focused branch coverage for org cache and lock helper logic."""
+
+from __future__ import annotations
+
+import errno
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+from cja_auto_sdr.org.cache import OrgReportCache, OrgReportLock
+from cja_auto_sdr.org.models import DataViewSummary
+
+
+def _summary(dv_id: str) -> DataViewSummary:
+    return DataViewSummary(
+        data_view_id=dv_id,
+        data_view_name=f"Data View {dv_id}",
+        metric_ids={"metric/1"},
+        dimension_ids={"dimension/1"},
+        metric_count=1,
+        dimension_count=1,
+    )
+
+
+def test_cache_default_dir_uses_home(tmp_path: Path):
+    with patch("cja_auto_sdr.org.cache.Path.home", return_value=tmp_path):
+        cache = OrgReportCache()
+    assert cache.cache_dir == tmp_path / ".cja_auto_sdr" / "cache"
+
+
+def test_load_cache_invalid_json_logs_warning(tmp_path: Path):
+    cache_file = tmp_path / "org_report_cache.json"
+    cache_file.write_text("{not valid json")
+    logger = Mock()
+
+    cache = OrgReportCache(cache_dir=tmp_path, logger=logger)
+
+    assert cache._cache == {}
+    logger.warning.assert_called_once()
+    assert "Failed to load org report cache" in logger.warning.call_args[0][0]
+
+
+def test_get_returns_none_without_fetched_at(tmp_path: Path):
+    cache = OrgReportCache(cache_dir=tmp_path)
+    cache._cache["dv_missing_fetched"] = {"data_view_id": "dv_missing_fetched"}
+    assert cache.get("dv_missing_fetched") is None
+
+
+def test_get_returns_none_for_stale_or_invalid_timestamp(tmp_path: Path):
+    cache = OrgReportCache(cache_dir=tmp_path)
+
+    stale_time = (datetime.now(UTC) - timedelta(hours=25)).isoformat()
+    cache._cache["dv_stale"] = {"fetched_at": stale_time}
+    assert cache.get("dv_stale", max_age_hours=24) is None
+
+    cache._cache["dv_bad_ts"] = {"fetched_at": "definitely-not-iso"}
+    assert cache.get("dv_bad_ts", max_age_hours=24) is None
+
+
+@pytest.mark.parametrize(
+    "required_flags",
+    [
+        {"include_names": True},
+        {"include_metadata": True},
+        {"include_component_types": True},
+    ],
+)
+def test_get_rejects_when_required_flags_missing(tmp_path: Path, required_flags: dict[str, bool]):
+    cache = OrgReportCache(cache_dir=tmp_path)
+    cache._cache["dv_flags"] = {
+        "data_view_id": "dv_flags",
+        "data_view_name": "Flags DV",
+        "fetched_at": datetime.now(UTC).isoformat(),
+    }
+
+    assert cache.get("dv_flags", required_flags=required_flags) is None
+
+
+def test_get_logs_debug_on_deserialization_failure(tmp_path: Path):
+    logger = Mock()
+    cache = OrgReportCache(cache_dir=tmp_path, logger=logger)
+    cache._cache["dv_broken"] = {
+        "data_view_id": "dv_broken",
+        "data_view_name": "Broken DV",
+        "metric_ids": 123,  # not iterable -> set(123) raises
+        "fetched_at": datetime.now(UTC).isoformat(),
+    }
+
+    assert cache.get("dv_broken") is None
+    logger.debug.assert_called_once()
+
+
+def test_put_many_empty_skips_save(tmp_path: Path):
+    cache = OrgReportCache(cache_dir=tmp_path)
+    with patch.object(cache, "_save_cache") as save:
+        cache.put_many([])
+    save.assert_not_called()
+
+
+def test_put_many_saves_once_for_multiple_entries(tmp_path: Path):
+    cache = OrgReportCache(cache_dir=tmp_path)
+    with patch.object(cache, "_save_cache") as save:
+        cache.put_many(
+            [_summary("dv_one"), _summary("dv_two")],
+            include_names=True,
+            include_metadata=True,
+            include_component_types=True,
+        )
+
+    save.assert_called_once()
+    assert set(cache._cache) == {"dv_one", "dv_two"}
+    assert cache._cache["dv_one"]["include_names"] is True
+    assert cache._cache["dv_one"]["include_metadata"] is True
+    assert cache._cache["dv_one"]["include_component_types"] is True
+
+
+def test_has_valid_entry_handles_missing_and_invalid_timestamps(tmp_path: Path):
+    cache = OrgReportCache(cache_dir=tmp_path)
+
+    cache._cache["dv_missing_fetched"] = {}
+    assert cache.has_valid_entry("dv_missing_fetched") is False
+
+    cache._cache["dv_invalid_fetched"] = {"fetched_at": "invalid"}
+    assert cache.has_valid_entry("dv_invalid_fetched") is False
+
+    stale_time = (datetime.now(UTC) - timedelta(hours=48)).isoformat()
+    cache._cache["dv_stale"] = {"fetched_at": stale_time}
+    assert cache.has_valid_entry("dv_stale", max_age_hours=24) is False
+
+
+def test_get_stats_reports_file_size(tmp_path: Path):
+    cache = OrgReportCache(cache_dir=tmp_path)
+
+    stats_before = cache.get_stats()
+    assert stats_before["entries"] == 0
+    assert stats_before["cache_size_bytes"] == 0
+
+    cache.put(_summary("dv_stats"))
+
+    stats_after = cache.get_stats()
+    assert stats_after["entries"] == 1
+    assert stats_after["cache_size_bytes"] > 0
+    assert stats_after["cache_file"].endswith("org_report_cache.json")
+
+
+def test_lock_property_and_health_delegate_to_manager(tmp_path: Path):
+    lock = OrgReportLock("org@test", lock_dir=tmp_path)
+    manager = Mock()
+    manager.lock_lost = True
+    manager.read_info.return_value = {"pid": 1234}
+    lock._manager = manager
+
+    assert lock.lock_lost is True
+    assert lock.get_lock_info() == {"pid": 1234}
+    lock.ensure_healthy()
+    manager.ensure_held.assert_called_once()
+
+
+def test_is_process_running_covers_os_kill_branches():
+    with patch("cja_auto_sdr.org.cache.os.kill", return_value=None):
+        assert OrgReportLock._is_process_running(123) is True
+
+    with patch("cja_auto_sdr.org.cache.os.kill", side_effect=ProcessLookupError):
+        assert OrgReportLock._is_process_running(123) is False
+
+    with patch("cja_auto_sdr.org.cache.os.kill", side_effect=OSError(errno.EPERM, "permission")):
+        assert OrgReportLock._is_process_running(123) is True
+
+    with patch("cja_auto_sdr.org.cache.os.kill", side_effect=OSError(errno.ESRCH, "missing")):
+        assert OrgReportLock._is_process_running(123) is False
+
+
+def test_is_process_running_handles_int_conversion_failures():
+    class OverflowInt:
+        def __int__(self):
+            raise OverflowError
+
+    assert OrgReportLock._is_process_running("not-a-pid") is False
+    assert OrgReportLock._is_process_running(OverflowInt()) is False

--- a/tests/test_org_cache_branches.py
+++ b/tests/test_org_cache_branches.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import errno
-import json
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import Mock, patch

--- a/tests/test_output_content_validation.py
+++ b/tests/test_output_content_validation.py
@@ -38,7 +38,7 @@ def rich_data_dict():
         "Metadata": pd.DataFrame(
             {
                 "Property": ["Generated At", "Data View ID", "Tool Version", "Total Metrics"],
-                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.2.6", 3],
+                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.2.7", 3],
             }
         ),
         "Data Quality": pd.DataFrame(
@@ -104,7 +104,7 @@ def rich_metadata_dict():
         "Generated At": "2025-01-15 10:30:00 PST",
         "Data View ID": "dv_content_test",
         "Data View Name": "Test DataView",
-        "Tool Version": "3.2.6",
+        "Tool Version": "3.2.7",
         "Metrics Count": "3",
         "Dimensions Count": "4",
     }
@@ -224,7 +224,7 @@ class TestJSONContentValidation:
             data = json.load(f)
 
         assert data["metadata"]["Data View ID"] == "dv_content_test"
-        assert data["metadata"]["Tool Version"] == "3.2.6"
+        assert data["metadata"]["Tool Version"] == "3.2.7"
 
 
 # ===================================================================

--- a/tests/test_ux_features.py
+++ b/tests/test_ux_features.py
@@ -344,11 +344,11 @@ class TestCombinedFeatures:
 class TestVersionUpdated:
     """Test that version is correct"""
 
-    def test_version_is_3_2_6(self):
-        """Test that version is 3.2.6"""
+    def test_version_is_3_2_7(self):
+        """Test that version is 3.2.7"""
         from cja_auto_sdr.generator import __version__
 
-        assert __version__ == "3.2.6"
+        assert __version__ == "3.2.7"
 
 
 class TestFormatAutoDetection:


### PR DESCRIPTION
## Summary

Patch release continuing the quality trajectory from v3.2.6:

- **Documentation accuracy**: Fixed output filename patterns in QUICK_REFERENCE.md (was `SDR_<name>_<date>`, actual is `CJA_DataView_<Name>_<ID>_SDR`); updated stale PERFORMANCE.md version note; corrected logger names, CLI flags, and version refs across docs
- **Lazy-forwarding standardization**: Converted 4 hand-rolled `__getattr__` to centralized `make_getattr()` helper; removed 4 phantom exports that referenced non-existent symbols
- **55 new tests** for lazy-forwarding infrastructure covering all 12 forwarding modules + `make_getattr()` unit tests
- **6 new ruff rule sets**: ISC, TID, A, PLE, RSE, PLW — with PLW3301 nested max() flattened, RSE102 bare raise parens removed
- **CI coverage threshold** raised from 73% to 80% (actual: 80%)
- **2,758 tests** (collected via `pytest --collect-only`)

## Test plan

- [x] `uv run pytest tests/ -v --tb=short --cov=cja_auto_sdr --cov-report=term --cov-fail-under=80` — 2,756 passed, 2 skipped, 80% coverage
- [x] `uv run ruff check src/ tests/` — all checks passed (24 rule sets)
- [x] `uv run ruff format --check src/ tests/` — 119 files formatted
- [x] `uv run python scripts/check_version_sync.py` — all version refs match 3.2.7
- [x] Backward compatibility tests pass (34/34)