### PR TITLE
v3.2.9: Code quality & CI coverage push to 90%

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Sync dependencies
         run: uv sync --dev
       - name: Run tests with coverage
-        run: uv run pytest tests/ -v --tb=short --cov=cja_auto_sdr --cov-report=term --cov-fail-under=85
+        run: uv run pytest tests/ -v --tb=short --cov=cja_auto_sdr --cov-report=term --cov-fail-under=90
 
   run-summary-contract:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.9] - 2026-02-16
+
+### Added
+- **Ruff rule expansion**: Enabled 16 new rule sets — FLY, FA, YTT, PD, SLOT,
+  ICN, EXE, INT, NPY, AIR, ASYNC, INP, ERA, Q, COM, TCH — bringing total
+  from 25 → 41 active rule sets; auto-fixed ~938 trailing comma violations
+- **CI coverage threshold**: Raised `--cov-fail-under` from 85% → 90%
+
+### Tests
+- Added ~258 tests across 4 new test files:
+  - `test_diff_inventory_output.py`: Inventory diff output across all formats
+    (console, JSON, HTML, Excel, Markdown, CSV, PR comment)
+  - `test_cli_command_handlers.py`: CLI dispatch for --stats, --org-report,
+    --list-snapshots, --prune-snapshots, inventory summary, diff config unpacking
+  - `test_profile_management.py`: Interactive profile creation, import, test, show
+  - `test_snapshot_commands.py`: Snapshot creation, comparison, name resolution
+
 ## [3.2.8] - 2026-02-16
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,14 +12,14 @@ CJA SDR Generator - A tool for generating Solution Design Reference (SDR) docume
 
 - Package manager: uv
 - Entry point: `cja_auto_sdr` command (via pyproject.toml scripts)
-- Current version: v3.2.8
+- Current version: v3.2.9
 - Main script: `generator.py` (~10k lines) — subpackages use lazy forwarding via `make_getattr()` in `core/lazy.py`
 
 ## CI & Quality
 
 - Run tests: `uv run pytest tests/`
-- Coverage gate: **85%** (`--cov-fail-under=85` in `.github/workflows/tests.yml`)
-- Linter: `uv run ruff check src/ tests/` (25 active rule sets)
+- Coverage gate: **90%** (`--cov-fail-under=90` in `.github/workflows/tests.yml`)
+- Linter: `uv run ruff check src/ tests/` (41 active rule sets)
 - Formatter: `uv run ruff format src/ tests/`
 
 ## Version Bump Checklist

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (3,678+ tests)
+├── tests/                     # Test suite (3,936+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -913,7 +913,7 @@ cja_auto_sdr --list-dataviews --log-level DEBUG
 At launch, the tool logs a diagnostic line containing the tool version, Python version, platform, active log level, and inferred run mode (batch, single, or discovery). This appears automatically at `INFO` level and is useful for troubleshooting environment issues in CI/CD logs or support requests:
 
 ```text
-CJA SDR Generator v3.2.8 | Python 3.14.2 | darwin | log_level=INFO | mode=single
+CJA SDR Generator v3.2.9 | Python 3.14.2 | darwin | log_level=INFO | mode=single
 ```
 
 ### Structured JSON Logging

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -203,7 +203,7 @@ This command:
 
 ```bash
 $ uv run cja_auto_sdr --version
-cja_auto_sdr 3.2.8
+cja_auto_sdr 3.2.9
 ```
 
 > **Important:** All commands in this guide assume you're in the `cja_auto_sdr` directory. If you see "command not found", make sure you're in the right directory and have run `uv sync`.

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Quick Reference Card
 
-Single-page command cheat sheet for CJA SDR Generator v3.2.8.
+Single-page command cheat sheet for CJA SDR Generator v3.2.9.
 
 ## Four Main Modes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ dev = [
     "pytest>=8.3.4",
     "pytest-cov>=4.1.0",
     "ruff>=0.9.0",
+    "openpyxl>=3.1.0",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,22 @@ select = [
     "LOG",  # flake8-logging (logging best practices)
     "ARG",  # flake8-unused-arguments
     "FURB", # refurb (modern Python idioms)
+    "FLY",  # flynt (f-string conversion)
+    "FA",   # flake8-future-annotations
+    "YTT",  # flake8-2020 (sys.version checks)
+    "PD",   # pandas-vet
+    "SLOT", # flake8-slots
+    "ICN",  # flake8-import-conventions
+    "EXE",  # flake8-executable
+    "INT",  # flake8-gettext
+    "NPY",  # numpy-specific rules
+    "AIR",  # airflow-specific rules
+    "ASYNC", # flake8-async
+    "INP",  # flake8-no-pep420 (implicit namespace packages)
+    "ERA",  # eradicate (commented-out code)
+    "Q",    # flake8-quotes
+    "COM",  # flake8-commas (trailing commas)
+    "TCH",  # flake8-type-checking
 ]
 ignore = [
     "E501",    # line too long (handled by formatter)
@@ -117,11 +133,17 @@ ignore = [
     "PT011",   # pytest.raises too broad (matching messages makes tests brittle)
     "PT012",   # multiline pytest.raises block (common with context managers)
     "PLW1510", # subprocess.run without check (intentional in git helpers)
+    "COM812",  # trailing comma (conflicts with ruff formatter)
+    "TC001",   # type-checking-only import (false positives on runtime imports)
+    "TC002",   # type-checking-only import (false positives on runtime imports)
+    "TC003",   # type-checking-only import (false positives on runtime imports)
 ]
 
 [tool.ruff.lint.per-file-ignores]
 "src/cja_auto_sdr/generator.py" = ["F401", "E402", "RUF001", "RUF003", "SIM115", "S105", "PLW2901", "T201"]  # F401: re-exports; E402: optional imports; RUF001/3: intentional Unicode symbols; SIM115: NamedTemporaryFile with delete=False; S105: token_name false positive; PLW2901: line=line.strip() pattern; T201: intentional CLI console output
 "src/cja_auto_sdr/core/credentials.py" = ["PLW2901"]  # line=line.strip() pattern
+"src/cja_auto_sdr/inventory/calculated_metrics.py" = ["ERA001"]  # section header comments
+"src/cja_auto_sdr/org/__init__.py" = ["ERA001"]  # section header comments
 "src/cja_auto_sdr/core/logging.py" = ["PLW0603", "T201"]  # legitimate global state for logging init; T201: fallback console output before logger is ready
 "src/cja_auto_sdr/api/*.py" = ["F822"]       # lazy forwarding modules (resolved via __getattr__)
 "src/cja_auto_sdr/cli/*.py" = ["F822"]       # lazy forwarding modules
@@ -131,7 +153,7 @@ ignore = [
 "src/cja_auto_sdr/inventory/*.py" = ["F822"] # lazy forwarding modules
 "src/cja_auto_sdr/output/**/*.py" = ["F822"] # lazy forwarding modules
 "src/cja_auto_sdr/pipeline/*.py" = ["F822"]  # lazy forwarding modules
-"tests/**" = ["B", "SIM", "RUF012", "PERF", "DTZ", "S105", "S108", "S110", "S314", "PT017", "PT018", "PT019", "ARG", "T201"]
+"tests/**" = ["B", "SIM", "RUF012", "PERF", "DTZ", "S105", "S108", "S110", "S314", "PT017", "PT018", "PT019", "ARG", "T201", "ERA001", "PD011", "FLY002"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["cja_auto_sdr"]

--- a/src/cja_auto_sdr/api/cache.py
+++ b/src/cja_auto_sdr/api/cache.py
@@ -59,7 +59,11 @@ class ValidationCache:
         self.logger.debug(f"ValidationCache initialized: max_size={max_size}, ttl={ttl_seconds}s")
 
     def _generate_cache_key(
-        self, df: pd.DataFrame, item_type: str, required_fields: list[str], critical_fields: list[str]
+        self,
+        df: pd.DataFrame,
+        item_type: str,
+        required_fields: list[str],
+        critical_fields: list[str],
     ) -> str:
         """
         Generate cache key from DataFrame content and configuration
@@ -98,7 +102,11 @@ class ValidationCache:
             return f"error:{time.time()}"
 
     def get(
-        self, df: pd.DataFrame, item_type: str, required_fields: list[str], critical_fields: list[str]
+        self,
+        df: pd.DataFrame,
+        item_type: str,
+        required_fields: list[str],
+        critical_fields: list[str],
     ) -> tuple[list[dict] | None, str]:
         """
         Retrieve cached validation results if available
@@ -240,7 +248,7 @@ class ValidationCache:
         estimated_time_saved = stats["hits"] * 0.049  # 49ms saved per hit
 
         self.logger.info(
-            f"Cache Statistics: {stats['hits']}/{stats['total_requests']} hits ({stats['hit_rate']:.1f}% hit rate)"
+            f"Cache Statistics: {stats['hits']}/{stats['total_requests']} hits ({stats['hit_rate']:.1f}% hit rate)",
         )
         self.logger.info(f"  - Cache size: {stats['size']}/{stats['max_size']} entries")
         if stats["evictions"] > 0:
@@ -316,7 +324,11 @@ class SharedValidationCache:
         atexit.register(self.shutdown)
 
     def _generate_cache_key(
-        self, df: pd.DataFrame, item_type: str, required_fields: list[str], critical_fields: list[str]
+        self,
+        df: pd.DataFrame,
+        item_type: str,
+        required_fields: list[str],
+        critical_fields: list[str],
     ) -> str:
         """
         Generate cache key from DataFrame content and configuration.
@@ -340,7 +352,11 @@ class SharedValidationCache:
             return f"error:{time.time()}"
 
     def get(
-        self, df: pd.DataFrame, item_type: str, required_fields: list[str], critical_fields: list[str]
+        self,
+        df: pd.DataFrame,
+        item_type: str,
+        required_fields: list[str],
+        critical_fields: list[str],
     ) -> tuple[list[dict] | None, str]:
         """
         Retrieve cached validation results if available.

--- a/src/cja_auto_sdr/api/client.py
+++ b/src/cja_auto_sdr/api/client.py
@@ -69,7 +69,9 @@ def _config_from_env(credentials: dict[str, str], logger: logging.Logger):
 
 
 def configure_cjapy(
-    profile: str | None = None, config_file: str = "config.json", logger: logging.Logger | None = None
+    profile: str | None = None,
+    config_file: str = "config.json",
+    logger: logging.Logger | None = None,
 ) -> tuple[bool, str, dict[str, str] | None]:
     """
     Configure cjapy with credentials using priority: profile > env > config file.
@@ -142,7 +144,9 @@ def configure_cjapy(
 
 
 def initialize_cja(
-    config_file: str | Path = "config.json", logger: logging.Logger | None = None, profile: str | None = None
+    config_file: str | Path = "config.json",
+    logger: logging.Logger | None = None,
+    profile: str | None = None,
 ) -> cjapy.CJA | None:
     """Initialize CJA connection with comprehensive error handling.
 
@@ -221,11 +225,13 @@ def initialize_cja(
         try:
             # Attempt to list data views to verify connection with retry
             test_call = make_api_call_with_retry(
-                cja.getDataViews, logger=logger, operation_name="getDataViews (connection test)"
+                cja.getDataViews,
+                logger=logger,
+                operation_name="getDataViews (connection test)",
             )
             if test_call is not None:
                 logger.info(
-                    f"\u2713 API connection successful! Found {len(test_call) if hasattr(test_call, '__len__') else 'multiple'} data view(s)"
+                    f"\u2713 API connection successful! Found {len(test_call) if hasattr(test_call, '__len__') else 'multiple'} data view(s)",
                 )
             else:
                 logger.warning("API connection test returned None - connection may be unstable")

--- a/src/cja_auto_sdr/api/fetch.py
+++ b/src/cja_auto_sdr/api/fetch.py
@@ -176,7 +176,11 @@ class ParallelAPIFetcher:
 
             # Use retry for transient network errors with circuit breaker support
             metrics = self._timed_api_call(
-                self.cja.getMetrics, data_view_id, inclType=True, full=True, operation_name="getMetrics"
+                self.cja.getMetrics,
+                data_view_id,
+                inclType=True,
+                full=True,
+                operation_name="getMetrics",
             )
 
             if metrics is None or (isinstance(metrics, pd.DataFrame) and metrics.empty):
@@ -203,7 +207,11 @@ class ParallelAPIFetcher:
 
             # Use retry for transient network errors with circuit breaker support
             dimensions = self._timed_api_call(
-                self.cja.getDimensions, data_view_id, inclType=True, full=True, operation_name="getDimensions"
+                self.cja.getDimensions,
+                data_view_id,
+                inclType=True,
+                full=True,
+                operation_name="getDimensions",
             )
 
             if dimensions is None or (isinstance(dimensions, pd.DataFrame) and dimensions.empty):

--- a/src/cja_auto_sdr/api/quality.py
+++ b/src/cja_auto_sdr/api/quality.py
@@ -33,7 +33,13 @@ class DataQualityChecker:
         self.log_high_severity_issues = log_high_severity_issues
 
     def add_issue(
-        self, severity: str, category: str, item_type: str, item_name: str, description: str, details: str = ""
+        self,
+        severity: str,
+        category: str,
+        item_type: str,
+        item_name: str,
+        description: str,
+        details: str = "",
     ) -> dict[str, str]:
         """Add a data quality issue to the tracker (thread-safe)"""
         issue = {
@@ -200,7 +206,11 @@ class DataQualityChecker:
             self.logger.error(_format_error_msg("checking ID validity", item_type, e))
 
     def check_all_quality_issues_optimized(
-        self, df: pd.DataFrame, item_type: str, required_fields: list[str], critical_fields: list[str]
+        self,
+        df: pd.DataFrame,
+        item_type: str,
+        required_fields: list[str],
+        critical_fields: list[str],
     ):
         """
         Optimized single-pass validation combining all checks
@@ -219,7 +229,11 @@ class DataQualityChecker:
             local_issues: list[dict[str, str]] = []
 
             def _record_issue(
-                severity: str, category: str, item_name: str, description: str, details: str = ""
+                severity: str,
+                category: str,
+                item_name: str,
+                description: str,
+                details: str = "",
             ) -> None:
                 issue = self.add_issue(
                     severity=severity,
@@ -346,10 +360,16 @@ class DataQualityChecker:
 
             tasks = {
                 "metrics": lambda: self.check_all_quality_issues_optimized(
-                    metrics_df, "Metrics", metrics_required_fields, critical_fields
+                    metrics_df,
+                    "Metrics",
+                    metrics_required_fields,
+                    critical_fields,
                 ),
                 "dimensions": lambda: self.check_all_quality_issues_optimized(
-                    dimensions_df, "Dimensions", dimensions_required_fields, critical_fields
+                    dimensions_df,
+                    "Dimensions",
+                    dimensions_required_fields,
+                    critical_fields,
                 ),
             }
 
@@ -400,7 +420,7 @@ class DataQualityChecker:
                         "Item Name": ["N/A"],
                         "Issue": ["No data quality issues detected"],
                         "Details": ["All validation checks passed successfully"],
-                    }
+                    },
                 )
 
             df = pd.DataFrame(self.issues)
@@ -434,7 +454,7 @@ class DataQualityChecker:
                     "Item Name": ["N/A"],
                     "Issue": ["Error generating data quality report"],
                     "Details": [str(e)],
-                }
+                },
             )
 
     def log_summary(self):

--- a/src/cja_auto_sdr/api/resilience.py
+++ b/src/cja_auto_sdr/api/resilience.py
@@ -47,7 +47,7 @@ def _effective_retry_config() -> dict[str, Any]:
         cfg["max_retries"] = parsed_max_retries
     elif "MAX_RETRIES" in os.environ:
         logger.warning(
-            f"Ignoring invalid MAX_RETRIES={os.environ.get('MAX_RETRIES')!r}; using default {cfg['max_retries']}"
+            f"Ignoring invalid MAX_RETRIES={os.environ.get('MAX_RETRIES')!r}; using default {cfg['max_retries']}",
         )
 
     parsed_base_delay = _parse_env_numeric(os.environ.get("RETRY_BASE_DELAY"), float)
@@ -56,7 +56,7 @@ def _effective_retry_config() -> dict[str, Any]:
     elif "RETRY_BASE_DELAY" in os.environ:
         logger.warning(
             f"Ignoring invalid RETRY_BASE_DELAY={os.environ.get('RETRY_BASE_DELAY')!r}; "
-            f"using default {cfg['base_delay']}"
+            f"using default {cfg['base_delay']}",
         )
 
     parsed_max_delay = _parse_env_numeric(os.environ.get("RETRY_MAX_DELAY"), float)
@@ -64,14 +64,14 @@ def _effective_retry_config() -> dict[str, Any]:
         cfg["max_delay"] = parsed_max_delay
     elif "RETRY_MAX_DELAY" in os.environ:
         logger.warning(
-            f"Ignoring invalid RETRY_MAX_DELAY={os.environ.get('RETRY_MAX_DELAY')!r}; using default {cfg['max_delay']}"
+            f"Ignoring invalid RETRY_MAX_DELAY={os.environ.get('RETRY_MAX_DELAY')!r}; using default {cfg['max_delay']}",
         )
 
     # Guard against invalid windows that can otherwise cause negative sleep.
     if cfg["max_delay"] < cfg["base_delay"]:
         logger.warning(
             f"Ignoring invalid retry delay window (max_delay={cfg['max_delay']} < base_delay={cfg['base_delay']}); "
-            f"using max_delay={cfg['base_delay']}"
+            f"using max_delay={cfg['base_delay']}",
         )
         cfg["max_delay"] = cfg["base_delay"]
 
@@ -398,7 +398,7 @@ class ErrorMessageHelper:
                 f"  {error_info['reason']}",
                 "",
                 "How to fix it:",
-            ]
+            ],
         )
 
         for suggestion in error_info["suggestions"]:
@@ -434,7 +434,7 @@ class ErrorMessageHelper:
                     "  2. Verify you have access to this data view in CJA",
                     "  3. List available data views to confirm the ID:",
                     "       cja_auto_sdr --list-dataviews",
-                ]
+                ],
             )
         else:
             output.extend(
@@ -447,7 +447,7 @@ class ErrorMessageHelper:
                     "       cja_auto_sdr --list-dataviews",
                     "  4. Use quotes around names with spaces:",
                     '       cja_auto_sdr "Production Analytics"',
-                ]
+                ],
             )
 
         if available_count is not None:
@@ -461,14 +461,14 @@ class ErrorMessageHelper:
                         "  - Your API credentials don't have CJA access",
                         "  - You're connected to the wrong Adobe organization",
                         "  - No data views exist in this organization",
-                    ]
+                    ],
                 )
 
         output.extend(
             [
                 "",
                 f"For more help: {ErrorMessageHelper.TROUBLESHOOTING_URL}#data-view-errors",
-            ]
+            ],
         )
 
         return "\n".join(output)
@@ -639,7 +639,7 @@ class CircuitBreaker:
         if old_state != new_state:
             self.logger.info(
                 f"Circuit breaker state: {old_state.value} → {new_state.value} "
-                f"(failures={self._failure_count}, successes={self._success_count})"
+                f"(failures={self._failure_count}, successes={self._success_count})",
             )
 
     def get_statistics(self) -> dict[str, Any]:
@@ -770,7 +770,8 @@ def retry_with_backoff(
                         # Provide enhanced error message based on exception type
                         if isinstance(e, RetryableHTTPError):
                             error_msg = ErrorMessageHelper.get_http_error_message(
-                                e.status_code, operation=func.__name__
+                                e.status_code,
+                                operation=func.__name__,
                             )
                             _logger.error("\n" + error_msg)
                         elif isinstance(e, (ConnectionError, TimeoutError, OSError)):
@@ -779,7 +780,7 @@ def retry_with_backoff(
                         else:
                             _logger.error(f"Error: {e!s}")
                             _logger.error(
-                                "Troubleshooting: Check network connectivity, verify API credentials, or try again later"
+                                "Troubleshooting: Check network connectivity, verify API credentials, or try again later",
                             )
                         raise
 
@@ -792,7 +793,7 @@ def retry_with_backoff(
 
                     _logger.warning(
                         f"⚠ {func.__name__} attempt {attempt + 1}/{_max_retries + 1} failed: {e!s}. "
-                        f"Retrying in {delay:.1f}s..."
+                        f"Retrying in {delay:.1f}s...",
                     )
                     time.sleep(delay)
                 except Exception as e:
@@ -906,7 +907,7 @@ def make_api_call_with_retry[T](
                 else:
                     _logger.error(f"Error: {e!s}")
                     _logger.error(
-                        "Troubleshooting: Check network connectivity, verify API credentials, or try again later"
+                        "Troubleshooting: Check network connectivity, verify API credentials, or try again later",
                     )
 
                 # Record failure to circuit breaker (only after all retries exhausted)
@@ -919,7 +920,7 @@ def make_api_call_with_retry[T](
                 delay = delay * random.uniform(0.5, 1.5)
 
             _logger.warning(
-                f"⚠ {operation_name} attempt {attempt + 1}/{max_retries + 1} failed: {e!s}. Retrying in {delay:.1f}s..."
+                f"⚠ {operation_name} attempt {attempt + 1}/{max_retries + 1} failed: {e!s}. Retrying in {delay:.1f}s...",
             )
             time.sleep(delay)
         except Exception as e:

--- a/src/cja_auto_sdr/api/tuning.py
+++ b/src/cja_auto_sdr/api/tuning.py
@@ -114,7 +114,7 @@ class APIWorkerTuner:
                     self._scale_ups += 1
                     self.logger.info(
                         f"API tuner: scaling UP {self._current_workers} \u2192 {new_workers} workers "
-                        f"(avg response: {avg_time:.0f}ms < {self.config.scale_up_threshold_ms}ms threshold)"
+                        f"(avg response: {avg_time:.0f}ms < {self.config.scale_up_threshold_ms}ms threshold)",
                     )
 
             elif avg_time > self.config.scale_down_threshold_ms and self._current_workers > self.config.min_workers:
@@ -123,7 +123,7 @@ class APIWorkerTuner:
                 self._scale_downs += 1
                 self.logger.info(
                     f"API tuner: scaling DOWN {self._current_workers} \u2192 {new_workers} workers "
-                    f"(avg response: {avg_time:.0f}ms > {self.config.scale_down_threshold_ms}ms threshold)"
+                    f"(avg response: {avg_time:.0f}ms > {self.config.scale_down_threshold_ms}ms threshold)",
                 )
 
             if new_workers is not None:

--- a/src/cja_auto_sdr/core/config_validation.py
+++ b/src/cja_auto_sdr/core/config_validation.py
@@ -160,7 +160,10 @@ class ConfigValidator:
 
 
 def validate_credentials(
-    credentials: dict[str, str], logger: logging.Logger, strict: bool = False, source: str = "unknown"
+    credentials: dict[str, str],
+    logger: logging.Logger,
+    strict: bool = False,
+    source: str = "unknown",
 ) -> tuple[bool, list[str]]:
     """Unified validation for credentials from any source.
 
@@ -193,7 +196,7 @@ def validate_credentials(
     if "scopes" not in credentials or not credentials.get("scopes", "").strip():
         logger.warning(
             f"Credentials from {source} missing OAuth scopes - "
-            "recommend setting scopes (copy from Adobe Developer Console)"
+            "recommend setting scopes (copy from Adobe Developer Console)",
         )
 
     # Filter credentials to known fields only
@@ -247,7 +250,8 @@ def validate_config_file(config_file: str | Path, logger: logging.Logger) -> boo
         # Check if file exists
         if not config_path.exists():
             error_msg = ErrorMessageHelper.get_config_error_message(
-                "file_not_found", details=f"Looking for: {config_path.absolute()}"
+                "file_not_found",
+                details=f"Looking for: {config_path.absolute()}",
             )
             logger.error("\n" + error_msg)
             return False
@@ -263,7 +267,8 @@ def validate_config_file(config_file: str | Path, logger: logging.Logger) -> boo
                 config_data = json.load(f)
         except json.JSONDecodeError as e:
             error_msg = ErrorMessageHelper.get_config_error_message(
-                "invalid_json", details=f"Line {e.lineno}, Column {e.colno}: {e.msg}"
+                "invalid_json",
+                details=f"Line {e.lineno}, Column {e.colno}: {e.msg}",
             )
             logger.error("\n" + error_msg)
             return False
@@ -280,7 +285,7 @@ def validate_config_file(config_file: str | Path, logger: logging.Logger) -> boo
             elif not isinstance(config_data[field_name], field_info["type"]):
                 validation_errors.append(
                     f"Invalid type for '{field_name}': expected {field_info['type'].__name__}, "
-                    f"got {type(config_data[field_name]).__name__}"
+                    f"got {type(config_data[field_name]).__name__}",
                 )
             elif not config_data[field_name] or (
                 isinstance(config_data[field_name], str) and not config_data[field_name].strip()
@@ -291,14 +296,14 @@ def validate_config_file(config_file: str | Path, logger: logging.Logger) -> boo
         if "scopes" not in config_data or not config_data.get("scopes", "").strip():
             validation_warnings.append(
                 "OAuth Server-to-Server auth: 'scopes' field not set. "
-                "Copy scopes from your Adobe Developer Console project."
+                "Copy scopes from your Adobe Developer Console project.",
             )
 
         # Validate optional fields if present
         for field_name, field_info in CONFIG_SCHEMA["optional_fields"].items():
             if field_name in config_data and not isinstance(config_data[field_name], field_info["type"]):
                 validation_warnings.append(
-                    f"Invalid type for optional field '{field_name}': expected {field_info['type'].__name__}"
+                    f"Invalid type for optional field '{field_name}': expected {field_info['type'].__name__}",
                 )
 
         # Check for deprecated JWT authentication fields
@@ -311,7 +316,7 @@ def validate_config_file(config_file: str | Path, logger: logging.Logger) -> boo
                 f"DEPRECATED: JWT authentication was removed in v3.0.8. "
                 f"Found JWT fields: {', '.join(deprecated_found)}. "
                 f"Please migrate to OAuth Server-to-Server authentication. "
-                f"See docs/QUICKSTART_GUIDE.md for setup instructions."
+                f"See docs/QUICKSTART_GUIDE.md for setup instructions.",
             )
 
         # Check for unknown fields (potential typos)
@@ -334,12 +339,14 @@ def validate_config_file(config_file: str | Path, logger: logging.Logger) -> boo
             # Provide enhanced error message if missing credentials
             if any("Missing required field" in err for err in validation_errors):
                 error_msg = ErrorMessageHelper.get_config_error_message(
-                    "missing_credentials", details="One or more required fields are missing from your config file"
+                    "missing_credentials",
+                    details="One or more required fields are missing from your config file",
                 )
                 logger.error(error_msg)
             elif any("Empty value" in err for err in validation_errors):
                 error_msg = ErrorMessageHelper.get_config_error_message(
-                    "invalid_format", details="One or more fields have empty or invalid values"
+                    "invalid_format",
+                    details="One or more fields have empty or invalid values",
                 )
                 logger.error(error_msg)
             return False

--- a/src/cja_auto_sdr/core/credentials.py
+++ b/src/cja_auto_sdr/core/credentials.py
@@ -196,7 +196,9 @@ class CredentialResolver:
         self.logger = logger
 
     def resolve(
-        self, profile: str | None = None, config_file: str | Path = "config.json"
+        self,
+        profile: str | None = None,
+        config_file: str | Path = "config.json",
     ) -> tuple[dict[str, str], str]:
         """Resolve credentials following priority order.
 
@@ -258,7 +260,10 @@ class CredentialResolver:
             creds = load_profile_credentials(profile_name, self.logger)
             if creds:
                 is_valid, issues = validate_credentials(
-                    creds, self.logger, strict=False, source=f"profile:{profile_name}"
+                    creds,
+                    self.logger,
+                    strict=False,
+                    source=f"profile:{profile_name}",
                 )
                 if is_valid:
                     self.logger.info(f"Using credentials from profile '{profile_name}'")
@@ -266,11 +271,17 @@ class CredentialResolver:
                 self.logger.warning(f"Profile '{profile_name}' credentials have issues: {issues}")
         except ProfileNotFoundError as e:
             raise CredentialSourceError(
-                str(e), source=f"profile:{profile_name}", reason="Profile directory not found", details=e.details
+                str(e),
+                source=f"profile:{profile_name}",
+                reason="Profile directory not found",
+                details=e.details,
             ) from e
         except ProfileConfigError as e:
             raise CredentialSourceError(
-                str(e), source=f"profile:{profile_name}", reason="Invalid profile configuration", details=e.details
+                str(e),
+                source=f"profile:{profile_name}",
+                reason="Invalid profile configuration",
+                details=e.details,
             ) from e
 
         return None, ""
@@ -316,7 +327,10 @@ class CredentialResolver:
 
         if creds:
             is_valid, issues = validate_credentials(
-                creds, self.logger, strict=False, source=f"config:{config_path.name}"
+                creds,
+                self.logger,
+                strict=False,
+                source=f"config:{config_path.name}",
             )
             if is_valid:
                 self.logger.info(f"Using credentials from {config_file}")

--- a/src/cja_auto_sdr/core/exceptions.py
+++ b/src/cja_auto_sdr/core/exceptions.py
@@ -30,7 +30,11 @@ class ConfigurationError(CJASDRError):
     """
 
     def __init__(
-        self, message: str, config_file: str | None = None, field: str | None = None, details: str | None = None
+        self,
+        message: str,
+        config_file: str | None = None,
+        field: str | None = None,
+        details: str | None = None,
     ):
         self.config_file = config_file
         self.field = field

--- a/src/cja_auto_sdr/core/locks/backends.py
+++ b/src/cja_auto_sdr/core/locks/backends.py
@@ -714,7 +714,8 @@ class LeaseFileLockBackend:
                 if lock_active is True:
                     return AcquireResult(status=AcquireStatus.CONTENDED)
                 if info_outcome.state == "missing" and not _is_missing_metadata_stale(
-                    lock_path, stale_threshold_seconds
+                    lock_path,
+                    stale_threshold_seconds,
                 ):
                     # Fresh missing metadata is usually a transient bootstrap window.
                     return AcquireResult(status=AcquireStatus.CONTENDED)

--- a/src/cja_auto_sdr/core/logging.py
+++ b/src/cja_auto_sdr/core/logging.py
@@ -69,7 +69,7 @@ _AUTHORIZATION_SCHEME_PATTERN = re.compile(
     (?P<value_quote>["']?)
     (?P<scheme>[A-Za-z]+)\s+(?P<credential>[A-Za-z0-9._~+/=-]+)
     (?P=value_quote)
-    """
+    """,
 )
 _AUTHORIZATION_VALUE_PATTERN = re.compile(
     rf"""(?ix)
@@ -77,7 +77,7 @@ _AUTHORIZATION_VALUE_PATTERN = re.compile(
     (?P<separator>\s*[:=]\s*)
     (?!["']?[A-Za-z]+\s+[A-Za-z0-9._~+/=\-\[\]]+["']?)
     (?P<value>{_MESSAGE_VALUE_REGEX})
-    """
+    """,
 )
 _GENERIC_BEARER_PATTERN = re.compile(r"(?i)\b(bearer)\s+([A-Za-z0-9._~+/=-]+)")
 _SENSITIVE_QUOTED_KEY_VALUE_PATTERN = re.compile(
@@ -85,14 +85,14 @@ _SENSITIVE_QUOTED_KEY_VALUE_PATTERN = re.compile(
     (?P<full_key>["'](?:{_SENSITIVE_KEY_REGEX})["'])
     (?P<separator>\s*[:=]\s*)
     (?P<value>{_MESSAGE_VALUE_REGEX})
-    """
+    """,
 )
 _SENSITIVE_UNQUOTED_KEY_VALUE_PATTERN = re.compile(
     rf"""(?ix)
     (?P<full_key>(?<![A-Za-z0-9_])(?:{_SENSITIVE_KEY_REGEX})(?![A-Za-z0-9_]))
     (?P<separator>\s*[:=]\s*)
     (?P<value>{_MESSAGE_VALUE_REGEX})
-    """
+    """,
 )
 
 
@@ -363,7 +363,8 @@ def _unwrap_logger(logger: logging.Logger | logging.LoggerAdapter | None) -> log
 
 
 def with_log_context(
-    logger: logging.Logger | logging.LoggerAdapter | object, **context: object
+    logger: logging.Logger | logging.LoggerAdapter | object,
+    **context: object,
 ) -> logging.Logger | logging.LoggerAdapter | object:
     """Return a logger enriched with persistent contextual fields."""
     if not isinstance(logger, (logging.Logger, logging.LoggerAdapter)):
@@ -420,7 +421,10 @@ def _infer_run_mode(data_view_id: str | None, batch_mode: bool) -> str:
 
 
 def setup_logging(
-    data_view_id: str | None = None, batch_mode: bool = False, log_level: str | None = None, log_format: str = "text"
+    data_view_id: str | None = None,
+    batch_mode: bool = False,
+    log_level: str | None = None,
+    log_format: str = "text",
 ) -> logging.Logger:
     """Setup logging to both file and console.
 

--- a/src/cja_auto_sdr/core/version.py
+++ b/src/cja_auto_sdr/core/version.py
@@ -1,3 +1,3 @@
 """Version information for CJA Auto SDR."""
 
-__version__ = "3.2.8"
+__version__ = "3.2.9"

--- a/src/cja_auto_sdr/diff/comparator.py
+++ b/src/cja_auto_sdr/diff/comparator.py
@@ -183,7 +183,7 @@ class DataViewComparator:
         self.logger.info("Comparison complete:")
         self.logger.info(f"  Metrics: +{summary.metrics_added} -{summary.metrics_removed} ~{summary.metrics_modified}")
         self.logger.info(
-            f"  Dimensions: +{summary.dimensions_added} -{summary.dimensions_removed} ~{summary.dimensions_modified}"
+            f"  Dimensions: +{summary.dimensions_added} -{summary.dimensions_removed} ~{summary.dimensions_modified}",
         )
 
         return DiffResult(
@@ -240,19 +240,24 @@ class DataViewComparator:
 
             if source_item and not target_item:
                 diffs.append(
-                    diff_factory(item_id, name_extractor(source_item), ChangeType.REMOVED, source_item, None, None)
+                    diff_factory(item_id, name_extractor(source_item), ChangeType.REMOVED, source_item, None, None),
                 )
             elif target_item and not source_item:
                 diffs.append(
-                    diff_factory(item_id, name_extractor(target_item), ChangeType.ADDED, None, target_item, None)
+                    diff_factory(item_id, name_extractor(target_item), ChangeType.ADDED, None, target_item, None),
                 )
             else:
                 changed_fields = find_changed_fields(source_item, target_item)
                 change_type = ChangeType.MODIFIED if changed_fields else ChangeType.UNCHANGED
                 diffs.append(
                     diff_factory(
-                        item_id, name_extractor(target_item), change_type, source_item, target_item, changed_fields
-                    )
+                        item_id,
+                        name_extractor(target_item),
+                        change_type,
+                        source_item,
+                        target_item,
+                        changed_fields,
+                    ),
                 )
 
         return diffs
@@ -283,11 +288,19 @@ class DataViewComparator:
             return self._find_inventory_changed_fields(source_item, target_item, inventory_type)
 
         return self._compare_items_generic(
-            source_list, target_list, id_field, name_extractor, diff_factory, find_changed
+            source_list,
+            target_list,
+            id_field,
+            name_extractor,
+            diff_factory,
+            find_changed,
         )
 
     def _find_inventory_changed_fields(
-        self, source: dict, target: dict, inventory_type: str
+        self,
+        source: dict,
+        target: dict,
+        inventory_type: str,
     ) -> dict[str, tuple[Any, Any]]:
         changed = {}
 
@@ -331,7 +344,10 @@ class DataViewComparator:
         return [d for d in diffs if d.change_type in allowed_types]
 
     def _compare_components(
-        self, source_list: list[dict], target_list: list[dict], _component_type: str
+        self,
+        source_list: list[dict],
+        target_list: list[dict],
+        _component_type: str,
     ) -> list[ComponentDiff]:
         def name_extractor(item: dict) -> str:
             return item.get("name", item.get("title", "Unknown"))
@@ -347,7 +363,12 @@ class DataViewComparator:
             )
 
         return self._compare_items_generic(
-            source_list, target_list, "id", name_extractor, diff_factory, self._find_changed_fields
+            source_list,
+            target_list,
+            "id",
+            name_extractor,
+            diff_factory,
+            self._find_changed_fields,
         )
 
     def _find_changed_fields(self, source: dict, target: dict) -> dict[str, tuple[Any, Any]]:

--- a/src/cja_auto_sdr/diff/git.py
+++ b/src/cja_auto_sdr/diff/git.py
@@ -23,7 +23,11 @@ def is_git_repository(path: Path) -> bool:
     """Check if the given path is inside a Git repository."""
     try:
         result = subprocess.run(
-            ["git", "rev-parse", "--git-dir"], cwd=str(path), capture_output=True, text=True, timeout=10
+            ["git", "rev-parse", "--git-dir"],
+            cwd=str(path),
+            capture_output=True,
+            text=True,
+            timeout=10,
         )
         return result.returncode == 0
     except subprocess.TimeoutExpired, FileNotFoundError:
@@ -84,7 +88,8 @@ def save_git_friendly_snapshot(
 
     if snapshot.calculated_metrics_inventory:
         calc_metrics_sorted = sorted(
-            snapshot.calculated_metrics_inventory, key=lambda x: x.get("id", x.get("metric_id", ""))
+            snapshot.calculated_metrics_inventory,
+            key=lambda x: x.get("id", x.get("metric_id", "")),
         )
         calc_metrics_file = dv_dir / "calculated-metrics.json"
         with open(calc_metrics_file, "w", encoding="utf-8") as f:
@@ -222,13 +227,20 @@ def git_commit_snapshot(
             return False, f"No snapshot directory found for data view '{data_view_id}' in {snapshot_dir}"
 
         result = subprocess.run(
-            ["git", "add", "-A", "--", *pathspecs], cwd=str(snapshot_dir), capture_output=True, text=True, timeout=30
+            ["git", "add", "-A", "--", *pathspecs],
+            cwd=str(snapshot_dir),
+            capture_output=True,
+            text=True,
+            timeout=30,
         )
         if result.returncode != 0:
             return False, f"git add failed: {result.stderr}"
 
         result = subprocess.run(
-            ["git", "diff", "--cached", "--quiet"], cwd=str(snapshot_dir), capture_output=True, timeout=10
+            ["git", "diff", "--cached", "--quiet"],
+            cwd=str(snapshot_dir),
+            capture_output=True,
+            timeout=10,
         )
         if result.returncode == 0:
             logger.info("No changes to commit (snapshot unchanged)")
@@ -246,13 +258,21 @@ def git_commit_snapshot(
 
         logger.info("Committing snapshot to Git")
         result = subprocess.run(
-            ["git", "commit", "-m", commit_message], cwd=str(snapshot_dir), capture_output=True, text=True, timeout=30
+            ["git", "commit", "-m", commit_message],
+            cwd=str(snapshot_dir),
+            capture_output=True,
+            text=True,
+            timeout=30,
         )
         if result.returncode != 0:
             return False, f"git commit failed: {result.stderr}"
 
         result = subprocess.run(
-            ["git", "rev-parse", "HEAD"], cwd=str(snapshot_dir), capture_output=True, text=True, timeout=10
+            ["git", "rev-parse", "HEAD"],
+            cwd=str(snapshot_dir),
+            capture_output=True,
+            text=True,
+            timeout=10,
         )
         commit_sha = result.stdout.strip()[:8] if result.returncode == 0 else "unknown"
 
@@ -297,13 +317,21 @@ def git_init_snapshot_repo(directory: Path, logger: logging.Logger | None = None
             user_email = "cja-auto-sdr@local"
 
         result = subprocess.run(
-            ["git", "config", "user.name", user_name], cwd=str(directory), capture_output=True, text=True, timeout=30
+            ["git", "config", "user.name", user_name],
+            cwd=str(directory),
+            capture_output=True,
+            text=True,
+            timeout=30,
         )
         if result.returncode != 0:
             return False, f"git config user.name failed: {result.stderr}"
 
         result = subprocess.run(
-            ["git", "config", "user.email", user_email], cwd=str(directory), capture_output=True, text=True, timeout=30
+            ["git", "config", "user.email", user_email],
+            cwd=str(directory),
+            capture_output=True,
+            text=True,
+            timeout=30,
         )
         if result.returncode != 0:
             return False, f"git config user.email failed: {result.stderr}"

--- a/src/cja_auto_sdr/diff/snapshot.py
+++ b/src/cja_auto_sdr/diff/snapshot.py
@@ -232,7 +232,7 @@ class SnapshotManager:
                                 "created_at": data.get("created_at", ""),
                                 "metrics_count": len(data.get("metrics", [])),
                                 "dimensions_count": len(data.get("dimensions", [])),
-                            }
+                            },
                         )
                 except OSError, json.JSONDecodeError:
                     continue

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -658,14 +658,17 @@ def load_quality_policy(policy_file: str | Path) -> dict[str, Any]:
 
     if "max_issues" in normalized_payload:
         normalized_policy["max_issues"] = _parse_non_negative_policy_int(
-            normalized_payload["max_issues"], key="max_issues"
+            normalized_payload["max_issues"],
+            key="max_issues",
         )
 
     return normalized_policy
 
 
 def apply_quality_policy_defaults(
-    args: argparse.Namespace, policy: dict[str, Any], argv: list[str] | None = None
+    args: argparse.Namespace,
+    policy: dict[str, Any],
+    argv: list[str] | None = None,
 ) -> dict[str, Any]:
     """Apply quality policy values only when the corresponding CLI flags were not explicitly set."""
     applied: dict[str, Any] = {}
@@ -858,7 +861,7 @@ def _infer_run_mode_enum(args: argparse.Namespace) -> RunMode:
                 or getattr(args, "profile_test", None)
                 or getattr(args, "profile_import", None)
                 or getattr(args, "profile_show", None)
-                or getattr(args, "profile_overwrite", False)
+                or getattr(args, "profile_overwrite", False),
             ),
         ),
         (RunMode.GIT_INIT, getattr(args, "git_init", False)),
@@ -867,7 +870,7 @@ def _infer_run_mode_enum(args: argparse.Namespace) -> RunMode:
             bool(
                 getattr(args, "list_dataviews", False)
                 or getattr(args, "list_connections", False)
-                or getattr(args, "list_datasets", False)
+                or getattr(args, "list_datasets", False),
             ),
         ),
         (RunMode.CONFIG_STATUS, bool(getattr(args, "config_status", False) or getattr(args, "config_json", False))),
@@ -985,7 +988,7 @@ def build_quality_step_summary(results: list[ProcessingResult]) -> str:
                 highest = severity
                 break
         lines.append(
-            f"| {result.data_view_name or '-'} | `{result.data_view_id}` | {result.dq_issues_count} | {highest} |"
+            f"| {result.data_view_name or '-'} | `{result.data_view_id}` | {result.dq_issues_count} | {highest} |",
         )
 
     return "\n".join(lines)
@@ -1017,12 +1020,12 @@ def build_diff_step_summary(diff_result: DiffResult) -> str:
     if summary.source_calc_metrics_count > 0 or summary.target_calc_metrics_count > 0:
         lines.append(
             f"| Calc Metrics | {summary.source_calc_metrics_count} | {summary.target_calc_metrics_count} | "
-            f"{summary.calc_metrics_added} | {summary.calc_metrics_removed} | {summary.calc_metrics_modified} | {summary.calc_metrics_unchanged} |"
+            f"{summary.calc_metrics_added} | {summary.calc_metrics_removed} | {summary.calc_metrics_modified} | {summary.calc_metrics_unchanged} |",
         )
     if summary.source_segments_count > 0 or summary.target_segments_count > 0:
         lines.append(
             f"| Segments | {summary.source_segments_count} | {summary.target_segments_count} | "
-            f"{summary.segments_added} | {summary.segments_removed} | {summary.segments_modified} | {summary.segments_unchanged} |"
+            f"{summary.segments_added} | {summary.segments_removed} | {summary.segments_modified} | {summary.segments_unchanged} |",
         )
 
     return "\n".join(lines)
@@ -1237,7 +1240,9 @@ def load_profile_credentials(profile_name: str, logger: logging.Logger) -> dict[
 
     if not profile_path.is_dir():
         raise ProfileConfigError(
-            "Profile path is not a directory", profile_name=profile_name, details=str(profile_path)
+            "Profile path is not a directory",
+            profile_name=profile_name,
+            details=str(profile_path),
         )
 
     # Load config.json first
@@ -1604,7 +1609,7 @@ def import_profile_non_interactive(profile_name: str, source_file: str | Path, o
 
     if profile_exists and (profile_path / ".env").exists():
         print(
-            "Warning: Existing .env file was kept and may override imported config.json values when this profile is used."
+            "Warning: Existing .env file was kept and may override imported config.json values when this profile is used.",
         )
 
     print()
@@ -1740,7 +1745,10 @@ def test_profile(profile_name: str) -> bool:
     try:
         # Create temp config file with restrictive permissions
         with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".json", delete=False, prefix="cja_profile_test_"
+            mode="w",
+            suffix=".json",
+            delete=False,
+            prefix="cja_profile_test_",
         ) as temp_config:
             os.chmod(temp_config.name, 0o600)
             json.dump(credentials, temp_config)
@@ -1966,7 +1974,11 @@ class ExcelFormatCache:
 
 
 def apply_excel_formatting(
-    writer, df, sheet_name, logger: logging.Logger, format_cache: ExcelFormatCache | None = None
+    writer,
+    df,
+    sheet_name,
+    logger: logging.Logger,
+    format_cache: ExcelFormatCache | None = None,
 ):
     """Apply formatting to Excel sheets with error handling.
 
@@ -2044,24 +2056,24 @@ def apply_excel_formatting(
                 "border": 1,
                 "align": "center",
                 "text_wrap": True,
-            }
+            },
         )
 
         grey_format = cache.get_format(
-            {"bg_color": "#F2F2F2", "border": 1, "text_wrap": True, "align": "top", "valign": "top"}
+            {"bg_color": "#F2F2F2", "border": 1, "text_wrap": True, "align": "top", "valign": "top"},
         )
 
         white_format = cache.get_format(
-            {"bg_color": "#FFFFFF", "border": 1, "text_wrap": True, "align": "top", "valign": "top"}
+            {"bg_color": "#FFFFFF", "border": 1, "text_wrap": True, "align": "top", "valign": "top"},
         )
 
         # Bold formats for Name column in Metrics/Dimensions sheets
         name_bold_grey = cache.get_format(
-            {"bg_color": "#F2F2F2", "border": 1, "text_wrap": True, "align": "top", "valign": "top", "bold": True}
+            {"bg_color": "#F2F2F2", "border": 1, "text_wrap": True, "align": "top", "valign": "top", "bold": True},
         )
 
         name_bold_white = cache.get_format(
-            {"bg_color": "#FFFFFF", "border": 1, "text_wrap": True, "align": "top", "valign": "top", "bold": True}
+            {"bg_color": "#FFFFFF", "border": 1, "text_wrap": True, "align": "top", "valign": "top", "bold": True},
         )
 
         # Special formats for Data Quality sheet
@@ -2084,7 +2096,7 @@ def apply_excel_formatting(
                     "text_wrap": True,
                     "align": "top",
                     "valign": "top",
-                }
+                },
             )
 
             high_format = cache.get_format(
@@ -2095,7 +2107,7 @@ def apply_excel_formatting(
                     "text_wrap": True,
                     "align": "top",
                     "valign": "top",
-                }
+                },
             )
 
             medium_format = cache.get_format(
@@ -2106,7 +2118,7 @@ def apply_excel_formatting(
                     "text_wrap": True,
                     "align": "top",
                     "valign": "top",
-                }
+                },
             )
 
             low_format = cache.get_format(
@@ -2117,7 +2129,7 @@ def apply_excel_formatting(
                     "text_wrap": True,
                     "align": "top",
                     "valign": "top",
-                }
+                },
             )
 
             info_format = cache.get_format(
@@ -2128,7 +2140,7 @@ def apply_excel_formatting(
                     "text_wrap": True,
                     "align": "top",
                     "valign": "top",
-                }
+                },
             )
 
             # Bold formats for Severity column (emphasize priority) - using cache
@@ -2140,7 +2152,7 @@ def apply_excel_formatting(
                     "border": 1,
                     "align": "center",
                     "valign": "vcenter",
-                }
+                },
             )
 
             high_bold = cache.get_format(
@@ -2151,7 +2163,7 @@ def apply_excel_formatting(
                     "border": 1,
                     "align": "center",
                     "valign": "vcenter",
-                }
+                },
             )
 
             medium_bold = cache.get_format(
@@ -2162,7 +2174,7 @@ def apply_excel_formatting(
                     "border": 1,
                     "align": "center",
                     "valign": "vcenter",
-                }
+                },
             )
 
             low_bold = cache.get_format(
@@ -2173,7 +2185,7 @@ def apply_excel_formatting(
                     "border": 1,
                     "align": "center",
                     "valign": "vcenter",
-                }
+                },
             )
 
             info_bold = cache.get_format(
@@ -2184,7 +2196,7 @@ def apply_excel_formatting(
                     "border": 1,
                     "align": "center",
                     "valign": "vcenter",
-                }
+                },
             )
 
             # Map severity to formats
@@ -2223,7 +2235,8 @@ def apply_excel_formatting(
             max_cap = column_width_caps.get(col_lower, default_cap)
             max_len = min(
                 max(
-                    max(len(str(val).split("\n")[0]) for val in series) if len(series) > 0 else 0, len(str(series.name))
+                    max(len(str(val).split("\n")[0]) for val in series) if len(series) > 0 else 0,
+                    len(str(series.name)),
                 )
                 + 2,
                 max_cap,
@@ -2282,7 +2295,10 @@ def apply_excel_formatting(
 
 
 def write_excel_output(
-    data_dict: dict[str, pd.DataFrame], base_filename: str, output_dir: str | Path, logger: logging.Logger
+    data_dict: dict[str, pd.DataFrame],
+    base_filename: str,
+    output_dir: str | Path,
+    logger: logging.Logger,
 ) -> str:
     """
     Write data to a formatted Excel workbook.
@@ -2326,7 +2342,10 @@ def write_excel_output(
 
 
 def write_csv_output(
-    data_dict: dict[str, pd.DataFrame], base_filename: str, output_dir: str | Path, logger: logging.Logger
+    data_dict: dict[str, pd.DataFrame],
+    base_filename: str,
+    output_dir: str | Path,
+    logger: logging.Logger,
 ) -> str:
     """
     Write data to CSV files (one per sheet)
@@ -2982,7 +3001,7 @@ def write_diff_console_output(
     total_width = 20 + src_width + tgt_width + 10 + 10 + 10 + 12 + 12 + 7  # +7 for spacing
 
     lines.append(
-        f"{'':20s} {src_header:>{src_width}s} {tgt_header:>{tgt_width}s} {'Added':>10s} {'Removed':>10s} {'Modified':>10s} {'Unchanged':>12s} {'Changed':>12s}"
+        f"{'':20s} {src_header:>{src_width}s} {tgt_header:>{tgt_width}s} {'Added':>10s} {'Removed':>10s} {'Modified':>10s} {'Unchanged':>12s} {'Changed':>12s}",
     )
     lines.append("-" * total_width)
 
@@ -3001,7 +3020,7 @@ def write_diff_console_output(
     )
     lines.append(
         f"{'Metrics':20s} {summary.source_metrics_count:{src_width}d} {summary.target_metrics_count:{tgt_width}d} "
-        f"{ANSIColors.rjust(added_str, 10)} {ANSIColors.rjust(removed_str, 10)} {ANSIColors.rjust(modified_str, 10)} {summary.metrics_unchanged:>12d} {metrics_pct:>12s}"
+        f"{ANSIColors.rjust(added_str, 10)} {ANSIColors.rjust(removed_str, 10)} {ANSIColors.rjust(modified_str, 10)} {summary.metrics_unchanged:>12d} {metrics_pct:>12s}",
     )
 
     # Dimensions row with percentage (using ANSI-aware padding for colored strings)
@@ -3023,7 +3042,7 @@ def write_diff_console_output(
     )
     lines.append(
         f"{'Dimensions':20s} {summary.source_dimensions_count:{src_width}d} {summary.target_dimensions_count:{tgt_width}d} "
-        f"{ANSIColors.rjust(added_str, 10)} {ANSIColors.rjust(removed_str, 10)} {ANSIColors.rjust(modified_str, 10)} {summary.dimensions_unchanged:>12d} {dims_pct:>12s}"
+        f"{ANSIColors.rjust(added_str, 10)} {ANSIColors.rjust(removed_str, 10)} {ANSIColors.rjust(modified_str, 10)} {summary.dimensions_unchanged:>12d} {dims_pct:>12s}",
     )
 
     # Inventory rows (if present)
@@ -3052,7 +3071,7 @@ def write_diff_console_output(
             )
             lines.append(
                 f"{'Calc Metrics':20s} {summary.source_calc_metrics_count:{src_width}d} {summary.target_calc_metrics_count:{tgt_width}d} "
-                f"{ANSIColors.rjust(added_str, 10)} {ANSIColors.rjust(removed_str, 10)} {ANSIColors.rjust(modified_str, 10)} {summary.calc_metrics_unchanged:>12d} {'':>12s}"
+                f"{ANSIColors.rjust(added_str, 10)} {ANSIColors.rjust(removed_str, 10)} {ANSIColors.rjust(modified_str, 10)} {summary.calc_metrics_unchanged:>12d} {'':>12s}",
             )
 
         # Segments row
@@ -3074,7 +3093,7 @@ def write_diff_console_output(
             )
             lines.append(
                 f"{'Segments':20s} {summary.source_segments_count:{src_width}d} {summary.target_segments_count:{tgt_width}d} "
-                f"{ANSIColors.rjust(added_str, 10)} {ANSIColors.rjust(removed_str, 10)} {ANSIColors.rjust(modified_str, 10)} {summary.segments_unchanged:>12d} {'':>12s}"
+                f"{ANSIColors.rjust(added_str, 10)} {ANSIColors.rjust(removed_str, 10)} {ANSIColors.rjust(modified_str, 10)} {summary.segments_unchanged:>12d} {'':>12s}",
             )
 
     lines.append("-" * total_width)
@@ -3191,20 +3210,20 @@ def write_diff_console_output(
         total_line = ", ".join(total_parts)
         lines.append(ANSIColors.bold(f"Total: {total_line}", c))
         lines.append(
-            f"  Metrics: {summary.metrics_added} added, {summary.metrics_removed} removed, {summary.metrics_modified} modified"
+            f"  Metrics: {summary.metrics_added} added, {summary.metrics_removed} removed, {summary.metrics_modified} modified",
         )
         lines.append(
-            f"  Dimensions: {summary.dimensions_added} added, {summary.dimensions_removed} removed, {summary.dimensions_modified} modified"
+            f"  Dimensions: {summary.dimensions_added} added, {summary.dimensions_removed} removed, {summary.dimensions_modified} modified",
         )
         # Add inventory summary lines if present
         if summary.has_inventory_changes:
             if summary.source_calc_metrics_count > 0 or summary.target_calc_metrics_count > 0:
                 lines.append(
-                    f"  Calc Metrics: {summary.calc_metrics_added} added, {summary.calc_metrics_removed} removed, {summary.calc_metrics_modified} modified"
+                    f"  Calc Metrics: {summary.calc_metrics_added} added, {summary.calc_metrics_removed} removed, {summary.calc_metrics_modified} modified",
                 )
             if summary.source_segments_count > 0 or summary.target_segments_count > 0:
                 lines.append(
-                    f"  Segments: {summary.segments_added} added, {summary.segments_removed} removed, {summary.segments_modified} modified"
+                    f"  Segments: {summary.segments_added} added, {summary.segments_removed} removed, {summary.segments_modified} modified",
                 )
     else:
         lines.append(ANSIColors.green("✓ No differences found", c))
@@ -3273,7 +3292,11 @@ def _get_inventory_change_detail(diff: InventoryItemDiff, truncate: bool = True)
 
 
 def _format_side_by_side(
-    diff: ComponentDiff, source_label: str, target_label: str, col_width: int = 35, max_col_width: int = 60
+    diff: ComponentDiff,
+    source_label: str,
+    target_label: str,
+    col_width: int = 35,
+    max_col_width: int = 60,
 ) -> list[str]:
     """
     Format a component diff as a side-by-side comparison table.
@@ -3393,7 +3416,7 @@ def write_diff_grouped_by_field_output(diff_result: DiffResult, use_color: bool 
         for comp_id, _comp_name, field, old_val, new_val in breaking_changes:
             lines.append(f"  {comp_id}: {field} changed")
             lines.append(
-                f"    '{_format_diff_value(old_val, truncate=False)}' → '{_format_diff_value(new_val, truncate=False)}'"
+                f"    '{_format_diff_value(old_val, truncate=False)}' → '{_format_diff_value(new_val, truncate=False)}'",
             )
 
     # Group by field
@@ -3469,12 +3492,12 @@ def write_diff_pr_comment_output(diff_result: DiffResult, _changes_only: bool = 
     lines.append(
         f"| Metrics | {summary.source_metrics_count} | {summary.target_metrics_count} | "
         f"+{summary.metrics_added} | -{summary.metrics_removed} | ~{summary.metrics_modified} | "
-        f"{summary.metrics_unchanged} | {summary.metrics_change_percent:.1f}% |"
+        f"{summary.metrics_unchanged} | {summary.metrics_change_percent:.1f}% |",
     )
     lines.append(
         f"| Dimensions | {summary.source_dimensions_count} | {summary.target_dimensions_count} | "
         f"+{summary.dimensions_added} | -{summary.dimensions_removed} | ~{summary.dimensions_modified} | "
-        f"{summary.dimensions_unchanged} | {summary.dimensions_change_percent:.1f}% |"
+        f"{summary.dimensions_unchanged} | {summary.dimensions_change_percent:.1f}% |",
     )
     lines.append("")
 
@@ -3495,7 +3518,7 @@ def write_diff_pr_comment_output(diff_result: DiffResult, _changes_only: bool = 
         lines.append("|-----------|-------|--------|-------|")
         for comp_id, field, old_val, new_val in breaking_changes[:10]:
             lines.append(
-                f"| `{comp_id}` | {field} | `{_format_diff_value(old_val, truncate=False)}` | `{_format_diff_value(new_val, truncate=False)}` |"
+                f"| `{comp_id}` | {field} | `{_format_diff_value(old_val, truncate=False)}` | `{_format_diff_value(new_val, truncate=False)}` |",
             )
         if len(breaking_changes) > 10:
             lines.append(f"| ... | | | +{len(breaking_changes) - 10} more |")
@@ -3517,7 +3540,8 @@ def write_diff_pr_comment_output(diff_result: DiffResult, _changes_only: bool = 
         lines.append("|--------|----|----- |")
         for diff in metric_changes[:25]:
             symbol = {ChangeType.ADDED: "➕", ChangeType.REMOVED: "➖", ChangeType.MODIFIED: "✏️"}.get(
-                diff.change_type, ""
+                diff.change_type,
+                "",
             )
             lines.append(f"| {symbol} | `{diff.id}` | {diff.name} |")
         if len(metric_changes) > 25:
@@ -3534,7 +3558,8 @@ def write_diff_pr_comment_output(diff_result: DiffResult, _changes_only: bool = 
         lines.append("|--------|----|----- |")
         for diff in dim_changes[:25]:
             symbol = {ChangeType.ADDED: "➕", ChangeType.REMOVED: "➖", ChangeType.MODIFIED: "✏️"}.get(
-                diff.change_type, ""
+                diff.change_type,
+                "",
             )
             lines.append(f"| {symbol} | `{diff.id}` | {diff.name} |")
         if len(dim_changes) > 25:
@@ -3579,7 +3604,7 @@ def detect_breaking_changes(diff_result: DiffResult) -> list[dict[str, Any]]:
                     "change_type": "removed",
                     "severity": "high",
                     "description": f"Component '{diff.name}' was removed",
-                }
+                },
             )
 
         # Check for type or schema changes
@@ -3596,7 +3621,7 @@ def detect_breaking_changes(diff_result: DiffResult) -> list[dict[str, Any]]:
                             "new_value": new_val,
                             "severity": "high",
                             "description": f"Data type changed from '{_format_diff_value(old_val, truncate=False)}' to '{_format_diff_value(new_val, truncate=False)}'",
-                        }
+                        },
                     )
                 elif field == "schemaPath":
                     breaking_changes.append(
@@ -3609,7 +3634,7 @@ def detect_breaking_changes(diff_result: DiffResult) -> list[dict[str, Any]]:
                             "new_value": new_val,
                             "severity": "medium",
                             "description": f"Schema path changed from '{_format_diff_value(old_val, truncate=False)}' to '{_format_diff_value(new_val, truncate=False)}'",
-                        }
+                        },
                     )
 
     return breaking_changes
@@ -3803,18 +3828,18 @@ def write_diff_markdown_output(
         # Summary table
         md_parts.append("## Summary\n")
         md_parts.append(
-            f"| Component | {diff_result.source_label} | {diff_result.target_label} | Added | Removed | Modified | Unchanged | Changed |"
+            f"| Component | {diff_result.source_label} | {diff_result.target_label} | Added | Removed | Modified | Unchanged | Changed |",
         )
         md_parts.append("| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |")
         md_parts.append(
             f"| Metrics | {summary.source_metrics_count} | {summary.target_metrics_count} | "
             f"+{summary.metrics_added} | -{summary.metrics_removed} | ~{summary.metrics_modified} | "
-            f"{summary.metrics_unchanged} | {summary.metrics_change_percent:.1f}% |"
+            f"{summary.metrics_unchanged} | {summary.metrics_change_percent:.1f}% |",
         )
         md_parts.append(
             f"| Dimensions | {summary.source_dimensions_count} | {summary.target_dimensions_count} | "
             f"+{summary.dimensions_added} | -{summary.dimensions_removed} | ~{summary.dimensions_modified} | "
-            f"{summary.dimensions_unchanged} | {summary.dimensions_change_percent:.1f}% |"
+            f"{summary.dimensions_unchanged} | {summary.dimensions_change_percent:.1f}% |",
         )
 
         # Add inventory rows to summary if present
@@ -3823,13 +3848,13 @@ def write_diff_markdown_output(
                 md_parts.append(
                     f"| **Calc Metrics** | {summary.source_calc_metrics_count} | {summary.target_calc_metrics_count} | "
                     f"+{summary.calc_metrics_added} | -{summary.calc_metrics_removed} | ~{summary.calc_metrics_modified} | "
-                    f"{summary.calc_metrics_unchanged} | - |"
+                    f"{summary.calc_metrics_unchanged} | - |",
                 )
             if summary.source_segments_count > 0 or summary.target_segments_count > 0:
                 md_parts.append(
                     f"| **Segments** | {summary.source_segments_count} | {summary.target_segments_count} | "
                     f"+{summary.segments_added} | -{summary.segments_removed} | ~{summary.segments_modified} | "
-                    f"{summary.segments_unchanged} | - |"
+                    f"{summary.segments_unchanged} | - |",
                 )
         md_parts.append("")
 
@@ -3857,7 +3882,7 @@ def write_diff_markdown_output(
                         md_parts.append("\n### Modified Metrics - Side by Side\n")
                         for diff in modified:
                             md_parts.extend(
-                                _format_markdown_side_by_side(diff, diff_result.source_label, diff_result.target_label)
+                                _format_markdown_side_by_side(diff, diff_result.source_label, diff_result.target_label),
                             )
             else:
                 md_parts.append("*No changes*")
@@ -3882,7 +3907,7 @@ def write_diff_markdown_output(
                         md_parts.append("\n### Modified Dimensions - Side by Side\n")
                         for diff in modified:
                             md_parts.extend(
-                                _format_markdown_side_by_side(diff, diff_result.source_label, diff_result.target_label)
+                                _format_markdown_side_by_side(diff, diff_result.source_label, diff_result.target_label),
                             )
             else:
                 md_parts.append("*No changes*")
@@ -4250,13 +4275,13 @@ def write_diff_html_output(
                 detail = _get_change_detail(diff)
                 detail_escaped = _html_escape(detail)
 
-                html += f'''
+                html += f"""
                 <tr class="{row_class}">
                     <td><span class="badge {badge_class}">{badge_text}</span></td>
                     <td><code>{_html_escape(str(diff.id))}</code></td>
                     <td>{_html_escape(str(diff.name))}</td>
                     <td>{detail_escaped}</td>
-                </tr>'''
+                </tr>"""
 
             html += "</table>\n"
             return html
@@ -4294,22 +4319,22 @@ def write_diff_html_output(
                     detail = _get_inventory_change_detail(diff)
                     detail_escaped = _html_escape(detail)
 
-                    html += f'''
+                    html += f"""
                     <tr class="{row_class}">
                         <td><span class="badge {badge_class}">{badge_text}</span></td>
                         <td><code>{_html_escape(str(diff.id))}</code></td>
                         <td>{_html_escape(str(diff.name))}</td>
                         <td>{detail_escaped}</td>
-                    </tr>'''
+                    </tr>"""
 
                 html += "</table>\n"
                 return html
 
             html_parts.append(
-                "<h2 style='border-top: 2px solid #3498db; padding-top: 20px; margin-top: 30px;'>Inventory Changes</h2>"
+                "<h2 style='border-top: 2px solid #3498db; padding-top: 20px; margin-top: 30px;'>Inventory Changes</h2>",
             )
             html_parts.append(
-                generate_inventory_diff_table(diff_result.calc_metrics_diffs, "Calculated Metrics Changes")
+                generate_inventory_diff_table(diff_result.calc_metrics_diffs, "Calculated Metrics Changes"),
             )
             html_parts.append(generate_inventory_diff_table(diff_result.segments_diffs, "Segments Changes"))
 
@@ -4407,7 +4432,7 @@ def write_diff_excel_output(
                         "Modified": summary.calc_metrics_modified,
                         "Unchanged": summary.calc_metrics_unchanged,
                         "Changed %": f"{summary.calc_metrics_change_percent:.1f}%",
-                    }
+                    },
                 )
             if diff_result.segments_diffs is not None:
                 summary_rows.append(
@@ -4420,7 +4445,7 @@ def write_diff_excel_output(
                         "Modified": summary.segments_modified,
                         "Unchanged": summary.segments_unchanged,
                         "Changed %": f"{summary.segments_change_percent:.1f}%",
-                    }
+                    },
                 )
 
             summary_df = pd.DataFrame(summary_rows)
@@ -4612,7 +4637,7 @@ def write_diff_csv_output(
                     "Modified": summary.calc_metrics_modified,
                     "Unchanged": summary.calc_metrics_unchanged,
                     "Changed_Percent": summary.calc_metrics_change_percent,
-                }
+                },
             )
         if diff_result.segments_diffs is not None:
             summary_rows.append(
@@ -4625,7 +4650,7 @@ def write_diff_csv_output(
                     "Modified": summary.segments_modified,
                     "Unchanged": summary.segments_unchanged,
                     "Changed_Percent": summary.segments_change_percent,
-                }
+                },
             )
 
         pd.DataFrame(summary_rows).to_csv(os.path.join(csv_dir, "summary.csv"), index=False)
@@ -4772,7 +4797,7 @@ def write_diff_output(
 
     if should_generate_format(output_format, "markdown"):
         output_files.append(
-            write_diff_markdown_output(diff_result, base_filename, output_dir, logger, changes_only, side_by_side)
+            write_diff_markdown_output(diff_result, base_filename, output_dir, logger, changes_only, side_by_side),
         )
 
     if should_generate_format(output_format, "html"):
@@ -5282,7 +5307,7 @@ def process_single_dataview(
         )
         if api_tuning_config is not None:
             logger.info(
-                f"API auto-tuning enabled (min={api_tuning_config.min_workers}, max={api_tuning_config.max_workers})"
+                f"API auto-tuning enabled (min={api_tuning_config.min_workers}, max={api_tuning_config.max_workers})",
             )
 
         metrics, dimensions, lookup_data = fetcher.fetch_all_data(data_view_id)
@@ -5293,7 +5318,7 @@ def process_single_dataview(
             logger.info(
                 f"API tuner stats: {tuner_stats['scale_ups']} scale-ups, "
                 f"{tuner_stats['scale_downs']} scale-downs, "
-                f"avg response: {tuner_stats['average_response_ms']:.0f}ms"
+                f"avg response: {tuner_stats['average_response_ms']:.0f}ms",
             )
 
         # Check if we have any data to process
@@ -5442,7 +5467,7 @@ def process_single_dataview(
                 inv_summary = derived_inventory_obj.get_summary()
                 logger.info(
                     f"Derived field inventory: {inv_summary.get('total_derived_fields', 0)} fields "
-                    f"({inv_summary.get('metrics_count', 0)} metrics, {inv_summary.get('dimensions_count', 0)} dimensions)"
+                    f"({inv_summary.get('metrics_count', 0)} metrics, {inv_summary.get('dimensions_count', 0)} dimensions)",
                 )
 
             except ImportError as e:
@@ -5590,7 +5615,7 @@ def process_single_dataview(
                         "Segments Complexity (Avg / Max)",
                         "Segments High Complexity (≥75)",
                         "Segments Elevated Complexity (50-74)",
-                    ]
+                    ],
                 )
                 metadata_values.extend([seg_count, f"{seg_avg:.1f} / {seg_max:.1f}", seg_high, seg_elevated])
 
@@ -5609,7 +5634,7 @@ def process_single_dataview(
                         "Calculated Metrics Complexity (Avg / Max)",
                         "Calculated Metrics High Complexity (≥75)",
                         "Calculated Metrics Elevated Complexity (50-74)",
-                    ]
+                    ],
                 )
                 metadata_values.extend([calc_count, f"{calc_avg:.1f} / {calc_max:.1f}", calc_high, calc_elevated])
 
@@ -5631,7 +5656,7 @@ def process_single_dataview(
                         "Derived Fields Complexity (Avg / Max)",
                         "Derived Fields High Complexity (≥75)",
                         "Derived Fields Elevated Complexity (50-74)",
-                    ]
+                    ],
                 )
                 metadata_values.extend(
                     [
@@ -5640,7 +5665,7 @@ def process_single_dataview(
                         f"{derived_avg:.1f} / {derived_max:.1f}",
                         derived_high,
                         derived_elevated,
-                    ]
+                    ],
                 )
 
             # Create enhanced metadata DataFrame
@@ -5722,7 +5747,7 @@ def process_single_dataview(
                     "Status": ["No derived fields found for this data view"],
                     "Data View ID": [data_view_id],
                     "Note": ["This data view has no derived fields configured"],
-                }
+                },
             )
 
         # Add calculated metrics inventory if available or placeholder if flag was used
@@ -5734,7 +5759,7 @@ def process_single_dataview(
                     "Status": ["No calculated metrics found for this data view"],
                     "Data View ID": [data_view_id],
                     "Note": ["This data view has no associated calculated metrics"],
-                }
+                },
             )
 
         # Add segments inventory if available or placeholder if flag was used
@@ -5746,7 +5771,7 @@ def process_single_dataview(
                     "Status": ["No segments found for this data view"],
                     "Data View ID": [data_view_id],
                     "Note": ["This data view has no associated segments"],
-                }
+                },
             )
 
         # Prepare metadata dictionary for JSON/HTML
@@ -5787,7 +5812,7 @@ def process_single_dataview(
                                 [
                                     (metadata_df, "Metadata"),
                                     (data_quality_df, "Data Quality"),
-                                ]
+                                ],
                             )
                             sheets_to_write.append((lookup_df, "DataView"))
                             # Add component sheets based on filters
@@ -5815,9 +5840,9 @@ def process_single_dataview(
                                             "Status": [f"No {name.lower()} found for this data view"],
                                             "Data View ID": [data_view_id],
                                             "Note": [
-                                                "This data view has no associated " + name.lower().replace(" ", " ")
+                                                "This data view has no associated " + name.lower().replace(" ", " "),
                                             ],
-                                        }
+                                        },
                                     )
                                     sheets_to_write.append((placeholder_df, name))
 
@@ -5847,7 +5872,12 @@ def process_single_dataview(
                         "segments": segments_inventory_obj,
                     }
                     json_output = write_json_output(
-                        data_dict, metadata_dict, base_filename, output_dir, logger, inventory_objects
+                        data_dict,
+                        metadata_dict,
+                        base_filename,
+                        output_dir,
+                        logger,
+                        inventory_objects,
                     )
                     output_files.append(json_output)
 
@@ -6199,12 +6229,12 @@ class BatchProcessor:
         except PermissionError as e:
             raise OutputError(
                 f"Permission denied creating output directory: {self.output_dir}. "
-                "Check that you have write permissions for the parent directory."
+                "Check that you have write permissions for the parent directory.",
             ) from e
         except OSError as e:
             raise OutputError(
                 f"Cannot create output directory '{self.output_dir}': {e}. "
-                "Verify the path is valid and the disk has available space."
+                "Verify the path is valid and the disk has available space.",
             ) from e
 
     def process_batch(self, data_view_ids: list[str]) -> dict:
@@ -6298,7 +6328,7 @@ class BatchProcessor:
 
                                 if not self.continue_on_error:
                                     self.logger.warning(
-                                        f"[{self.batch_id}] Stopping batch processing due to error (use --continue-on-error to continue)"
+                                        f"[{self.batch_id}] Stopping batch processing due to error (use --continue-on-error to continue)",
                                     )
                                     # Cancel remaining tasks
                                     for f in future_to_dv:
@@ -6320,7 +6350,7 @@ class BatchProcessor:
                                     success=False,
                                     duration=0,
                                     error_message=str(e),
-                                )
+                                ),
                             )
 
                             if not self.continue_on_error:
@@ -6336,7 +6366,7 @@ class BatchProcessor:
                 cache_stats = self._shared_cache.get_statistics()
                 self.logger.info(
                     f"[{self.batch_id}] Shared cache stats: {cache_stats['hits']} hits, "
-                    f"{cache_stats['misses']} misses ({cache_stats['hit_rate']:.1f}% hit rate)"
+                    f"{cache_stats['misses']} misses ({cache_stats['hit_rate']:.1f}% hit rate)",
                 )
                 self._shared_cache.shutdown()
                 self._shared_cache = None
@@ -6407,7 +6437,7 @@ class BatchProcessor:
                 line = f"  {result.data_view_id:20s}  {result.data_view_name:30s}  {size_str:>10s}  {result.duration:5.1f}s"
                 print(ConsoleColors.success("  ✓") + line[3:])
                 self.logger.info(
-                    f"  ✓ {result.data_view_id:20s}  {result.data_view_name:30s}  {size_str:>10s}  {result.duration:5.1f}s"
+                    f"  ✓ {result.data_view_id:20s}  {result.data_view_name:30s}  {size_str:>10s}  {result.duration:5.1f}s",
                 )
             print()
             self.logger.info("")
@@ -6510,7 +6540,9 @@ def run_dry_run(data_views: list[str], config_file: str, logger: logging.Logger,
 
         # Test API with getDataViews call (with retry for transient errors)
         available_dvs = make_api_call_with_retry(
-            cja.getDataViews, logger=logger, operation_name="getDataViews (dry-run)"
+            cja.getDataViews,
+            logger=logger,
+            operation_name="getDataViews (dry-run)",
         )
         if available_dvs is not None:
             dv_count = len(available_dvs) if hasattr(available_dvs, "__len__") else 0
@@ -6556,7 +6588,10 @@ def run_dry_run(data_views: list[str], config_file: str, logger: logging.Logger,
         # Try to get data view info (with retry for transient errors)
         try:
             dv_info = make_api_call_with_retry(
-                cja.getDataView, dv_id, logger=logger, operation_name=f"getDataView({dv_id})"
+                cja.getDataView,
+                dv_id,
+                logger=logger,
+                operation_name=f"getDataView({dv_id})",
             )
             if dv_info:
                 dv_name = dv_info.get("name", "Unknown")
@@ -6566,7 +6601,10 @@ def run_dry_run(data_views: list[str], config_file: str, logger: logging.Logger,
                 dimensions_count = 0
                 try:
                     metrics = make_api_call_with_retry(
-                        cja.getMetrics, dv_id, logger=logger, operation_name=f"getMetrics({dv_id})"
+                        cja.getMetrics,
+                        dv_id,
+                        logger=logger,
+                        operation_name=f"getMetrics({dv_id})",
                     )
                     if metrics is not None:
                         metrics_count = len(metrics) if hasattr(metrics, "__len__") else 0
@@ -6575,7 +6613,10 @@ def run_dry_run(data_views: list[str], config_file: str, logger: logging.Logger,
 
                 try:
                     dimensions = make_api_call_with_retry(
-                        cja.getDimensions, dv_id, logger=logger, operation_name=f"getDimensions({dv_id})"
+                        cja.getDimensions,
+                        dv_id,
+                        logger=logger,
+                        operation_name=f"getDimensions({dv_id})",
                     )
                     if dimensions is not None:
                         dimensions_count = len(dimensions) if hasattr(dimensions, "__len__") else 0
@@ -6585,7 +6626,7 @@ def run_dry_run(data_views: list[str], config_file: str, logger: logging.Logger,
                 total_metrics += metrics_count
                 total_dimensions += dimensions_count
                 dv_details.append(
-                    {"id": dv_id, "name": dv_name, "metrics": metrics_count, "dimensions": dimensions_count}
+                    {"id": dv_id, "name": dv_name, "metrics": metrics_count, "dimensions": dimensions_count},
                 )
 
                 print(f"  ✓ {dv_id}: {dv_name}")
@@ -6668,7 +6709,10 @@ def _safe_env_number(env_var: str, default: int | float, cast: Callable[[str], i
 
 
 def parse_arguments(
-    argv: list[str] | None = None, *, return_parser: bool = False, enable_autocomplete: bool = True
+    argv: list[str] | None = None,
+    *,
+    return_parser: bool = False,
+    enable_autocomplete: bool = True,
 ) -> argparse.Namespace | argparse.ArgumentParser:
     """Build and parse CLI arguments.
 
@@ -6847,7 +6891,10 @@ Requirements:
     )
 
     parser.add_argument(
-        "--version", action="version", version=f"%(prog)s {__version__}", help="Show program version and exit"
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
+        help="Show program version and exit",
     )
 
     parser.add_argument("--exit-codes", action="store_true", help="Display exit code reference and exit")
@@ -6881,11 +6928,16 @@ Requirements:
     )
 
     parser.add_argument(
-        "--config-file", type=str, default="config.json", help="Path to CJA configuration file (default: config.json)"
+        "--config-file",
+        type=str,
+        default="config.json",
+        help="Path to CJA configuration file (default: config.json)",
     )
 
     parser.add_argument(
-        "--continue-on-error", action="store_true", help="Continue processing remaining data views if one fails"
+        "--continue-on-error",
+        action="store_true",
+        help="Continue processing remaining data views if one fails",
     )
 
     parser.add_argument(
@@ -6906,7 +6958,9 @@ Requirements:
     )
 
     parser.add_argument(
-        "--production", action="store_true", help="Enable production mode (minimal logging for maximum performance)"
+        "--production",
+        action="store_true",
+        help="Enable production mode (minimal logging for maximum performance)",
     )
 
     parser.add_argument(
@@ -6959,7 +7013,8 @@ Requirements:
     # ==================== RELIABILITY/PERFORMANCE ARGUMENTS ====================
 
     reliability_group = parser.add_argument_group(
-        "Reliability & Performance", "Options for API resilience and performance tuning"
+        "Reliability & Performance",
+        "Options for API resilience and performance tuning",
     )
 
     reliability_group.add_argument(
@@ -7032,11 +7087,15 @@ Requirements:
     )
 
     parser.add_argument(
-        "--quiet", "-q", action="store_true", help="Quiet mode - suppress all output except errors and final summary"
+        "--quiet",
+        "-q",
+        action="store_true",
+        help="Quiet mode - suppress all output except errors and final summary",
     )
 
     discovery_group = parser.add_argument_group(
-        "Discovery", "Commands to explore available CJA resources (mutually exclusive)"
+        "Discovery",
+        "Commands to explore available CJA resources (mutually exclusive)",
     )
     discovery_mx = discovery_group.add_mutually_exclusive_group()
 
@@ -7047,7 +7106,9 @@ Requirements:
     )
 
     discovery_mx.add_argument(
-        "--list-connections", action="store_true", help="List all accessible connections with their datasets and exit"
+        "--list-connections",
+        action="store_true",
+        help="List all accessible connections with their datasets and exit",
     )
 
     discovery_mx.add_argument(
@@ -7140,7 +7201,9 @@ Requirements:
     )
 
     parser.add_argument(
-        "--open", action="store_true", help="Open the generated file(s) in the default application after creation"
+        "--open",
+        action="store_true",
+        help="Open the generated file(s) in the default application after creation",
     )
 
     parser.add_argument(
@@ -7213,7 +7276,10 @@ Requirements:
     )
 
     diff_group.add_argument(
-        "--diff-snapshot", type=str, metavar="FILE", help="Compare data view against a saved snapshot file"
+        "--diff-snapshot",
+        type=str,
+        metavar="FILE",
+        help="Compare data view against a saved snapshot file",
     )
 
     diff_group.add_argument(
@@ -7231,7 +7297,9 @@ Requirements:
     )
 
     diff_group.add_argument(
-        "--changes-only", action="store_true", help="Only show changed items in diff output (hide unchanged)"
+        "--changes-only",
+        action="store_true",
+        help="Only show changed items in diff output (hide unchanged)",
     )
 
     diff_group.add_argument("--summary", action="store_true", help="Show summary statistics only (no detailed changes)")
@@ -7300,7 +7368,9 @@ Requirements:
     )
 
     diff_group.add_argument(
-        "--reverse-diff", action="store_true", help="Reverse the comparison direction (swap source and target)"
+        "--reverse-diff",
+        action="store_true",
+        help="Reverse the comparison direction (swap source and target)",
     )
 
     diff_group.add_argument(
@@ -7311,7 +7381,9 @@ Requirements:
     )
 
     diff_group.add_argument(
-        "--group-by-field", action="store_true", help="Group changes by field name instead of by component"
+        "--group-by-field",
+        action="store_true",
+        help="Group changes by field name instead of by component",
     )
 
     diff_group.add_argument(
@@ -7323,7 +7395,10 @@ Requirements:
     )
 
     diff_group.add_argument(
-        "--diff-output", type=str, metavar="FILE", help="Write diff output directly to file instead of stdout"
+        "--diff-output",
+        type=str,
+        metavar="FILE",
+        help="Write diff output directly to file instead of stdout",
     )
 
     diff_group.add_argument(
@@ -7378,7 +7453,8 @@ Requirements:
     # ==================== PROFILE MANAGEMENT ARGUMENTS ====================
 
     profile_group = parser.add_argument_group(
-        "Profile Management", "Manage organization/credential profiles stored in ~/.cja/orgs/"
+        "Profile Management",
+        "Manage organization/credential profiles stored in ~/.cja/orgs/",
     )
 
     profile_group.add_argument(
@@ -7395,11 +7471,17 @@ Requirements:
     profile_group.add_argument("--profile-add", type=str, metavar="NAME", help="Create a new profile interactively")
 
     profile_group.add_argument(
-        "--profile-test", type=str, metavar="NAME", help="Test profile credentials and API connectivity"
+        "--profile-test",
+        type=str,
+        metavar="NAME",
+        help="Test profile credentials and API connectivity",
     )
 
     profile_group.add_argument(
-        "--profile-show", type=str, metavar="NAME", help="Show profile configuration (with masked secrets)"
+        "--profile-show",
+        type=str,
+        metavar="NAME",
+        help="Show profile configuration (with masked secrets)",
     )
 
     profile_group.add_argument(
@@ -7428,11 +7510,16 @@ Requirements:
     )
 
     git_group.add_argument(
-        "--git-push", action="store_true", help="Push to remote after committing (requires --git-commit)"
+        "--git-push",
+        action="store_true",
+        help="Push to remote after committing (requires --git-commit)",
     )
 
     git_group.add_argument(
-        "--git-message", type=str, metavar="MESSAGE", help="Custom message for Git commit (used with --git-commit)"
+        "--git-message",
+        type=str,
+        metavar="MESSAGE",
+        help="Custom message for Git commit (used with --git-commit)",
     )
 
     git_group.add_argument(
@@ -7445,13 +7532,16 @@ Requirements:
     )
 
     git_group.add_argument(
-        "--git-init", action="store_true", help="Initialize a new Git repository for snapshots at --git-dir location"
+        "--git-init",
+        action="store_true",
+        help="Initialize a new Git repository for snapshots at --git-dir location",
     )
 
     # ==================== DERIVED FIELD INVENTORY ARGUMENTS ====================
 
     derived_group = parser.add_argument_group(
-        "Derived Field Inventory", "Include summary inventory of derived fields in SDR output"
+        "Derived Field Inventory",
+        "Include summary inventory of derived fields in SDR output",
     )
 
     derived_group.add_argument(
@@ -7467,7 +7557,8 @@ Requirements:
     # ==================== CALCULATED METRICS INVENTORY ARGUMENTS ====================
 
     calc_metrics_group = parser.add_argument_group(
-        "Calculated Metrics Inventory", "Include summary inventory of calculated metrics in SDR output"
+        "Calculated Metrics Inventory",
+        "Include summary inventory of calculated metrics in SDR output",
     )
 
     calc_metrics_group.add_argument(
@@ -7481,7 +7572,8 @@ Requirements:
     # ==================== SEGMENTS INVENTORY ARGUMENTS ====================
 
     segments_group = parser.add_argument_group(
-        "Segments Inventory", "Include summary inventory of segments (filters) in SDR output"
+        "Segments Inventory",
+        "Include summary inventory of segments (filters) in SDR output",
     )
 
     segments_group.add_argument(
@@ -7495,7 +7587,8 @@ Requirements:
     # ==================== INVENTORY-ONLY MODE ====================
 
     inventory_only_group = parser.add_argument_group(
-        "Inventory-Only Mode", "Generate output with only inventory sheets (no standard SDR content)"
+        "Inventory-Only Mode",
+        "Generate output with only inventory sheets (no standard SDR content)",
     )
 
     inventory_only_group.add_argument(
@@ -7530,7 +7623,8 @@ Requirements:
     # ==================== ORG-WIDE ANALYSIS ARGUMENTS ====================
 
     org_group = parser.add_argument_group(
-        "Org-Wide Analysis", "Analyze component distribution across all data views in the organization"
+        "Org-Wide Analysis",
+        "Analyze component distribution across all data views in the organization",
     )
 
     org_group.add_argument(
@@ -7625,11 +7719,15 @@ Requirements:
     )
 
     org_group.add_argument(
-        "--org-summary", action="store_true", help="Show only summary statistics, suppress detailed component lists"
+        "--org-summary",
+        action="store_true",
+        help="Show only summary statistics, suppress detailed component lists",
     )
 
     org_group.add_argument(
-        "--org-verbose", action="store_true", help="Include full component lists and detailed breakdowns in output"
+        "--org-verbose",
+        action="store_true",
+        help="Include full component lists and detailed breakdowns in output",
     )
 
     # Component type breakdown (enabled by default)
@@ -7675,7 +7773,11 @@ Requirements:
     )
 
     org_group.add_argument(
-        "--sample-seed", type=int, metavar="SEED", dest="org_sample_seed", help="Random seed for reproducible sampling"
+        "--sample-seed",
+        type=int,
+        metavar="SEED",
+        dest="org_sample_seed",
+        help="Random seed for reproducible sampling",
     )
 
     org_group.add_argument(
@@ -7876,7 +7978,10 @@ def levenshtein_distance(s1: str, s2: str) -> int:
 
 
 def find_similar_names(
-    target: str, available_names: list[str], max_suggestions: int = 3, max_distance: int | None = None
+    target: str,
+    available_names: list[str],
+    max_suggestions: int = 3,
+    max_distance: int | None = None,
 ) -> list[tuple[str, int]]:
     """
     Find names similar to the target using Levenshtein distance.
@@ -8008,7 +8113,7 @@ def _build_data_view_cache_key(
             key: str(value).strip() for key, value in credentials.items() if value is not None and str(value).strip()
         }
     credentials_fingerprint = hashlib.sha256(
-        json.dumps(normalized_credentials, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+        json.dumps(normalized_credentials, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8"),
     ).hexdigest()
 
     return "|".join(
@@ -8017,7 +8122,7 @@ def _build_data_view_cache_key(
             str(profile or ""),
             str(credential_source or ""),
             credentials_fingerprint,
-        ]
+        ],
     )
 
 
@@ -8212,7 +8317,7 @@ def resolve_data_view_names(
                             best_name, best_distance = similar[0]
                             matching_ids = name_to_id_lookup.get(best_name)
                             logger.warning(
-                                f"Name '{identifier}' fuzzy-matched to '{best_name}' (distance: {best_distance})"
+                                f"Name '{identifier}' fuzzy-matched to '{best_name}' (distance: {best_distance})",
                             )
 
                 if matching_ids:
@@ -8785,7 +8890,9 @@ def list_dataviews(
         output_file=output_file,
         profile=profile,
         validate_inputs=lambda: _validate_discovery_query_inputs(
-            filter_pattern=filter_pattern, exclude_pattern=exclude_pattern, limit=limit
+            filter_pattern=filter_pattern,
+            exclude_pattern=exclude_pattern,
+            limit=limit,
         ),
     )
 
@@ -8848,7 +8955,7 @@ def _fetch_connections(
                             "connections": derived,
                             "count": len(derived),
                             "warning": _PERM_WARNING.replace("\n", " "),
-                        }
+                        },
                     )
                 if output_format == "csv":
                     flat = [
@@ -8902,7 +9009,7 @@ def _fetch_connections(
                     "name": conn_name,
                     "owner": owner_name,
                     "datasets": datasets,
-                }
+                },
             )
 
         display_data = _apply_discovery_filters_and_sort(
@@ -8940,10 +9047,11 @@ def _fetch_connections(
                             "owner": conn["owner"],
                             "dataset_id": "",
                             "dataset_name": "",
-                        }
+                        },
                     )
             return _format_as_csv(
-                ["connection_id", "connection_name", "owner", "dataset_id", "dataset_name"], flat_rows
+                ["connection_id", "connection_name", "owner", "dataset_id", "dataset_name"],
+                flat_rows,
             )
         lines: list[str] = []
         lines.append("")
@@ -8990,7 +9098,9 @@ def list_connections(
         output_file=output_file,
         profile=profile,
         validate_inputs=lambda: _validate_discovery_query_inputs(
-            filter_pattern=filter_pattern, exclude_pattern=exclude_pattern, limit=limit
+            filter_pattern=filter_pattern,
+            exclude_pattern=exclude_pattern,
+            limit=limit,
         ),
     )
 
@@ -9076,7 +9186,7 @@ def _fetch_datasets(
                     "name": dv_name,
                     "connection": {"id": parent_conn_id or "N/A", "name": conn_name},
                     "datasets": datasets,
-                }
+                },
             )
 
         display_data = _apply_discovery_filters_and_sort(
@@ -9131,7 +9241,7 @@ def _fetch_datasets(
                             "connection_name": conn_name_val,
                             "dataset_id": "",
                             "dataset_name": "",
-                        }
+                        },
                     )
             return _format_as_csv(
                 ["dataview_id", "dataview_name", "connection_id", "connection_name", "dataset_id", "dataset_name"],
@@ -9189,7 +9299,9 @@ def list_datasets(
         output_file=output_file,
         profile=profile,
         validate_inputs=lambda: _validate_discovery_query_inputs(
-            filter_pattern=filter_pattern, exclude_pattern=exclude_pattern, limit=limit
+            filter_pattern=filter_pattern,
+            exclude_pattern=exclude_pattern,
+            limit=limit,
         ),
     )
 
@@ -9274,7 +9386,7 @@ def interactive_select_dataviews(config_file: str = "config.json", profile: str 
 
         for idx, item in enumerate(display_data, 1):
             print(
-                f"{idx:<{num_width}} {item['id']:<{max_id_width}} {item['name']:<{max_name_width}} {item['owner']:<{max_owner_width}}"
+                f"{idx:<{num_width}} {item['id']:<{max_id_width}} {item['name']:<{max_name_width}} {item['owner']:<{max_owner_width}}",
             )
 
         print()
@@ -9349,7 +9461,7 @@ def interactive_select_dataviews(config_file: str = "config.json", profile: str 
             invalid_indices = [i for i in selected_indices if i < 1 or i > len(display_data)]
             if invalid_indices:
                 print(
-                    ConsoleColors.error(f"Invalid selection(s): {invalid_indices}. Valid range: 1-{len(display_data)}")
+                    ConsoleColors.error(f"Invalid selection(s): {invalid_indices}. Valid range: 1-{len(display_data)}"),
                 )
                 continue
 
@@ -10183,7 +10295,7 @@ def show_stats(
                         "dimensions": dimensions_count,
                         "total_components": metrics_count + dimensions_count,
                         "description": description[:100] + "..." if len(description) > 100 else description,
-                    }
+                    },
                 )
 
             except Exception as e:
@@ -10196,7 +10308,7 @@ def show_stats(
                         "dimensions": 0,
                         "total_components": 0,
                         "description": f"Error: {e!s}",
-                    }
+                    },
                 )
 
         # Output based on format
@@ -10226,7 +10338,7 @@ def show_stats(
                 name = item["name"].replace('"', '""')
                 owner = item["owner"].replace('"', '""')
                 lines.append(
-                    f'{item["id"]},"{name}","{owner}",{item["metrics"]},{item["dimensions"]},{item["total_components"]}'
+                    f'{item["id"]},"{name}","{owner}",{item["metrics"]},{item["dimensions"]},{item["total_components"]}',
                 )
             output_data = "\n".join(lines)
             if is_stdout:
@@ -10258,7 +10370,7 @@ def show_stats(
                         else item["name"]
                     )
                     print(
-                        f"{item['id']:<{max_id_width}} {name:<{max_name_width}} {item['metrics']:>8} {item['dimensions']:>10} {item['total_components']:>8}"
+                        f"{item['id']:<{max_id_width}} {name:<{max_name_width}} {item['metrics']:>8} {item['dimensions']:>10} {item['total_components']:>8}",
                     )
 
                 # Print totals
@@ -10267,7 +10379,7 @@ def show_stats(
                 total_dims = sum(s["dimensions"] for s in stats_data)
                 total_all = sum(s["total_components"] for s in stats_data)
                 print(
-                    f"{'TOTAL':<{max_id_width}} {'':<{max_name_width}} {total_metrics:>8} {total_dims:>10} {total_all:>8}"
+                    f"{'TOTAL':<{max_id_width}} {'':<{max_name_width}} {total_metrics:>8} {total_dims:>10} {total_all:>8}",
                 )
 
             print()
@@ -10342,11 +10454,13 @@ def compare_org_reports(current: OrgReportResult, previous_path: str) -> OrgRepo
     # Backward/forward compatible totals from metrics/dimensions counts
     if prev_core is None:
         prev_core = prev_dist.get("core", {}).get("metrics_count", 0) + prev_dist.get("core", {}).get(
-            "dimensions_count", 0
+            "dimensions_count",
+            0,
         )
     if prev_isolated is None:
         prev_isolated = prev_dist.get("isolated", {}).get("metrics_count", 0) + prev_dist.get("isolated", {}).get(
-            "dimensions_count", 0
+            "dimensions_count",
+            0,
         )
 
     # High-similarity pairs comparison (normalize order for stability)
@@ -10440,7 +10554,7 @@ def write_org_report_console(result: OrgReportResult, config: OrgReportConfig, q
     print(f"Generated: {result.timestamp}")
     if result.is_sampled:
         print(
-            f"Data Views Analyzed: {result.successful_data_views} / {result.total_data_views} (sampled from {result.total_available_data_views})"
+            f"Data Views Analyzed: {result.successful_data_views} / {result.total_data_views} (sampled from {result.total_available_data_views})",
         )
     else:
         print(f"Data Views Analyzed: {result.successful_data_views} / {result.total_data_views}")
@@ -10490,24 +10604,24 @@ def write_org_report_console(result: OrgReportResult, config: OrgReportConfig, q
     print(f"{'':30} {'Metrics':>12} {'Dimensions':>12} {'Total':>10}")
     print(f"{'Total unique components':<30} {total_metrics:>12} {total_dims:>12} {total_all:>10}")
     print(
-        f"{'Total (non-unique)':<30} {total_metrics_aggregate:>12} {total_dimensions_aggregate:>12} {total_components_aggregate:>10}"
+        f"{'Total (non-unique)':<30} {total_metrics_aggregate:>12} {total_dimensions_aggregate:>12} {total_components_aggregate:>10}",
     )
     print(
-        f"{'Derived fields (non-unique)':<30} {total_derived_metrics:>12} {total_derived_dimensions:>12} {total_derived_fields:>10}"
+        f"{'Derived fields (non-unique)':<30} {total_derived_metrics:>12} {total_derived_dimensions:>12} {total_derived_fields:>10}",
     )
     # Add "+" suffix only for percentage labels; absolute labels already have ">="
     core_label_suffix = " DVs" if config.core_min_count is not None else "+ DVs"
     print(
-        f"{'Core (in ' + core_threshold_label + core_label_suffix + ')':<30} {len(dist.core_metrics):>12} {len(dist.core_dimensions):>12} {dist.total_core:>10}"
+        f"{'Core (in ' + core_threshold_label + core_label_suffix + ')':<30} {len(dist.core_metrics):>12} {len(dist.core_dimensions):>12} {dist.total_core:>10}",
     )
     print(
-        f"{'Common (in 25-49% DVs)':<30} {len(dist.common_metrics):>12} {len(dist.common_dimensions):>12} {dist.total_common:>10}"
+        f"{'Common (in 25-49% DVs)':<30} {len(dist.common_metrics):>12} {len(dist.common_dimensions):>12} {dist.total_common:>10}",
     )
     print(
-        f"{'Limited (in 2+ DVs)':<30} {len(dist.limited_metrics):>12} {len(dist.limited_dimensions):>12} {dist.total_limited:>10}"
+        f"{'Limited (in 2+ DVs)':<30} {len(dist.limited_metrics):>12} {len(dist.limited_dimensions):>12} {dist.total_limited:>10}",
     )
     print(
-        f"{'Isolated (in 1 DV only)':<30} {len(dist.isolated_metrics):>12} {len(dist.isolated_dimensions):>12} {dist.total_isolated:>10}"
+        f"{'Isolated (in 1 DV only)':<30} {len(dist.isolated_metrics):>12} {len(dist.isolated_dimensions):>12} {dist.total_isolated:>10}",
     )
     print()
 
@@ -10519,28 +10633,28 @@ def write_org_report_console(result: OrgReportResult, config: OrgReportConfig, q
     print("Metrics by data view coverage:")
     print(f"  Core:     {_render_distribution_bar(len(dist.core_metrics), total_metrics)} ({len(dist.core_metrics)})")
     print(
-        f"  Common:   {_render_distribution_bar(len(dist.common_metrics), total_metrics)} ({len(dist.common_metrics)})"
+        f"  Common:   {_render_distribution_bar(len(dist.common_metrics), total_metrics)} ({len(dist.common_metrics)})",
     )
     print(
-        f"  Limited:  {_render_distribution_bar(len(dist.limited_metrics), total_metrics)} ({len(dist.limited_metrics)})"
+        f"  Limited:  {_render_distribution_bar(len(dist.limited_metrics), total_metrics)} ({len(dist.limited_metrics)})",
     )
     print(
-        f"  Isolated: {_render_distribution_bar(len(dist.isolated_metrics), total_metrics)} ({len(dist.isolated_metrics)})"
+        f"  Isolated: {_render_distribution_bar(len(dist.isolated_metrics), total_metrics)} ({len(dist.isolated_metrics)})",
     )
     print()
 
     print("Dimensions by data view coverage:")
     print(
-        f"  Core:     {_render_distribution_bar(len(dist.core_dimensions), total_dims)} ({len(dist.core_dimensions)})"
+        f"  Core:     {_render_distribution_bar(len(dist.core_dimensions), total_dims)} ({len(dist.core_dimensions)})",
     )
     print(
-        f"  Common:   {_render_distribution_bar(len(dist.common_dimensions), total_dims)} ({len(dist.common_dimensions)})"
+        f"  Common:   {_render_distribution_bar(len(dist.common_dimensions), total_dims)} ({len(dist.common_dimensions)})",
     )
     print(
-        f"  Limited:  {_render_distribution_bar(len(dist.limited_dimensions), total_dims)} ({len(dist.limited_dimensions)})"
+        f"  Limited:  {_render_distribution_bar(len(dist.limited_dimensions), total_dims)} ({len(dist.limited_dimensions)})",
     )
     print(
-        f"  Isolated: {_render_distribution_bar(len(dist.isolated_dimensions), total_dims)} ({len(dist.isolated_dimensions)})"
+        f"  Isolated: {_render_distribution_bar(len(dist.isolated_dimensions), total_dims)} ({len(dist.isolated_dimensions)})",
     )
     print()
 
@@ -10648,10 +10762,10 @@ def write_org_report_console(result: OrgReportResult, config: OrgReportConfig, q
             der_dim_pct = (total_derived_dims / total_dims * 100) if total_dims > 0 else 0
             print(f"{'':18} {'Total':>10} {'Standard':>12} {'% Total':>8} {'Derived':>10} {'% Total':>8}")
             print(
-                f"{'Metrics':<18} {total_metrics:>10} {total_standard_metrics:>12} {std_metric_pct:>7.1f}% {total_derived_metrics:>10} {der_metric_pct:>7.1f}%"
+                f"{'Metrics':<18} {total_metrics:>10} {total_standard_metrics:>12} {std_metric_pct:>7.1f}% {total_derived_metrics:>10} {der_metric_pct:>7.1f}%",
             )
             print(
-                f"{'Dimensions':<18} {total_dims:>10} {total_standard_dims:>12} {std_dim_pct:>7.1f}% {total_derived_dims:>10} {der_dim_pct:>7.1f}%"
+                f"{'Dimensions':<18} {total_dims:>10} {total_standard_dims:>12} {std_dim_pct:>7.1f}% {total_derived_dims:>10} {der_dim_pct:>7.1f}%",
             )
             print()
 
@@ -10697,7 +10811,7 @@ def write_org_report_console(result: OrgReportResult, config: OrgReportConfig, q
             print(
                 f"{owner[:30]:<30} {stats.get('data_view_count', 0):>6} "
                 f"{stats.get('total_metrics', 0):>10} {stats.get('total_dimensions', 0):>12} "
-                f"{stats.get('avg_components_per_dv', 0):>8.1f}"
+                f"{stats.get('avg_components_per_dv', 0):>8.1f}",
             )
         if len(sorted_owners) > 15:
             print(f"  ... and {len(sorted_owners) - 15} more owners")
@@ -11115,7 +11229,10 @@ def build_org_report_json_data(result: OrgReportResult) -> dict[str, Any]:
 
 
 def write_org_report_json(
-    result: OrgReportResult, output_path: Path | None, output_dir: str, logger: logging.Logger
+    result: OrgReportResult,
+    output_path: Path | None,
+    output_dir: str,
+    logger: logging.Logger,
 ) -> str:
     """Write org report as structured JSON.
 
@@ -11146,7 +11263,10 @@ def write_org_report_json(
 
 
 def write_org_report_excel(
-    result: OrgReportResult, output_path: Path | None, output_dir: str, logger: logging.Logger
+    result: OrgReportResult,
+    output_path: Path | None,
+    output_dir: str,
+    logger: logging.Logger,
 ) -> str:
     """Write org report as multi-sheet Excel workbook.
 
@@ -11297,7 +11417,7 @@ def write_org_report_excel(
                         "Coverage %": info.presence_count / result.successful_data_views
                         if result.successful_data_views > 0
                         else 0,
-                    }
+                    },
                 )
         for comp_id in result.distribution.core_dimensions:
             info = result.component_index.get(comp_id)
@@ -11311,7 +11431,7 @@ def write_org_report_excel(
                         "Coverage %": info.presence_count / result.successful_data_views
                         if result.successful_data_views > 0
                         else 0,
-                    }
+                    },
                 )
 
         if core_data:
@@ -11346,7 +11466,7 @@ def write_org_report_excel(
                         "Isolated Metrics": len(isolated_metrics),
                         "Isolated Dimensions": len(isolated_dims),
                         "Total Isolated": len(isolated_metrics) + len(isolated_dims),
-                    }
+                    },
                 )
 
         if isolated_data:
@@ -11401,7 +11521,7 @@ def write_org_report_excel(
                                 "Component ID": comp_id,
                                 "Component Name": name,
                                 "Location": f"Only in {pair.dv1_name}",
-                            }
+                            },
                         )
                     for comp_id in pair.only_in_dv2:
                         name = pair.only_in_dv2_names.get(comp_id, "") if pair.only_in_dv2_names else ""
@@ -11414,7 +11534,7 @@ def write_org_report_excel(
                                 "Component ID": comp_id,
                                 "Component Name": name,
                                 "Location": f"Only in {pair.dv2_name}",
-                            }
+                            },
                         )
             if drift_data:
                 drift_df = pd.DataFrame(drift_data)
@@ -11474,7 +11594,10 @@ def write_org_report_excel(
 
 
 def write_org_report_markdown(
-    result: OrgReportResult, output_path: Path | None, output_dir: str, logger: logging.Logger
+    result: OrgReportResult,
+    output_path: Path | None,
+    output_dir: str,
+    logger: logging.Logger,
 ) -> str:
     """Write org report as GitHub-flavored markdown.
 
@@ -11546,16 +11669,16 @@ def write_org_report_markdown(
         core_desc = f"{result.parameters.core_min_count} or more"
 
     lines.append(
-        f"| Core ({core_label} DVs) | {len(dist.core_metrics)} | {len(dist.core_dimensions)} | {dist.total_core} |"
+        f"| Core ({core_label} DVs) | {len(dist.core_metrics)} | {len(dist.core_dimensions)} | {dist.total_core} |",
     )
     lines.append(
-        f"| Common (25-49% DVs) | {len(dist.common_metrics)} | {len(dist.common_dimensions)} | {dist.total_common} |"
+        f"| Common (25-49% DVs) | {len(dist.common_metrics)} | {len(dist.common_dimensions)} | {dist.total_common} |",
     )
     lines.append(
-        f"| Limited (2+ DVs) | {len(dist.limited_metrics)} | {len(dist.limited_dimensions)} | {dist.total_limited} |"
+        f"| Limited (2+ DVs) | {len(dist.limited_metrics)} | {len(dist.limited_dimensions)} | {dist.total_limited} |",
     )
     lines.append(
-        f"| Isolated (1 DV only) | {len(dist.isolated_metrics)} | {len(dist.isolated_dimensions)} | {dist.total_isolated} |"
+        f"| Isolated (1 DV only) | {len(dist.isolated_metrics)} | {len(dist.isolated_dimensions)} | {dist.total_isolated} |",
     )
     lines.append("")
 
@@ -11690,7 +11813,10 @@ def write_org_report_markdown(
 
 
 def write_org_report_html(
-    result: OrgReportResult, output_path: Path | None, output_dir: str, logger: logging.Logger
+    result: OrgReportResult,
+    output_path: Path | None,
+    output_dir: str,
+    logger: logging.Logger,
 ) -> str:
     """Write org report as styled HTML.
 
@@ -12017,7 +12143,10 @@ def write_org_report_html(
 
 
 def write_org_report_csv(
-    result: OrgReportResult, output_path: Path | None, output_dir: str, logger: logging.Logger
+    result: OrgReportResult,
+    output_path: Path | None,
+    output_dir: str,
+    logger: logging.Logger,
 ) -> str:
     """Write org report as multiple CSV files.
 
@@ -12079,7 +12208,7 @@ def write_org_report_csv(
             "Overlap Threshold (Configured)": result.parameters.overlap_threshold,
             "Overlap Threshold (Effective)": effective_overlap_threshold,
             "Analysis Duration (s)": round(result.duration, 2),
-        }
+        },
     ]
     summary_df = pd.DataFrame(summary_data)
     summary_path = csv_dir / "org_report_summary.csv"
@@ -12129,7 +12258,7 @@ def write_org_report_csv(
                 "Coverage (%)": round(coverage_pct, 1),
                 "Distribution Bucket": bucket,
                 "Data Views": ";".join(sorted(info.data_views)),
-            }
+            },
         )
     comp_df = pd.DataFrame(comp_data)
     comp_df = comp_df.sort_values(["Distribution Bucket", "Data View Count"], ascending=[True, False])
@@ -12209,7 +12338,9 @@ def _normalize_org_report_output_format(output_format: str | None) -> str:
 
 
 def _validate_org_report_output_request(
-    output_format: str, output_to_stdout: bool, status_print: Callable[..., None]
+    output_format: str,
+    output_to_stdout: bool,
+    status_print: Callable[..., None],
 ) -> bool:
     """Validate org-report output arguments before expensive analysis starts."""
     valid_formats = {"console", "json", "excel", "markdown", "html", "csv", "all", *FORMAT_ALIASES}
@@ -12217,14 +12348,14 @@ def _validate_org_report_output_request(
         status_print(
             ConsoleColors.error(
                 f"ERROR: Unknown format '{output_format}'. Valid formats: "
-                "console, json, excel, markdown, html, csv, all, reports, data, ci"
-            )
+                "console, json, excel, markdown, html, csv, all, reports, data, ci",
+            ),
         )
         return False
 
     if output_to_stdout and output_format not in {"json", "console"}:
         status_print(
-            ConsoleColors.error("ERROR: --output stdout is only supported for --format json in org-report mode.")
+            ConsoleColors.error("ERROR: --output stdout is only supported for --format json in org-report mode."),
         )
         return False
 
@@ -12321,7 +12452,7 @@ def run_org_report(
                 _status_print(ConsoleColors.error(f"ERROR: Previous report not found: {org_config.compare_org_report}"))
             except json.JSONDecodeError:
                 _status_print(
-                    ConsoleColors.error(f"ERROR: Invalid JSON in previous report: {org_config.compare_org_report}")
+                    ConsoleColors.error(f"ERROR: Invalid JSON in previous report: {org_config.compare_org_report}"),
                 )
             except Exception as e:
                 _status_print(ConsoleColors.warning(f"Warning: Could not compare reports: {e}"))
@@ -12396,8 +12527,8 @@ def run_org_report(
             if output_to_stdout:
                 _status_print(
                     ConsoleColors.error(
-                        "ERROR: CSV output for org-report writes multiple files and cannot be sent to stdout. Use --output-dir or a file path."
-                    )
+                        "ERROR: CSV output for org-report writes multiple files and cannot be sent to stdout. Use --output-dir or a file path.",
+                    ),
                 )
                 return False, False
             csv_dir = write_org_report_csv(result, output_path_obj, output_dir, logger)
@@ -12432,8 +12563,8 @@ def run_org_report(
             if result.thresholds_exceeded and org_config.fail_on_threshold:
                 _status_print(
                     ConsoleColors.warning(
-                        f"GOVERNANCE THRESHOLDS EXCEEDED - {len(result.governance_violations or [])} violation(s)"
-                    )
+                        f"GOVERNANCE THRESHOLDS EXCEEDED - {len(result.governance_violations or [])} violation(s)",
+                    ),
                 )
             _status_print("=" * 110)
 
@@ -12767,10 +12898,14 @@ def handle_diff_command(
                 days = parse_retention_period(effective_keep_since)
                 if days:
                     deleted_source = snapshot_manager.apply_date_retention_policy(
-                        snapshot_dir, source_id, keep_since_days=days
+                        snapshot_dir,
+                        source_id,
+                        keep_since_days=days,
                     )
                     deleted_target = snapshot_manager.apply_date_retention_policy(
-                        snapshot_dir, target_id, keep_since_days=days
+                        snapshot_dir,
+                        target_id,
+                        keep_since_days=days,
                     )
                     total_deleted += len(deleted_source) + len(deleted_target)
 
@@ -12798,14 +12933,15 @@ def handle_diff_command(
         exit_code_override = None
         if warn_threshold is not None:
             max_change_pct = max(
-                diff_result.summary.metrics_change_percent, diff_result.summary.dimensions_change_percent
+                diff_result.summary.metrics_change_percent,
+                diff_result.summary.dimensions_change_percent,
             )
             if max_change_pct > warn_threshold:
                 exit_code_override = 3
                 if not quiet_diff:
                     print(
                         ConsoleColors.warning(
-                            f"WARNING: Change threshold exceeded! {max_change_pct:.1f}% > {warn_threshold}%"
+                            f"WARNING: Change threshold exceeded! {max_change_pct:.1f}% > {warn_threshold}%",
                         ),
                         file=sys.stderr,
                     )
@@ -13140,7 +13276,9 @@ def handle_diff_snapshot_command(
                 days = parse_retention_period(effective_keep_since)
                 if days:
                     deleted = snapshot_manager.apply_date_retention_policy(
-                        snapshot_dir, data_view_id, keep_since_days=days
+                        snapshot_dir,
+                        data_view_id,
+                        keep_since_days=days,
                     )
                     total_deleted += len(deleted)
 
@@ -13174,14 +13312,15 @@ def handle_diff_snapshot_command(
         exit_code_override = None
         if warn_threshold is not None:
             max_change_pct = max(
-                diff_result.summary.metrics_change_percent, diff_result.summary.dimensions_change_percent
+                diff_result.summary.metrics_change_percent,
+                diff_result.summary.dimensions_change_percent,
             )
             if max_change_pct > warn_threshold:
                 exit_code_override = 3
                 if not quiet_diff:
                     print(
                         ConsoleColors.warning(
-                            f"WARNING: Change threshold exceeded! {max_change_pct:.1f}% > {warn_threshold}%"
+                            f"WARNING: Change threshold exceeded! {max_change_pct:.1f}% > {warn_threshold}%",
                         ),
                         file=sys.stderr,
                     )
@@ -13401,14 +13540,15 @@ def handle_compare_snapshots_command(
         exit_code_override = None
         if warn_threshold is not None:
             max_change_pct = max(
-                diff_result.summary.metrics_change_percent, diff_result.summary.dimensions_change_percent
+                diff_result.summary.metrics_change_percent,
+                diff_result.summary.dimensions_change_percent,
             )
             if max_change_pct > warn_threshold:
                 exit_code_override = 3
                 if not quiet_diff:
                     print(
                         ConsoleColors.warning(
-                            f"WARNING: Change threshold exceeded! {max_change_pct:.1f}% > {warn_threshold}%"
+                            f"WARNING: Change threshold exceeded! {max_change_pct:.1f}% > {warn_threshold}%",
                         ),
                         file=sys.stderr,
                     )
@@ -14067,12 +14207,14 @@ def _main_impl(run_state: dict[str, Any] | None = None):
                 for dv_id in target_ids:
                     deleted_paths.extend(
                         snapshot_manager.apply_date_retention_policy(
-                            snapshot_dir, dv_id, keep_since_days=keep_since_days
-                        )
+                            snapshot_dir,
+                            dv_id,
+                            keep_since_days=keep_since_days,
+                        ),
                     )
             else:
                 deleted_paths.extend(
-                    snapshot_manager.apply_date_retention_policy(snapshot_dir, "*", keep_since_days=keep_since_days)
+                    snapshot_manager.apply_date_retention_policy(snapshot_dir, "*", keep_since_days=keep_since_days),
                 )
 
         unique_deleted = sorted(set(deleted_paths))
@@ -14131,7 +14273,7 @@ def _main_impl(run_state: dict[str, Any] | None = None):
         if getattr(args, "inventory_only", False):
             print(
                 ConsoleColors.error(
-                    "ERROR: --inventory-only is only available in SDR mode, not with --compare-snapshots"
+                    "ERROR: --inventory-only is only available in SDR mode, not with --compare-snapshots",
                 ),
                 file=sys.stderr,
             )
@@ -14201,7 +14343,8 @@ def _main_impl(run_state: dict[str, Any] | None = None):
                 file=sys.stderr,
             )
             print(
-                "Inventory IDs are data-view-scoped and cannot be matched across different data views.", file=sys.stderr
+                "Inventory IDs are data-view-scoped and cannot be matched across different data views.",
+                file=sys.stderr,
             )
             print(
                 "For same-data-view comparisons, use: --diff-snapshot, --compare-snapshots, or --compare-with-prev",
@@ -14211,12 +14354,13 @@ def _main_impl(run_state: dict[str, Any] | None = None):
         if getattr(args, "include_calculated_metrics", False):
             print(
                 ConsoleColors.error(
-                    "ERROR: --include-calculated cannot be used with --diff (cross-data-view comparison)"
+                    "ERROR: --include-calculated cannot be used with --diff (cross-data-view comparison)",
                 ),
                 file=sys.stderr,
             )
             print(
-                "Inventory IDs are data-view-scoped and cannot be matched across different data views.", file=sys.stderr
+                "Inventory IDs are data-view-scoped and cannot be matched across different data views.",
+                file=sys.stderr,
             )
             print(
                 "For same-data-view comparisons, use: --diff-snapshot, --compare-snapshots, or --compare-with-prev",
@@ -14226,12 +14370,13 @@ def _main_impl(run_state: dict[str, Any] | None = None):
         if getattr(args, "include_segments_inventory", False):
             print(
                 ConsoleColors.error(
-                    "ERROR: --include-segments cannot be used with --diff (cross-data-view comparison)"
+                    "ERROR: --include-segments cannot be used with --diff (cross-data-view comparison)",
                 ),
                 file=sys.stderr,
             )
             print(
-                "Inventory IDs are data-view-scoped and cannot be matched across different data views.", file=sys.stderr
+                "Inventory IDs are data-view-scoped and cannot be matched across different data views.",
+                file=sys.stderr,
             )
             print(
                 "For same-data-view comparisons, use: --diff-snapshot, --compare-snapshots, or --compare-with-prev",
@@ -14268,7 +14413,8 @@ def _main_impl(run_state: dict[str, Any] | None = None):
             # Ambiguous - try interactive selection if in terminal
             options = [(dv_id, f"{source_input} ({dv_id})") for dv_id in source_resolved]
             selected = prompt_for_selection(
-                options, f"Source name '{source_input}' matches {len(source_resolved)} data views. Please select one:"
+                options,
+                f"Source name '{source_input}' matches {len(source_resolved)} data views. Please select one:",
             )
             if selected:
                 source_resolved = [selected]
@@ -14276,7 +14422,7 @@ def _main_impl(run_state: dict[str, Any] | None = None):
                 # Not interactive or user cancelled
                 print(
                     ConsoleColors.error(
-                        f"ERROR: Source name '{source_input}' is ambiguous - matches {len(source_resolved)} data views:"
+                        f"ERROR: Source name '{source_input}' is ambiguous - matches {len(source_resolved)} data views:",
                     ),
                     file=sys.stderr,
                 )
@@ -14300,7 +14446,8 @@ def _main_impl(run_state: dict[str, Any] | None = None):
             # Ambiguous - try interactive selection if in terminal
             options = [(dv_id, f"{target_input} ({dv_id})") for dv_id in target_resolved]
             selected = prompt_for_selection(
-                options, f"Target name '{target_input}' matches {len(target_resolved)} data views. Please select one:"
+                options,
+                f"Target name '{target_input}' matches {len(target_resolved)} data views. Please select one:",
             )
             if selected:
                 target_resolved = [selected]
@@ -14308,7 +14455,7 @@ def _main_impl(run_state: dict[str, Any] | None = None):
                 # Not interactive or user cancelled
                 print(
                     ConsoleColors.error(
-                        f"ERROR: Target name '{target_input}' is ambiguous - matches {len(target_resolved)} data views:"
+                        f"ERROR: Target name '{target_input}' is ambiguous - matches {len(target_resolved)} data views:",
                     ),
                     file=sys.stderr,
                 )
@@ -14406,14 +14553,15 @@ def _main_impl(run_state: dict[str, Any] | None = None):
             dv_name = data_view_inputs[0]
             options = [(dv_id, f"{dv_name} ({dv_id})") for dv_id in resolved_ids]
             selected = prompt_for_selection(
-                options, f"Name '{dv_name}' matches {len(resolved_ids)} data views. Please select one:"
+                options,
+                f"Name '{dv_name}' matches {len(resolved_ids)} data views. Please select one:",
             )
             if selected:
                 resolved_ids = [selected]
             else:
                 print(
                     ConsoleColors.error(
-                        f"ERROR: Name '{dv_name}' is ambiguous - matches {len(resolved_ids)} data views:"
+                        f"ERROR: Name '{dv_name}' is ambiguous - matches {len(resolved_ids)} data views:",
                     ),
                     file=sys.stderr,
                 )
@@ -14450,7 +14598,7 @@ def _main_impl(run_state: dict[str, Any] | None = None):
         if getattr(args, "inventory_only", False):
             print(
                 ConsoleColors.error(
-                    "ERROR: --inventory-only is only available in SDR mode, not with --compare-with-prev"
+                    "ERROR: --inventory-only is only available in SDR mode, not with --compare-with-prev",
                 ),
                 file=sys.stderr,
             )
@@ -14475,14 +14623,15 @@ def _main_impl(run_state: dict[str, Any] | None = None):
             dv_name = data_view_inputs[0]
             options = [(dv_id, f"{dv_name} ({dv_id})") for dv_id in resolved_ids]
             selected = prompt_for_selection(
-                options, f"Name '{dv_name}' matches {len(resolved_ids)} data views. Please select one:"
+                options,
+                f"Name '{dv_name}' matches {len(resolved_ids)} data views. Please select one:",
             )
             if selected:
                 resolved_ids = [selected]
             else:
                 print(
                     ConsoleColors.error(
-                        f"ERROR: Name '{dv_name}' is ambiguous - matches {len(resolved_ids)} data views:"
+                        f"ERROR: Name '{dv_name}' is ambiguous - matches {len(resolved_ids)} data views:",
                     ),
                     file=sys.stderr,
                 )
@@ -14499,7 +14648,7 @@ def _main_impl(run_state: dict[str, Any] | None = None):
         if not prev_snapshot:
             print(
                 ConsoleColors.error(
-                    f"ERROR: No previous snapshots found for data view '{resolved_ids[0]}' in {snapshot_dir}"
+                    f"ERROR: No previous snapshots found for data view '{resolved_ids[0]}' in {snapshot_dir}",
                 ),
                 file=sys.stderr,
             )
@@ -14520,7 +14669,8 @@ def _main_impl(run_state: dict[str, Any] | None = None):
     if hasattr(args, "diff_snapshot") and args.diff_snapshot:
         if len(data_view_inputs) != 1:
             print(
-                ConsoleColors.error("ERROR: --diff-snapshot requires exactly 1 data view ID or name"), file=sys.stderr
+                ConsoleColors.error("ERROR: --diff-snapshot requires exactly 1 data view ID or name"),
+                file=sys.stderr,
             )
             print("Usage: cja_auto_sdr DATA_VIEW --diff-snapshot ./snapshots/baseline.json", file=sys.stderr)
             sys.exit(1)
@@ -14564,14 +14714,15 @@ def _main_impl(run_state: dict[str, Any] | None = None):
             dv_name = data_view_inputs[0]
             options = [(dv_id, f"{dv_name} ({dv_id})") for dv_id in resolved_ids]
             selected = prompt_for_selection(
-                options, f"Name '{dv_name}' matches {len(resolved_ids)} data views. Please select one:"
+                options,
+                f"Name '{dv_name}' matches {len(resolved_ids)} data views. Please select one:",
             )
             if selected:
                 resolved_ids = [selected]
             else:
                 print(
                     ConsoleColors.error(
-                        f"ERROR: Name '{dv_name}' is ambiguous - matches {len(resolved_ids)} data views:"
+                        f"ERROR: Name '{dv_name}' is ambiguous - matches {len(resolved_ids)} data views:",
                     ),
                     file=sys.stderr,
                 )
@@ -14828,13 +14979,14 @@ def _main_impl(run_state: dict[str, Any] | None = None):
     api_tuning_config = None
     if getattr(args, "api_auto_tune", False):
         api_tuning_config = APITuningConfig(
-            min_workers=getattr(args, "api_min_workers", 1), max_workers=getattr(args, "api_max_workers", 10)
+            min_workers=getattr(args, "api_min_workers", 1),
+            max_workers=getattr(args, "api_max_workers", 10),
         )
         if not args.quiet:
             print(
                 ConsoleColors.info(
-                    f"API auto-tuning enabled (workers: {api_tuning_config.min_workers}-{api_tuning_config.max_workers})"
-                )
+                    f"API auto-tuning enabled (workers: {api_tuning_config.min_workers}-{api_tuning_config.max_workers})",
+                ),
             )
 
     # Create circuit breaker config if enabled
@@ -14847,8 +14999,8 @@ def _main_impl(run_state: dict[str, Any] | None = None):
         if not args.quiet:
             print(
                 ConsoleColors.info(
-                    f"Circuit breaker enabled (threshold: {circuit_breaker_config.failure_threshold}, timeout: {circuit_breaker_config.timeout_seconds}s)"
-                )
+                    f"Circuit breaker enabled (threshold: {circuit_breaker_config.failure_threshold}, timeout: {circuit_breaker_config.timeout_seconds}s)",
+                ),
             )
 
     # Validate --inventory-only requires at least one --include-* flag
@@ -14905,14 +15057,16 @@ def _main_impl(run_state: dict[str, Any] | None = None):
         )
         if not has_inventory:
             print(
-                ConsoleColors.error("ERROR: --inventory-summary requires at least one inventory flag"), file=sys.stderr
+                ConsoleColors.error("ERROR: --inventory-summary requires at least one inventory flag"),
+                file=sys.stderr,
             )
             print("Use: --include-derived, --include-calculated, and/or --include-segments", file=sys.stderr)
             print("\nExample: cja_auto_sdr dv_12345 --include-segments --inventory-summary", file=sys.stderr)
             sys.exit(1)
         if getattr(args, "inventory_only", False):
             print(
-                ConsoleColors.error("ERROR: --inventory-summary cannot be used with --inventory-only"), file=sys.stderr
+                ConsoleColors.error("ERROR: --inventory-summary cannot be used with --inventory-only"),
+                file=sys.stderr,
             )
             print(
                 "Use --inventory-summary alone for quick stats, or --inventory-only for inventory sheets without full SDR.",
@@ -15012,8 +15166,8 @@ def _main_impl(run_state: dict[str, Any] | None = None):
                 if not args.quiet:
                     print(
                         ConsoleColors.success(
-                            f"✓ {result.data_view_name} ({result.data_view_id}): {result.dq_issues_count} issues"
-                        )
+                            f"✓ {result.data_view_name} ({result.data_view_id}): {result.dq_issues_count} issues",
+                        ),
                     )
             else:
                 # Quality report mode should still fail overall if any DV fails,
@@ -15039,15 +15193,15 @@ def _main_impl(run_state: dict[str, Any] | None = None):
                 cpu_count = os.cpu_count() or 4
                 print(
                     ConsoleColors.info(
-                        f"Auto-detected workers: {args.workers} (based on {cpu_count} CPU cores, {len(data_views)} data views)"
-                    )
+                        f"Auto-detected workers: {args.workers} (based on {cpu_count} CPU cores, {len(data_views)} data views)",
+                    ),
                 )
 
         if not args.quiet:
             print(
                 ConsoleColors.info(
-                    f"Processing {len(data_views)} data view(s) in batch mode with {args.workers} workers..."
-                )
+                    f"Processing {len(data_views)} data view(s) in batch mode with {args.workers} workers...",
+                ),
             )
             print()
 
@@ -15199,8 +15353,8 @@ def _main_impl(run_state: dict[str, Any] | None = None):
                     if result.total_high_complexity > 0:
                         print(
                             ConsoleColors.warning(
-                                f"  ⚠ {result.total_high_complexity} high-complexity items (≥75) - review recommended"
-                            )
+                                f"  ⚠ {result.total_high_complexity} high-complexity items (≥75) - review recommended",
+                            ),
                         )
 
                 # Handle --git-commit for single mode
@@ -15339,7 +15493,7 @@ def _main_impl(run_state: dict[str, Any] | None = None):
                 issue
                 for issue in all_quality_issues
                 if QUALITY_SEVERITY_RANK.get(str(issue.get("Severity", "")).upper(), 99) <= threshold_rank
-            ]
+            ],
         )
         if not args.quiet:
             print(

--- a/src/cja_auto_sdr/inventory/calculated_metrics.py
+++ b/src/cja_auto_sdr/inventory/calculated_metrics.py
@@ -320,7 +320,7 @@ class CalculatedMetricsInventory:
                     "modified",
                     "shared_to",
                     "definition_json",
-                ]
+                ],
             )
 
         # Sort by complexity score descending
@@ -519,7 +519,8 @@ class CalculatedMetricsInventoryBuilder:
         # Extract timestamps
         created = self._coerce_display_text(metric_data.get("created", metric_data.get("createdDate", "")), fallback="")
         modified = self._coerce_display_text(
-            metric_data.get("modified", metric_data.get("modifiedDate", "")), fallback=""
+            metric_data.get("modified", metric_data.get("modifiedDate", "")),
+            fallback="",
         )
 
         # Extract sharing info

--- a/src/cja_auto_sdr/inventory/derived_fields.py
+++ b/src/cja_auto_sdr/inventory/derived_fields.py
@@ -242,7 +242,7 @@ class DerivedFieldInventory:
                     "summary",
                     "output_type",
                     "definition_json",
-                ]
+                ],
             )
 
         # Sort by complexity score descending
@@ -345,7 +345,7 @@ class DerivedFieldInventoryBuilder:
 
         self.logger.info(
             f"Derived field inventory built: {inventory.total_derived_fields} fields "
-            f"({inventory.metrics_count} metrics, {inventory.dimensions_count} dimensions)"
+            f"({inventory.metrics_count} metrics, {inventory.dimensions_count} dimensions)",
         )
 
         return inventory
@@ -388,7 +388,7 @@ class DerivedFieldInventoryBuilder:
             else:
                 component_name = self._coerce_display_text(row.get("name", "Unknown"), fallback="Unknown")
                 self.logger.warning(
-                    f"Derived field '{component_name}' has unexpected definition type: {type(field_def_str)}"
+                    f"Derived field '{component_name}' has unexpected definition type: {type(field_def_str)}",
                 )
                 if stats:
                     stats.record_skip("unexpected definition type", component_name)
@@ -1053,7 +1053,11 @@ class DerivedFieldInventoryBuilder:
         return str(map_to)
 
     def _describe_predicate(
-        self, pred: dict[str, Any], max_depth: int = 2, label_map: dict[str, str] | None = None, match_field: str = ""
+        self,
+        pred: dict[str, Any],
+        max_depth: int = 2,
+        label_map: dict[str, str] | None = None,
+        match_field: str = "",
     ) -> str:
         """Convert a predicate to a brief human-readable condition."""
         if not isinstance(pred, dict) or max_depth <= 0:

--- a/src/cja_auto_sdr/inventory/segments.py
+++ b/src/cja_auto_sdr/inventory/segments.py
@@ -302,7 +302,7 @@ class SegmentsInventory:
                     "modified",
                     "shared_to",
                     "definition_json",
-                ]
+                ],
             )
 
         # Sort by complexity score descending
@@ -475,10 +475,12 @@ class SegmentsInventoryBuilder:
 
         # Extract timestamps
         created = self._coerce_display_text(
-            segment_data.get("created", segment_data.get("createdDate", "")), fallback=""
+            segment_data.get("created", segment_data.get("createdDate", "")),
+            fallback="",
         )
         modified = self._coerce_display_text(
-            segment_data.get("modified", segment_data.get("modifiedDate", "")), fallback=""
+            segment_data.get("modified", segment_data.get("modifiedDate", "")),
+            fallback="",
         )
 
         # Extract sharing info

--- a/src/cja_auto_sdr/inventory/utils.py
+++ b/src/cja_auto_sdr/inventory/utils.py
@@ -310,7 +310,7 @@ class BatchProcessingStats:
         if self.skipped > 0:
             skip_pct = (self.skipped / total) * 100
             self.logger.warning(
-                f"Batch processing: {self.processed} {item_type} processed, {self.skipped} skipped ({skip_pct:.1f}%)"
+                f"Batch processing: {self.processed} {item_type} processed, {self.skipped} skipped ({skip_pct:.1f}%)",
             )
         else:
             self.logger.info(f"Batch processing: {self.processed} {item_type} processed successfully")

--- a/src/cja_auto_sdr/org/analyzer.py
+++ b/src/cja_auto_sdr/org/analyzer.py
@@ -272,7 +272,9 @@ class OrgComponentAnalyzer:
         if self.config.duplicate_threshold is not None or self.config.isolated_threshold is not None:
             self.logger.info("Checking governance thresholds...")
             governance_violations, thresholds_exceeded = self._check_governance_thresholds(
-                similarity_pairs, distribution, len(component_index)
+                similarity_pairs,
+                distribution,
+                len(component_index),
             )
             if thresholds_exceeded:
                 self.logger.warning(f"Governance thresholds exceeded: {len(governance_violations)} violation(s)")
@@ -347,7 +349,7 @@ class OrgComponentAnalyzer:
         for dp in dangerous_patterns:
             if re.search(dp, pattern):
                 self.logger.warning(
-                    f"Potentially dangerous {name} pattern rejected (may cause slow matching): {pattern}"
+                    f"Potentially dangerous {name} pattern rejected (may cause slow matching): {pattern}",
                 )
                 return None
 
@@ -492,7 +494,7 @@ class OrgComponentAnalyzer:
                 cache_stale = stale_count
                 if cache_hits > 0 or cache_stale > 0:
                     self.logger.info(
-                        f"Cache validation: {cache_hits} valid, {cache_stale} stale, {len(to_fetch)} to fetch"
+                        f"Cache validation: {cache_hits} valid, {cache_stale} stale, {len(to_fetch)} to fetch",
                     )
             else:
                 # Standard age-based cache lookup
@@ -572,7 +574,7 @@ class OrgComponentAnalyzer:
                                     data_view_id=dv.get("id", "unknown"),
                                     data_view_name=dv.get("name", "Unknown"),
                                     error=error_msg,
-                                )
+                                ),
                             )
                         pbar.update(1)
                         self._assert_lock_healthy()
@@ -657,7 +659,8 @@ class OrgComponentAnalyzer:
                         .str.lower()
                     )
                     is_derived = type_col.str.contains("derived", na=False) | source_col.str.contains(
-                        "derived", na=False
+                        "derived",
+                        na=False,
                     )
                     derived_metric_count = int(is_derived.sum())
                     standard_metric_count = len(metrics_df) - derived_metric_count
@@ -696,7 +699,8 @@ class OrgComponentAnalyzer:
                         .str.lower()
                     )
                     is_derived = type_col.str.contains("derived", na=False) | source_col.str.contains(
-                        "derived", na=False
+                        "derived",
+                        na=False,
                     )
                     derived_dimension_count = int(is_derived.sum())
                     standard_dimension_count = len(dimensions_df) - derived_dimension_count
@@ -754,7 +758,10 @@ class OrgComponentAnalyzer:
         except Exception as e:
             error_msg = str(e) or f"{type(e).__name__}"
             return DataViewSummary(
-                data_view_id=dv_id, data_view_name=dv_name, error=error_msg, fetch_duration=time.time() - start_time
+                data_view_id=dv_id,
+                data_view_name=dv_name,
+                error=error_msg,
+                fetch_duration=time.time() - start_time,
             )
 
     def _build_component_index(self, summaries: list[DataViewSummary]) -> dict[str, ComponentInfo]:
@@ -780,7 +787,10 @@ class OrgComponentAnalyzer:
                     if summary.metric_names:
                         metric_name = summary.metric_names.get(metric_id)
                     index[metric_id] = ComponentInfo(
-                        component_id=metric_id, component_type="metric", name=metric_name, data_views=set()
+                        component_id=metric_id,
+                        component_type="metric",
+                        name=metric_name,
+                        data_views=set(),
                     )
                 index[metric_id].data_views.add(summary.data_view_id)
 
@@ -792,7 +802,10 @@ class OrgComponentAnalyzer:
                     if summary.dimension_names:
                         dim_name = summary.dimension_names.get(dim_id)
                     index[dim_id] = ComponentInfo(
-                        component_id=dim_id, component_type="dimension", name=dim_name, data_views=set()
+                        component_id=dim_id,
+                        component_type="dimension",
+                        name=dim_name,
+                        data_views=set(),
                     )
                 index[dim_id].data_views.add(summary.data_view_id)
 
@@ -1017,7 +1030,7 @@ class OrgComponentAnalyzer:
                         only_in_dv2=only_in_dv2,
                         only_in_dv1_names=only_in_dv1_names,
                         only_in_dv2_names=only_in_dv2_names,
-                    )
+                    ),
                 )
 
         return sorted(pairs, key=lambda p: p.jaccard_similarity, reverse=True)
@@ -1045,7 +1058,7 @@ class OrgComponentAnalyzer:
             from scipy.spatial.distance import squareform
         except ImportError:
             self.logger.warning(
-                "scipy not available - skipping clustering. Install with: uv pip install 'cja-auto-sdr[clustering]'"
+                "scipy not available - skipping clustering. Install with: uv pip install 'cja-auto-sdr[clustering]'",
             )
             return None
 
@@ -1113,7 +1126,7 @@ class OrgComponentAnalyzer:
                     data_view_ids=dv_ids,
                     data_view_names=dv_names,
                     cohesion_score=round(cohesion, 4),
-                )
+                ),
             )
 
         # Sort by cluster size descending
@@ -1196,7 +1209,7 @@ class OrgComponentAnalyzer:
                         "isolated_count": len(isolated),
                         "reason": f"Data view has {len(isolated)} components not used elsewhere. "
                         "Consider if these are needed or if this DV serves a specialized purpose.",
-                    }
+                    },
                 )
 
         # Recommendation: High overlap pairs
@@ -1235,7 +1248,7 @@ class OrgComponentAnalyzer:
                         "count": near_core_count,
                         "reason": f"{near_core_count} components are in 70-99% of data views. "
                         "Consider standardizing these across all data views.",
-                    }
+                    },
                 )
 
         # Recommendation: Fetch errors
@@ -1248,7 +1261,7 @@ class OrgComponentAnalyzer:
                     "count": error_count,
                     "reason": f"{error_count} data view(s) could not be analyzed due to errors. "
                     "Check permissions and data view status.",
-                }
+                },
             )
 
         # Recommendation: High derived ratio (if component types enabled)
@@ -1270,7 +1283,7 @@ class OrgComponentAnalyzer:
                             "ratio": round(derived_count / total_components, 2),
                             "reason": f"Data view has {derived_count}/{total_components} ({derived_count * 100 // total_components}%) derived components. "
                             "High derived ratios may indicate complex transformations or maintenance burden.",
-                        }
+                        },
                     )
 
         # Recommendation: Stale data views (if metadata enabled)
@@ -1293,7 +1306,7 @@ class OrgComponentAnalyzer:
                                 "modified": summary.modified,
                                 "reason": f"Data view not modified since {summary.modified[:10]}. "
                                 "Consider reviewing if still needed or if updates are required.",
-                            }
+                            },
                         )
                 except ValueError, TypeError:
                     pass
@@ -1309,7 +1322,7 @@ class OrgComponentAnalyzer:
                         "count": no_desc_count,
                         "reason": f"{no_desc_count} data view(s) have no description. "
                         "Adding descriptions improves discoverability and governance.",
-                    }
+                    },
                 )
 
         # Recommendation: Drift in high-overlap pairs (if drift enabled)
@@ -1331,7 +1344,10 @@ class OrgComponentAnalyzer:
         return recommendations
 
     def _check_governance_thresholds(
-        self, similarity_pairs: list[SimilarityPair] | None, distribution: ComponentDistribution, total_components: int
+        self,
+        similarity_pairs: list[SimilarityPair] | None,
+        distribution: ComponentDistribution,
+        total_components: int,
     ) -> tuple[list[dict[str, Any]], bool]:
         """Check if governance thresholds are exceeded (Feature 1).
 
@@ -1356,7 +1372,7 @@ class OrgComponentAnalyzer:
                         "threshold": self.config.duplicate_threshold,
                         "actual": len(high_sim_pairs),
                         "message": f"Found {len(high_sim_pairs)} high-similarity pairs (>=90%), threshold is {self.config.duplicate_threshold}",
-                    }
+                    },
                 )
                 exceeded = True
 
@@ -1373,7 +1389,7 @@ class OrgComponentAnalyzer:
                         "isolated_count": isolated_count,
                         "total_components": total_components,
                         "message": f"Isolated components at {isolated_pct * 100:.1f}% ({isolated_count}/{total_components}), threshold is {self.config.isolated_threshold * 100:.1f}%",
-                    }
+                    },
                 )
                 exceeded = True
 
@@ -1438,7 +1454,7 @@ class OrgComponentAnalyzer:
                         "name": name,
                         "pattern": "stale_keyword",
                         "data_views": list(info.data_views)[:3],  # First 3 DVs
-                    }
+                    },
                 )
             elif _VERSION_SUFFIX_RE.search(name):
                 audit["stale_patterns"].append(
@@ -1447,7 +1463,7 @@ class OrgComponentAnalyzer:
                         "name": name,
                         "pattern": "version_suffix",
                         "data_views": list(info.data_views)[:3],
-                    }
+                    },
                 )
             elif _DATE_PATTERN_RE.search(name):
                 audit["stale_patterns"].append(
@@ -1456,7 +1472,7 @@ class OrgComponentAnalyzer:
                         "name": name,
                         "pattern": "date_pattern",
                         "data_views": list(info.data_views)[:3],
-                    }
+                    },
                 )
 
         # Generate recommendations
@@ -1470,7 +1486,7 @@ class OrgComponentAnalyzer:
                     "severity": "low",
                     "message": f"Mixed naming conventions detected. Dominant style is {dominant_style}, "
                     f"but {non_dominant} components use different styles.",
-                }
+                },
             )
 
         if len(audit["stale_patterns"]) > 0:
@@ -1481,7 +1497,7 @@ class OrgComponentAnalyzer:
                     "count": len(audit["stale_patterns"]),
                     "message": f"Found {len(audit['stale_patterns'])} components with stale naming patterns "
                     "(test, old, temp, version suffixes, or date stamps).",
-                }
+                },
             )
 
         return audit
@@ -1536,12 +1552,15 @@ class OrgComponentAnalyzer:
             "by_owner": owner_stats,
             "total_owners": len(owner_stats),
             "owners_sorted_by_dv_count": sorted(
-                owner_stats.keys(), key=lambda o: owner_stats[o]["data_view_count"], reverse=True
+                owner_stats.keys(),
+                key=lambda o: owner_stats[o]["data_view_count"],
+                reverse=True,
             ),
         }
 
     def _validate_cache_entries(
-        self, data_views: list[dict[str, Any]]
+        self,
+        data_views: list[dict[str, Any]],
     ) -> tuple[list[dict[str, Any]], list[DataViewSummary], int, int]:
         """Validate cached entries using modification timestamps from getDataViews() response.
 
@@ -1588,7 +1607,10 @@ class OrgComponentAnalyzer:
 
             # Try to get from cache with validation
             cached = self.cache.get(
-                dv_id, self.config.cache_max_age_hours, required_flags=required_flags, current_modified=current_modified
+                dv_id,
+                self.config.cache_max_age_hours,
+                required_flags=required_flags,
+                current_modified=current_modified,
             )
 
             if cached:
@@ -1637,7 +1659,7 @@ class OrgComponentAnalyzer:
                         "pattern": pattern_matched,
                         "presence_count": info.presence_count,
                         "data_views": list(info.data_views)[:5],  # First 5 DVs
-                    }
+                    },
                 )
 
         return stale_components

--- a/tests/README.md
+++ b/tests/README.md
@@ -65,10 +65,14 @@ tests/
 ├── test_generator_coverage.py       # Generator utility function coverage
 ├── test_segments_coverage.py        # Segments module coverage (operators, containers)
 ├── test_small_module_coverage.py    # Small module coverage (logging, utils, calc metrics)
+├── test_diff_inventory_output.py   # Inventory diff output across all formats
+├── test_cli_command_handlers.py    # CLI dispatch (--stats, --org-report, --list-snapshots)
+├── test_profile_management.py      # Interactive profile creation, import, test, show
+├── test_snapshot_commands.py        # Snapshot creation, comparison, name resolution
 └── README.md                        # This file
 ```
 
-**Total: 3,678 comprehensive tests**
+**Total: 3,936 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -132,7 +136,11 @@ tests/
 | `test_generator_coverage.py` | 143 | Generator utility functions — coercion, normalization, diff formatting |
 | `test_segments_coverage.py` | 73 | Segment comparison operators, container types, sequence variants |
 | `test_small_module_coverage.py` | 113 | Logging, utils, calculated metrics, constants, lazy, tuning, locks, org cache |
-| **Total** | **3,678** | **Collected via pytest --collect-only** |
+| `test_diff_inventory_output.py` | 88 | Inventory diff output across all formats (console, JSON, HTML, Excel, MD, CSV) |
+| `test_cli_command_handlers.py` | 69 | CLI dispatch for --stats, --org-report, --list-snapshots, diff config unpacking |
+| `test_profile_management.py` | 45 | Interactive profile creation, import, test, show |
+| `test_snapshot_commands.py` | 56 | Snapshot creation, comparison, name resolution |
+| **Total** | **3,936** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -536,7 +544,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (3,678 tests total)
+- [x] Comprehensive test coverage (3,936 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 48 tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -161,7 +161,7 @@ def rich_org_report_result():
                 "metric/isolated/1": "Isolated Metric",
                 "dimension/isolated/1": "Isolated Dimension",
             },
-        )
+        ),
     ]
     similarity_pairs.extend(
         [
@@ -175,7 +175,7 @@ def rich_org_report_result():
                 union_count=22,
             )
             for i in range(10, 31)
-        ]
+        ],
     )
 
     clusters = [
@@ -208,7 +208,10 @@ def rich_org_report_result():
         {"pattern": "deprecated_prefix", "name": f"old_metric_{i}", "component_id": f"metric/old/{i}"} for i in range(6)
     ]
     stale_components.extend(
-        [{"pattern": "legacy_suffix", "name": f"segment_{i}_old", "component_id": f"segment/old/{i}"} for i in range(3)]
+        [
+            {"pattern": "legacy_suffix", "name": f"segment_{i}_old", "component_id": f"segment/old/{i}"}
+            for i in range(3)
+        ],
     )
 
     recommendations = [
@@ -354,7 +357,7 @@ def sample_metrics_df():
                 "title": "Test Metric 2 Title",
                 "description": None,
             },
-        ]
+        ],
     )
 
 
@@ -384,7 +387,7 @@ def sample_dimensions_df():
                 "title": "Test Dimension Duplicate",
                 "description": "Duplicate dimension",
             },
-        ]
+        ],
     )
 
 
@@ -407,7 +410,7 @@ def large_sample_dataframe():
             "type": ["metric" if i % 2 == 0 else "calculated" for i in range(size)],
             "description": [f"Description {i}" if i % 3 != 0 else None for i in range(size)],  # Some nulls
             "title": [f"Title {i}" for i in range(size)],
-        }
+        },
     )
 
 
@@ -419,7 +422,7 @@ def sample_data_dict(sample_metrics_df, sample_dimensions_df):
             {
                 "Property": ["Generated At", "Data View ID", "Tool Version"],
                 "Value": ["2024-01-01 12:00:00", "dv_test_12345", "3.0"],
-            }
+            },
         ),
         "Data Quality": pd.DataFrame(
             [
@@ -430,11 +433,11 @@ def sample_data_dict(sample_metrics_df, sample_dimensions_df):
                     "Item Name": "Test Dimension 1",
                     "Issue": "Duplicate name found 2 times",
                     "Details": "This dimension appears multiple times",
-                }
-            ]
+                },
+            ],
         ),
         "DataView Details": pd.DataFrame(
-            {"Property": ["Name", "ID", "Owner"], "Value": ["Test Data View 1", "dv_test_12345", "Test Owner"]}
+            {"Property": ["Name", "ID", "Owner"], "Value": ["Test Data View 1", "dv_test_12345", "Test Owner"]},
         ),
         "Metrics": sample_metrics_df,
         "Dimensions": sample_dimensions_df,
@@ -466,7 +469,7 @@ def large_metrics_df():
                 "type": "calculated",
                 "title": f"Metric {i}",
                 "description": f"Description {i}" if i % 2 == 0 else "",  # Some missing
-            }
+            },
         )
     return pd.DataFrame(data)
 
@@ -483,7 +486,7 @@ def large_dimensions_df():
                 "type": "string",
                 "title": f"Dimension {i}",
                 "description": f"Description {i}" if i % 3 == 0 else "",  # Some missing
-            }
+            },
         )
     return pd.DataFrame(data)
 
@@ -617,7 +620,7 @@ def sample_derived_metric():
                     "#rule_name": "Bounces",
                     "#rule_type": "caseWhen",
                 },
-            ]
+            ],
         ),
         "dataSetType": "event",
     }
@@ -648,7 +651,7 @@ def sample_derived_dimension():
                     ],
                     "#rule_name": "Channel Classification",
                 },
-            ]
+            ],
         ),
         "dataSetType": "event",
     }
@@ -669,7 +672,7 @@ def sample_derived_metrics_df(sample_derived_metric):
                 "fieldDefinition": None,
                 "dataSetType": "event",
             },
-        ]
+        ],
     )
 
 
@@ -688,7 +691,7 @@ def sample_derived_dimensions_df(sample_derived_dimension):
                 "fieldDefinition": None,
                 "dataSetType": "event",
             },
-        ]
+        ],
     )
 
 
@@ -752,7 +755,7 @@ def mock_cja_with_calculated_metrics(sample_simple_calculated_metric, sample_com
 
     # Return calculated metrics as a DataFrame
     mock_cja.getCalculatedMetrics.return_value = pd.DataFrame(
-        [sample_simple_calculated_metric, sample_complex_calculated_metric]
+        [sample_simple_calculated_metric, sample_complex_calculated_metric],
     )
 
     return mock_cja

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -262,7 +262,9 @@ class TestConfigureCjapyProfileErrors:
         """CredentialSourceError is caught and returns failure tuple."""
         mock_resolver = Mock()
         mock_resolver.resolve.side_effect = CredentialSourceError(
-            "No valid credentials found", source="all", reason="All sources failed"
+            "No valid credentials found",
+            source="all",
+            reason="All sources failed",
         )
         mock_resolver_class.return_value = mock_resolver
 
@@ -301,7 +303,10 @@ class TestInitializeCjaCredentialDetails:
 
     @patch("cja_auto_sdr.api.client.CredentialResolver")
     def test_credential_error_without_details_skips_details_line(
-        self, mock_resolver_class, mock_logger, mock_config_file
+        self,
+        mock_resolver_class,
+        mock_logger,
+        mock_config_file,
     ):
         """When CredentialSourceError has no .details, the details line is skipped."""
         mock_resolver = Mock()
@@ -426,7 +431,12 @@ class TestInitializeCjaGenericException:
     @patch("cja_auto_sdr.api.client.cjapy")
     @patch("cja_auto_sdr.api.client.make_api_call_with_retry")
     def test_unexpected_error_during_api_test(
-        self, mock_api_call, mock_cjapy, mock_resolver_class, mock_logger, mock_config_file
+        self,
+        mock_api_call,
+        mock_cjapy,
+        mock_resolver_class,
+        mock_logger,
+        mock_config_file,
     ):
         """Generic exception during post-CJA-creation flow triggers handler."""
         mock_resolver = Mock()
@@ -547,7 +557,11 @@ class TestConfigureCjapyEnvProfileResolution:
     @patch("cja_auto_sdr.api.client.CredentialResolver")
     @patch("cja_auto_sdr.api.client._config_from_env")
     def test_cja_profile_env_var_whitespace_ignored(
-        self, mock_config_env, mock_resolver_class, mock_dotenv, mock_logger
+        self,
+        mock_config_env,
+        mock_resolver_class,
+        mock_dotenv,
+        mock_logger,
     ):
         """CJA_PROFILE env var with only whitespace is treated as not set."""
         mock_resolver = Mock()
@@ -567,7 +581,11 @@ class TestConfigureCjapyEnvProfileResolution:
     @patch("cja_auto_sdr.api.client.CredentialResolver")
     @patch("cja_auto_sdr.api.client._config_from_env")
     def test_cja_profile_env_var_used_when_no_cli_profile(
-        self, mock_config_env, mock_resolver_class, mock_dotenv, mock_logger
+        self,
+        mock_config_env,
+        mock_resolver_class,
+        mock_dotenv,
+        mock_logger,
     ):
         """CJA_PROFILE env var is used when profile argument is None."""
         mock_resolver = Mock()

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -46,7 +46,7 @@ def _sample_df() -> pd.DataFrame:
             "name": ["Metric A", "Metric B"],
             "type": ["numeric", "numeric"],
             "description": ["desc1", "desc2"],
-        }
+        },
     )
 
 
@@ -343,7 +343,7 @@ class TestGetIssuesDataframeException:
         checker = DataQualityChecker(logger=logger)
         # Add an issue so the empty-check is bypassed
         checker.issues = [
-            {"Severity": "HIGH", "Category": "Test", "Type": "t", "Item Name": "n", "Issue": "i", "Details": "d"}
+            {"Severity": "HIGH", "Category": "Test", "Type": "t", "Item Name": "n", "Issue": "i", "Details": "d"},
         ]
         # Patch CategoricalDtype to raise *after* the initial DataFrame is built
         # This triggers the except block at lines 427-429

--- a/tests/test_api_tuning.py
+++ b/tests/test_api_tuning.py
@@ -115,7 +115,11 @@ class TestAPIWorkerTunerScaling:
     def test_does_not_exceed_max_workers(self):
         """Should not scale beyond max_workers"""
         config = APITuningConfig(
-            min_workers=1, max_workers=3, scale_up_threshold_ms=200, sample_window=3, cooldown_seconds=0
+            min_workers=1,
+            max_workers=3,
+            scale_up_threshold_ms=200,
+            sample_window=3,
+            cooldown_seconds=0,
         )
         tuner = APIWorkerTuner(config=config, initial_workers=3)
 
@@ -130,7 +134,11 @@ class TestAPIWorkerTunerScaling:
     def test_does_not_go_below_min_workers(self):
         """Should not scale below min_workers"""
         config = APITuningConfig(
-            min_workers=2, max_workers=10, scale_down_threshold_ms=2000, sample_window=3, cooldown_seconds=0
+            min_workers=2,
+            max_workers=10,
+            scale_down_threshold_ms=2000,
+            sample_window=3,
+            cooldown_seconds=0,
         )
         tuner = APIWorkerTuner(config=config, initial_workers=2)
 
@@ -208,7 +216,11 @@ class TestAPIWorkerTunerStatistics:
     def test_tracks_scale_ups(self):
         """Should track scale-up count"""
         config = APITuningConfig(
-            min_workers=1, max_workers=10, scale_up_threshold_ms=200, sample_window=3, cooldown_seconds=0
+            min_workers=1,
+            max_workers=10,
+            scale_up_threshold_ms=200,
+            sample_window=3,
+            cooldown_seconds=0,
         )
         tuner = APIWorkerTuner(config=config, initial_workers=3)
 
@@ -222,7 +234,11 @@ class TestAPIWorkerTunerStatistics:
     def test_tracks_scale_downs(self):
         """Should track scale-down count"""
         config = APITuningConfig(
-            min_workers=1, max_workers=10, scale_down_threshold_ms=2000, sample_window=3, cooldown_seconds=0
+            min_workers=1,
+            max_workers=10,
+            scale_down_threshold_ms=2000,
+            sample_window=3,
+            cooldown_seconds=0,
         )
         tuner = APIWorkerTuner(config=config, initial_workers=5)
 

--- a/tests/test_batch_processor.py
+++ b/tests/test_batch_processor.py
@@ -119,7 +119,11 @@ class TestBatchProcessorInit:
         mock_setup_logging.return_value = Mock()
 
         processor = BatchProcessor(
-            config_file=mock_config_file, output_dir=temp_output_dir, enable_cache=True, cache_size=500, cache_ttl=1800
+            config_file=mock_config_file,
+            output_dir=temp_output_dir,
+            enable_cache=True,
+            cache_size=500,
+            cache_ttl=1800,
         )
 
         assert processor.enable_cache is True
@@ -165,7 +169,13 @@ class TestBatchProcessorProcessBatch:
     @patch("cja_auto_sdr.generator.ProcessPoolExecutor")
     @patch("cja_auto_sdr.generator.tqdm")
     def test_process_batch_single_success(
-        self, mock_tqdm, mock_executor, mock_setup_logging, mock_config_file, temp_output_dir, successful_result
+        self,
+        mock_tqdm,
+        mock_executor,
+        mock_setup_logging,
+        mock_config_file,
+        temp_output_dir,
+        successful_result,
     ):
         """Test processing a single data view successfully"""
         mock_setup_logging.return_value = Mock()
@@ -197,7 +207,13 @@ class TestBatchProcessorProcessBatch:
     @patch("cja_auto_sdr.generator.ProcessPoolExecutor")
     @patch("cja_auto_sdr.generator.tqdm")
     def test_process_batch_single_failure(
-        self, mock_tqdm, mock_executor, mock_setup_logging, mock_config_file, temp_output_dir, failed_result
+        self,
+        mock_tqdm,
+        mock_executor,
+        mock_setup_logging,
+        mock_config_file,
+        temp_output_dir,
+        failed_result,
     ):
         """Test processing a single data view that fails"""
         mock_setup_logging.return_value = Mock()
@@ -264,7 +280,12 @@ class TestBatchProcessorProcessBatch:
     @patch("cja_auto_sdr.generator.ProcessPoolExecutor")
     @patch("cja_auto_sdr.generator.tqdm")
     def test_process_batch_exception_handling(
-        self, mock_tqdm, mock_executor, mock_setup_logging, mock_config_file, temp_output_dir
+        self,
+        mock_tqdm,
+        mock_executor,
+        mock_setup_logging,
+        mock_config_file,
+        temp_output_dir,
     ):
         """Test handling of exceptions during batch processing"""
         mock_setup_logging.return_value = Mock()
@@ -293,7 +314,12 @@ class TestBatchProcessorProcessBatch:
     @patch("cja_auto_sdr.generator.ProcessPoolExecutor")
     @patch("cja_auto_sdr.generator.tqdm")
     def test_process_batch_exception_cancels_remaining_when_continue_on_error_false(
-        self, mock_tqdm, mock_executor, mock_setup_logging, mock_config_file, temp_output_dir
+        self,
+        mock_tqdm,
+        mock_executor,
+        mock_setup_logging,
+        mock_config_file,
+        temp_output_dir,
     ):
         """Exceptions should cancel outstanding futures when stopping early."""
         mock_setup_logging.return_value = Mock()
@@ -314,7 +340,9 @@ class TestBatchProcessorProcessBatch:
 
         with patch("cja_auto_sdr.generator.as_completed", return_value=[mock_future]):
             processor = BatchProcessor(
-                config_file=mock_config_file, output_dir=temp_output_dir, continue_on_error=False
+                config_file=mock_config_file,
+                output_dir=temp_output_dir,
+                continue_on_error=False,
             )
             processor.process_batch(["dv_test_12345"])
 
@@ -324,7 +352,12 @@ class TestBatchProcessorProcessBatch:
     @patch("cja_auto_sdr.generator.ProcessPoolExecutor")
     @patch("cja_auto_sdr.generator.tqdm")
     def test_process_batch_shared_cache_shutdown_on_interrupt(
-        self, mock_tqdm, mock_executor, mock_setup_logging, mock_config_file, temp_output_dir
+        self,
+        mock_tqdm,
+        mock_executor,
+        mock_setup_logging,
+        mock_config_file,
+        temp_output_dir,
     ):
         """Shared cache should be shutdown even when processing is interrupted."""
         mock_setup_logging.return_value = Mock()
@@ -364,7 +397,13 @@ class TestBatchProcessorProcessBatch:
     @patch("cja_auto_sdr.generator.ProcessPoolExecutor")
     @patch("cja_auto_sdr.generator.tqdm")
     def test_process_batch_calculates_total_duration(
-        self, mock_tqdm, mock_executor, mock_setup_logging, mock_config_file, temp_output_dir, successful_result
+        self,
+        mock_tqdm,
+        mock_executor,
+        mock_setup_logging,
+        mock_config_file,
+        temp_output_dir,
+        successful_result,
     ):
         """Test that total duration is calculated"""
         mock_setup_logging.return_value = Mock()
@@ -395,7 +434,12 @@ class TestBatchProcessorPrintSummary:
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("builtins.print")
     def test_print_summary_all_successful(
-        self, mock_print, mock_setup_logging, mock_config_file, temp_output_dir, successful_result
+        self,
+        mock_print,
+        mock_setup_logging,
+        mock_config_file,
+        temp_output_dir,
+        successful_result,
     ):
         """Test summary output with all successful results"""
         mock_setup_logging.return_value = Mock()
@@ -413,7 +457,13 @@ class TestBatchProcessorPrintSummary:
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("builtins.print")
     def test_print_summary_with_failures(
-        self, mock_print, mock_setup_logging, mock_config_file, temp_output_dir, successful_result, failed_result
+        self,
+        mock_print,
+        mock_setup_logging,
+        mock_config_file,
+        temp_output_dir,
+        successful_result,
+        failed_result,
     ):
         """Test summary output with some failures"""
         mock_setup_logging.return_value = Mock()
@@ -430,7 +480,13 @@ class TestBatchProcessorPrintSummary:
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("builtins.print")
     def test_print_summary_calculates_success_rate(
-        self, mock_print, mock_setup_logging, mock_config_file, temp_output_dir, successful_result, failed_result
+        self,
+        mock_print,
+        mock_setup_logging,
+        mock_config_file,
+        temp_output_dir,
+        successful_result,
+        failed_result,
     ):
         """Test that success rate is calculated correctly"""
         mock_setup_logging.return_value = Mock()
@@ -463,7 +519,11 @@ class TestBatchProcessorPrintSummary:
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("builtins.print")
     def test_print_summary_calculates_total_file_size(
-        self, mock_print, mock_setup_logging, mock_config_file, temp_output_dir
+        self,
+        mock_print,
+        mock_setup_logging,
+        mock_config_file,
+        temp_output_dir,
     ):
         """Test that total file size is calculated"""
         mock_setup_logging.return_value = Mock()
@@ -471,10 +531,18 @@ class TestBatchProcessorPrintSummary:
         processor = BatchProcessor(config_file=mock_config_file, output_dir=temp_output_dir)
 
         result1 = ProcessingResult(
-            data_view_id="dv_1", data_view_name="DV1", success=True, duration=1.0, file_size_bytes=1024
+            data_view_id="dv_1",
+            data_view_name="DV1",
+            success=True,
+            duration=1.0,
+            file_size_bytes=1024,
         )
         result2 = ProcessingResult(
-            data_view_id="dv_2", data_view_name="DV2", success=True, duration=1.0, file_size_bytes=2048
+            data_view_id="dv_2",
+            data_view_name="DV2",
+            success=True,
+            duration=1.0,
+            file_size_bytes=2048,
         )
 
         results = {"successful": [result1, result2], "failed": [], "total": 2, "total_duration": 2.0}
@@ -492,7 +560,13 @@ class TestBatchProcessorWorkerArgs:
     @patch("cja_auto_sdr.generator.ProcessPoolExecutor")
     @patch("cja_auto_sdr.generator.tqdm")
     def test_worker_args_include_all_settings(
-        self, mock_tqdm, mock_executor, mock_setup_logging, mock_config_file, temp_output_dir, successful_result
+        self,
+        mock_tqdm,
+        mock_executor,
+        mock_setup_logging,
+        mock_config_file,
+        temp_output_dir,
+        successful_result,
     ):
         """Test that worker args include all processor settings"""
         mock_setup_logging.return_value = Mock()
@@ -543,7 +617,12 @@ class TestBatchProcessorEdgeCases:
     @patch("cja_auto_sdr.generator.ProcessPoolExecutor")
     @patch("cja_auto_sdr.generator.tqdm")
     def test_empty_data_view_list(
-        self, mock_tqdm, mock_executor, mock_setup_logging, mock_config_file, temp_output_dir
+        self,
+        mock_tqdm,
+        mock_executor,
+        mock_setup_logging,
+        mock_config_file,
+        temp_output_dir,
     ):
         """Test processing with empty data view list"""
         mock_setup_logging.return_value = Mock()

--- a/tests/test_calculated_metrics_inventory.py
+++ b/tests/test_calculated_metrics_inventory.py
@@ -2875,7 +2875,7 @@ class TestProcessMetricEdgeCases:
                 "id": "cm_1",
                 "name": "No Formula",
                 "definition": {"func": "calc-metric"},
-            }
+            },
         )
         assert result is None
 
@@ -2886,7 +2886,7 @@ class TestProcessMetricEdgeCases:
                 "id": "cm_1",
                 "name": "Empty Formula",
                 "definition": {"formula": "   "},
-            }
+            },
         )
         assert result is None
 
@@ -2897,7 +2897,7 @@ class TestProcessMetricEdgeCases:
                 "id": "cm_1",
                 "name": "Empty List Formula",
                 "definition": {"formula": []},
-            }
+            },
         )
         assert result is None
 
@@ -2908,7 +2908,7 @@ class TestProcessMetricEdgeCases:
                 "id": "cm_1",
                 "name": "String Definition",
                 "definition": "not a dict",
-            }
+            },
         )
         assert result is None
 
@@ -2919,7 +2919,7 @@ class TestProcessMetricEdgeCases:
                 "id": "cm_1",
                 "name": "None Definition",
                 "definition": None,
-            }
+            },
         )
         assert result is None
 
@@ -2933,7 +2933,7 @@ class TestProcessMetricEdgeCases:
                 "approved": True,
                 "favorite": True,
                 "tags": [{"name": "production"}, {"name": "kpi"}],
-            }
+            },
         )
         assert result is not None
         assert result.approved is True
@@ -2948,7 +2948,7 @@ class TestProcessMetricEdgeCases:
                 "name": "Shared Metric",
                 "definition": {"formula": {"func": "metric", "name": "metrics/a"}},
                 "shares": [{"type": "user", "id": "u1"}, {"type": "group", "id": "g1"}],
-            }
+            },
         )
         assert result is not None
         assert result.shared_to_count == 2
@@ -2962,7 +2962,7 @@ class TestProcessMetricEdgeCases:
                 "name": "Bad Shares",
                 "definition": {"formula": {"func": "metric", "name": "metrics/a"}},
                 "shares": "not a list",
-            }
+            },
         )
         assert result is not None
         assert result.shares == []
@@ -2976,7 +2976,7 @@ class TestProcessMetricEdgeCases:
                 "name": "DV Metric",
                 "definition": {"formula": {"func": "metric", "name": "metrics/a"}},
                 "dataId": "dv_12345",
-            }
+            },
         )
         assert result is not None
         assert result.data_view_id == "dv_12345"
@@ -2989,7 +2989,7 @@ class TestProcessMetricEdgeCases:
                 "name": "RSID Metric",
                 "definition": {"formula": {"func": "metric", "name": "metrics/a"}},
                 "rsid": "rsid_67890",
-            }
+            },
         )
         assert result is not None
         assert result.data_view_id == "rsid_67890"
@@ -3002,7 +3002,7 @@ class TestProcessMetricEdgeCases:
                 "name": "Site Title Metric",
                 "definition": {"formula": {"func": "metric", "name": "metrics/a"}},
                 "siteTitle": "My Analytics Site",
-            }
+            },
         )
         assert result is not None
         assert result.site_title == "My Analytics Site"
@@ -3016,7 +3016,7 @@ class TestProcessMetricEdgeCases:
                 "definition": {"formula": {"func": "metric", "name": "metrics/a"}},
                 "createdDate": "2025-01-01T00:00:00Z",
                 "modifiedDate": "2025-06-01T00:00:00Z",
-            }
+            },
         )
         assert result is not None
         assert "2025-01-01" in result.created
@@ -3032,7 +3032,7 @@ class TestProcessMetricEdgeCases:
                 "polarity": "negative",
                 "type": "percent",
                 "precision": 4,
-            }
+            },
         )
         assert result is not None
         assert result.polarity == "negative"
@@ -3058,7 +3058,7 @@ class TestProcessMetricEdgeCases:
                     "formula": {"func": "metric", "name": "metrics/a"},
                     "version": [1, 0, 0],
                 },
-            }
+            },
         )
         assert result is not None
         assert '"formula"' in result.definition_json
@@ -3071,7 +3071,7 @@ class TestProcessMetricEdgeCases:
                 "id": "cm_str_formula",
                 "name": "String Formula",
                 "definition": {"formula": "metrics/revenue"},
-            }
+            },
         )
         assert result is not None
         assert "revenue" in result.formula_summary.lower()
@@ -3083,7 +3083,7 @@ class TestProcessMetricEdgeCases:
                 "id": "cm_list_formula",
                 "name": "List Formula",
                 "definition": {"formula": [{"func": "metric", "name": "metrics/revenue"}]},
-            }
+            },
         )
         assert result is not None
         assert "revenue" in result.formula_summary.lower()
@@ -3095,7 +3095,7 @@ class TestProcessMetricEdgeCases:
                 "id": "cm_bool",
                 "name": "Bool Formula",
                 "definition": {"formula": True},
-            }
+            },
         )
         assert result is not None
 
@@ -3106,7 +3106,7 @@ class TestProcessMetricEdgeCases:
                 "id": "cm_int",
                 "name": "Int Formula",
                 "definition": {"formula": 99},
-            }
+            },
         )
         assert result is not None
         assert "99" in result.formula_summary

--- a/tests/test_cja_initialization.py
+++ b/tests/test_cja_initialization.py
@@ -61,7 +61,7 @@ def invalid_config_file(tmp_path):
 def incomplete_config_file(tmp_path):
     """Create a config file with missing required fields"""
     config_data = {
-        "org_id": "test_org@AdobeOrg"
+        "org_id": "test_org@AdobeOrg",
         # Missing client_id and secret
     }
     config_file = tmp_path / "incomplete_config.json"
@@ -99,7 +99,13 @@ class TestInitializeCjaSuccess:
     @patch("cja_auto_sdr.api.client.cjapy")
     @patch("cja_auto_sdr.api.client.make_api_call_with_retry")
     def test_init_with_env_credentials(
-        self, mock_api_call, mock_cjapy, mock_config_env, mock_resolver_class, mock_logger, mock_config_file
+        self,
+        mock_api_call,
+        mock_cjapy,
+        mock_config_env,
+        mock_resolver_class,
+        mock_logger,
+        mock_config_file,
     ):
         """Test successful initialization with environment credentials"""
         # Mock CredentialResolver to return env credentials
@@ -123,7 +129,12 @@ class TestInitializeCjaSuccess:
     @patch("cja_auto_sdr.api.client.cjapy")
     @patch("cja_auto_sdr.api.client.make_api_call_with_retry")
     def test_init_logs_connection_success(
-        self, mock_api_call, mock_cjapy, mock_resolver_class, mock_logger, mock_config_file
+        self,
+        mock_api_call,
+        mock_cjapy,
+        mock_resolver_class,
+        mock_logger,
+        mock_config_file,
     ):
         """Test that successful connection is logged"""
         # Mock CredentialResolver
@@ -198,7 +209,9 @@ class TestInitializeCjaFailures:
         # Mock CredentialResolver to raise CredentialSourceError
         mock_resolver = Mock()
         mock_resolver.resolve.side_effect = CredentialSourceError(
-            "No valid credentials found", source="all", reason="Config validation failed"
+            "No valid credentials found",
+            source="all",
+            reason="Config validation failed",
         )
         mock_resolver_class.return_value = mock_resolver
 
@@ -213,7 +226,9 @@ class TestInitializeCjaFailures:
         # Mock CredentialResolver to raise CredentialSourceError
         mock_resolver = Mock()
         mock_resolver.resolve.side_effect = CredentialSourceError(
-            "No valid credentials found", source="all", reason="Config file not found"
+            "No valid credentials found",
+            source="all",
+            reason="Config file not found",
         )
         mock_resolver_class.return_value = mock_resolver
 
@@ -365,7 +380,12 @@ class TestInitializeCjaConnectionTest:
     @patch("cja_auto_sdr.api.client.cjapy")
     @patch("cja_auto_sdr.api.client.make_api_call_with_retry")
     def test_connection_test_returns_none(
-        self, mock_api_call, mock_cjapy, mock_resolver_class, mock_logger, mock_config_file
+        self,
+        mock_api_call,
+        mock_cjapy,
+        mock_resolver_class,
+        mock_logger,
+        mock_config_file,
     ):
         """Test handling when connection test returns None"""
         mock_resolver = Mock()
@@ -389,7 +409,12 @@ class TestInitializeCjaConnectionTest:
     @patch("cja_auto_sdr.api.client.cjapy")
     @patch("cja_auto_sdr.api.client.make_api_call_with_retry")
     def test_connection_test_raises_exception(
-        self, mock_api_call, mock_cjapy, mock_resolver_class, mock_logger, mock_config_file
+        self,
+        mock_api_call,
+        mock_cjapy,
+        mock_resolver_class,
+        mock_logger,
+        mock_config_file,
     ):
         """Test handling when connection test raises exception"""
         mock_resolver = Mock()
@@ -557,7 +582,7 @@ class TestListDataviews:
         mock_cja = Mock()
         mock_cjapy.CJA.return_value = mock_cja
         mock_cja.getDataViews.return_value = pd.DataFrame(
-            [{"id": "dv_1", "name": "Data View 1", "owner": {"name": "Owner 1"}}]
+            [{"id": "dv_1", "name": "Data View 1", "owner": {"name": "Owner 1"}}],
         )
 
         result = list_dataviews(mock_config_file)
@@ -611,7 +636,13 @@ class TestValidateConfigOnly:
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("builtins.print")
     def test_validates_env_credentials(
-        self, mock_print, mock_cjapy, mock_config_env, mock_validate_env, mock_load_env, mock_config_file
+        self,
+        mock_print,
+        mock_cjapy,
+        mock_config_env,
+        mock_validate_env,
+        mock_load_env,
+        mock_config_file,
     ):
         """Test validation with environment credentials"""
         mock_load_env.return_value = {"org_id": "test@AdobeOrg", "client_id": "test_client", "secret": "test_secret"}
@@ -682,7 +713,12 @@ class TestInitializeCjaEnvFallback:
     @patch("cja_auto_sdr.api.client.cjapy")
     @patch("cja_auto_sdr.api.client.make_api_call_with_retry")
     def test_falls_back_to_config_when_env_incomplete(
-        self, mock_api_call, mock_cjapy, mock_resolver_class, mock_logger, mock_config_file
+        self,
+        mock_api_call,
+        mock_cjapy,
+        mock_resolver_class,
+        mock_logger,
+        mock_config_file,
     ):
         """Test fallback to config file when env credentials incomplete"""
         # CredentialResolver handles fallback internally — mock it to return config source
@@ -708,7 +744,9 @@ class TestInitializeCjaEnvFallback:
         # CredentialResolver raises when no valid credentials found
         mock_resolver = Mock()
         mock_resolver.resolve.side_effect = CredentialSourceError(
-            "No valid credentials found", source="all", reason="All sources failed"
+            "No valid credentials found",
+            source="all",
+            reason="All sources failed",
         )
         mock_resolver_class.return_value = mock_resolver
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -357,7 +357,11 @@ class TestProcessingResult:
         from cja_auto_sdr.generator import ProcessingResult
 
         result = ProcessingResult(
-            data_view_id="dv_test", data_view_name="Test", success=True, duration=1.0, file_size_bytes=500
+            data_view_id="dv_test",
+            data_view_name="Test",
+            success=True,
+            duration=1.0,
+            file_size_bytes=500,
         )
         assert result.file_size_formatted == "500 B"
 
@@ -366,7 +370,11 @@ class TestProcessingResult:
         from cja_auto_sdr.generator import ProcessingResult
 
         result = ProcessingResult(
-            data_view_id="dv_test", data_view_name="Test", success=True, duration=1.0, file_size_bytes=2048
+            data_view_id="dv_test",
+            data_view_name="Test",
+            success=True,
+            duration=1.0,
+            file_size_bytes=2048,
         )
         assert result.file_size_formatted == "2.0 KB"
 
@@ -375,7 +383,11 @@ class TestProcessingResult:
         from cja_auto_sdr.generator import ProcessingResult
 
         result = ProcessingResult(
-            data_view_id="dv_test", data_view_name="Test", success=True, duration=1.0, file_size_bytes=1048576
+            data_view_id="dv_test",
+            data_view_name="Test",
+            success=True,
+            duration=1.0,
+            file_size_bytes=1048576,
         )
         assert result.file_size_formatted == "1.0 MB"
 
@@ -384,7 +396,11 @@ class TestProcessingResult:
         from cja_auto_sdr.generator import ProcessingResult
 
         result = ProcessingResult(
-            data_view_id="dv_test", data_view_name="Test", success=True, duration=1.0, file_size_bytes=0
+            data_view_id="dv_test",
+            data_view_name="Test",
+            success=True,
+            duration=1.0,
+            file_size_bytes=0,
         )
         assert result.file_size_formatted == "0 B"
 
@@ -709,7 +725,10 @@ class TestQualityGateAndReport:
     @patch("cja_auto_sdr.generator.process_single_dataview")
     @patch("cja_auto_sdr.generator.resolve_data_view_names")
     def test_quality_report_continue_on_error_still_exits_1_on_processing_failure(
-        self, mock_resolve, mock_process, mock_write_report
+        self,
+        mock_resolve,
+        mock_process,
+        mock_write_report,
     ):
         """--continue-on-error should continue processing but still fail on processing errors."""
         from cja_auto_sdr.generator import ProcessingResult, main
@@ -804,7 +823,11 @@ class TestQualityGateAndReport:
     @patch("cja_auto_sdr.generator.process_single_dataview")
     @patch("cja_auto_sdr.generator.resolve_data_view_names")
     def test_quality_report_write_error_exits_cleanly_with_code_1(
-        self, mock_resolve, mock_process, mock_write_report, capsys
+        self,
+        mock_resolve,
+        mock_process,
+        mock_write_report,
+        capsys,
     ):
         """Quality report write failures should be handled with a clean exit code 1."""
         from cja_auto_sdr.generator import ProcessingResult, main
@@ -821,7 +844,9 @@ class TestQualityGateAndReport:
         )
 
         with patch.object(
-            sys, "argv", ["cja_auto_sdr", "dv_ok", "--quality-report", "json", "--output", "report.json"]
+            sys,
+            "argv",
+            ["cja_auto_sdr", "dv_ok", "--quality-report", "json", "--output", "report.json"],
         ):
             with pytest.raises(SystemExit) as exc_info:
                 main()
@@ -960,7 +985,8 @@ class TestQualityGateAndReport:
 
         policy_path = tmp_path / "quality_policy.json"
         policy_path.write_text(
-            json.dumps({"fail_on_quality": "HIGH", "quality_report": "csv", "max_issues": 5}), encoding="utf-8"
+            json.dumps({"fail_on_quality": "HIGH", "quality_report": "csv", "max_issues": 5}),
+            encoding="utf-8",
         )
         mock_list_dataviews.return_value = True
 
@@ -984,7 +1010,9 @@ class TestQualityGateAndReport:
     @patch("cja_auto_sdr.generator.BatchProcessor")
     @patch("cja_auto_sdr.generator.resolve_data_view_names")
     def test_batch_failures_take_precedence_over_quality_gate_with_continue_on_error(
-        self, mock_resolve, mock_batch_cls
+        self,
+        mock_resolve,
+        mock_batch_cls,
     ):
         """Batch processing failures should keep exit code 1 precedence over quality gate exit 2."""
         from cja_auto_sdr.generator import ProcessingResult, main
@@ -1001,7 +1029,7 @@ class TestQualityGateAndReport:
                     dq_issues_count=1,
                     dq_issues=[{"Severity": "HIGH", "Issue": "Threshold issue"}],
                     dq_severity_counts={"HIGH": 1},
-                )
+                ),
             ],
             "failed": [
                 ProcessingResult(
@@ -1010,7 +1038,7 @@ class TestQualityGateAndReport:
                     success=False,
                     duration=0.1,
                     error_message="mock failure",
-                )
+                ),
             ],
             "total": 2,
             "total_duration": 0.2,
@@ -1054,7 +1082,7 @@ class TestQualityGateAndReport:
                     dq_issues_count=0,
                     dq_issues=[],
                     dq_severity_counts={},
-                )
+                ),
             ],
             "failed": [
                 ProcessingResult(
@@ -1063,7 +1091,7 @@ class TestQualityGateAndReport:
                     success=False,
                     duration=0.1,
                     error_message="mock failure",
-                )
+                ),
             ],
             "total": 2,
             "total_duration": 0.2,
@@ -1143,7 +1171,9 @@ class TestQualityGateAndReport:
         mock_handle_diff.return_value = (True, False, None)
 
         with patch.object(
-            sys, "argv", ["cja_auto_sdr", "--diff", "dv_a", "dv_b", "--auto-snapshot", "--auto-prune", "--keep-last=0"]
+            sys,
+            "argv",
+            ["cja_auto_sdr", "--diff", "dv_a", "dv_b", "--auto-snapshot", "--auto-prune", "--keep-last=0"],
         ):
             with pytest.raises(SystemExit) as exc_info:
                 main()
@@ -1728,8 +1758,8 @@ class TestListConnectionsFunction:
                     "name": "Production Connection",
                     "ownerFullName": "John Doe",
                     "dataSets": [{"id": "ds_456", "name": "Web Events"}, {"id": "ds_789", "name": "Mobile Events"}],
-                }
-            ]
+                },
+            ],
         }
 
         import io
@@ -1756,7 +1786,7 @@ class TestListConnectionsFunction:
             "content": [
                 {"id": "conn_1", "name": "Prod Connection", "ownerFullName": "Owner A", "dataSets": []},
                 {"id": "conn_2", "name": "Staging Connection", "ownerFullName": "Owner B", "dataSets": []},
-            ]
+            ],
         }
 
         import io
@@ -1843,8 +1873,8 @@ class TestListConnectionsFunction:
                     "name": "Test Conn",
                     "ownerFullName": "Owner",
                     "dataSets": [{"id": "ds_1", "name": "Dataset One"}],
-                }
-            ]
+                },
+            ],
         }
 
         import io
@@ -1874,8 +1904,8 @@ class TestListConnectionsFunction:
                     "name": "Test Conn",
                     "ownerFullName": None,
                     "dataSets": [{"id": "ds_1", "name": "Dataset One"}],
-                }
-            ]
+                },
+            ],
         }
 
         import io
@@ -1897,7 +1927,7 @@ class TestListConnectionsFunction:
         mock_configure.return_value = (True, "config", None)
         mock_cja_instance = mock_cjapy.CJA.return_value
         mock_cja_instance.getConnections.return_value = {
-            "content": [{"id": "conn_1", "name": "Test Conn", "ownerFullName": None, "dataSets": []}]
+            "content": [{"id": "conn_1", "name": "Test Conn", "ownerFullName": None, "dataSets": []}],
         }
 
         import io
@@ -1920,7 +1950,7 @@ class TestListConnectionsFunction:
         mock_configure.return_value = (True, "config", None)
         mock_cja_instance = mock_cjapy.CJA.return_value
         mock_cja_instance.getConnections.return_value = {
-            "content": [{"id": "conn_1", "name": "Test Conn", "dataSets": []}]
+            "content": [{"id": "conn_1", "name": "Test Conn", "dataSets": []}],
         }
 
         import io
@@ -1948,8 +1978,8 @@ class TestListConnectionsFunction:
                     "name": "Test Conn",
                     "ownerFullName": "",
                     "dataSets": [{"id": "ds_1", "name": "Dataset One"}],
-                }
-            ]
+                },
+            ],
         }
 
         import io
@@ -1971,7 +2001,7 @@ class TestListConnectionsFunction:
         mock_configure.return_value = (True, "config", None)
         mock_cja_instance = mock_cjapy.CJA.return_value
         mock_cja_instance.getConnections.return_value = {
-            "content": [{"id": "conn_1", "name": "Test Conn", "ownerFullName": "", "dataSets": []}]
+            "content": [{"id": "conn_1", "name": "Test Conn", "ownerFullName": "", "dataSets": []}],
         }
 
         import io
@@ -2037,11 +2067,11 @@ class TestListDatasetsFunction:
                     "id": "conn_456",
                     "name": "Production Connection",
                     "dataSets": [{"id": "ds_789", "name": "Web Events"}],
-                }
-            ]
+                },
+            ],
         }
         mock_cja_instance.getDataViews.return_value = [
-            {"id": "dv_123", "name": "Web Data View", "parentDataGroupId": "conn_456"}
+            {"id": "dv_123", "name": "Web Data View", "parentDataGroupId": "conn_456"},
         ]
 
         import io
@@ -2123,7 +2153,7 @@ class TestListDatasetsFunction:
         mock_cja_instance = mock_cjapy.CJA.return_value
         mock_cja_instance.getConnections.return_value = {"content": []}
         mock_cja_instance.getDataViews.return_value = pd.DataFrame(
-            [{"id": "dv_orphan_nan", "name": "Orphan NaN", "parentDataGroupId": float("nan")}]
+            [{"id": "dv_orphan_nan", "name": "Orphan NaN", "parentDataGroupId": float("nan")}],
         )
 
         import io
@@ -2148,10 +2178,10 @@ class TestListDatasetsFunction:
         mock_configure.return_value = (True, "config", None)
         mock_cja_instance = mock_cjapy.CJA.return_value
         mock_cja_instance.getConnections.return_value = {
-            "content": [{"id": "conn_1", "name": "Conn One", "dataSets": [{"id": "ds_1", "name": "Dataset"}]}]
+            "content": [{"id": "conn_1", "name": "Conn One", "dataSets": [{"id": "ds_1", "name": "Dataset"}]}],
         }
         mock_cja_instance.getDataViews.return_value = [
-            {"id": "dv_1", "name": "View One", "parentDataGroupId": "conn_1"}
+            {"id": "dv_1", "name": "View One", "parentDataGroupId": "conn_1"},
         ]
 
         import io
@@ -2340,8 +2370,8 @@ class TestFileOutput:
                     "name": "Test Conn",
                     "ownerFullName": "Owner",
                     "dataSets": [{"id": "ds_1", "name": "Dataset One"}],
-                }
-            ]
+                },
+            ],
         }
 
         out_file = str(tmp_path / "connections.json")
@@ -2367,8 +2397,8 @@ class TestFileOutput:
                     "name": "Test Conn",
                     "ownerFullName": "Owner",
                     "dataSets": [{"id": "ds_1", "name": "Dataset One"}],
-                }
-            ]
+                },
+            ],
         }
 
         out_file = str(tmp_path / "connections.csv")
@@ -2389,10 +2419,10 @@ class TestFileOutput:
         mock_configure.return_value = (True, "config", None)
         mock_cja_instance = mock_cjapy.CJA.return_value
         mock_cja_instance.getConnections.return_value = {
-            "content": [{"id": "conn_1", "name": "Conn One", "dataSets": [{"id": "ds_1", "name": "Dataset"}]}]
+            "content": [{"id": "conn_1", "name": "Conn One", "dataSets": [{"id": "ds_1", "name": "Dataset"}]}],
         }
         mock_cja_instance.getDataViews.return_value = [
-            {"id": "dv_1", "name": "View One", "parentDataGroupId": "conn_1"}
+            {"id": "dv_1", "name": "View One", "parentDataGroupId": "conn_1"},
         ]
 
         out_file = str(tmp_path / "datasets.json")
@@ -2412,7 +2442,7 @@ class TestFileOutput:
         mock_configure.return_value = (True, "config", None)
         mock_cja_instance = mock_cjapy.CJA.return_value
         mock_cja_instance.getDataViews.return_value = [
-            {"id": "dv_1", "name": "My View", "owner": {"name": "Test User"}}
+            {"id": "dv_1", "name": "My View", "owner": {"name": "Test User"}},
         ]
 
         out_file = str(tmp_path / "dataviews.json")
@@ -2438,8 +2468,8 @@ class TestFileOutput:
                     "name": "Test Conn",
                     "ownerFullName": "Owner",
                     "dataSets": [{"id": "ds_1", "name": "Dataset One"}],
-                }
-            ]
+                },
+            ],
         }
 
         out_file = str(tmp_path / "connections.txt")
@@ -2459,7 +2489,7 @@ class TestFileOutput:
         mock_configure.return_value = (True, "config", None)
         mock_cja_instance = mock_cjapy.CJA.return_value
         mock_cja_instance.getConnections.return_value = {
-            "content": [{"id": "conn_1", "name": "Test", "ownerFullName": "Owner", "dataSets": []}]
+            "content": [{"id": "conn_1", "name": "Test", "ownerFullName": "Owner", "dataSets": []}],
         }
 
         out_file = str(tmp_path / "subdir" / "nested" / "connections.json")
@@ -2483,11 +2513,11 @@ class TestFileOutput:
                     "id": "conn_1",
                     "name": "Conn One",
                     "dataSets": [{"id": "ds_1", "name": "Dataset A"}, {"id": "ds_2", "name": "Dataset B"}],
-                }
-            ]
+                },
+            ],
         }
         mock_cja_instance.getDataViews.return_value = [
-            {"id": "dv_1", "name": "View One", "parentDataGroupId": "conn_1"}
+            {"id": "dv_1", "name": "View One", "parentDataGroupId": "conn_1"},
         ]
 
         out_file = str(tmp_path / "datasets.csv")
@@ -3003,7 +3033,8 @@ class TestRunSummaryOutput:
 
         policy_path = tmp_path / "quality_policy.json"
         policy_path.write_text(
-            json.dumps({"fail_on_quality": "HIGH", "quality_report": "csv", "max_issues": 5}), encoding="utf-8"
+            json.dumps({"fail_on_quality": "HIGH", "quality_report": "csv", "max_issues": 5}),
+            encoding="utf-8",
         )
         mock_list_dataviews.return_value = True
         summary_file = tmp_path / "run_summary_discovery_quality_policy.json"
@@ -3033,7 +3064,10 @@ class TestRunSummaryOutput:
     @patch("cja_auto_sdr.generator.run_org_report")
     @patch("cja_auto_sdr.generator.list_dataviews")
     def test_run_summary_mode_precedence_matches_dispatch_order(
-        self, mock_list_dataviews, mock_run_org_report, tmp_path
+        self,
+        mock_list_dataviews,
+        mock_run_org_report,
+        tmp_path,
     ):
         """When multiple mode flags are present, summary mode should match the first dispatch branch."""
         from cja_auto_sdr.generator import main
@@ -3089,7 +3123,11 @@ class TestRunSummaryOutput:
     @patch("cja_auto_sdr.generator.resolve_data_view_names")
     @patch("cja_auto_sdr.generator.interactive_wizard")
     def test_run_summary_interactive_refreshes_data_view_inputs(
-        self, mock_wizard, mock_resolve, mock_process, tmp_path
+        self,
+        mock_wizard,
+        mock_resolve,
+        mock_process,
+        tmp_path,
     ):
         """Interactive runs should record wizard-selected data view inputs in run summary."""
         from cja_auto_sdr.generator import ProcessingResult, WizardConfig, main
@@ -3216,7 +3254,11 @@ class TestRunSummaryOutput:
     @patch("cja_auto_sdr.generator.process_single_dataview")
     @patch("cja_auto_sdr.generator.resolve_data_view_names")
     def test_run_summary_quality_report_uses_quality_report_format(
-        self, mock_resolve, mock_process, mock_write_report, tmp_path
+        self,
+        mock_resolve,
+        mock_process,
+        mock_write_report,
+        tmp_path,
     ):
         """Run summary output_format should reflect --quality-report format, not internal SDR writer format."""
         from cja_auto_sdr.generator import ProcessingResult, main

--- a/tests/test_cli_command_handlers.py
+++ b/tests/test_cli_command_handlers.py
@@ -1678,10 +1678,12 @@ class TestMainImplDiffLabels:
     """Tests for --diff-labels parsing (lines 14073-14076)."""
 
     @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
     @patch("cja_auto_sdr.generator.handle_diff_command")
-    def test_diff_labels_parsed_as_tuple(self, mock_diff):
+    def test_diff_labels_parsed_as_tuple(self, mock_diff, mock_resolve):
         """--diff-labels should be parsed and passed as tuple."""
         mock_diff.return_value = (True, False, None)
+        mock_resolve.return_value = (["dv_a"], {})
 
         with pytest.raises(SystemExit):
             with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:

--- a/tests/test_cli_command_handlers.py
+++ b/tests/test_cli_command_handlers.py
@@ -15,8 +15,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-from contextlib import redirect_stderr, redirect_stdout
-from io import StringIO
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -264,7 +262,7 @@ class TestProcessInventorySummary:
 
         # Should use data_view_id as the name fallback
         call_kwargs = mock_display.call_args
-        assert call_kwargs[1]["data_view_name"] == "dv_test123" or call_kwargs[1]["data_view_id"] == "dv_test123"
+        assert call_kwargs[1]["data_view_name"] == "dv_test123"
 
 
 # ==================== handle_diff_command ====================
@@ -670,7 +668,7 @@ class TestHandleDiffCommand:
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")
     def test_diff_non_console_format_prints_success(
-        self, mock_conf, mock_cjapy, mock_sm_cls, mock_comp_cls, mock_write, mock_build, mock_append
+        self, mock_conf, mock_cjapy, mock_sm_cls, mock_comp_cls, mock_write, mock_build, mock_append, capsys
     ):
         """Non-console output format should print success message when not quiet."""
         mock_conf.return_value = (True, "config_path", {})
@@ -686,17 +684,15 @@ class TestHandleDiffCommand:
         mock_comp_cls.return_value = mock_comp
         mock_write.return_value = ""
 
-        stdout_buf = StringIO()
-        with redirect_stdout(stdout_buf):
-            handle_diff_command(
-                source_id="dv_a",
-                target_id="dv_b",
-                output_format="json",
-                quiet=False,
-            )
+        handle_diff_command(
+            source_id="dv_a",
+            target_id="dv_b",
+            output_format="json",
+            quiet=False,
+        )
 
-        output = stdout_buf.getvalue()
-        assert "Diff report generated successfully" in output or "COMPARING" in output
+        captured = capsys.readouterr()
+        assert "Diff report generated successfully" in captured.out
 
 
 # ==================== handle_diff_snapshot_command ====================
@@ -774,7 +770,7 @@ class TestHandleDiffSnapshotCommand:
         assert success is False
 
     @patch("cja_auto_sdr.generator.SnapshotManager")
-    def test_missing_inventory_blocks_diff(self, mock_sm_cls):
+    def test_missing_inventory_blocks_diff(self, mock_sm_cls, capsys):
         """Requesting calc metrics from snapshot that lacks them returns failure."""
         snap = _make_mock_snapshot()
         snap.has_calculated_metrics_inventory = False
@@ -784,17 +780,16 @@ class TestHandleDiffSnapshotCommand:
         mock_sm.load_snapshot.return_value = snap
         mock_sm_cls.return_value = mock_sm
 
-        stderr_buf = StringIO()
-        with redirect_stderr(stderr_buf):
-            success, _, _ = handle_diff_snapshot_command(
-                data_view_id="dv_test",
-                snapshot_file="snap.json",
-                include_calc_metrics=True,
-                quiet=True,
-            )
+        success, _, _ = handle_diff_snapshot_command(
+            data_view_id="dv_test",
+            snapshot_file="snap.json",
+            include_calc_metrics=True,
+            quiet=True,
+        )
 
         assert success is False
-        assert "missing" in stderr_buf.getvalue().lower() or "ERROR" in stderr_buf.getvalue()
+        captured = capsys.readouterr()
+        assert "snapshot missing requested data" in captured.err
 
     @patch("cja_auto_sdr.generator.append_github_step_summary")
     @patch("cja_auto_sdr.generator.build_diff_step_summary")
@@ -1016,37 +1011,33 @@ class TestMainImplGitInit:
 
     @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
     @patch("cja_auto_sdr.generator.git_init_snapshot_repo")
-    def test_git_init_success(self, mock_git_init):
+    def test_git_init_success(self, mock_git_init, capsys):
         mock_git_init.return_value = (True, "Repository initialized")
         run_state = {"mode": "unknown", "details": {}}
 
-        stdout_buf = StringIO()
         with pytest.raises(SystemExit) as exc_info:
-            with redirect_stdout(stdout_buf):
-                with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
-                    mock_pa.return_value = parse_arguments(["--git-init"])
-                    _main_impl(run_state=run_state)
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                mock_pa.return_value = parse_arguments(["--git-init"])
+                _main_impl(run_state=run_state)
 
         assert exc_info.value.code == 0
-        output = stdout_buf.getvalue()
-        assert "SUCCESS" in output or "Repository initialized" in output
+        captured = capsys.readouterr()
+        assert "SUCCESS: Repository initialized" in captured.out
 
     @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
     @patch("cja_auto_sdr.generator.git_init_snapshot_repo")
-    def test_git_init_failure(self, mock_git_init):
+    def test_git_init_failure(self, mock_git_init, capsys):
         mock_git_init.return_value = (False, "Directory not empty")
         run_state = {"mode": "unknown", "details": {}}
 
-        stdout_buf = StringIO()
         with pytest.raises(SystemExit) as exc_info:
-            with redirect_stdout(stdout_buf):
-                with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
-                    mock_pa.return_value = parse_arguments(["--git-init"])
-                    _main_impl(run_state=run_state)
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                mock_pa.return_value = parse_arguments(["--git-init"])
+                _main_impl(run_state=run_state)
 
         assert exc_info.value.code == 1
-        output = stdout_buf.getvalue()
-        assert "FAILED" in output
+        captured = capsys.readouterr()
+        assert "FAILED" in captured.out
 
 
 # ==================== _main_impl: --git-push without --git-commit ====================
@@ -1058,15 +1049,13 @@ class TestMainImplGitPushValidation:
     @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
     def test_git_push_without_commit_errors(self):
         """--git-push without --git-commit should exit 1."""
-        stderr_buf = StringIO()
         with pytest.raises(SystemExit) as exc_info:
-            with redirect_stderr(stderr_buf):
-                with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
-                    args = parse_arguments(["dv_test123"])
-                    args.git_push = True
-                    args.git_commit = False
-                    mock_pa.return_value = args
-                    _main_impl()
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["dv_test123"])
+                args.git_push = True
+                args.git_commit = False
+                mock_pa.return_value = args
+                _main_impl()
 
         assert exc_info.value.code == 1
 
@@ -1200,10 +1189,9 @@ class TestMainImplStats:
         mock_resolve.return_value = ([], {})
 
         with pytest.raises(SystemExit) as exc_info:
-            with redirect_stderr(StringIO()):
-                with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
-                    mock_pa.return_value = parse_arguments(["--stats", "nonexistent_dv"])
-                    _main_impl()
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                mock_pa.return_value = parse_arguments(["--stats", "nonexistent_dv"])
+                _main_impl()
 
         assert exc_info.value.code == 1
 
@@ -1211,10 +1199,9 @@ class TestMainImplStats:
     def test_stats_no_data_views_exits_one(self):
         """--stats without data views should exit 1."""
         with pytest.raises(SystemExit) as exc_info:
-            with redirect_stderr(StringIO()):
-                with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
-                    mock_pa.return_value = parse_arguments(["--stats"])
-                    _main_impl()
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                mock_pa.return_value = parse_arguments(["--stats"])
+                _main_impl()
 
         assert exc_info.value.code == 1
 
@@ -1485,14 +1472,13 @@ class TestMainImplShowOnlyAndInventory:
     def test_show_only_invalid_types_exits_one(self):
         """Invalid --show-only types should exit 1."""
         with pytest.raises(SystemExit) as exc_info:
-            with redirect_stderr(StringIO()):
-                with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
-                    args = parse_arguments(["dv_test123"])
-                    # Simulate diff mode with invalid show_only
-                    args.diff = ["dv_a", "dv_b"]
-                    args.show_only = "added,invalid_type"
-                    mock_pa.return_value = args
-                    _main_impl()
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["dv_test123"])
+                # Simulate diff mode with invalid show_only
+                args.diff = ["dv_a", "dv_b"]
+                args.show_only = "added,invalid_type"
+                mock_pa.return_value = args
+                _main_impl()
 
         assert exc_info.value.code == 1
 
@@ -1506,13 +1492,12 @@ class TestMainImplShowOnlyAndInventory:
         mock_sm_cls.return_value = mock_sm
 
         with pytest.raises(SystemExit):
-            with redirect_stdout(StringIO()):
-                with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
-                    args = parse_arguments(["--list-snapshots"])
-                    args.include_all_inventory = True
-                    args.snapshot = "dv_test123"  # snapshot-like mode
-                    mock_pa.return_value = args
-                    _main_impl()
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--list-snapshots"])
+                args.include_all_inventory = True
+                args.snapshot = "dv_test123"  # snapshot-like mode
+                mock_pa.return_value = args
+                _main_impl()
 
         # In snapshot-like mode, include_derived_inventory should remain unset
 
@@ -1610,11 +1595,10 @@ class TestMainImplPruneSnapshots:
         mock_sm_cls.return_value = mock_sm
 
         with pytest.raises(SystemExit) as exc_info:
-            with redirect_stderr(StringIO()):
-                with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
-                    args = parse_arguments(["--prune-snapshots"])
-                    mock_pa.return_value = args
-                    _main_impl()
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--prune-snapshots"])
+                mock_pa.return_value = args
+                _main_impl()
 
         assert exc_info.value.code == 1
 

--- a/tests/test_cli_command_handlers.py
+++ b/tests/test_cli_command_handlers.py
@@ -1667,7 +1667,7 @@ class TestMainImplDiffLabels:
     def test_diff_labels_parsed_as_tuple(self, mock_diff, mock_resolve):
         """--diff-labels should be parsed and passed as tuple."""
         mock_diff.return_value = (True, False, None)
-        mock_resolve.return_value = (["dv_a"], {})
+        mock_resolve.side_effect = [(["dv_a"], {}), (["dv_b"], {})]
 
         with pytest.raises(SystemExit):
             with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
@@ -1675,5 +1675,6 @@ class TestMainImplDiffLabels:
                 mock_pa.return_value = args
                 _main_impl()
 
-        # Labels should have been passed through
-        assert mock_diff.called
+        # Labels should have been parsed as a tuple and passed through
+        mock_diff.assert_called_once()
+        assert mock_diff.call_args[1]["labels"] == ("Before", "After")

--- a/tests/test_cli_command_handlers.py
+++ b/tests/test_cli_command_handlers.py
@@ -1,0 +1,1693 @@
+"""Tests for CLI command handlers and dispatch functions in generator.py.
+
+Targets uncovered lines in:
+- process_inventory_summary (lines 5049-5117)
+- handle_diff_command config unpacking (lines 12755-12988)
+- handle_diff_snapshot_command (lines 13068-13373)
+- _main_impl: --stats handler (lines 13811-13978)
+- _main_impl: --org-report routing (lines 13893-14055)
+- _main_impl: --list-snapshots (lines 14103-14171)
+- _main_impl: --prune-snapshots & more CLI dispatch (lines 14065-14249)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cja_auto_sdr.generator import (
+    DiffConfig,
+    DiffSnapshotConfig,
+    _main_impl,
+    handle_diff_command,
+    handle_diff_snapshot_command,
+    parse_arguments,
+    process_inventory_summary,
+)
+
+
+def _mock_cli_option_specified(option_name, argv=None):
+    """Stub that always returns False — prevents _known_long_options() from
+    calling parse_arguments(return_parser=True) while it is mocked."""
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_snapshot(data_view_id="dv_test123", data_view_name="Test DV"):
+    """Build a lightweight mock DataViewSnapshot."""
+    snap = MagicMock()
+    snap.data_view_id = data_view_id
+    snap.data_view_name = data_view_name
+    snap.created_at = "2025-01-15T10:00:00+00:00"
+    snap.metrics = [{"id": "m1", "name": "Metric1"}]
+    snap.dimensions = [{"id": "d1", "name": "Dim1"}]
+    snap.has_calculated_metrics_inventory = False
+    snap.has_segments_inventory = False
+    snap.calculated_metrics_inventory = None
+    snap.segments_inventory = None
+    snap.get_inventory_summary.return_value = {
+        "calculated_metrics": {"present": False, "count": 0},
+        "segments": {"present": False, "count": 0},
+    }
+    return snap
+
+
+def _make_mock_diff_result(has_changes=False):
+    """Build a mock DiffResult with summary."""
+    result = MagicMock()
+    result.summary.has_changes = has_changes
+    result.summary.metrics_change_percent = 0.0
+    result.summary.dimensions_change_percent = 0.0
+    result.metrics_diffs = []
+    result.dimensions_diffs = []
+    return result
+
+
+# ==================== process_inventory_summary ====================
+
+
+class TestProcessInventorySummary:
+    """Tests for process_inventory_summary() covering lines 5049-5127."""
+
+    @patch("cja_auto_sdr.generator.display_inventory_summary")
+    @patch("cja_auto_sdr.generator.initialize_cja")
+    @patch("cja_auto_sdr.generator.with_log_context")
+    @patch("cja_auto_sdr.generator.setup_logging")
+    def test_cja_init_failure_returns_error(self, mock_setup, mock_ctx, mock_init, mock_display):
+        """When initialize_cja returns None, function should return error dict."""
+        mock_setup.return_value = logging.getLogger("test")
+        mock_ctx.return_value = logging.getLogger("test")
+        mock_init.return_value = None
+
+        result = process_inventory_summary("dv_test123", config_file="config.json")
+
+        assert "error" in result
+        assert result["error"] == "CJA initialization failed"
+        mock_display.assert_not_called()
+
+    @patch("cja_auto_sdr.generator.display_inventory_summary")
+    @patch("cja_auto_sdr.generator.initialize_cja")
+    @patch("cja_auto_sdr.generator.with_log_context")
+    @patch("cja_auto_sdr.generator.setup_logging")
+    def test_data_view_fetch_failure_returns_error(self, mock_setup, mock_ctx, mock_init, mock_display):
+        """When cja.dataviews.get_single raises, function should return error dict."""
+        mock_setup.return_value = logging.getLogger("test")
+        mock_ctx.return_value = logging.getLogger("test")
+
+        mock_cja = MagicMock()
+        mock_cja.dataviews.get_single.side_effect = Exception("API Error 404")
+        mock_init.return_value = mock_cja
+
+        result = process_inventory_summary("dv_bad_id", config_file="config.json")
+
+        assert "error" in result
+        assert "API Error 404" in result["error"]
+
+    @patch("cja_auto_sdr.generator.display_inventory_summary")
+    @patch("cja_auto_sdr.generator.initialize_cja")
+    @patch("cja_auto_sdr.generator.with_log_context")
+    @patch("cja_auto_sdr.generator.setup_logging")
+    def test_successful_fetch_no_inventory(self, mock_setup, mock_ctx, mock_init, mock_display):
+        """Successful fetch with no inventory flags returns display_inventory_summary result."""
+        mock_setup.return_value = logging.getLogger("test")
+        mock_ctx.return_value = logging.getLogger("test")
+
+        mock_cja = MagicMock()
+        mock_cja.dataviews.get_single.return_value = {"name": "My DV"}
+        mock_init.return_value = mock_cja
+        mock_display.return_value = {"total": 0}
+
+        result = process_inventory_summary("dv_test123", config_file="config.json")
+
+        assert result == {"total": 0}
+        mock_display.assert_called_once()
+
+    @patch("cja_auto_sdr.generator.display_inventory_summary")
+    @patch("cja_auto_sdr.generator.initialize_cja")
+    @patch("cja_auto_sdr.generator.with_log_context")
+    @patch("cja_auto_sdr.generator.setup_logging")
+    def test_successful_with_quiet_mode(self, mock_setup, mock_ctx, mock_init, mock_display):
+        """Quiet mode should suppress progress output but still return results."""
+        mock_setup.return_value = logging.getLogger("test")
+        mock_ctx.return_value = logging.getLogger("test")
+
+        mock_cja = MagicMock()
+        mock_cja.dataviews.get_single.return_value = {"name": "Quiet DV"}
+        mock_init.return_value = mock_cja
+        mock_display.return_value = {"status": "ok"}
+
+        result = process_inventory_summary("dv_test123", quiet=True)
+
+        assert result == {"status": "ok"}
+
+    @patch("cja_auto_sdr.generator.display_inventory_summary")
+    @patch("cja_auto_sdr.generator.initialize_cja")
+    @patch("cja_auto_sdr.generator.with_log_context")
+    @patch("cja_auto_sdr.generator.setup_logging")
+    def test_include_derived_success(self, mock_setup, mock_ctx, mock_init, mock_display):
+        """Test include_derived path when import and build succeed."""
+        mock_setup.return_value = logging.getLogger("test")
+        mock_ctx.return_value = logging.getLogger("test")
+
+        mock_cja = MagicMock()
+        mock_cja.dataviews.get_single.return_value = {"name": "DV1"}
+        mock_cja.dataviews.get_metrics.return_value = [{"id": "m1"}]
+        mock_cja.dataviews.get_dimensions.return_value = [{"id": "d1"}]
+        mock_init.return_value = mock_cja
+        mock_display.return_value = {"derived": 5}
+
+        mock_builder_cls = MagicMock()
+        mock_inventory = MagicMock()
+        mock_inventory.total_derived_fields = 5
+        mock_builder_cls.return_value.build.return_value = mock_inventory
+
+        with patch.dict(
+            "sys.modules",
+            {"cja_auto_sdr.inventory.derived_fields": MagicMock(DerivedFieldInventoryBuilder=mock_builder_cls)},
+        ):
+            result = process_inventory_summary("dv_test123", include_derived=True)
+
+        assert result == {"derived": 5}
+
+    @patch("cja_auto_sdr.generator.display_inventory_summary")
+    @patch("cja_auto_sdr.generator.initialize_cja")
+    @patch("cja_auto_sdr.generator.with_log_context")
+    @patch("cja_auto_sdr.generator.setup_logging")
+    def test_include_derived_import_failure_logs_warning(self, mock_setup, mock_ctx, mock_init, mock_display):
+        """When derived fields import fails, should log warning and continue."""
+        logger = logging.getLogger("test")
+        mock_setup.return_value = logger
+        mock_ctx.return_value = logger
+
+        mock_cja = MagicMock()
+        mock_cja.dataviews.get_single.return_value = {"name": "DV1"}
+        mock_cja.dataviews.get_metrics.side_effect = Exception("metrics API error")
+        mock_init.return_value = mock_cja
+        mock_display.return_value = {"ok": True}
+
+        result = process_inventory_summary("dv_test123", include_derived=True)
+
+        # Should still succeed; derived failure is non-fatal
+        assert result == {"ok": True}
+
+    @patch("cja_auto_sdr.generator.display_inventory_summary")
+    @patch("cja_auto_sdr.generator.initialize_cja")
+    @patch("cja_auto_sdr.generator.with_log_context")
+    @patch("cja_auto_sdr.generator.setup_logging")
+    def test_include_calculated_import_failure(self, mock_setup, mock_ctx, mock_init, mock_display):
+        """When calculated metrics import fails, should continue gracefully."""
+        mock_setup.return_value = logging.getLogger("test")
+        mock_ctx.return_value = logging.getLogger("test")
+
+        mock_cja = MagicMock()
+        mock_cja.dataviews.get_single.return_value = {"name": "DV1"}
+        mock_init.return_value = mock_cja
+        mock_display.return_value = {"ok": True}
+
+        # Force import to fail
+        with patch.dict(
+            "sys.modules",
+            {"cja_calculated_metrics_inventory": None},
+        ):
+            result = process_inventory_summary("dv_test123", include_calculated=True)
+
+        assert result == {"ok": True}
+
+    @patch("cja_auto_sdr.generator.display_inventory_summary")
+    @patch("cja_auto_sdr.generator.initialize_cja")
+    @patch("cja_auto_sdr.generator.with_log_context")
+    @patch("cja_auto_sdr.generator.setup_logging")
+    def test_include_segments_import_failure(self, mock_setup, mock_ctx, mock_init, mock_display):
+        """When segments import fails, should continue gracefully."""
+        mock_setup.return_value = logging.getLogger("test")
+        mock_ctx.return_value = logging.getLogger("test")
+
+        mock_cja = MagicMock()
+        mock_cja.dataviews.get_single.return_value = {"name": "DV1"}
+        mock_init.return_value = mock_cja
+        mock_display.return_value = {"ok": True}
+
+        # Force import to fail
+        with patch.dict(
+            "sys.modules",
+            {"cja_segments_inventory": None},
+        ):
+            result = process_inventory_summary("dv_test123", include_segments=True)
+
+        assert result == {"ok": True}
+
+    @patch("cja_auto_sdr.generator.display_inventory_summary")
+    @patch("cja_auto_sdr.generator.initialize_cja")
+    @patch("cja_auto_sdr.generator.with_log_context")
+    @patch("cja_auto_sdr.generator.setup_logging")
+    def test_data_view_lookup_returns_non_dict(self, mock_setup, mock_ctx, mock_init, mock_display):
+        """When lookup_data is not a dict, should use data_view_id as name."""
+        mock_setup.return_value = logging.getLogger("test")
+        mock_ctx.return_value = logging.getLogger("test")
+
+        mock_cja = MagicMock()
+        mock_cja.dataviews.get_single.return_value = "not_a_dict"
+        mock_init.return_value = mock_cja
+        mock_display.return_value = {}
+
+        process_inventory_summary("dv_test123")
+
+        # Should use data_view_id as the name fallback
+        call_kwargs = mock_display.call_args
+        assert call_kwargs[1]["data_view_name"] == "dv_test123" or call_kwargs[1]["data_view_id"] == "dv_test123"
+
+
+# ==================== handle_diff_command ====================
+
+
+class TestHandleDiffCommand:
+    """Tests for handle_diff_command() covering lines 12755-12988."""
+
+    @patch("cja_auto_sdr.generator.append_github_step_summary")
+    @patch("cja_auto_sdr.generator.build_diff_step_summary")
+    @patch("cja_auto_sdr.generator.write_diff_output")
+    @patch("cja_auto_sdr.generator.DataViewComparator")
+    @patch("cja_auto_sdr.generator.SnapshotManager")
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_basic_diff_no_changes(
+        self, mock_conf, mock_cjapy, mock_sm_cls, mock_comp_cls, mock_write, mock_build, mock_append
+    ):
+        """Basic diff with no changes returns (True, False, None)."""
+        mock_conf.return_value = (True, "config_path", {})
+        mock_cjapy.CJA.return_value = MagicMock()
+
+        mock_sm = MagicMock()
+        mock_sm.create_snapshot.return_value = _make_mock_snapshot()
+        mock_sm_cls.return_value = mock_sm
+
+        diff_result = _make_mock_diff_result(has_changes=False)
+        mock_comp = MagicMock()
+        mock_comp.compare.return_value = diff_result
+        mock_comp_cls.return_value = mock_comp
+
+        mock_write.return_value = "output text"
+
+        success, has_changes, exit_override = handle_diff_command(
+            source_id="dv_source",
+            target_id="dv_target",
+            quiet=True,
+        )
+
+        assert success is True
+        assert has_changes is False
+        assert exit_override is None
+
+    @patch("cja_auto_sdr.generator.append_github_step_summary")
+    @patch("cja_auto_sdr.generator.build_diff_step_summary")
+    @patch("cja_auto_sdr.generator.write_diff_output")
+    @patch("cja_auto_sdr.generator.DataViewComparator")
+    @patch("cja_auto_sdr.generator.SnapshotManager")
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_diff_with_changes(
+        self, mock_conf, mock_cjapy, mock_sm_cls, mock_comp_cls, mock_write, mock_build, mock_append
+    ):
+        """Diff that finds changes returns has_changes=True."""
+        mock_conf.return_value = (True, "config_path", {})
+        mock_cjapy.CJA.return_value = MagicMock()
+
+        mock_sm = MagicMock()
+        mock_sm.create_snapshot.return_value = _make_mock_snapshot()
+        mock_sm_cls.return_value = mock_sm
+
+        diff_result = _make_mock_diff_result(has_changes=True)
+        mock_comp = MagicMock()
+        mock_comp.compare.return_value = diff_result
+        mock_comp_cls.return_value = mock_comp
+        mock_write.return_value = "changes output"
+
+        success, has_changes, _ = handle_diff_command(
+            source_id="dv_a",
+            target_id="dv_b",
+            quiet=True,
+        )
+
+        assert success is True
+        assert has_changes is True
+
+    @patch("cja_auto_sdr.generator.append_github_step_summary")
+    @patch("cja_auto_sdr.generator.build_diff_step_summary")
+    @patch("cja_auto_sdr.generator.write_diff_output")
+    @patch("cja_auto_sdr.generator.DataViewComparator")
+    @patch("cja_auto_sdr.generator.SnapshotManager")
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_diff_config_failure(
+        self, mock_conf, mock_cjapy, mock_sm_cls, mock_comp_cls, mock_write, mock_build, mock_append
+    ):
+        """Configuration failure returns (False, False, None)."""
+        mock_conf.return_value = (False, "Bad creds", {})
+
+        success, _has_changes, _exit_override = handle_diff_command(
+            source_id="dv_a",
+            target_id="dv_b",
+            quiet=True,
+        )
+
+        assert success is False
+        assert _has_changes is False
+
+    @patch("cja_auto_sdr.generator.append_github_step_summary")
+    @patch("cja_auto_sdr.generator.build_diff_step_summary")
+    @patch("cja_auto_sdr.generator.write_diff_output")
+    @patch("cja_auto_sdr.generator.DataViewComparator")
+    @patch("cja_auto_sdr.generator.SnapshotManager")
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_diff_warn_threshold_exceeded(
+        self, mock_conf, mock_cjapy, mock_sm_cls, mock_comp_cls, mock_write, mock_build, mock_append
+    ):
+        """When warn_threshold is exceeded, exit_code_override should be 3."""
+        mock_conf.return_value = (True, "config_path", {})
+        mock_cjapy.CJA.return_value = MagicMock()
+
+        mock_sm = MagicMock()
+        mock_sm.create_snapshot.return_value = _make_mock_snapshot()
+        mock_sm_cls.return_value = mock_sm
+
+        diff_result = _make_mock_diff_result(has_changes=True)
+        diff_result.summary.metrics_change_percent = 25.0
+        diff_result.summary.dimensions_change_percent = 5.0
+        mock_comp = MagicMock()
+        mock_comp.compare.return_value = diff_result
+        mock_comp_cls.return_value = mock_comp
+        mock_write.return_value = "output"
+
+        _, _, exit_override = handle_diff_command(
+            source_id="dv_a",
+            target_id="dv_b",
+            warn_threshold=10.0,
+            quiet=True,
+        )
+
+        assert exit_override == 3
+
+    @patch("cja_auto_sdr.generator.append_github_step_summary")
+    @patch("cja_auto_sdr.generator.build_diff_step_summary")
+    @patch("cja_auto_sdr.generator.write_diff_output")
+    @patch("cja_auto_sdr.generator.DataViewComparator")
+    @patch("cja_auto_sdr.generator.SnapshotManager")
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_diff_reverse_swaps_ids(
+        self, mock_conf, mock_cjapy, mock_sm_cls, mock_comp_cls, mock_write, mock_build, mock_append
+    ):
+        """Reverse diff should swap source and target."""
+        mock_conf.return_value = (True, "config_path", {})
+        mock_cjapy.CJA.return_value = MagicMock()
+
+        source_snap = _make_mock_snapshot("dv_source", "Source")
+        target_snap = _make_mock_snapshot("dv_target", "Target")
+
+        mock_sm = MagicMock()
+        # First call -> source snapshot, second -> target snapshot
+        mock_sm.create_snapshot.side_effect = [source_snap, target_snap]
+        mock_sm_cls.return_value = mock_sm
+
+        diff_result = _make_mock_diff_result()
+        mock_comp = MagicMock()
+        mock_comp.compare.return_value = diff_result
+        mock_comp_cls.return_value = mock_comp
+        mock_write.return_value = ""
+
+        handle_diff_command(
+            source_id="dv_source",
+            target_id="dv_target",
+            reverse_diff=True,
+            quiet=True,
+        )
+
+        # Verify compare was called (reverse should have swapped the IDs before snapshot creation)
+        mock_comp.compare.assert_called_once()
+
+    @patch("cja_auto_sdr.generator.append_github_step_summary")
+    @patch("cja_auto_sdr.generator.build_diff_step_summary")
+    @patch("cja_auto_sdr.generator.write_diff_output")
+    @patch("cja_auto_sdr.generator.DataViewComparator")
+    @patch("cja_auto_sdr.generator.SnapshotManager")
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_diff_quiet_diff_suppresses_output(
+        self, mock_conf, mock_cjapy, mock_sm_cls, mock_comp_cls, mock_write, mock_build, mock_append
+    ):
+        """quiet_diff=True should skip write_diff_output."""
+        mock_conf.return_value = (True, "config_path", {})
+        mock_cjapy.CJA.return_value = MagicMock()
+
+        mock_sm = MagicMock()
+        mock_sm.create_snapshot.return_value = _make_mock_snapshot()
+        mock_sm_cls.return_value = mock_sm
+
+        diff_result = _make_mock_diff_result()
+        mock_comp = MagicMock()
+        mock_comp.compare.return_value = diff_result
+        mock_comp_cls.return_value = mock_comp
+
+        handle_diff_command(
+            source_id="dv_a",
+            target_id="dv_b",
+            quiet_diff=True,
+            quiet=True,
+        )
+
+        mock_write.assert_not_called()
+
+    @patch("cja_auto_sdr.generator.append_github_step_summary")
+    @patch("cja_auto_sdr.generator.build_diff_step_summary")
+    @patch("cja_auto_sdr.generator.write_diff_output")
+    @patch("cja_auto_sdr.generator.DataViewComparator")
+    @patch("cja_auto_sdr.generator.SnapshotManager")
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_diff_with_diff_output_writes_to_file(
+        self, mock_conf, mock_cjapy, mock_sm_cls, mock_comp_cls, mock_write, mock_build, mock_append, tmp_path
+    ):
+        """--diff-output should write content to specified file."""
+        mock_conf.return_value = (True, "config_path", {})
+        mock_cjapy.CJA.return_value = MagicMock()
+
+        mock_sm = MagicMock()
+        mock_sm.create_snapshot.return_value = _make_mock_snapshot()
+        mock_sm_cls.return_value = mock_sm
+
+        diff_result = _make_mock_diff_result()
+        mock_comp = MagicMock()
+        mock_comp.compare.return_value = diff_result
+        mock_comp_cls.return_value = mock_comp
+        mock_write.return_value = "diff content here"
+
+        diff_file = str(tmp_path / "out.txt")
+
+        handle_diff_command(
+            source_id="dv_a",
+            target_id="dv_b",
+            diff_output=diff_file,
+            quiet=True,
+        )
+
+        assert os.path.isfile(diff_file)
+        with open(diff_file) as f:
+            assert f.read() == "diff content here"
+
+    @patch("cja_auto_sdr.generator.append_github_step_summary")
+    @patch("cja_auto_sdr.generator.build_diff_step_summary")
+    @patch("cja_auto_sdr.generator.write_diff_output")
+    @patch("cja_auto_sdr.generator.DataViewComparator")
+    @patch("cja_auto_sdr.generator.resolve_auto_prune_retention")
+    @patch("cja_auto_sdr.generator.SnapshotManager")
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_diff_auto_snapshot_saves(
+        self,
+        mock_conf,
+        mock_cjapy,
+        mock_sm_cls,
+        mock_retention,
+        mock_comp_cls,
+        mock_write,
+        mock_build,
+        mock_append,
+        tmp_path,
+    ):
+        """auto_snapshot=True should save snapshots to snapshot_dir."""
+        mock_conf.return_value = (True, "config_path", {})
+        mock_cjapy.CJA.return_value = MagicMock()
+
+        mock_sm = MagicMock()
+        mock_sm.create_snapshot.return_value = _make_mock_snapshot()
+        mock_sm.generate_snapshot_filename.return_value = "snap_file.json"
+        mock_sm_cls.return_value = mock_sm
+
+        mock_retention.return_value = (0, None)
+
+        diff_result = _make_mock_diff_result()
+        mock_comp = MagicMock()
+        mock_comp.compare.return_value = diff_result
+        mock_comp_cls.return_value = mock_comp
+        mock_write.return_value = ""
+
+        snap_dir = str(tmp_path / "snaps")
+
+        handle_diff_command(
+            source_id="dv_a",
+            target_id="dv_b",
+            auto_snapshot=True,
+            snapshot_dir=snap_dir,
+            quiet=True,
+        )
+
+        assert mock_sm.save_snapshot.call_count == 2  # Source + target
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_diff_exception_returns_false(self, mock_conf, mock_cjapy):
+        """General exception during diff returns (False, False, None)."""
+        mock_conf.return_value = (True, "config_path", {})
+        mock_cjapy.CJA.side_effect = Exception("Unexpected boom")
+
+        success, has_changes, exit_override = handle_diff_command(
+            source_id="dv_a",
+            target_id="dv_b",
+            quiet=True,
+        )
+
+        assert success is False
+        assert has_changes is False
+        assert exit_override is None
+
+    def test_diff_config_dataclass_unpacking(self):
+        """DiffConfig is correctly unpacked into local vars in handle_diff_command."""
+        config = DiffConfig(
+            source_id="dv_src",
+            target_id="dv_tgt",
+            quiet=True,
+            quiet_diff=True,
+            labels=("Before", "After"),
+        )
+
+        with patch("cja_auto_sdr.generator.configure_cjapy") as mock_conf:
+            mock_conf.return_value = (False, "fail", {})
+
+            success, _, _ = handle_diff_command(
+                source_id="ignored",
+                target_id="ignored",
+                diff_config=config,
+            )
+
+        assert success is False
+
+    @patch("cja_auto_sdr.generator.append_github_step_summary")
+    @patch("cja_auto_sdr.generator.build_diff_step_summary")
+    @patch("cja_auto_sdr.generator.write_diff_output")
+    @patch("cja_auto_sdr.generator.DataViewComparator")
+    @patch("cja_auto_sdr.generator.SnapshotManager")
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_diff_format_pr_comment(
+        self, mock_conf, mock_cjapy, mock_sm_cls, mock_comp_cls, mock_write, mock_build, mock_append
+    ):
+        """format_pr_comment=True should set effective format to 'pr-comment'."""
+        mock_conf.return_value = (True, "config_path", {})
+        mock_cjapy.CJA.return_value = MagicMock()
+
+        mock_sm = MagicMock()
+        mock_sm.create_snapshot.return_value = _make_mock_snapshot()
+        mock_sm_cls.return_value = mock_sm
+
+        diff_result = _make_mock_diff_result()
+        mock_comp = MagicMock()
+        mock_comp.compare.return_value = diff_result
+        mock_comp_cls.return_value = mock_comp
+        mock_write.return_value = "pr output"
+
+        handle_diff_command(
+            source_id="dv_a",
+            target_id="dv_b",
+            format_pr_comment=True,
+            quiet=True,
+        )
+
+        # write_diff_output should receive "pr-comment" as format
+        call_args = mock_write.call_args
+        assert call_args[0][1] == "pr-comment"
+
+    @patch("cja_auto_sdr.generator.append_github_step_summary")
+    @patch("cja_auto_sdr.generator.build_diff_step_summary")
+    @patch("cja_auto_sdr.generator.write_diff_output")
+    @patch("cja_auto_sdr.generator.DataViewComparator")
+    @patch("cja_auto_sdr.generator.SnapshotManager")
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_diff_with_labels(
+        self, mock_conf, mock_cjapy, mock_sm_cls, mock_comp_cls, mock_write, mock_build, mock_append
+    ):
+        """Custom labels are passed through to comparator."""
+        mock_conf.return_value = (True, "config_path", {})
+        mock_cjapy.CJA.return_value = MagicMock()
+
+        mock_sm = MagicMock()
+        mock_sm.create_snapshot.return_value = _make_mock_snapshot()
+        mock_sm_cls.return_value = mock_sm
+
+        diff_result = _make_mock_diff_result()
+        mock_comp = MagicMock()
+        mock_comp.compare.return_value = diff_result
+        mock_comp_cls.return_value = mock_comp
+        mock_write.return_value = ""
+
+        handle_diff_command(
+            source_id="dv_a",
+            target_id="dv_b",
+            labels=("Prod", "Staging"),
+            quiet=True,
+        )
+
+        compare_call = mock_comp.compare.call_args
+        assert compare_call[0][2] == "Prod"
+        assert compare_call[0][3] == "Staging"
+
+    @patch("cja_auto_sdr.generator.append_github_step_summary")
+    @patch("cja_auto_sdr.generator.build_diff_step_summary")
+    @patch("cja_auto_sdr.generator.write_diff_output")
+    @patch("cja_auto_sdr.generator.DataViewComparator")
+    @patch("cja_auto_sdr.generator.SnapshotManager")
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_diff_non_console_format_prints_success(
+        self, mock_conf, mock_cjapy, mock_sm_cls, mock_comp_cls, mock_write, mock_build, mock_append
+    ):
+        """Non-console output format should print success message when not quiet."""
+        mock_conf.return_value = (True, "config_path", {})
+        mock_cjapy.CJA.return_value = MagicMock()
+
+        mock_sm = MagicMock()
+        mock_sm.create_snapshot.return_value = _make_mock_snapshot()
+        mock_sm_cls.return_value = mock_sm
+
+        diff_result = _make_mock_diff_result()
+        mock_comp = MagicMock()
+        mock_comp.compare.return_value = diff_result
+        mock_comp_cls.return_value = mock_comp
+        mock_write.return_value = ""
+
+        stdout_buf = StringIO()
+        with redirect_stdout(stdout_buf):
+            handle_diff_command(
+                source_id="dv_a",
+                target_id="dv_b",
+                output_format="json",
+                quiet=False,
+            )
+
+        output = stdout_buf.getvalue()
+        assert "Diff report generated successfully" in output or "COMPARING" in output
+
+
+# ==================== handle_diff_snapshot_command ====================
+
+
+class TestHandleDiffSnapshotCommand:
+    """Tests for handle_diff_snapshot_command() covering lines 13068-13373."""
+
+    @patch("cja_auto_sdr.generator.append_github_step_summary")
+    @patch("cja_auto_sdr.generator.build_diff_step_summary")
+    @patch("cja_auto_sdr.generator.write_diff_output")
+    @patch("cja_auto_sdr.generator.DataViewComparator")
+    @patch("cja_auto_sdr.generator.SnapshotManager")
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_basic_snapshot_diff(
+        self, mock_conf, mock_cjapy, mock_sm_cls, mock_comp_cls, mock_write, mock_build, mock_append
+    ):
+        """Basic diff against snapshot succeeds."""
+        mock_conf.return_value = (True, "config_path", {})
+        mock_cjapy.CJA.return_value = MagicMock()
+
+        source_snap = _make_mock_snapshot()
+        target_snap = _make_mock_snapshot("dv_live", "Live")
+
+        mock_sm = MagicMock()
+        mock_sm.load_snapshot.return_value = source_snap
+        mock_sm.create_snapshot.return_value = target_snap
+        mock_sm_cls.return_value = mock_sm
+
+        diff_result = _make_mock_diff_result()
+        mock_comp = MagicMock()
+        mock_comp.compare.return_value = diff_result
+        mock_comp_cls.return_value = mock_comp
+        mock_write.return_value = ""
+
+        success, has_changes, exit_code = handle_diff_snapshot_command(
+            data_view_id="dv_live",
+            snapshot_file="snapshot.json",
+            quiet=True,
+        )
+
+        assert success is True
+        assert has_changes is False
+        assert exit_code is None
+
+    @patch("cja_auto_sdr.generator.SnapshotManager")
+    def test_snapshot_file_not_found(self, mock_sm_cls):
+        """Missing snapshot file returns (False, False, None)."""
+        mock_sm = MagicMock()
+        mock_sm.load_snapshot.side_effect = FileNotFoundError("not found")
+        mock_sm_cls.return_value = mock_sm
+
+        success, _has_changes, _exit_code = handle_diff_snapshot_command(
+            data_view_id="dv_test",
+            snapshot_file="missing.json",
+            quiet=True,
+        )
+
+        assert success is False
+
+    @patch("cja_auto_sdr.generator.SnapshotManager")
+    def test_invalid_snapshot_file(self, mock_sm_cls):
+        """Invalid snapshot file (ValueError) returns (False, False, None)."""
+        mock_sm = MagicMock()
+        mock_sm.load_snapshot.side_effect = ValueError("corrupt snapshot")
+        mock_sm_cls.return_value = mock_sm
+
+        success, _, _ = handle_diff_snapshot_command(
+            data_view_id="dv_test",
+            snapshot_file="bad.json",
+            quiet=True,
+        )
+
+        assert success is False
+
+    @patch("cja_auto_sdr.generator.SnapshotManager")
+    def test_missing_inventory_blocks_diff(self, mock_sm_cls):
+        """Requesting calc metrics from snapshot that lacks them returns failure."""
+        snap = _make_mock_snapshot()
+        snap.has_calculated_metrics_inventory = False
+        snap.has_segments_inventory = False
+
+        mock_sm = MagicMock()
+        mock_sm.load_snapshot.return_value = snap
+        mock_sm_cls.return_value = mock_sm
+
+        stderr_buf = StringIO()
+        with redirect_stderr(stderr_buf):
+            success, _, _ = handle_diff_snapshot_command(
+                data_view_id="dv_test",
+                snapshot_file="snap.json",
+                include_calc_metrics=True,
+                quiet=True,
+            )
+
+        assert success is False
+        assert "missing" in stderr_buf.getvalue().lower() or "ERROR" in stderr_buf.getvalue()
+
+    @patch("cja_auto_sdr.generator.append_github_step_summary")
+    @patch("cja_auto_sdr.generator.build_diff_step_summary")
+    @patch("cja_auto_sdr.generator.write_diff_output")
+    @patch("cja_auto_sdr.generator.DataViewComparator")
+    @patch("cja_auto_sdr.generator.SnapshotManager")
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_snapshot_diff_config_failure(
+        self, mock_conf, mock_cjapy, mock_sm_cls, mock_comp_cls, mock_write, mock_build, mock_append
+    ):
+        """Config failure in snapshot diff returns (False, False, None)."""
+        source_snap = _make_mock_snapshot()
+
+        mock_sm = MagicMock()
+        mock_sm.load_snapshot.return_value = source_snap
+        mock_sm_cls.return_value = mock_sm
+
+        mock_conf.return_value = (False, "Bad config", {})
+
+        success, _, _ = handle_diff_snapshot_command(
+            data_view_id="dv_test",
+            snapshot_file="snap.json",
+            quiet=True,
+        )
+
+        assert success is False
+
+    @patch("cja_auto_sdr.generator.append_github_step_summary")
+    @patch("cja_auto_sdr.generator.build_diff_step_summary")
+    @patch("cja_auto_sdr.generator.write_diff_output")
+    @patch("cja_auto_sdr.generator.DataViewComparator")
+    @patch("cja_auto_sdr.generator.SnapshotManager")
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_snapshot_diff_with_warn_threshold(
+        self, mock_conf, mock_cjapy, mock_sm_cls, mock_comp_cls, mock_write, mock_build, mock_append
+    ):
+        """Warn threshold exceeded returns exit_code=3."""
+        mock_conf.return_value = (True, "config_path", {})
+        mock_cjapy.CJA.return_value = MagicMock()
+
+        source_snap = _make_mock_snapshot()
+        target_snap = _make_mock_snapshot("dv_live", "Live")
+
+        mock_sm = MagicMock()
+        mock_sm.load_snapshot.return_value = source_snap
+        mock_sm.create_snapshot.return_value = target_snap
+        mock_sm_cls.return_value = mock_sm
+
+        diff_result = _make_mock_diff_result(has_changes=True)
+        diff_result.summary.metrics_change_percent = 50.0
+        mock_comp = MagicMock()
+        mock_comp.compare.return_value = diff_result
+        mock_comp_cls.return_value = mock_comp
+        mock_write.return_value = ""
+
+        _, _, exit_code = handle_diff_snapshot_command(
+            data_view_id="dv_test",
+            snapshot_file="snap.json",
+            warn_threshold=10.0,
+            quiet=True,
+        )
+
+        assert exit_code == 3
+
+    def test_diff_snapshot_config_dataclass_unpacking(self):
+        """DiffSnapshotConfig is correctly unpacked in handle_diff_snapshot_command."""
+        config = DiffSnapshotConfig(
+            data_view_id="dv_test",
+            snapshot_file="snap.json",
+            quiet=True,
+            quiet_diff=True,
+        )
+
+        with patch("cja_auto_sdr.generator.SnapshotManager") as mock_sm_cls:
+            mock_sm = MagicMock()
+            mock_sm.load_snapshot.side_effect = FileNotFoundError("nope")
+            mock_sm_cls.return_value = mock_sm
+
+            success, _, _ = handle_diff_snapshot_command(
+                data_view_id="ignored",
+                snapshot_file="ignored",
+                diff_snapshot_config=config,
+            )
+
+        assert success is False
+
+    @patch("cja_auto_sdr.generator.append_github_step_summary")
+    @patch("cja_auto_sdr.generator.build_diff_step_summary")
+    @patch("cja_auto_sdr.generator.write_diff_output")
+    @patch("cja_auto_sdr.generator.DataViewComparator")
+    @patch("cja_auto_sdr.generator.SnapshotManager")
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_snapshot_diff_reverse(
+        self, mock_conf, mock_cjapy, mock_sm_cls, mock_comp_cls, mock_write, mock_build, mock_append
+    ):
+        """reverse_diff=True should swap source and target snapshots."""
+        mock_conf.return_value = (True, "config_path", {})
+        mock_cjapy.CJA.return_value = MagicMock()
+
+        source_snap = _make_mock_snapshot("dv_snap", "Snap")
+        target_snap = _make_mock_snapshot("dv_live", "Live")
+
+        mock_sm = MagicMock()
+        mock_sm.load_snapshot.return_value = source_snap
+        mock_sm.create_snapshot.return_value = target_snap
+        mock_sm_cls.return_value = mock_sm
+
+        diff_result = _make_mock_diff_result()
+        mock_comp = MagicMock()
+        mock_comp.compare.return_value = diff_result
+        mock_comp_cls.return_value = mock_comp
+        mock_write.return_value = ""
+
+        handle_diff_snapshot_command(
+            data_view_id="dv_live",
+            snapshot_file="snap.json",
+            reverse_diff=True,
+            quiet=True,
+        )
+
+        # After reverse, target_snap becomes source and source_snap becomes target
+        compare_call = mock_comp.compare.call_args
+        assert compare_call[0][0] == target_snap
+        assert compare_call[0][1] == source_snap
+
+    @patch("cja_auto_sdr.generator.SnapshotManager")
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_snapshot_diff_general_exception(self, mock_conf, mock_cjapy, mock_sm_cls):
+        """General exception returns (False, False, None)."""
+        source_snap = _make_mock_snapshot()
+
+        mock_sm = MagicMock()
+        mock_sm.load_snapshot.return_value = source_snap
+        mock_sm_cls.return_value = mock_sm
+
+        mock_conf.return_value = (True, "config_path", {})
+        mock_cjapy.CJA.side_effect = RuntimeError("unexpected")
+
+        success, _has_changes, _ = handle_diff_snapshot_command(
+            data_view_id="dv_test",
+            snapshot_file="snap.json",
+            quiet=True,
+        )
+
+        assert success is False
+
+
+# ==================== _main_impl: --profile-add / --profile-test / --profile-show ====================
+
+
+class TestMainImplProfileCommands:
+    """Tests for profile commands in _main_impl (lines 13810-13828)."""
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.add_profile_interactive")
+    def test_profile_add_dispatches_and_tracks_run_state(self, mock_add):
+        mock_add.return_value = True
+        run_state = {"mode": "unknown", "details": {}}
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                mock_pa.return_value = parse_arguments(["--profile-add", "new_profile"])
+                _main_impl(run_state=run_state)
+
+        assert exc_info.value.code == 0
+        mock_add.assert_called_once_with("new_profile")
+        assert run_state["details"]["operation_success"] is True
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.add_profile_interactive")
+    def test_profile_add_failure_exits_one(self, mock_add):
+        mock_add.return_value = False
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                mock_pa.return_value = parse_arguments(["--profile-add", "bad_profile"])
+                _main_impl()
+
+        assert exc_info.value.code == 1
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.test_profile")
+    def test_profile_test_tracks_run_state(self, mock_test):
+        mock_test.return_value = True
+        run_state = {"mode": "unknown", "details": {}}
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                mock_pa.return_value = parse_arguments(["--profile-test", "myprof"])
+                _main_impl(run_state=run_state)
+
+        assert exc_info.value.code == 0
+        assert run_state["details"]["operation_success"] is True
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.show_profile")
+    def test_profile_show_tracks_run_state(self, mock_show):
+        mock_show.return_value = True
+        run_state = {"mode": "unknown", "details": {}}
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                mock_pa.return_value = parse_arguments(["--profile-show", "myprof"])
+                _main_impl(run_state=run_state)
+
+        assert exc_info.value.code == 0
+        assert run_state["details"]["operation_success"] is True
+
+
+# ==================== _main_impl: --git-init ====================
+
+
+class TestMainImplGitInit:
+    """Tests for --git-init dispatch in _main_impl (lines 13831-13847)."""
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.git_init_snapshot_repo")
+    def test_git_init_success(self, mock_git_init):
+        mock_git_init.return_value = (True, "Repository initialized")
+        run_state = {"mode": "unknown", "details": {}}
+
+        stdout_buf = StringIO()
+        with pytest.raises(SystemExit) as exc_info:
+            with redirect_stdout(stdout_buf):
+                with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                    mock_pa.return_value = parse_arguments(["--git-init"])
+                    _main_impl(run_state=run_state)
+
+        assert exc_info.value.code == 0
+        output = stdout_buf.getvalue()
+        assert "SUCCESS" in output or "Repository initialized" in output
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.git_init_snapshot_repo")
+    def test_git_init_failure(self, mock_git_init):
+        mock_git_init.return_value = (False, "Directory not empty")
+        run_state = {"mode": "unknown", "details": {}}
+
+        stdout_buf = StringIO()
+        with pytest.raises(SystemExit) as exc_info:
+            with redirect_stdout(stdout_buf):
+                with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                    mock_pa.return_value = parse_arguments(["--git-init"])
+                    _main_impl(run_state=run_state)
+
+        assert exc_info.value.code == 1
+        output = stdout_buf.getvalue()
+        assert "FAILED" in output
+
+
+# ==================== _main_impl: --git-push without --git-commit ====================
+
+
+class TestMainImplGitPushValidation:
+    """Tests for git argument validation (lines 13850-13852)."""
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    def test_git_push_without_commit_errors(self):
+        """--git-push without --git-commit should exit 1."""
+        stderr_buf = StringIO()
+        with pytest.raises(SystemExit) as exc_info:
+            with redirect_stderr(stderr_buf):
+                with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                    args = parse_arguments(["dv_test123"])
+                    args.git_push = True
+                    args.git_commit = False
+                    mock_pa.return_value = args
+                    _main_impl()
+
+        assert exc_info.value.code == 1
+
+
+# ==================== _main_impl: discovery format routing (line 13874) ====================
+
+
+class TestMainImplDiscoveryFormatRouting:
+    """Tests for discovery command output format logic (lines 13868-13888)."""
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.list_dataviews")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_discovery_stdout_forces_json(self, _mock_conf, mock_list_dv):
+        """When output is stdout, discovery format should default to json."""
+        mock_list_dv.return_value = True
+        run_state = {"mode": "unknown", "details": {}}
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--list-dataviews", "--output", "-"])
+                mock_pa.return_value = args
+                _main_impl(run_state=run_state)
+
+        assert exc_info.value.code == 0
+        assert run_state["output_format"] == "json"
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.list_dataviews")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_discovery_csv_format_preserved(self, _mock_conf, mock_list_dv):
+        """Explicit csv format should be preserved for discovery commands."""
+        mock_list_dv.return_value = True
+        run_state = {"mode": "unknown", "details": {}}
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                mock_pa.return_value = parse_arguments(["--list-dataviews", "--format", "csv"])
+                _main_impl(run_state=run_state)
+
+        assert exc_info.value.code == 0
+        assert run_state["output_format"] == "csv"
+
+
+# ==================== _main_impl: --config-status / --validate-config ====================
+
+
+class TestMainImplConfigCommands:
+    """Tests for --config-status and --validate-config (lines 13892-13904)."""
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.show_config_status")
+    def test_config_status_dispatches(self, mock_show):
+        mock_show.return_value = True
+        run_state = {"mode": "unknown", "details": {}}
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                mock_pa.return_value = parse_arguments(["--config-status"])
+                _main_impl(run_state=run_state)
+
+        assert exc_info.value.code == 0
+        mock_show.assert_called_once()
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.validate_config_only")
+    def test_validate_config_dispatches(self, mock_validate):
+        mock_validate.return_value = True
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                mock_pa.return_value = parse_arguments(["--validate-config"])
+                _main_impl()
+
+        assert exc_info.value.code == 0
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.validate_config_only")
+    def test_validate_config_failure_exits_one(self, mock_validate):
+        mock_validate.return_value = False
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                mock_pa.return_value = parse_arguments(["--validate-config"])
+                _main_impl()
+
+        assert exc_info.value.code == 1
+
+
+# ==================== _main_impl: --stats ====================
+
+
+class TestMainImplStats:
+    """Tests for --stats handler in _main_impl (lines 13937-13978)."""
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.show_stats")
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    def test_stats_success(self, mock_resolve, mock_stats):
+        mock_resolve.return_value = (["dv_resolved"], {})
+        mock_stats.return_value = True
+        run_state = {"mode": "unknown", "details": {}}
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                mock_pa.return_value = parse_arguments(["--stats", "dv_test123"])
+                _main_impl(run_state=run_state)
+
+        assert exc_info.value.code == 0
+        assert run_state["details"]["operation_success"] is True
+        assert run_state["output_format"] == "table"
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.show_stats")
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    def test_stats_failure_exits_one(self, mock_resolve, mock_stats):
+        mock_resolve.return_value = (["dv_resolved"], {})
+        mock_stats.return_value = False
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                mock_pa.return_value = parse_arguments(["--stats", "dv_test123"])
+                _main_impl()
+
+        assert exc_info.value.code == 1
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    def test_stats_no_resolved_ids_exits_one(self, mock_resolve):
+        """When name resolution finds nothing, should exit 1."""
+        mock_resolve.return_value = ([], {})
+
+        with pytest.raises(SystemExit) as exc_info:
+            with redirect_stderr(StringIO()):
+                with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                    mock_pa.return_value = parse_arguments(["--stats", "nonexistent_dv"])
+                    _main_impl()
+
+        assert exc_info.value.code == 1
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    def test_stats_no_data_views_exits_one(self):
+        """--stats without data views should exit 1."""
+        with pytest.raises(SystemExit) as exc_info:
+            with redirect_stderr(StringIO()):
+                with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                    mock_pa.return_value = parse_arguments(["--stats"])
+                    _main_impl()
+
+        assert exc_info.value.code == 1
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.show_stats")
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    def test_stats_json_format(self, mock_resolve, mock_stats):
+        mock_resolve.return_value = (["dv_test"], {})
+        mock_stats.return_value = True
+        run_state = {"mode": "unknown", "details": {}}
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                mock_pa.return_value = parse_arguments(["--stats", "--format", "json", "dv_test"])
+                _main_impl(run_state=run_state)
+
+        assert exc_info.value.code == 0
+        assert run_state["output_format"] == "json"
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.show_stats")
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    def test_stats_stdout_forces_json(self, mock_resolve, mock_stats):
+        """--output stdout should force json format for stats."""
+        mock_resolve.return_value = (["dv_test"], {})
+        mock_stats.return_value = True
+        run_state = {"mode": "unknown", "details": {}}
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                mock_pa.return_value = parse_arguments(["--stats", "--output", "-", "dv_test"])
+                _main_impl(run_state=run_state)
+
+        assert exc_info.value.code == 0
+        assert run_state["output_format"] == "json"
+
+
+# ==================== _main_impl: --org-report ====================
+
+
+class TestMainImplOrgReport:
+    """Tests for --org-report routing in _main_impl (lines 13981-14055)."""
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.run_org_report")
+    def test_org_report_success(self, mock_org):
+        mock_org.return_value = (True, False)
+        run_state = {"mode": "unknown", "details": {}}
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                mock_pa.return_value = parse_arguments(["--org-report"])
+                _main_impl(run_state=run_state)
+
+        assert exc_info.value.code == 0
+        assert run_state["details"]["operation_success"] is True
+        assert run_state["details"]["thresholds_exceeded"] is False
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.run_org_report")
+    def test_org_report_failure_exits_one(self, mock_org):
+        mock_org.return_value = (False, False)
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                mock_pa.return_value = parse_arguments(["--org-report"])
+                _main_impl()
+
+        assert exc_info.value.code == 1
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.run_org_report")
+    def test_org_report_thresholds_exceeded_without_fail(self, mock_org):
+        """Thresholds exceeded without --fail-on-threshold should exit 0."""
+        mock_org.return_value = (True, True)
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                mock_pa.return_value = parse_arguments(["--org-report"])
+                _main_impl()
+
+        assert exc_info.value.code == 0
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.run_org_report")
+    def test_org_report_thresholds_exceeded_with_fail(self, mock_org):
+        """Thresholds exceeded with --fail-on-threshold should exit 2."""
+        mock_org.return_value = (True, True)
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                mock_pa.return_value = parse_arguments(["--org-report", "--fail-on-threshold"])
+                _main_impl()
+
+        assert exc_info.value.code == 2
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.run_org_report")
+    def test_org_report_with_json_format(self, mock_org):
+        mock_org.return_value = (True, False)
+        run_state = {"mode": "unknown", "details": {}}
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                mock_pa.return_value = parse_arguments(["--org-report", "--format", "json"])
+                _main_impl(run_state=run_state)
+
+        assert exc_info.value.code == 0
+        assert run_state["output_format"] == "json"
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.run_org_report")
+    def test_org_report_builds_config_with_filter(self, mock_org):
+        """OrgReportConfig should receive filter_pattern from args."""
+        mock_org.return_value = (True, False)
+
+        with pytest.raises(SystemExit):
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                mock_pa.return_value = parse_arguments(["--org-report", "--filter", "prod.*"])
+                _main_impl()
+
+        # Verify org_config passed to run_org_report
+        call_kwargs = mock_org.call_args[1]
+        assert call_kwargs["org_config"].filter_pattern == "prod.*"
+
+
+# ==================== _main_impl: --list-snapshots ====================
+
+
+class TestMainImplListSnapshots:
+    """Tests for --list-snapshots mode (lines 14103-14171)."""
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator._emit_output")
+    @patch("cja_auto_sdr.generator.SnapshotManager")
+    def test_list_snapshots_table_output(self, mock_sm_cls, mock_emit):
+        mock_sm = MagicMock()
+        mock_sm.list_snapshots.return_value = [
+            {
+                "data_view_id": "dv_test",
+                "data_view_name": "Test",
+                "created_at": "2025-01-01",
+                "metrics_count": 10,
+                "dimensions_count": 5,
+                "filepath": "/path/to/snap.json",
+            }
+        ]
+        mock_sm_cls.return_value = mock_sm
+        run_state = {"mode": "unknown", "details": {}}
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                mock_pa.return_value = parse_arguments(["--list-snapshots"])
+                _main_impl(run_state=run_state)
+
+        assert exc_info.value.code == 0
+        assert run_state["details"]["snapshot_count"] == 1
+        mock_emit.assert_called_once()
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator._emit_output")
+    @patch("cja_auto_sdr.generator.SnapshotManager")
+    def test_list_snapshots_json_output(self, mock_sm_cls, mock_emit):
+        mock_sm = MagicMock()
+        mock_sm.list_snapshots.return_value = []
+        mock_sm_cls.return_value = mock_sm
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                mock_pa.return_value = parse_arguments(["--list-snapshots", "--format", "json"])
+                _main_impl()
+
+        assert exc_info.value.code == 0
+        emitted = mock_emit.call_args[0][0]
+        parsed = json.loads(emitted)
+        assert parsed["count"] == 0
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator._emit_output")
+    @patch("cja_auto_sdr.generator.SnapshotManager")
+    def test_list_snapshots_csv_output(self, mock_sm_cls, mock_emit):
+        mock_sm = MagicMock()
+        mock_sm.list_snapshots.return_value = [
+            {
+                "data_view_id": "dv_csv",
+                "data_view_name": "CSV Test",
+                "created_at": "2025-02-01",
+                "metrics_count": 3,
+                "dimensions_count": 2,
+                "filepath": "/snap.json",
+            }
+        ]
+        mock_sm_cls.return_value = mock_sm
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                mock_pa.return_value = parse_arguments(["--list-snapshots", "--format", "csv"])
+                _main_impl()
+
+        assert exc_info.value.code == 0
+        emitted = mock_emit.call_args[0][0]
+        assert "dv_csv" in emitted
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator._emit_output")
+    @patch("cja_auto_sdr.generator.SnapshotManager")
+    def test_list_snapshots_filter_by_dv_id(self, mock_sm_cls, mock_emit):
+        """When data view IDs provided, only matching snapshots shown."""
+        mock_sm = MagicMock()
+        mock_sm.list_snapshots.return_value = [
+            {
+                "data_view_id": "dv_match",
+                "data_view_name": "Match",
+                "created_at": "2025-01-01",
+                "metrics_count": 1,
+                "dimensions_count": 1,
+                "filepath": "/snap1.json",
+            },
+            {
+                "data_view_id": "dv_other",
+                "data_view_name": "Other",
+                "created_at": "2025-01-01",
+                "metrics_count": 1,
+                "dimensions_count": 1,
+                "filepath": "/snap2.json",
+            },
+        ]
+        mock_sm_cls.return_value = mock_sm
+        run_state = {"mode": "unknown", "details": {}}
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                mock_pa.return_value = parse_arguments(["--list-snapshots", "--format", "json", "dv_match"])
+                _main_impl(run_state=run_state)
+
+        assert exc_info.value.code == 0
+        emitted = mock_emit.call_args[0][0]
+        parsed = json.loads(emitted)
+        assert parsed["count"] == 1
+        assert parsed["snapshots"][0]["data_view_id"] == "dv_match"
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator._emit_output")
+    @patch("cja_auto_sdr.generator.SnapshotManager")
+    def test_list_snapshots_empty_table(self, mock_sm_cls, mock_emit):
+        """Empty snapshot list should show 'No snapshots found' message."""
+        mock_sm = MagicMock()
+        mock_sm.list_snapshots.return_value = []
+        mock_sm_cls.return_value = mock_sm
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                mock_pa.return_value = parse_arguments(["--list-snapshots"])
+                _main_impl()
+
+        assert exc_info.value.code == 0
+        emitted = mock_emit.call_args[0][0]
+        assert "No snapshots found" in emitted
+
+
+# ==================== _main_impl: --show-only / --include-all-inventory ====================
+
+
+class TestMainImplShowOnlyAndInventory:
+    """Tests for --show-only parsing and --include-all-inventory (lines 14065-14101)."""
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    def test_show_only_invalid_types_exits_one(self):
+        """Invalid --show-only types should exit 1."""
+        with pytest.raises(SystemExit) as exc_info:
+            with redirect_stderr(StringIO()):
+                with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                    args = parse_arguments(["dv_test123"])
+                    # Simulate diff mode with invalid show_only
+                    args.diff = ["dv_a", "dv_b"]
+                    args.show_only = "added,invalid_type"
+                    mock_pa.return_value = args
+                    _main_impl()
+
+        assert exc_info.value.code == 1
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator._emit_output")
+    @patch("cja_auto_sdr.generator.SnapshotManager")
+    def test_include_all_inventory_snapshot_mode(self, mock_sm_cls, mock_emit):
+        """--include-all-inventory in snapshot-like mode should not enable derived."""
+        mock_sm = MagicMock()
+        mock_sm.list_snapshots.return_value = []
+        mock_sm_cls.return_value = mock_sm
+
+        with pytest.raises(SystemExit):
+            with redirect_stdout(StringIO()):
+                with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                    args = parse_arguments(["--list-snapshots"])
+                    args.include_all_inventory = True
+                    args.snapshot = "dv_test123"  # snapshot-like mode
+                    mock_pa.return_value = args
+                    _main_impl()
+
+        # In snapshot-like mode, include_derived_inventory should remain unset
+
+
+# ==================== _main_impl: --prune-snapshots ====================
+
+
+class TestMainImplPruneSnapshots:
+    """Tests for --prune-snapshots mode (lines 14173-14261)."""
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.resolve_auto_prune_retention")
+    @patch("cja_auto_sdr.generator.SnapshotManager")
+    @patch("cja_auto_sdr.generator._emit_output")
+    def test_prune_json_output(self, mock_emit, mock_sm_cls, mock_retention):
+        mock_retention.return_value = (5, None)
+
+        mock_sm = MagicMock()
+        mock_sm.list_snapshots.return_value = [
+            {"data_view_id": "dv_test", "filepath": "/snap1.json"},
+        ]
+        mock_sm.apply_retention_policy.return_value = ["/snap_old.json"]
+        mock_sm_cls.return_value = mock_sm
+
+        run_state = {"mode": "unknown", "details": {}}
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--prune-snapshots", "--keep-last", "5", "--format", "json"])
+                mock_pa.return_value = args
+                _main_impl(run_state=run_state)
+
+        assert exc_info.value.code == 0
+        emitted = mock_emit.call_args[0][0]
+        parsed = json.loads(emitted)
+        assert parsed["deleted_count"] >= 0
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.resolve_auto_prune_retention")
+    @patch("cja_auto_sdr.generator.SnapshotManager")
+    @patch("cja_auto_sdr.generator._emit_output")
+    def test_prune_csv_output(self, mock_emit, mock_sm_cls, mock_retention):
+        mock_retention.return_value = (3, None)
+
+        mock_sm = MagicMock()
+        mock_sm.list_snapshots.return_value = [
+            {"data_view_id": "dv_test", "filepath": "/snap1.json"},
+        ]
+        mock_sm.apply_retention_policy.return_value = ["/deleted.json"]
+        mock_sm_cls.return_value = mock_sm
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--prune-snapshots", "--keep-last", "3", "--format", "csv"])
+                mock_pa.return_value = args
+                _main_impl()
+
+        assert exc_info.value.code == 0
+        emitted = mock_emit.call_args[0][0]
+        assert "filepath" in emitted
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.resolve_auto_prune_retention")
+    @patch("cja_auto_sdr.generator.SnapshotManager")
+    @patch("cja_auto_sdr.generator._emit_output")
+    def test_prune_table_output(self, mock_emit, mock_sm_cls, mock_retention):
+        mock_retention.return_value = (2, None)
+
+        mock_sm = MagicMock()
+        mock_sm.list_snapshots.return_value = [
+            {"data_view_id": "dv_test", "filepath": "/snap.json"},
+        ]
+        mock_sm.apply_retention_policy.return_value = ["/old1.json", "/old2.json"]
+        mock_sm_cls.return_value = mock_sm
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--prune-snapshots", "--keep-last", "2"])
+                mock_pa.return_value = args
+                _main_impl()
+
+        assert exc_info.value.code == 0
+        emitted = mock_emit.call_args[0][0]
+        assert "Deleted files" in emitted
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.resolve_auto_prune_retention")
+    @patch("cja_auto_sdr.generator.SnapshotManager")
+    def test_prune_no_retention_policy_exits_error(self, mock_sm_cls, mock_retention):
+        """--prune-snapshots without retention flags should exit 1."""
+        mock_retention.return_value = (0, None)
+
+        mock_sm = MagicMock()
+        mock_sm.list_snapshots.return_value = []
+        mock_sm_cls.return_value = mock_sm
+
+        with pytest.raises(SystemExit) as exc_info:
+            with redirect_stderr(StringIO()):
+                with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                    args = parse_arguments(["--prune-snapshots"])
+                    mock_pa.return_value = args
+                    _main_impl()
+
+        assert exc_info.value.code == 1
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.parse_retention_period")
+    @patch("cja_auto_sdr.generator.resolve_auto_prune_retention")
+    @patch("cja_auto_sdr.generator.SnapshotManager")
+    @patch("cja_auto_sdr.generator._emit_output")
+    def test_prune_with_keep_since(self, mock_emit, mock_sm_cls, mock_retention, mock_parse_period):
+        mock_retention.return_value = (0, "7d")
+        mock_parse_period.return_value = 7
+
+        mock_sm = MagicMock()
+        mock_sm.list_snapshots.return_value = [
+            {"data_view_id": "dv_test", "filepath": "/snap.json"},
+        ]
+        mock_sm.apply_date_retention_policy.return_value = ["/old.json"]
+        mock_sm_cls.return_value = mock_sm
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--prune-snapshots", "--keep-since", "7d", "--format", "json"])
+                mock_pa.return_value = args
+                _main_impl()
+
+        assert exc_info.value.code == 0
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.resolve_auto_prune_retention")
+    @patch("cja_auto_sdr.generator.SnapshotManager")
+    @patch("cja_auto_sdr.generator._emit_output")
+    def test_prune_with_dv_filter(self, mock_emit, mock_sm_cls, mock_retention):
+        """Prune with specific data view IDs should only prune those."""
+        mock_retention.return_value = (3, None)
+
+        mock_sm = MagicMock()
+        mock_sm.list_snapshots.return_value = [
+            {"data_view_id": "dv_keep", "filepath": "/snap_keep.json"},
+            {"data_view_id": "dv_prune", "filepath": "/snap_prune.json"},
+        ]
+        mock_sm.apply_retention_policy.return_value = []
+        mock_sm_cls.return_value = mock_sm
+
+        run_state = {"mode": "unknown", "details": {}}
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--prune-snapshots", "--keep-last", "3", "--format", "json", "dv_prune"])
+                mock_pa.return_value = args
+                _main_impl(run_state=run_state)
+
+        assert exc_info.value.code == 0
+        # Should have pruned for dv_prune only
+        mock_sm.apply_retention_policy.assert_called_once()
+
+
+# ==================== _main_impl: --diff-labels ====================
+
+
+class TestMainImplDiffLabels:
+    """Tests for --diff-labels parsing (lines 14073-14076)."""
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.handle_diff_command")
+    def test_diff_labels_parsed_as_tuple(self, mock_diff):
+        """--diff-labels should be parsed and passed as tuple."""
+        mock_diff.return_value = (True, False, None)
+
+        with pytest.raises(SystemExit):
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--diff", "dv_a", "dv_b", "--diff-labels", "Before", "After"])
+                mock_pa.return_value = args
+                _main_impl()
+
+        # Labels should have been passed through
+        assert mock_diff.called

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -548,8 +548,8 @@ class TestCredentialResolver:
                     "client_id": "a" * 32,
                     "secret": "b" * 32,
                     "scopes": "openid",
-                }
-            )
+                },
+            ),
         )
 
         creds, source = resolver.resolve(config_file=config_path)
@@ -705,8 +705,8 @@ class TestCredentialResolverTryConfigFile:
                     "client_id": "a" * 32,
                     "secret": "b" * 32,
                     "scopes": "openid",
-                }
-            )
+                },
+            ),
         )
 
         creds, source = resolver._try_config_file(config_path)
@@ -732,8 +732,8 @@ class TestCredentialResolverTryConfigFile:
                     "client_id": "a" * 32,
                     # secret is missing
                     "scopes": "openid",
-                }
-            )
+                },
+            ),
         )
 
         with pytest.raises(CredentialSourceError) as exc_info:

--- a/tests/test_data_quality.py
+++ b/tests/test_data_quality.py
@@ -31,8 +31,8 @@ class TestDataQualityValidation:
                             "type": "calculated",
                             "title": "Duplicate Metric",
                             "description": "Duplicate",
-                        }
-                    ]
+                        },
+                    ],
                 ),
             ],
             ignore_index=True,
@@ -130,8 +130,8 @@ class TestDataQualityValidation:
                     "id": "metric1",
                     "name": None,  # Missing required field
                     "type": "calculated",
-                }
-            ]
+                },
+            ],
         )
 
         validator.check_required_fields(incomplete_df, "Metrics", ["id", "name", "type"])
@@ -151,7 +151,7 @@ class TestDataQualityValidation:
                 {"id": None, "name": "Test 1", "type": "metric"},
                 {"id": "", "name": "Test 2", "type": "metric"},
                 {"id": "valid_id", "name": "Test 3", "type": "metric"},
-            ]
+            ],
         )
 
         validator.check_id_validity(df_with_invalid_ids, "Metrics")

--- a/tests/test_derived_fields_coverage.py
+++ b/tests/test_derived_fields_coverage.py
@@ -43,8 +43,8 @@ def _build_one(definition, component_type="Dimension"):
                 "sourceFieldType": "derived",
                 "fieldDefinition": field_def,
                 "dataSetType": "event",
-            }
-        ]
+            },
+        ],
     )
     metrics_df = df if col == "Metric" else pd.DataFrame()
     dims_df = df if col == "Dimension" else pd.DataFrame()
@@ -186,7 +186,8 @@ class TestInferOutputType:
         assert b._infer_output_type([{"func": func}]) == "numeric"
 
     @pytest.mark.parametrize(
-        "func", ["lowercase", "uppercase", "trim", "concatenate", "split", "url-parse", "regex-replace"]
+        "func",
+        ["lowercase", "uppercase", "trim", "concatenate", "split", "url-parse", "regex-replace"],
     )
     def test_string_operations(self, func):
         b = _builder()
@@ -202,8 +203,8 @@ class TestInferOutputType:
                         {"pred": {"func": "true"}, "map-to": 1},
                         {"pred": {"func": "eq", "val": "a"}, "map-to": 2.5},
                     ],
-                }
-            ]
+                },
+            ],
         )
         assert result == "numeric"
 
@@ -217,8 +218,8 @@ class TestInferOutputType:
                         {"pred": {"func": "true"}, "map-to": "yes"},
                         {"pred": {"func": "eq", "val": "a"}, "map-to": "no"},
                     ],
-                }
-            ]
+                },
+            ],
         )
         assert result == "string"
 
@@ -233,8 +234,8 @@ class TestInferOutputType:
                         {"pred": {"func": "true"}, "map-to": 42},
                         {"pred": {"func": "eq", "val": "a"}, "map-to": "text"},
                     ],
-                }
-            ]
+                },
+            ],
         )
         assert result == "unknown"
 
@@ -265,7 +266,7 @@ class TestLogicSummaryHandlers:
             [
                 {"func": "raw-field", "id": "events", "label": "ev"},
                 {"func": "summarize"},
-            ]
+            ],
         )
         assert "summarize" in field.logic_summary.lower()
 
@@ -274,7 +275,7 @@ class TestLogicSummaryHandlers:
             [
                 {"func": "raw-field", "id": "pageId", "label": "p"},
                 {"func": "deduplicate", "scope": "session", "args": [{"func": "raw-field", "id": "pageId"}]},
-            ]
+            ],
         )
         assert "deduplicate" in field.logic_summary.lower()
         assert "session" in field.logic_summary.lower()
@@ -284,7 +285,7 @@ class TestLogicSummaryHandlers:
             [
                 {"func": "raw-field", "id": "pageId", "label": "p"},
                 {"func": "deduplicate", "args": [{"func": "raw-field", "id": "pageId"}]},
-            ]
+            ],
         )
         assert "deduplicate" in field.logic_summary.lower()
 
@@ -294,7 +295,7 @@ class TestLogicSummaryHandlers:
                 {"func": "raw-field", "id": "fieldA", "label": "a"},
                 {"func": "raw-field", "id": "fieldB", "label": "b"},
                 {"func": "merge"},
-            ]
+            ],
         )
         assert "merge" in field.logic_summary.lower()
 
@@ -303,7 +304,7 @@ class TestLogicSummaryHandlers:
             [
                 {"func": "raw-field", "id": "url_path", "label": "u"},
                 {"func": "split", "delimiter": "/", "index": 2, "args": [{"func": "raw-field", "id": "url_path"}]},
-            ]
+            ],
         )
         assert "split" in field.logic_summary.lower()
         assert "part 3" in field.logic_summary  # 0-indexed + 1
@@ -317,7 +318,7 @@ class TestLogicSummaryHandlers:
                     "component": "dayOfWeek",
                     "args": [{"func": "raw-field", "id": "ts_field"}],
                 },
-            ]
+            ],
         )
         assert "dayofweek" in field.logic_summary.lower() or "dayOfWeek" in field.logic_summary
 
@@ -326,7 +327,7 @@ class TestLogicSummaryHandlers:
         field = _build_one(
             [
                 {"func": "datetime-slice", "component": "month"},
-            ]
+            ],
         )
         assert "month" in field.logic_summary.lower()
 
@@ -340,7 +341,7 @@ class TestLogicSummaryHandlers:
                     "to": "US/Pacific",
                     "args": [{"func": "raw-field", "id": "event_time"}],
                 },
-            ]
+            ],
         )
         assert "utc" in field.logic_summary.lower()
         assert "us/pacific" in field.logic_summary.lower() or "US/Pacific" in field.logic_summary
@@ -349,7 +350,7 @@ class TestLogicSummaryHandlers:
         field = _build_one(
             [
                 {"func": "timezone-shift", "to": "Europe/Berlin"},
-            ]
+            ],
         )
         assert "europe/berlin" in field.logic_summary.lower() or "Europe/Berlin" in field.logic_summary
 
@@ -358,7 +359,7 @@ class TestLogicSummaryHandlers:
         field = _build_one(
             [
                 {"func": "timezone-shift"},
-            ]
+            ],
         )
         assert "timezone" in field.logic_summary.lower()
 
@@ -372,7 +373,7 @@ class TestLogicSummaryHandlers:
                     "replace": "",
                     "args": [{"func": "raw-field", "id": "domain"}],
                 },
-            ]
+            ],
         )
         # Empty replace => "Removes 'www.' from domain"
         assert "remove" in field.logic_summary.lower() or "replace" in field.logic_summary.lower()
@@ -382,7 +383,7 @@ class TestLogicSummaryHandlers:
         field = _build_one(
             [
                 {"func": "find-replace"},
-            ]
+            ],
         )
         assert "find and replace" in field.logic_summary.lower()
 
@@ -395,7 +396,7 @@ class TestLogicSummaryHandlers:
                     "delimiter": "|",
                     "args": [{"func": "raw-field", "id": "site_section"}],
                 },
-            ]
+            ],
         )
         assert "depth" in field.logic_summary.lower()
         assert "'|'" in field.logic_summary
@@ -404,7 +405,7 @@ class TestLogicSummaryHandlers:
         field = _build_one(
             [
                 {"func": "depth"},
-            ]
+            ],
         )
         assert "depth" in field.logic_summary.lower()
 
@@ -412,7 +413,7 @@ class TestLogicSummaryHandlers:
         field = _build_one(
             [
                 {"func": "profile", "attribute": "email", "namespace": "crm"},
-            ]
+            ],
         )
         assert "profile" in field.logic_summary.lower()
         assert "crm" in field.logic_summary.lower() or "crm/email" in field.logic_summary
@@ -422,7 +423,7 @@ class TestLogicSummaryHandlers:
         field = _build_one(
             [
                 {"func": "profile"},
-            ]
+            ],
         )
         assert "profile" in field.logic_summary.lower()
 
@@ -434,7 +435,7 @@ class TestLogicSummaryHandlers:
                 {"func": "deduplicate", "args": [{"func": "raw-field", "id": "pageName"}]},
                 {"func": "lowercase", "field": "p"},
                 {"func": "trim", "field": "p"},
-            ]
+            ],
         )
         assert "lowercase" in field.logic_summary.lower()
         assert "trim" in field.logic_summary.lower()
@@ -445,7 +446,7 @@ class TestLogicSummaryHandlers:
             [
                 {"func": "raw-field", "id": "pageName", "label": "p"},
                 {"func": "uppercase", "field": "p"},
-            ]
+            ],
         )
         assert "applies" in field.logic_summary.lower()
         assert "uppercase" in field.logic_summary.lower()
@@ -455,7 +456,7 @@ class TestLogicSummaryHandlers:
         field = _build_one(
             [
                 {"func": "raw-field", "id": "web.pageURL", "label": "url_ref"},
-            ]
+            ],
         )
         assert "references" in field.logic_summary.lower()
 
@@ -466,7 +467,7 @@ class TestLogicSummaryHandlers:
                 {"func": "raw-field", "id": "fieldA", "label": "a"},
                 {"func": "raw-field", "id": "fieldB", "label": "b"},
                 {"func": "raw-field", "id": "fieldC", "label": "c"},
-            ]
+            ],
         )
         assert "combines" in field.logic_summary.lower() or "3 fields" in field.logic_summary
 
@@ -483,7 +484,7 @@ class TestLogicSummaryHandlers:
                 "field": "f",
                 "#rule_name": "Rule1",
                 "branches": [],
-            }
+            },
         )
         # Additional rules via separate functions
         for i in range(2, 7):
@@ -493,7 +494,7 @@ class TestLogicSummaryHandlers:
                     "field": "f",
                     "#rule_name": f"Rule{i}",
                     "branches": [],
-                }
+                },
             )
 
         builder = _builder()
@@ -781,7 +782,7 @@ class TestDescribeMatchLogic:
         result = b._describe_match_logic(
             [
                 {"func": "match", "branches": ["not_a_dict", 123]},
-            ]
+            ],
         )
         assert result == ""
 
@@ -797,7 +798,7 @@ class TestDescribeMatchLogic:
                     ],
                     "default": "No",
                 },
-            ]
+            ],
         )
         assert 'else: "No"' in result
 
@@ -816,7 +817,7 @@ class TestDescribeMatchLogic:
                         {"pred": {"func": "eq", "field": "ch", "val": "yahoo"}, "map-to": "Search"},
                     ],
                 },
-            ]
+            ],
         )
         assert "OR" in result
         assert "Search" in result
@@ -828,7 +829,7 @@ class TestDescribeMatchLogic:
         result = b._describe_match_logic(
             [
                 {"func": "match", "field": "ch", "branches": branches},
-            ]
+            ],
         )
         assert "+4 more" in result or "+3 more" in result
 
@@ -848,7 +849,7 @@ class TestDescribeMatchLogic:
                         },
                     ],
                 },
-            ]
+            ],
         )
         assert "[pageName]" in result
 
@@ -862,7 +863,7 @@ class TestDescribeMatchLogic:
                         {"pred": {"func": "true"}, "map-to": {"val": "hello"}},
                     ],
                 },
-            ]
+            ],
         )
         assert '"hello"' in result
 
@@ -876,7 +877,7 @@ class TestDescribeMatchLogic:
                         {"pred": {"func": "true"}, "map-to": {"type": "computed"}},
                     ],
                 },
-            ]
+            ],
         )
         assert "[dynamic]" in result
 
@@ -890,7 +891,7 @@ class TestDescribeMatchLogic:
                         {"pred": {"func": "true"}, "map-to": 42},
                     ],
                 },
-            ]
+            ],
         )
         assert "42" in result
 
@@ -1014,7 +1015,7 @@ class TestProcessRowEmptyFunctions:
                 "sourceFieldType": "derived",
                 "fieldDefinition": "[]",
                 "dataSetType": "event",
-            }
+            },
         )
         result = builder._process_row(row, "Dimension")
         assert result is None
@@ -1029,7 +1030,7 @@ class TestProcessRowEmptyFunctions:
                 "sourceFieldType": "derived",
                 "fieldDefinition": '{"func": "raw-field"}',
                 "dataSetType": "event",
-            }
+            },
         )
         result = builder._process_row(row, "Dimension")
         assert result is None
@@ -1109,7 +1110,7 @@ class TestDescribeMatchLogicEdgeCases:
         result = builder._describe_match_logic(
             [
                 {"func": "match", "branches": "invalid"},
-            ]
+            ],
         )
         assert result == ""
 
@@ -1124,7 +1125,7 @@ class TestDescribeMatchLogicEdgeCases:
                         {"pred": {"func": "true"}, "map-to": "fallback_value"},
                     ],
                 },
-            ]
+            ],
         )
         assert "default" in result.lower()
         assert "fallback_value" in result
@@ -1203,7 +1204,7 @@ class TestDescribeLookupLogicNoClassify:
         result = builder._describe_lookup_logic(
             [
                 {"func": "raw-field", "id": "some_field"},
-            ]
+            ],
         )
         assert result == ""
 
@@ -1228,7 +1229,7 @@ class TestDescribeSequentialLogic:
                     "persistence": "first",
                     "args": [{"func": "raw-field", "id": "marketing.channel"}],
                 },
-            ]
+            ],
         )
         assert "Next" in result
         assert "channel" in result
@@ -1243,7 +1244,7 @@ class TestDescribeSequentialLogic:
                     "persistence": "last",
                     "args": [{"func": "raw-field", "id": "page.section"}],
                 },
-            ]
+            ],
         )
         assert "Previous" in result
         assert "section" in result
@@ -1254,7 +1255,7 @@ class TestDescribeSequentialLogic:
         result = builder._describe_sequential_logic(
             [
                 {"func": "next"},
-            ]
+            ],
         )
         assert result == "Next value lookup"
 
@@ -1266,7 +1267,7 @@ class TestDescribeSequentialLogic:
                     "func": "previous",
                     "args": [{"func": "raw-field", "id": "web.pageName"}],
                 },
-            ]
+            ],
         )
         assert "Previous value of pageName" == result
 
@@ -1275,7 +1276,7 @@ class TestDescribeSequentialLogic:
         result = builder._describe_sequential_logic(
             [
                 {"func": "raw-field", "id": "some_field"},
-            ]
+            ],
         )
         assert result == "Sequential value lookup"
 
@@ -1296,7 +1297,7 @@ class TestDescribeSplitLogic:
                     "index": 1,
                     "args": [{"func": "raw-field", "id": "site.section"}],
                 },
-            ]
+            ],
         )
         assert "Split section" in result
         assert '"|"' in result
@@ -1311,7 +1312,7 @@ class TestDescribeSplitLogic:
                     "delimiter": "/",
                     "index": 0,
                 },
-            ]
+            ],
         )
         assert result == 'Split by "/", get part 1'
 
@@ -1320,7 +1321,7 @@ class TestDescribeSplitLogic:
         result = builder._describe_split_logic(
             [
                 {"func": "raw-field", "id": "x"},
-            ]
+            ],
         )
         assert result == "Split string"
 
@@ -1396,7 +1397,7 @@ class TestDescribeTypecastLogic:
                     "type": "integer",
                     "args": [{"func": "raw-field", "id": "web.pageViews"}],
                 },
-            ]
+            ],
         )
         assert result == "Converts pageViews to integer"
 
@@ -1409,7 +1410,7 @@ class TestDescribeTypecastLogic:
                     "type": "string",
                     "field": "order_id_label",
                 },
-            ]
+            ],
         )
         assert result == "Converts order_id_label to string"
 
@@ -1421,7 +1422,7 @@ class TestDescribeTypecastLogic:
                     "func": "typecast",
                     "type": "double",
                 },
-            ]
+            ],
         )
         assert result == "Converts to double"
 
@@ -1431,7 +1432,7 @@ class TestDescribeTypecastLogic:
         result = builder._describe_typecast_logic(
             [
                 {"func": "raw-field", "id": "some_field"},
-            ]
+            ],
         )
         assert result == "Type conversion"
 
@@ -1451,7 +1452,7 @@ class TestDescribeDatetimeBucketLogic:
                     "bucket": "week",
                     "args": [{"func": "raw-field", "id": "event.timestamp"}],
                 },
-            ]
+            ],
         )
         assert result == "Buckets timestamp by week"
 
@@ -1464,7 +1465,7 @@ class TestDescribeDatetimeBucketLogic:
                     "interval": "month",
                     "field": "ts_label",
                 },
-            ]
+            ],
         )
         assert result == "Buckets ts_label by month"
 
@@ -1476,7 +1477,7 @@ class TestDescribeDatetimeBucketLogic:
                     "func": "datetime-bucket",
                     "granularity": "day",
                 },
-            ]
+            ],
         )
         assert result == "Date bucketing by day"
 
@@ -1485,7 +1486,7 @@ class TestDescribeDatetimeBucketLogic:
         result = builder._describe_datetime_bucket_logic(
             [
                 {"func": "raw-field", "id": "f"},
-            ]
+            ],
         )
         assert result == "Date bucketing"
 

--- a/tests/test_derived_inventory.py
+++ b/tests/test_derived_inventory.py
@@ -42,7 +42,7 @@ def sample_derived_field_definition():
                 "#rule_id": "rule-0",
                 "#rule_type": "caseWhen",
             },
-        ]
+        ],
     )
 
 
@@ -77,7 +77,7 @@ def sample_complex_derived_field():
                 }
                 for _ in range(25)  # Many branches
             ],
-        }
+        },
     )
 
     return json.dumps(functions)
@@ -102,7 +102,7 @@ def sample_marketing_channel_field():
                 "#rule_name": "Marketing Channel",
                 "#rule_type": "caseWhen",
             },
-        ]
+        ],
     )
 
 
@@ -122,7 +122,7 @@ def sample_lookup_field():
                 },
                 "source-field": "campaign_key",
             },
-        ]
+        ],
     )
 
 
@@ -135,7 +135,7 @@ def sample_math_only_field():
             {"func": "raw-field", "id": "cost", "label": "cost"},
             {"func": "subtract", "fields": ["rev", "cost"], "label": "profit"},
             {"func": "divide", "dividend": "profit", "divisor": "rev"},
-        ]
+        ],
     )
 
 
@@ -143,7 +143,7 @@ def sample_math_only_field():
 def sample_simple_lowercase_field():
     """Derived field that only does lowercase"""
     return json.dumps(
-        [{"func": "raw-field", "id": "pageName", "label": "page"}, {"func": "lowercase", "field": "page"}]
+        [{"func": "raw-field", "id": "pageName", "label": "page"}, {"func": "lowercase", "field": "page"}],
     )
 
 
@@ -179,7 +179,7 @@ def sample_metrics_df(sample_derived_field_definition, sample_math_only_field):
                 "fieldDefinition": pd.NA,
                 "dataSetType": "event",
             },
-        ]
+        ],
     )
 
 
@@ -224,7 +224,7 @@ def sample_dimensions_df(sample_marketing_channel_field, sample_lookup_field, sa
                 "fieldDefinition": pd.NA,
                 "dataSetType": "event",
             },
-        ]
+        ],
     )
 
 
@@ -282,8 +282,8 @@ class TestDerivedFieldInventoryBuilder:
                     "sourceFieldType": "derived",
                     "fieldDefinition": sample_marketing_channel_field,
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         inventory = builder.build(pd.DataFrame(), df, "dv_test", "Test")
@@ -303,8 +303,8 @@ class TestDerivedFieldInventoryBuilder:
                     "sourceFieldType": "derived",
                     "fieldDefinition": sample_derived_field_definition,
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         inventory = builder.build(df, pd.DataFrame(), "dv_test", "Test")
@@ -324,8 +324,8 @@ class TestDerivedFieldInventoryBuilder:
                     "sourceFieldType": "derived",
                     "fieldDefinition": sample_marketing_channel_field,
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         inventory = builder.build(pd.DataFrame(), df, "dv_test", "Test")
@@ -346,8 +346,8 @@ class TestDerivedFieldInventoryBuilder:
                     "sourceFieldType": "derived",
                     "fieldDefinition": sample_lookup_field,
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         inventory = builder.build(pd.DataFrame(), df, "dv_test", "Test")
@@ -366,8 +366,8 @@ class TestDerivedFieldInventoryBuilder:
                     "sourceFieldType": "derived",
                     "fieldDefinition": sample_marketing_channel_field,
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         inventory = builder.build(pd.DataFrame(), df, "dv_test", "Test")
@@ -463,8 +463,8 @@ class TestComplexityScore:
                     "sourceFieldType": "derived",
                     "fieldDefinition": sample_simple_lowercase_field,
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         inventory = builder.build(pd.DataFrame(), df, "dv_test", "Test")
@@ -483,8 +483,8 @@ class TestComplexityScore:
                     "sourceFieldType": "derived",
                     "fieldDefinition": sample_complex_derived_field,
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         inventory = builder.build(df, pd.DataFrame(), "dv_test", "Test")
@@ -510,8 +510,8 @@ class TestLogicSummary:
                     "sourceFieldType": "derived",
                     "fieldDefinition": sample_marketing_channel_field,
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         inventory = builder.build(pd.DataFrame(), df, "dv_test", "Test")
@@ -535,8 +535,8 @@ class TestLogicSummary:
                     "sourceFieldType": "derived",
                     "fieldDefinition": sample_math_only_field,
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         inventory = builder.build(df, pd.DataFrame(), "dv_test", "Test")
@@ -555,8 +555,8 @@ class TestLogicSummary:
                     "sourceFieldType": "derived",
                     "fieldDefinition": sample_lookup_field,
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         inventory = builder.build(pd.DataFrame(), df, "dv_test", "Test")
@@ -575,8 +575,8 @@ class TestLogicSummary:
                     "sourceFieldType": "derived",
                     "fieldDefinition": sample_simple_lowercase_field,
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         inventory = builder.build(pd.DataFrame(), df, "dv_test", "Test")
@@ -602,8 +602,8 @@ class TestInferredOutputType:
                     "sourceFieldType": "derived",
                     "fieldDefinition": sample_math_only_field,
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         inventory = builder.build(df, pd.DataFrame(), "dv_test", "Test")
@@ -622,8 +622,8 @@ class TestInferredOutputType:
                     "sourceFieldType": "derived",
                     "fieldDefinition": sample_marketing_channel_field,
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         inventory = builder.build(pd.DataFrame(), df, "dv_test", "Test")
@@ -642,8 +642,8 @@ class TestInferredOutputType:
                     "sourceFieldType": "derived",
                     "fieldDefinition": sample_simple_lowercase_field,
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         inventory = builder.build(pd.DataFrame(), df, "dv_test", "Test")
@@ -668,8 +668,8 @@ class TestEdgeCases:
                     "sourceFieldType": "derived",
                     "fieldDefinition": [{"func": "raw-field", "id": "test", "label": "test"}],
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         builder = DerivedFieldInventoryBuilder()
@@ -687,8 +687,8 @@ class TestEdgeCases:
                     "sourceFieldType": "derived",
                     "fieldDefinition": [],
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         builder = DerivedFieldInventoryBuilder()
@@ -707,8 +707,8 @@ class TestEdgeCases:
                     "sourceFieldType": "derived",
                     "fieldDefinition": None,
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         builder = DerivedFieldInventoryBuilder()
@@ -726,8 +726,8 @@ class TestEdgeCases:
                     "sourceFieldType": "derived",
                     "fieldDefinition": "not valid json",
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         builder = DerivedFieldInventoryBuilder()
@@ -753,7 +753,7 @@ class TestEdgeCases:
                     "fieldDefinition": '[{"func": "raw-field", "id": "test"}]',
                     "dataSetType": "event",
                 },
-            ]
+            ],
         )
 
         builder = DerivedFieldInventoryBuilder()
@@ -772,8 +772,8 @@ class TestEdgeCases:
                     "sourceFieldType": ["derived"],
                     "fieldDefinition": json.dumps([{"func": "raw-field", "id": "test", "label": "test"}]),
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         builder = DerivedFieldInventoryBuilder()
@@ -791,8 +791,8 @@ class TestEdgeCases:
                     "sourceFieldType": "derived",
                     "fieldDefinition": json.dumps([{"func": "raw-field", "id": 123, "label": "num_field"}]),
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         builder = DerivedFieldInventoryBuilder()
@@ -818,7 +818,7 @@ class TestEdgeCases:
                         {"pred": {"func": "true"}, "map-to": "Other"},
                     ],
                 },
-            ]
+            ],
         )
         df = pd.DataFrame(
             [
@@ -828,8 +828,8 @@ class TestEdgeCases:
                     "sourceFieldType": "derived",
                     "fieldDefinition": definition,
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         builder = DerivedFieldInventoryBuilder()
@@ -851,7 +851,7 @@ class TestEdgeCases:
                         {"pred": {"func": "true"}, "map-to": "Other"},
                     ],
                 },
-            ]
+            ],
         )
         df = pd.DataFrame(
             [
@@ -861,8 +861,8 @@ class TestEdgeCases:
                     "sourceFieldType": "derived",
                     "fieldDefinition": definition,
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         builder = DerivedFieldInventoryBuilder()
@@ -882,7 +882,7 @@ class TestEdgeCases:
                     "component": {"func": "query", "param": "utm_campaign"},
                     "args": [{"func": "raw-field", "id": "web.webPageDetails.URL"}],
                 },
-            ]
+            ],
         )
         df = pd.DataFrame(
             [
@@ -892,8 +892,8 @@ class TestEdgeCases:
                     "sourceFieldType": "derived",
                     "fieldDefinition": definition,
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         builder = DerivedFieldInventoryBuilder()
@@ -912,8 +912,8 @@ class TestEdgeCases:
                     "sourceFieldType": "derived",
                     "fieldDefinition": json.dumps([{"func": "raw-field", "id": "x", "label": "field"}]),
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         builder = DerivedFieldInventoryBuilder()
@@ -930,7 +930,7 @@ class TestEdgeCases:
                     "component": "hostname",
                     "args": {"func": "raw-field", "id": "test"},
                 },
-            ]
+            ],
         )
         df = pd.DataFrame(
             [
@@ -940,8 +940,8 @@ class TestEdgeCases:
                     "sourceFieldType": "derived",
                     "fieldDefinition": definition,
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         builder = DerivedFieldInventoryBuilder()
@@ -963,7 +963,7 @@ class TestEdgeCases:
                         {"func": "raw-field", "id": "field_b"},
                     ],
                 },
-            ]
+            ],
         )
         df = pd.DataFrame(
             [
@@ -973,8 +973,8 @@ class TestEdgeCases:
                     "sourceFieldType": "derived",
                     "fieldDefinition": definition,
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         builder = DerivedFieldInventoryBuilder()
@@ -994,7 +994,7 @@ class TestEdgeCases:
                     "replacement": 123,
                     "args": [{"func": "raw-field", "id": "field_a"}],
                 },
-            ]
+            ],
         )
         df = pd.DataFrame(
             [
@@ -1004,8 +1004,8 @@ class TestEdgeCases:
                     "sourceFieldType": "derived",
                     "fieldDefinition": definition,
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         builder = DerivedFieldInventoryBuilder()
@@ -1025,7 +1025,7 @@ class TestEdgeCases:
                     "replacement": None,
                     "args": [{"func": "raw-field", "id": "field_a"}],
                 },
-            ]
+            ],
         )
         df = pd.DataFrame(
             [
@@ -1035,8 +1035,8 @@ class TestEdgeCases:
                     "sourceFieldType": "derived",
                     "fieldDefinition": definition,
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         builder = DerivedFieldInventoryBuilder()
@@ -1061,10 +1061,10 @@ class TestEdgeCases:
                                 "preds": {"func": "eq", "field": "a", "value": "x"},
                             },
                             "map-to": "X",
-                        }
+                        },
                     ],
                 },
-            ]
+            ],
         )
         df = pd.DataFrame(
             [
@@ -1074,8 +1074,8 @@ class TestEdgeCases:
                     "sourceFieldType": "derived",
                     "fieldDefinition": definition,
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         builder = DerivedFieldInventoryBuilder()
@@ -1095,7 +1095,7 @@ class TestEdgeCases:
                     "replacement": "bar",
                     "args": [{"func": "raw-field", "id": "field_a"}],
                 },
-            ]
+            ],
         )
         df = pd.DataFrame(
             [
@@ -1105,8 +1105,8 @@ class TestEdgeCases:
                     "sourceFieldType": "derived",
                     "fieldDefinition": definition,
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         builder = DerivedFieldInventoryBuilder()
@@ -1133,8 +1133,8 @@ class TestEdgeCases:
                         },
                     ],
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         builder = DerivedFieldInventoryBuilder()
@@ -1156,7 +1156,7 @@ class TestEdgeCases:
                         "dataset": {"id": 123},
                     },
                 },
-            ]
+            ],
         )
         df = pd.DataFrame(
             [
@@ -1166,8 +1166,8 @@ class TestEdgeCases:
                     "sourceFieldType": "derived",
                     "fieldDefinition": definition,
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         builder = DerivedFieldInventoryBuilder()
@@ -1186,7 +1186,7 @@ class TestEdgeCases:
                     "field": "a",
                     "branches": ["string_branch", 123, {"pred": {"func": "true"}, "map-to": "OK"}],
                 },
-            ]
+            ],
         )
         df = pd.DataFrame(
             [
@@ -1196,8 +1196,8 @@ class TestEdgeCases:
                     "sourceFieldType": "derived",
                     "fieldDefinition": definition,
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         builder = DerivedFieldInventoryBuilder()
@@ -1215,8 +1215,8 @@ class TestEdgeCases:
                     "sourceFieldType": "derived",
                     "fieldDefinition": {"ambiguous": True},
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         builder = DerivedFieldInventoryBuilder()
@@ -1242,8 +1242,8 @@ class TestDescriptionExtraction:
                     "sourceFieldType": "derived",
                     "fieldDefinition": json.dumps([{"func": "raw-field", "id": "test", "label": "test"}]),
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         builder = DerivedFieldInventoryBuilder()
@@ -1263,8 +1263,8 @@ class TestDescriptionExtraction:
                     "sourceFieldType": "derived",
                     "fieldDefinition": json.dumps([{"func": "raw-field", "id": "test", "label": "test"}]),
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         builder = DerivedFieldInventoryBuilder()
@@ -1285,8 +1285,8 @@ class TestDescriptionExtraction:
                     "sourceFieldType": "derived",
                     "fieldDefinition": json.dumps([{"func": "raw-field", "id": "test", "label": "test"}]),
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         builder = DerivedFieldInventoryBuilder()
@@ -1306,8 +1306,8 @@ class TestDescriptionExtraction:
                     "sourceFieldType": "derived",
                     "fieldDefinition": json.dumps([{"func": "raw-field", "id": "test", "label": "test"}]),
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         builder = DerivedFieldInventoryBuilder()
@@ -1326,8 +1326,8 @@ class TestDescriptionExtraction:
                     "sourceFieldType": "derived",
                     "fieldDefinition": json.dumps([{"func": "raw-field", "id": "test", "label": "test"}]),
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         builder = DerivedFieldInventoryBuilder()
@@ -1347,8 +1347,8 @@ class TestDescriptionExtraction:
                     "sourceFieldType": "derived",
                     "fieldDefinition": json.dumps([{"func": "raw-field", "id": "test", "label": "test"}]),
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         builder = DerivedFieldInventoryBuilder()
@@ -1402,7 +1402,7 @@ class TestNewLogicSummaryHandlers:
             [
                 {"func": "raw-field", "id": "stringValue", "label": "input"},
                 {"func": "typecast", "field": "input", "type": "integer"},
-            ]
+            ],
         )
         df = pd.DataFrame(
             [
@@ -1412,8 +1412,8 @@ class TestNewLogicSummaryHandlers:
                     "sourceFieldType": "derived",
                     "fieldDefinition": definition,
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         builder = DerivedFieldInventoryBuilder()
@@ -1428,7 +1428,7 @@ class TestNewLogicSummaryHandlers:
             [
                 {"func": "raw-field", "id": "timestamp", "label": "ts"},
                 {"func": "datetime-bucket", "field": "ts", "bucket": "week"},
-            ]
+            ],
         )
         df = pd.DataFrame(
             [
@@ -1438,8 +1438,8 @@ class TestNewLogicSummaryHandlers:
                     "sourceFieldType": "derived",
                     "fieldDefinition": definition,
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         builder = DerivedFieldInventoryBuilder()
@@ -1454,7 +1454,7 @@ class TestNewLogicSummaryHandlers:
             [
                 {"func": "raw-field", "id": "timestamp", "label": "ts"},
                 {"func": "datetime-slice", "field": "ts", "component": "hour"},
-            ]
+            ],
         )
         df = pd.DataFrame(
             [
@@ -1464,8 +1464,8 @@ class TestNewLogicSummaryHandlers:
                     "sourceFieldType": "derived",
                     "fieldDefinition": definition,
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         builder = DerivedFieldInventoryBuilder()
@@ -1480,7 +1480,7 @@ class TestNewLogicSummaryHandlers:
             [
                 {"func": "raw-field", "id": "timestamp", "label": "ts"},
                 {"func": "timezone-shift", "field": "ts", "from": "UTC", "to": "America/New_York"},
-            ]
+            ],
         )
         df = pd.DataFrame(
             [
@@ -1490,8 +1490,8 @@ class TestNewLogicSummaryHandlers:
                     "sourceFieldType": "derived",
                     "fieldDefinition": definition,
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         builder = DerivedFieldInventoryBuilder()
@@ -1506,7 +1506,7 @@ class TestNewLogicSummaryHandlers:
             [
                 {"func": "raw-field", "id": "pageName", "label": "page"},
                 {"func": "find-replace", "field": "page", "find": "www.", "replace": ""},
-            ]
+            ],
         )
         df = pd.DataFrame(
             [
@@ -1516,8 +1516,8 @@ class TestNewLogicSummaryHandlers:
                     "sourceFieldType": "derived",
                     "fieldDefinition": definition,
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         builder = DerivedFieldInventoryBuilder()
@@ -1532,7 +1532,7 @@ class TestNewLogicSummaryHandlers:
             [
                 {"func": "raw-field", "id": "pagePath", "label": "path"},
                 {"func": "depth", "field": "path", "delimiter": "/"},
-            ]
+            ],
         )
         df = pd.DataFrame(
             [
@@ -1542,8 +1542,8 @@ class TestNewLogicSummaryHandlers:
                     "sourceFieldType": "derived",
                     "fieldDefinition": definition,
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         builder = DerivedFieldInventoryBuilder()
@@ -1564,8 +1564,8 @@ class TestNewLogicSummaryHandlers:
                     "sourceFieldType": "derived",
                     "fieldDefinition": definition,
                     "dataSetType": "event",
-                }
-            ]
+                },
+            ],
         )
 
         builder = DerivedFieldInventoryBuilder()

--- a/tests/test_diff_comparison.py
+++ b/tests/test_diff_comparison.py
@@ -335,7 +335,10 @@ class TestDataViewComparator:
         """Test comparing with custom labels"""
         comparator = DataViewComparator(logger)
         result = comparator.compare(
-            source_snapshot, target_snapshot_identical, source_label="Production", target_label="Staging"
+            source_snapshot,
+            target_snapshot_identical,
+            source_label="Production",
+            target_label="Staging",
         )
 
         assert result.source_label == "Production"
@@ -408,7 +411,10 @@ class TestDiffOutputWriters:
         """Create a sample diff result for output testing"""
         comparator = DataViewComparator(logger)
         return comparator.compare(
-            source_snapshot, target_snapshot_with_changes, source_label="Source", target_label="Target"
+            source_snapshot,
+            target_snapshot_with_changes,
+            source_label="Source",
+            target_label="Target",
         )
 
     def test_console_output(self, sample_diff_result):
@@ -566,7 +572,10 @@ class TestEdgeCases:
         """Test when all items are added (empty source)"""
         source = DataViewSnapshot(data_view_id="dv_empty", data_view_name="Empty", metrics=[], dimensions=[])
         target = DataViewSnapshot(
-            data_view_id="dv_full", data_view_name="Full", metrics=sample_metrics, dimensions=sample_dimensions
+            data_view_id="dv_full",
+            data_view_name="Full",
+            metrics=sample_metrics,
+            dimensions=sample_dimensions,
         )
 
         comparator = DataViewComparator(logger)
@@ -579,7 +588,10 @@ class TestEdgeCases:
     def test_all_removed(self, logger, sample_metrics, sample_dimensions):
         """Test when all items are removed (empty target)"""
         source = DataViewSnapshot(
-            data_view_id="dv_full", data_view_name="Full", metrics=sample_metrics, dimensions=sample_dimensions
+            data_view_id="dv_full",
+            data_view_name="Full",
+            metrics=sample_metrics,
+            dimensions=sample_dimensions,
         )
         target = DataViewSnapshot(data_view_id="dv_empty", data_view_name="Empty", metrics=[], dimensions=[])
 
@@ -632,7 +644,7 @@ class TestComparisonFields:
                     "description": "Original Description",
                     "type": "int",
                     "schemaPath": "/path/original",
-                }
+                },
             ],
             dimensions=[],
         )
@@ -647,7 +659,7 @@ class TestComparisonFields:
                     "description": "Changed Description",
                     "type": "decimal",
                     "schemaPath": "/path/changed",
-                }
+                },
             ],
             dimensions=[],
         )
@@ -993,7 +1005,7 @@ class TestExtendedFieldComparison:
                     "type": "int",
                     "hidden": True,
                     "precision": 4,  # Changed
-                }
+                },
             ],
             dimensions=[],
         )
@@ -1027,7 +1039,7 @@ class TestExtendedFieldComparison:
                     "id": "m1",
                     "name": "Metric",
                     "attribution": {"model": "firstTouch", "lookback": 30},  # Model changed
-                }
+                },
             ],
             dimensions=[],
         )
@@ -1059,7 +1071,7 @@ class TestExtendedFieldComparison:
                     "segment_references": ["segments/x", "segments/y"],
                     "nesting_depth": 1,
                     "tags": ["Finance", "KPI"],
-                }
+                },
             ],
         )
         target = DataViewSnapshot(
@@ -1081,7 +1093,7 @@ class TestExtendedFieldComparison:
                     "segment_references": ["segments/y", "segments/x"],  # Reordered only
                     "nesting_depth": 1,
                     "tags": ["KPI", "Finance"],  # Reordered only
-                }
+                },
             ],
         )
 
@@ -1183,7 +1195,10 @@ class TestMetricsOnlyAndDimensionsOnly:
     def test_metrics_only_flag(self, logger, sample_metrics, sample_dimensions):
         """Test that --metrics-only excludes dimensions"""
         source = DataViewSnapshot(
-            data_view_id="dv_1", data_view_name="Source", metrics=sample_metrics, dimensions=sample_dimensions
+            data_view_id="dv_1",
+            data_view_name="Source",
+            metrics=sample_metrics,
+            dimensions=sample_dimensions,
         )
         target = DataViewSnapshot(
             data_view_id="dv_2",
@@ -1203,7 +1218,10 @@ class TestMetricsOnlyAndDimensionsOnly:
     def test_dimensions_only_flag(self, logger, sample_metrics, sample_dimensions):
         """Test that --dimensions-only excludes metrics"""
         source = DataViewSnapshot(
-            data_view_id="dv_1", data_view_name="Source", metrics=sample_metrics, dimensions=sample_dimensions
+            data_view_id="dv_1",
+            data_view_name="Source",
+            metrics=sample_metrics,
+            dimensions=sample_dimensions,
         )
         target = DataViewSnapshot(
             data_view_id="dv_2",
@@ -1324,7 +1342,10 @@ class TestLargeDatasetPerformance:
         import time
 
         source = DataViewSnapshot(
-            data_view_id="dv_large_1", data_view_name="Large Source", metrics=large_metrics, dimensions=large_dimensions
+            data_view_id="dv_large_1",
+            data_view_name="Large Source",
+            metrics=large_metrics,
+            dimensions=large_dimensions,
         )
         target = DataViewSnapshot(
             data_view_id="dv_large_2",
@@ -1360,11 +1381,14 @@ class TestLargeDatasetPerformance:
                     "name": f"New Metric {i}",
                     "type": "int",
                     "description": f"New description {i}",
-                }
+                },
             )
 
         source = DataViewSnapshot(
-            data_view_id="dv_large_1", data_view_name="Large Source", metrics=large_metrics, dimensions=large_dimensions
+            data_view_id="dv_large_1",
+            data_view_name="Large Source",
+            metrics=large_metrics,
+            dimensions=large_dimensions,
         )
         target = DataViewSnapshot(
             data_view_id="dv_large_2",
@@ -1388,7 +1412,10 @@ class TestLargeDatasetPerformance:
         """Test that large dataset comparison doesn't consume excessive memory"""
 
         source = DataViewSnapshot(
-            data_view_id="dv_large_1", data_view_name="Large Source", metrics=large_metrics, dimensions=large_dimensions
+            data_view_id="dv_large_1",
+            data_view_name="Large Source",
+            metrics=large_metrics,
+            dimensions=large_dimensions,
         )
         target = DataViewSnapshot(
             data_view_id="dv_large_2",
@@ -1465,7 +1492,7 @@ class TestUnicodeEdgeCases:
                     "name": 'Metric with <html> & "quotes"',
                     "description": "Line1\nLine2\tTabbed",
                     "type": "int",
-                }
+                },
             ],
             dimensions=[],
         )
@@ -1478,7 +1505,7 @@ class TestUnicodeEdgeCases:
                     "name": 'Metric with <html> & "quotes"',
                     "description": "Different\nContent",
                     "type": "int",
-                }
+                },
             ],
             dimensions=[],
         )
@@ -1535,7 +1562,7 @@ class TestDeeplyNestedStructures:
                         "model": "lastTouch",
                         "lookback": {"type": "visitor", "granularity": "day", "numPeriods": 30},
                     },
-                }
+                },
             ],
             dimensions=[],
         )
@@ -1554,7 +1581,7 @@ class TestDeeplyNestedStructures:
                             "numPeriods": 60,  # Changed from 30 to 60
                         },
                     },
-                }
+                },
             ],
             dimensions=[],
         )
@@ -1575,7 +1602,7 @@ class TestDeeplyNestedStructures:
                     "id": "m1",
                     "name": "Currency",
                     "format": {"type": "currency", "currency": "USD", "precision": 2, "negativeFormat": "parentheses"},
-                }
+                },
             ],
             dimensions=[],
         )
@@ -1592,7 +1619,7 @@ class TestDeeplyNestedStructures:
                         "precision": 2,
                         "negativeFormat": "parentheses",
                     },
-                }
+                },
             ],
             dimensions=[],
         )
@@ -1617,7 +1644,7 @@ class TestDeeplyNestedStructures:
                         "buckets": [0, 100, 500, 1000],
                         "labels": ["Low", "Medium", "High", "Premium"],
                     },
-                }
+                },
             ],
         )
         target = DataViewSnapshot(
@@ -1633,7 +1660,7 @@ class TestDeeplyNestedStructures:
                         "buckets": [0, 50, 200, 500, 1000],  # Changed
                         "labels": ["Very Low", "Low", "Medium", "High", "Premium"],  # Changed
                     },
-                }
+                },
             ],
         )
 
@@ -1654,7 +1681,10 @@ class TestConcurrentComparison:
         from concurrent.futures import ThreadPoolExecutor, as_completed
 
         source = DataViewSnapshot(
-            data_view_id="dv_source", data_view_name="Source", metrics=sample_metrics, dimensions=sample_dimensions
+            data_view_id="dv_source",
+            data_view_name="Source",
+            metrics=sample_metrics,
+            dimensions=sample_dimensions,
         )
 
         targets = [
@@ -1865,7 +1895,11 @@ class TestDiffSummaryPercentages:
         from cja_auto_sdr.generator import DiffSummary
 
         summary = DiffSummary(
-            source_metrics_count=100, target_metrics_count=100, metrics_added=5, metrics_removed=3, metrics_modified=2
+            source_metrics_count=100,
+            target_metrics_count=100,
+            metrics_added=5,
+            metrics_removed=3,
+            metrics_modified=2,
         )
 
         assert summary.metrics_changed == 10
@@ -2842,7 +2876,10 @@ class TestSnapshotToSnapshotComparison:
 
         source_file, target_file = temp_snapshots
         success, has_changes, _exit_code = handle_compare_snapshots_command(
-            source_file=source_file, target_file=target_file, quiet=True, quiet_diff=True
+            source_file=source_file,
+            target_file=target_file,
+            quiet=True,
+            quiet_diff=True,
         )
 
         assert success is True
@@ -2873,7 +2910,10 @@ class TestSnapshotToSnapshotComparison:
             json.dump(snapshot_data, f)
 
         success, has_changes, _ = handle_compare_snapshots_command(
-            source_file=str(file1), target_file=str(file2), quiet=True, quiet_diff=True
+            source_file=str(file1),
+            target_file=str(file2),
+            quiet=True,
+            quiet_diff=True,
         )
 
         assert success is True
@@ -2898,7 +2938,11 @@ class TestSnapshotToSnapshotComparison:
 
         source_file, target_file = temp_snapshots
         success, has_changes, _ = handle_compare_snapshots_command(
-            source_file=source_file, target_file=target_file, reverse_diff=True, quiet=True, quiet_diff=True
+            source_file=source_file,
+            target_file=target_file,
+            reverse_diff=True,
+            quiet=True,
+            quiet_diff=True,
         )
 
         assert success is True

--- a/tests/test_diff_coverage.py
+++ b/tests/test_diff_coverage.py
@@ -243,7 +243,11 @@ class TestInventoryItemDiffPostInit:
 
     def test_changed_fields_none_defaults_to_empty(self):
         diff = InventoryItemDiff(
-            id="i1", name="item", change_type=ChangeType.ADDED, inventory_type="calculated_metric", changed_fields=None
+            id="i1",
+            name="item",
+            change_type=ChangeType.ADDED,
+            inventory_type="calculated_metric",
+            changed_fields=None,
         )
         assert diff.changed_fields == {}
 
@@ -750,7 +754,10 @@ class TestBuildSummaryWithCalcMetrics:
 
         cm_diffs = [
             InventoryItemDiff(
-                id="cm1", name="CM1", change_type=ChangeType.UNCHANGED, inventory_type="calculated_metric"
+                id="cm1",
+                name="CM1",
+                change_type=ChangeType.UNCHANGED,
+                inventory_type="calculated_metric",
             ),
             InventoryItemDiff(id="cm2", name="CM2", change_type=ChangeType.REMOVED, inventory_type="calculated_metric"),
             InventoryItemDiff(id="cm3", name="CM3", change_type=ChangeType.REMOVED, inventory_type="calculated_metric"),

--- a/tests/test_diff_inventory_output.py
+++ b/tests/test_diff_inventory_output.py
@@ -1,0 +1,1490 @@
+"""Tests targeting diff output with inventory sections across all formats.
+
+Covers uncovered lines in generator.py related to diff output when inventory
+diffs (calc_metrics_diffs, segments_diffs) are populated, and inventory summary
+display functions.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from unittest.mock import MagicMock
+
+from cja_auto_sdr.diff.models import (
+    ChangeType,
+    ComponentDiff,
+    DiffResult,
+    DiffSummary,
+    InventoryItemDiff,
+    MetadataDiff,
+)
+from cja_auto_sdr.generator import (
+    _get_inventory_change_detail,
+    display_inventory_summary,
+    write_diff_console_output,
+    write_diff_csv_output,
+    write_diff_excel_output,
+    write_diff_html_output,
+    write_diff_json_output,
+    write_diff_markdown_output,
+    write_diff_output,
+    write_diff_pr_comment_output,
+)
+
+# ==================== Helpers ====================
+
+
+def _make_metadata(**overrides) -> MetadataDiff:
+    """Build a minimal MetadataDiff with sensible defaults."""
+    defaults = {
+        "source_name": "Source DV",
+        "target_name": "Target DV",
+        "source_id": "dv_source",
+        "target_id": "dv_target",
+    }
+    defaults.update(overrides)
+    return MetadataDiff(**defaults)
+
+
+def _make_summary_with_inventory(**overrides) -> DiffSummary:
+    """Build a DiffSummary that includes inventory counts."""
+    defaults = {
+        "source_metrics_count": 10,
+        "target_metrics_count": 12,
+        "source_dimensions_count": 20,
+        "target_dimensions_count": 22,
+        "metrics_added": 2,
+        "metrics_removed": 0,
+        "metrics_modified": 1,
+        "metrics_unchanged": 9,
+        "dimensions_added": 3,
+        "dimensions_removed": 1,
+        "dimensions_modified": 2,
+        "dimensions_unchanged": 16,
+        # Inventory counts
+        "source_calc_metrics_count": 5,
+        "target_calc_metrics_count": 7,
+        "calc_metrics_added": 2,
+        "calc_metrics_removed": 0,
+        "calc_metrics_modified": 1,
+        "calc_metrics_unchanged": 4,
+        "source_segments_count": 8,
+        "target_segments_count": 9,
+        "segments_added": 1,
+        "segments_removed": 0,
+        "segments_modified": 2,
+        "segments_unchanged": 6,
+    }
+    defaults.update(overrides)
+    return DiffSummary(**defaults)
+
+
+def _make_component_diffs() -> list[ComponentDiff]:
+    """Build a list of ComponentDiff entries for metrics or dimensions."""
+    return [
+        ComponentDiff(
+            id="m1",
+            name="Revenue",
+            change_type=ChangeType.ADDED,
+        ),
+        ComponentDiff(
+            id="m2",
+            name="Conversions",
+            change_type=ChangeType.MODIFIED,
+            changed_fields={"description": ("old desc", "new desc")},
+        ),
+        ComponentDiff(
+            id="m3",
+            name="PageViews",
+            change_type=ChangeType.UNCHANGED,
+        ),
+    ]
+
+
+def _make_inventory_diffs(inv_type: str = "calculated_metric") -> list[InventoryItemDiff]:
+    """Build a list of InventoryItemDiff entries."""
+    return [
+        InventoryItemDiff(
+            id="cm1",
+            name="Revenue Per Visit",
+            change_type=ChangeType.ADDED,
+            inventory_type=inv_type,
+        ),
+        InventoryItemDiff(
+            id="cm2",
+            name="Conversion Rate",
+            change_type=ChangeType.MODIFIED,
+            inventory_type=inv_type,
+            changed_fields={"formula": ("A/B", "A/(B+C)"), "description": ("old", "new")},
+        ),
+        InventoryItemDiff(
+            id="cm3",
+            name="Bounce Rate",
+            change_type=ChangeType.UNCHANGED,
+            inventory_type=inv_type,
+        ),
+        InventoryItemDiff(
+            id="cm4",
+            name="Obsolete Metric",
+            change_type=ChangeType.REMOVED,
+            inventory_type=inv_type,
+        ),
+    ]
+
+
+def _make_segment_diffs() -> list[InventoryItemDiff]:
+    """Build segment inventory diffs."""
+    return [
+        InventoryItemDiff(
+            id="s1",
+            name="High Value Users",
+            change_type=ChangeType.ADDED,
+            inventory_type="segment",
+        ),
+        InventoryItemDiff(
+            id="s2",
+            name="Mobile Visitors",
+            change_type=ChangeType.MODIFIED,
+            inventory_type="segment",
+            changed_fields={"definition_summary": ("visits > 5", "visits > 10")},
+        ),
+        InventoryItemDiff(
+            id="s3",
+            name="Existing Segment",
+            change_type=ChangeType.UNCHANGED,
+            inventory_type="segment",
+        ),
+    ]
+
+
+def _make_diff_result_with_inventory(**overrides) -> DiffResult:
+    """Build a DiffResult with populated inventory diffs."""
+    defaults = {
+        "summary": _make_summary_with_inventory(),
+        "metadata_diff": _make_metadata(),
+        "metric_diffs": _make_component_diffs(),
+        "dimension_diffs": _make_component_diffs(),
+        "source_label": "Before",
+        "target_label": "After",
+        "generated_at": "2025-01-15 12:00:00",
+        "tool_version": "3.2.8",
+        "calc_metrics_diffs": _make_inventory_diffs("calculated_metric"),
+        "segments_diffs": _make_segment_diffs(),
+    }
+    defaults.update(overrides)
+    return DiffResult(**defaults)
+
+
+def _make_logger() -> logging.Logger:
+    """Create a test logger that does not write to stdout."""
+    logger = logging.getLogger("test_diff_inventory_output")
+    logger.setLevel(logging.DEBUG)
+    logger.handlers = []  # Remove all handlers
+    logger.addHandler(logging.NullHandler())
+    return logger
+
+
+# ==================== Console output with inventory ====================
+
+
+class TestConsoleOutputWithInventory:
+    """Tests for write_diff_console_output when inventory diffs are populated."""
+
+    def test_console_output_includes_inventory_header(self):
+        result = _make_diff_result_with_inventory()
+        output = write_diff_console_output(result, use_color=False)
+
+        assert "INVENTORY" in output
+
+    def test_console_output_includes_calc_metrics_summary_row(self):
+        result = _make_diff_result_with_inventory()
+        output = write_diff_console_output(result, use_color=False)
+
+        assert "Calc Metrics" in output
+
+    def test_console_output_includes_segments_summary_row(self):
+        result = _make_diff_result_with_inventory()
+        output = write_diff_console_output(result, use_color=False)
+
+        assert "Segments" in output
+
+    def test_console_output_includes_inventory_changes_section(self):
+        result = _make_diff_result_with_inventory()
+        output = write_diff_console_output(result, use_color=False)
+
+        assert "INVENTORY CHANGES" in output
+
+    def test_console_output_includes_calculated_metrics_changes(self):
+        result = _make_diff_result_with_inventory()
+        output = write_diff_console_output(result, use_color=False)
+
+        assert "CALCULATED METRICS" in output
+        assert "Revenue Per Visit" in output
+        assert "Conversion Rate" in output
+
+    def test_console_output_includes_segments_changes(self):
+        result = _make_diff_result_with_inventory()
+        output = write_diff_console_output(result, use_color=False)
+
+        assert "SEGMENTS" in output
+        assert "High Value Users" in output
+        assert "Mobile Visitors" in output
+
+    def test_console_output_inventory_change_detail_for_modified(self):
+        result = _make_diff_result_with_inventory()
+        output = write_diff_console_output(result, use_color=False)
+
+        # Modified calc metric should show field changes
+        assert "formula" in output
+        assert "A/B" in output
+        assert "A/(B+C)" in output
+
+    def test_console_output_inventory_footer_includes_inventory_counts(self):
+        result = _make_diff_result_with_inventory()
+        output = write_diff_console_output(result, use_color=False)
+
+        # Footer should include inventory summary lines
+        assert "Calc Metrics: 2 added, 0 removed, 1 modified" in output
+        assert "Segments: 1 added, 0 removed, 2 modified" in output
+
+    def test_console_output_with_color_enabled(self):
+        result = _make_diff_result_with_inventory()
+        output = write_diff_console_output(result, use_color=True)
+
+        # Should still contain the key text (with ANSI codes around it)
+        assert "INVENTORY" in output
+        assert "Calc Metrics" in output
+
+    def test_console_output_summary_only_with_inventory(self):
+        result = _make_diff_result_with_inventory()
+        output = write_diff_console_output(result, summary_only=True, use_color=False)
+
+        # Summary-only should still show the summary table with inventory rows
+        assert "Calc Metrics" in output
+
+    def test_console_output_changes_only_filters_unchanged_inventory(self):
+        result = _make_diff_result_with_inventory()
+        output = write_diff_console_output(result, changes_only=True, use_color=False)
+
+        # "Existing Segment" and "Bounce Rate" are UNCHANGED, should not appear in changes section
+        # But they may still appear in the summary table counts
+        assert "INVENTORY CHANGES" in output
+
+    def test_console_output_only_calc_metrics_no_segments(self):
+        """Test output when only calc_metrics_diffs is present, no segments."""
+        result = _make_diff_result_with_inventory(
+            segments_diffs=None,
+            summary=_make_summary_with_inventory(
+                source_segments_count=0,
+                target_segments_count=0,
+                segments_added=0,
+                segments_removed=0,
+                segments_modified=0,
+                segments_unchanged=0,
+            ),
+        )
+        output = write_diff_console_output(result, use_color=False)
+
+        assert "CALCULATED METRICS" in output
+        # Should not have SEGMENTS section in inventory changes
+        assert "SEGMENTS" not in output or output.index("CALCULATED METRICS") < output.rindex("=")
+
+    def test_console_output_only_segments_no_calc_metrics(self):
+        """Test output when only segments_diffs is present, no calc metrics."""
+        result = _make_diff_result_with_inventory(
+            calc_metrics_diffs=None,
+            summary=_make_summary_with_inventory(
+                source_calc_metrics_count=0,
+                target_calc_metrics_count=0,
+                calc_metrics_added=0,
+                calc_metrics_removed=0,
+                calc_metrics_modified=0,
+                calc_metrics_unchanged=0,
+            ),
+        )
+        output = write_diff_console_output(result, use_color=False)
+
+        # Should have segments section
+        assert "High Value Users" in output
+
+    def test_console_inventory_no_changes_shows_no_changes_message(self):
+        """When inventory diffs exist but all are UNCHANGED, show 'No changes'."""
+        unchanged_calc = [
+            InventoryItemDiff(id="cm1", name="X", change_type=ChangeType.UNCHANGED, inventory_type="calculated_metric"),
+        ]
+        unchanged_seg = [
+            InventoryItemDiff(id="s1", name="Y", change_type=ChangeType.UNCHANGED, inventory_type="segment"),
+        ]
+        summary = _make_summary_with_inventory(
+            calc_metrics_added=0,
+            calc_metrics_removed=0,
+            calc_metrics_modified=0,
+            segments_added=0,
+            segments_removed=0,
+            segments_modified=0,
+        )
+        result = _make_diff_result_with_inventory(
+            calc_metrics_diffs=unchanged_calc,
+            segments_diffs=unchanged_seg,
+            summary=summary,
+        )
+        output = write_diff_console_output(result, use_color=False)
+
+        assert "No changes" in output
+
+
+# ==================== JSON output with inventory ====================
+
+
+class TestJsonOutputWithInventory:
+    """Tests for write_diff_json_output when inventory diffs are populated."""
+
+    def test_json_output_includes_inventory_summary(self, tmp_path):
+        result = _make_diff_result_with_inventory()
+        logger = _make_logger()
+
+        json_file = write_diff_json_output(result, "test_diff", str(tmp_path), logger)
+
+        assert os.path.exists(json_file)
+        with open(json_file) as f:
+            data = json.load(f)
+
+        assert "inventory_summary" in data
+        assert "calculated_metrics" in data["inventory_summary"]
+        assert "segments" in data["inventory_summary"]
+
+    def test_json_output_inventory_summary_counts(self, tmp_path):
+        result = _make_diff_result_with_inventory()
+        logger = _make_logger()
+
+        json_file = write_diff_json_output(result, "test_diff", str(tmp_path), logger)
+
+        with open(json_file) as f:
+            data = json.load(f)
+
+        calc = data["inventory_summary"]["calculated_metrics"]
+        assert calc["source_count"] == 5
+        assert calc["target_count"] == 7
+        assert calc["added"] == 2
+        assert calc["removed"] == 0
+        assert calc["modified"] == 1
+
+        seg = data["inventory_summary"]["segments"]
+        assert seg["source_count"] == 8
+        assert seg["target_count"] == 9
+        assert seg["added"] == 1
+
+    def test_json_output_includes_calc_metrics_diffs(self, tmp_path):
+        result = _make_diff_result_with_inventory()
+        logger = _make_logger()
+
+        json_file = write_diff_json_output(result, "test_diff", str(tmp_path), logger)
+
+        with open(json_file) as f:
+            data = json.load(f)
+
+        assert "calculated_metrics_diffs" in data
+        # Should include all diffs (not changes_only by default)
+        assert len(data["calculated_metrics_diffs"]) == 4
+
+    def test_json_output_includes_segments_diffs(self, tmp_path):
+        result = _make_diff_result_with_inventory()
+        logger = _make_logger()
+
+        json_file = write_diff_json_output(result, "test_diff", str(tmp_path), logger)
+
+        with open(json_file) as f:
+            data = json.load(f)
+
+        assert "segments_diffs" in data
+        assert len(data["segments_diffs"]) == 3
+
+    def test_json_output_changes_only_filters_unchanged(self, tmp_path):
+        result = _make_diff_result_with_inventory()
+        logger = _make_logger()
+
+        json_file = write_diff_json_output(result, "test_diff", str(tmp_path), logger, changes_only=True)
+
+        with open(json_file) as f:
+            data = json.load(f)
+
+        # Calc metrics: 4 total, 1 UNCHANGED = 3 remaining
+        assert len(data["calculated_metrics_diffs"]) == 3
+        # Segments: 3 total, 1 UNCHANGED = 2 remaining
+        assert len(data["segments_diffs"]) == 2
+
+    def test_json_output_inventory_diff_serialization(self, tmp_path):
+        result = _make_diff_result_with_inventory()
+        logger = _make_logger()
+
+        json_file = write_diff_json_output(result, "test_diff", str(tmp_path), logger)
+
+        with open(json_file) as f:
+            data = json.load(f)
+
+        # Check that modified calc metric has changed_fields serialized
+        modified_diffs = [d for d in data["calculated_metrics_diffs"] if d["change_type"] == "modified"]
+        assert len(modified_diffs) == 1
+        assert "formula" in modified_diffs[0]["changed_fields"]
+        assert modified_diffs[0]["changed_fields"]["formula"]["source"] == "A/B"
+        assert modified_diffs[0]["changed_fields"]["formula"]["target"] == "A/(B+C)"
+
+    def test_json_output_no_inventory_when_not_present(self, tmp_path):
+        result = _make_diff_result_with_inventory(
+            calc_metrics_diffs=None,
+            segments_diffs=None,
+        )
+        # Also zero out the summary counts
+        result.summary = _make_summary_with_inventory(
+            source_calc_metrics_count=0,
+            target_calc_metrics_count=0,
+            calc_metrics_added=0,
+            calc_metrics_removed=0,
+            calc_metrics_modified=0,
+            calc_metrics_unchanged=0,
+            source_segments_count=0,
+            target_segments_count=0,
+            segments_added=0,
+            segments_removed=0,
+            segments_modified=0,
+            segments_unchanged=0,
+        )
+        logger = _make_logger()
+
+        json_file = write_diff_json_output(result, "test_diff", str(tmp_path), logger)
+
+        with open(json_file) as f:
+            data = json.load(f)
+
+        assert "inventory_summary" not in data
+        assert "calculated_metrics_diffs" not in data
+        assert "segments_diffs" not in data
+
+
+# ==================== Markdown output with inventory ====================
+
+
+class TestMarkdownOutputWithInventory:
+    """Tests for write_diff_markdown_output when inventory diffs are populated."""
+
+    def test_markdown_output_includes_inventory_summary_rows(self, tmp_path):
+        result = _make_diff_result_with_inventory()
+        logger = _make_logger()
+
+        md_file = write_diff_markdown_output(result, "test_diff", str(tmp_path), logger)
+
+        assert os.path.exists(md_file)
+        with open(md_file) as f:
+            content = f.read()
+
+        assert "**Calc Metrics**" in content
+        assert "**Segments**" in content
+
+    def test_markdown_output_includes_inventory_changes_section(self, tmp_path):
+        result = _make_diff_result_with_inventory()
+        logger = _make_logger()
+
+        md_file = write_diff_markdown_output(result, "test_diff", str(tmp_path), logger)
+
+        with open(md_file) as f:
+            content = f.read()
+
+        assert "# Inventory Changes" in content
+        assert "## Calculated Metrics Changes" in content
+        assert "## Segments Changes" in content
+
+    def test_markdown_output_inventory_change_details(self, tmp_path):
+        result = _make_diff_result_with_inventory()
+        logger = _make_logger()
+
+        md_file = write_diff_markdown_output(result, "test_diff", str(tmp_path), logger)
+
+        with open(md_file) as f:
+            content = f.read()
+
+        assert "Revenue Per Visit" in content
+        assert "Conversion Rate" in content
+        assert "High Value Users" in content
+
+    def test_markdown_output_inventory_no_changes_shows_message(self, tmp_path):
+        unchanged_calc = [
+            InventoryItemDiff(id="cm1", name="X", change_type=ChangeType.UNCHANGED, inventory_type="calculated_metric"),
+        ]
+        summary = _make_summary_with_inventory(
+            calc_metrics_added=0,
+            calc_metrics_removed=0,
+            calc_metrics_modified=0,
+            segments_added=0,
+            segments_removed=0,
+            segments_modified=0,
+        )
+        result = _make_diff_result_with_inventory(
+            calc_metrics_diffs=unchanged_calc,
+            segments_diffs=[
+                InventoryItemDiff(id="s1", name="Y", change_type=ChangeType.UNCHANGED, inventory_type="segment"),
+            ],
+            summary=summary,
+        )
+        logger = _make_logger()
+
+        md_file = write_diff_markdown_output(result, "test_diff", str(tmp_path), logger)
+
+        with open(md_file) as f:
+            content = f.read()
+
+        assert "*No changes*" in content
+
+    def test_markdown_output_changes_only_with_inventory(self, tmp_path):
+        result = _make_diff_result_with_inventory()
+        logger = _make_logger()
+
+        md_file = write_diff_markdown_output(result, "test_diff", str(tmp_path), logger, changes_only=True)
+
+        assert os.path.exists(md_file)
+        with open(md_file) as f:
+            content = f.read()
+
+        # Inventory changes section should exist
+        assert "# Inventory Changes" in content
+
+    def test_markdown_side_by_side_with_inventory(self, tmp_path):
+        result = _make_diff_result_with_inventory()
+        logger = _make_logger()
+
+        md_file = write_diff_markdown_output(result, "test_diff", str(tmp_path), logger, side_by_side=True)
+
+        assert os.path.exists(md_file)
+        with open(md_file) as f:
+            content = f.read()
+
+        # Side-by-side should show modified metrics detail
+        assert "Modified Metrics - Side by Side" in content
+
+
+# ==================== HTML output with inventory ====================
+
+
+class TestHtmlOutputWithInventory:
+    """Tests for write_diff_html_output when inventory diffs are populated."""
+
+    def test_html_output_includes_inventory_summary_rows(self, tmp_path):
+        result = _make_diff_result_with_inventory()
+        logger = _make_logger()
+
+        html_file = write_diff_html_output(result, "test_diff", str(tmp_path), logger)
+
+        assert os.path.exists(html_file)
+        with open(html_file) as f:
+            content = f.read()
+
+        assert "<strong>Calc Metrics</strong>" in content
+        assert "<strong>Segments</strong>" in content
+
+    def test_html_output_includes_inventory_diff_tables(self, tmp_path):
+        result = _make_diff_result_with_inventory()
+        logger = _make_logger()
+
+        html_file = write_diff_html_output(result, "test_diff", str(tmp_path), logger)
+
+        with open(html_file) as f:
+            content = f.read()
+
+        assert "Inventory Changes" in content
+        assert "Calculated Metrics Changes" in content
+        assert "Segments Changes" in content
+
+    def test_html_output_inventory_diff_table_rows(self, tmp_path):
+        result = _make_diff_result_with_inventory()
+        logger = _make_logger()
+
+        html_file = write_diff_html_output(result, "test_diff", str(tmp_path), logger)
+
+        with open(html_file) as f:
+            content = f.read()
+
+        # Check that inventory item names appear in the HTML
+        assert "Revenue Per Visit" in content
+        assert "Conversion Rate" in content
+        assert "High Value Users" in content
+
+    def test_html_output_inventory_badge_classes(self, tmp_path):
+        result = _make_diff_result_with_inventory()
+        logger = _make_logger()
+
+        html_file = write_diff_html_output(result, "test_diff", str(tmp_path), logger)
+
+        with open(html_file) as f:
+            content = f.read()
+
+        # Badge classes should be present for inventory diff rows
+        assert "badge-added" in content
+        assert "badge-modified" in content
+        assert "badge-removed" in content
+
+    def test_html_output_changes_only_filters_inventory(self, tmp_path):
+        result = _make_diff_result_with_inventory()
+        logger = _make_logger()
+
+        html_file = write_diff_html_output(result, "test_diff", str(tmp_path), logger, changes_only=True)
+
+        assert os.path.exists(html_file)
+
+    def test_html_output_no_inventory_changes_shows_no_changes(self, tmp_path):
+        unchanged_calc = [
+            InventoryItemDiff(id="cm1", name="X", change_type=ChangeType.UNCHANGED, inventory_type="calculated_metric"),
+        ]
+        summary = _make_summary_with_inventory(
+            calc_metrics_added=0,
+            calc_metrics_removed=0,
+            calc_metrics_modified=0,
+            segments_added=0,
+            segments_removed=0,
+            segments_modified=0,
+        )
+        result = _make_diff_result_with_inventory(
+            calc_metrics_diffs=unchanged_calc,
+            segments_diffs=[
+                InventoryItemDiff(id="s1", name="Y", change_type=ChangeType.UNCHANGED, inventory_type="segment"),
+            ],
+            summary=summary,
+        )
+        logger = _make_logger()
+
+        html_file = write_diff_html_output(result, "test_diff", str(tmp_path), logger)
+
+        with open(html_file) as f:
+            content = f.read()
+
+        assert "No changes" in content
+
+
+# ==================== Excel output with inventory ====================
+
+
+class TestExcelOutputWithInventory:
+    """Tests for write_diff_excel_output when inventory diffs are populated."""
+
+    def test_excel_output_creates_inventory_sheets(self, tmp_path):
+        result = _make_diff_result_with_inventory()
+        logger = _make_logger()
+
+        excel_file = write_diff_excel_output(result, "test_diff", str(tmp_path), logger)
+
+        assert os.path.exists(excel_file)
+        assert excel_file.endswith(".xlsx")
+
+    def test_excel_output_changes_only_with_inventory(self, tmp_path):
+        result = _make_diff_result_with_inventory()
+        logger = _make_logger()
+
+        excel_file = write_diff_excel_output(result, "test_diff", str(tmp_path), logger, changes_only=True)
+
+        assert os.path.exists(excel_file)
+
+    def test_excel_output_summary_includes_inventory_rows(self, tmp_path):
+        """Verify Excel summary sheet includes inventory component rows."""
+        import pandas as pd
+
+        result = _make_diff_result_with_inventory()
+        logger = _make_logger()
+
+        excel_file = write_diff_excel_output(result, "test_diff", str(tmp_path), logger)
+
+        summary_df = pd.read_excel(excel_file, sheet_name="Summary")
+        components = summary_df["Component"].tolist()
+        assert "Calc Metrics" in components
+        assert "Segments" in components
+
+    def test_excel_output_has_calc_metrics_diff_sheet(self, tmp_path):
+        """Verify calc metrics diff sheet is created."""
+        import pandas as pd
+
+        result = _make_diff_result_with_inventory()
+        logger = _make_logger()
+
+        excel_file = write_diff_excel_output(result, "test_diff", str(tmp_path), logger)
+
+        calc_df = pd.read_excel(excel_file, sheet_name="Calc Metrics Diff")
+        assert len(calc_df) > 0
+        assert "ID" in calc_df.columns
+        assert "Status" in calc_df.columns
+
+    def test_excel_output_has_segments_diff_sheet(self, tmp_path):
+        """Verify segments diff sheet is created."""
+        import pandas as pd
+
+        result = _make_diff_result_with_inventory()
+        logger = _make_logger()
+
+        excel_file = write_diff_excel_output(result, "test_diff", str(tmp_path), logger)
+
+        seg_df = pd.read_excel(excel_file, sheet_name="Segments Diff")
+        assert len(seg_df) > 0
+
+    def test_excel_output_inventory_empty_when_no_changes(self, tmp_path):
+        """When all inventory items are unchanged and changes_only=True, sheet should show 'No changes'."""
+        import pandas as pd
+
+        unchanged_calc = [
+            InventoryItemDiff(id="cm1", name="X", change_type=ChangeType.UNCHANGED, inventory_type="calculated_metric"),
+        ]
+        result = _make_diff_result_with_inventory(calc_metrics_diffs=unchanged_calc)
+        logger = _make_logger()
+
+        excel_file = write_diff_excel_output(result, "test_diff", str(tmp_path), logger, changes_only=True)
+
+        calc_df = pd.read_excel(excel_file, sheet_name="Calc Metrics Diff")
+        # When changes_only and all unchanged, should get "No changes" message
+        assert "No changes" in str(calc_df.values)
+
+
+# ==================== CSV output with inventory ====================
+
+
+class TestCsvOutputWithInventory:
+    """Tests for write_diff_csv_output when inventory diffs are populated."""
+
+    def test_csv_output_creates_inventory_files(self, tmp_path):
+        result = _make_diff_result_with_inventory()
+        logger = _make_logger()
+
+        csv_dir = write_diff_csv_output(result, "test_diff", str(tmp_path), logger)
+
+        assert os.path.isdir(csv_dir)
+        assert os.path.exists(os.path.join(csv_dir, "calc_metrics_diff.csv"))
+        assert os.path.exists(os.path.join(csv_dir, "segments_diff.csv"))
+
+    def test_csv_output_summary_includes_inventory_rows(self, tmp_path):
+        import pandas as pd
+
+        result = _make_diff_result_with_inventory()
+        logger = _make_logger()
+
+        csv_dir = write_diff_csv_output(result, "test_diff", str(tmp_path), logger)
+
+        summary_df = pd.read_csv(os.path.join(csv_dir, "summary.csv"))
+        components = summary_df["Component"].tolist()
+        assert "Calc_Metrics" in components
+        assert "Segments" in components
+
+    def test_csv_output_calc_metrics_file_content(self, tmp_path):
+        import pandas as pd
+
+        result = _make_diff_result_with_inventory()
+        logger = _make_logger()
+
+        csv_dir = write_diff_csv_output(result, "test_diff", str(tmp_path), logger)
+
+        calc_df = pd.read_csv(os.path.join(csv_dir, "calc_metrics_diff.csv"))
+        assert len(calc_df) == 4  # All 4 entries
+        assert "status" in calc_df.columns
+        assert "id" in calc_df.columns
+
+    def test_csv_output_segments_file_content(self, tmp_path):
+        import pandas as pd
+
+        result = _make_diff_result_with_inventory()
+        logger = _make_logger()
+
+        csv_dir = write_diff_csv_output(result, "test_diff", str(tmp_path), logger)
+
+        seg_df = pd.read_csv(os.path.join(csv_dir, "segments_diff.csv"))
+        assert len(seg_df) == 3
+
+    def test_csv_output_changes_only_filters_unchanged(self, tmp_path):
+        import pandas as pd
+
+        result = _make_diff_result_with_inventory()
+        logger = _make_logger()
+
+        csv_dir = write_diff_csv_output(result, "test_diff", str(tmp_path), logger, changes_only=True)
+
+        calc_df = pd.read_csv(os.path.join(csv_dir, "calc_metrics_diff.csv"))
+        # 4 total, 1 UNCHANGED = 3 remaining
+        assert len(calc_df) == 3
+
+        seg_df = pd.read_csv(os.path.join(csv_dir, "segments_diff.csv"))
+        # 3 total, 1 UNCHANGED = 2 remaining
+        assert len(seg_df) == 2
+
+    def test_csv_output_no_inventory_files_when_not_present(self, tmp_path):
+        result = _make_diff_result_with_inventory(calc_metrics_diffs=None, segments_diffs=None)
+        logger = _make_logger()
+
+        csv_dir = write_diff_csv_output(result, "test_diff", str(tmp_path), logger)
+
+        assert not os.path.exists(os.path.join(csv_dir, "calc_metrics_diff.csv"))
+        assert not os.path.exists(os.path.join(csv_dir, "segments_diff.csv"))
+
+    def test_csv_output_inventory_change_percent(self, tmp_path):
+        import pandas as pd
+
+        result = _make_diff_result_with_inventory()
+        logger = _make_logger()
+
+        csv_dir = write_diff_csv_output(result, "test_diff", str(tmp_path), logger)
+
+        summary_df = pd.read_csv(os.path.join(csv_dir, "summary.csv"))
+        calc_row = summary_df[summary_df["Component"] == "Calc_Metrics"]
+        assert len(calc_row) == 1
+        assert calc_row.iloc[0]["Added"] == 2
+
+
+# ==================== PR comment output with inventory ====================
+
+
+class TestPrCommentOutputWithInventory:
+    """Tests for write_diff_pr_comment_output (PR comment format)."""
+
+    def test_pr_comment_basic_structure(self):
+        result = _make_diff_result_with_inventory()
+        output = write_diff_pr_comment_output(result)
+
+        assert "Data View Comparison" in output
+        assert "**Before**" in output
+        assert "**After**" in output
+
+    def test_pr_comment_includes_summary_table(self):
+        result = _make_diff_result_with_inventory()
+        output = write_diff_pr_comment_output(result)
+
+        assert "| Metrics |" in output
+        assert "| Dimensions |" in output
+
+    def test_pr_comment_includes_metric_changes_section(self):
+        result = _make_diff_result_with_inventory()
+        output = write_diff_pr_comment_output(result)
+
+        # Metrics changes collapsible section
+        assert "Metrics Changes" in output
+
+    def test_pr_comment_includes_natural_language_summary(self):
+        result = _make_diff_result_with_inventory()
+        output = write_diff_pr_comment_output(result)
+
+        # Natural language summary should include inventory info
+        assert "**Summary:**" in output
+
+    def test_pr_comment_includes_version_footer(self):
+        result = _make_diff_result_with_inventory()
+        output = write_diff_pr_comment_output(result)
+
+        assert "CJA SDR Generator" in output
+
+
+# ==================== _get_inventory_change_detail ====================
+
+
+class TestGetInventoryChangeDetail:
+    """Tests for the _get_inventory_change_detail helper."""
+
+    def test_modified_with_changed_fields(self):
+        diff = InventoryItemDiff(
+            id="cm1",
+            name="Test",
+            change_type=ChangeType.MODIFIED,
+            inventory_type="calculated_metric",
+            changed_fields={"formula": ("old_f", "new_f"), "description": ("old_d", "new_d")},
+        )
+        detail = _get_inventory_change_detail(diff)
+
+        assert "formula" in detail
+        assert "old_f" in detail
+        assert "new_f" in detail
+        assert "description" in detail
+
+    def test_added_returns_empty(self):
+        diff = InventoryItemDiff(
+            id="cm1",
+            name="Test",
+            change_type=ChangeType.ADDED,
+            inventory_type="calculated_metric",
+        )
+        detail = _get_inventory_change_detail(diff)
+        assert detail == ""
+
+    def test_removed_returns_empty(self):
+        diff = InventoryItemDiff(
+            id="cm1",
+            name="Test",
+            change_type=ChangeType.REMOVED,
+            inventory_type="calculated_metric",
+        )
+        detail = _get_inventory_change_detail(diff)
+        assert detail == ""
+
+    def test_unchanged_returns_empty(self):
+        diff = InventoryItemDiff(
+            id="cm1",
+            name="Test",
+            change_type=ChangeType.UNCHANGED,
+            inventory_type="calculated_metric",
+        )
+        detail = _get_inventory_change_detail(diff)
+        assert detail == ""
+
+    def test_modified_no_changed_fields_returns_empty(self):
+        diff = InventoryItemDiff(
+            id="cm1",
+            name="Test",
+            change_type=ChangeType.MODIFIED,
+            inventory_type="calculated_metric",
+            changed_fields={},
+        )
+        detail = _get_inventory_change_detail(diff)
+        assert detail == ""
+
+    def test_truncation(self):
+        long_val = "x" * 100
+        diff = InventoryItemDiff(
+            id="cm1",
+            name="Test",
+            change_type=ChangeType.MODIFIED,
+            inventory_type="calculated_metric",
+            changed_fields={"field": (long_val, "short")},
+        )
+        detail = _get_inventory_change_detail(diff, truncate=True)
+        # Truncated to max_len=30 by default
+        assert len(detail) < len(long_val) + 50  # rough check
+
+    def test_no_truncation(self):
+        long_val = "x" * 100
+        diff = InventoryItemDiff(
+            id="cm1",
+            name="Test",
+            change_type=ChangeType.MODIFIED,
+            inventory_type="calculated_metric",
+            changed_fields={"field": (long_val, "short")},
+        )
+        detail = _get_inventory_change_detail(diff, truncate=False)
+        assert long_val in detail
+
+
+# ==================== write_diff_output dispatcher with inventory ====================
+
+
+class TestWriteDiffOutputDispatcher:
+    """Tests for write_diff_output with inventory data across different formats."""
+
+    def test_dispatch_console_with_inventory(self, capsys):
+        result = _make_diff_result_with_inventory()
+        logger = _make_logger()
+
+        output = write_diff_output(result, "console", "test", "/tmp/test_diff_out", logger, use_color=False)
+
+        assert output is not None
+        assert "INVENTORY" in output
+
+    def test_dispatch_json_with_inventory(self, tmp_path):
+        result = _make_diff_result_with_inventory()
+        logger = _make_logger()
+
+        write_diff_output(result, "json", "test_diff", str(tmp_path), logger)
+
+        json_file = os.path.join(str(tmp_path), "test_diff.json")
+        assert os.path.exists(json_file)
+
+    def test_dispatch_markdown_with_inventory(self, tmp_path):
+        result = _make_diff_result_with_inventory()
+        logger = _make_logger()
+
+        write_diff_output(result, "markdown", "test_diff", str(tmp_path), logger)
+
+        md_file = os.path.join(str(tmp_path), "test_diff.md")
+        assert os.path.exists(md_file)
+
+    def test_dispatch_html_with_inventory(self, tmp_path):
+        result = _make_diff_result_with_inventory()
+        logger = _make_logger()
+
+        write_diff_output(result, "html", "test_diff", str(tmp_path), logger)
+
+        html_file = os.path.join(str(tmp_path), "test_diff.html")
+        assert os.path.exists(html_file)
+
+    def test_dispatch_excel_with_inventory(self, tmp_path):
+        result = _make_diff_result_with_inventory()
+        logger = _make_logger()
+
+        write_diff_output(result, "excel", "test_diff", str(tmp_path), logger)
+
+        excel_file = os.path.join(str(tmp_path), "test_diff.xlsx")
+        assert os.path.exists(excel_file)
+
+    def test_dispatch_csv_with_inventory(self, tmp_path):
+        result = _make_diff_result_with_inventory()
+        logger = _make_logger()
+
+        write_diff_output(result, "csv", "test_diff", str(tmp_path), logger)
+
+        csv_dir = os.path.join(str(tmp_path), "test_diff_csv")
+        assert os.path.isdir(csv_dir)
+
+    def test_dispatch_pr_comment_with_inventory(self, capsys):
+        result = _make_diff_result_with_inventory()
+        logger = _make_logger()
+
+        output = write_diff_output(result, "pr-comment", "test_diff", "/tmp/test_diff_out", logger)
+
+        assert output is not None
+        assert "Data View Comparison" in output
+
+
+# ==================== display_inventory_summary ====================
+
+
+class TestDisplayInventorySummary:
+    """Tests for display_inventory_summary function."""
+
+    def _make_segments_inventory(self):
+        """Create a mock segments inventory object."""
+        inv = MagicMock()
+        inv.segments = [
+            MagicMock(segment_name="Seg A", complexity_score=80, definition_summary="visits > 5"),
+            MagicMock(segment_name="Seg B", complexity_score=30, definition_summary="page = home"),
+        ]
+        inv.get_summary.return_value = {
+            "total_segments": 2,
+            "governance": {"approved_count": 1, "shared_count": 1, "tagged_count": 0},
+            "container_types": {"visitor": 1, "visit": 1},
+            "complexity": {
+                "average": 55.0,
+                "max": 80.0,
+                "high_complexity_count": 1,
+                "elevated_complexity_count": 0,
+            },
+        }
+        return inv
+
+    def _make_calculated_inventory(self):
+        """Create a mock calculated metrics inventory object."""
+        inv = MagicMock()
+        inv.metrics = [
+            MagicMock(metric_name="RPV", complexity_score=75, formula_summary="revenue / visits"),
+            MagicMock(metric_name="CVR", complexity_score=40, formula_summary="conversions / visits"),
+        ]
+        inv.get_summary.return_value = {
+            "total_calculated_metrics": 2,
+            "governance": {"approved_count": 1, "shared_count": 2, "tagged_count": 1},
+            "complexity": {
+                "average": 57.5,
+                "max": 75.0,
+                "high_complexity_count": 1,
+                "elevated_complexity_count": 0,
+            },
+        }
+        return inv
+
+    def _make_derived_inventory(self):
+        """Create a mock derived fields inventory object."""
+        inv = MagicMock()
+        inv.fields = [
+            MagicMock(component_name="DF1", complexity_score=90, logic_summary="if condition then A else B"),
+            MagicMock(component_name="DF2", complexity_score=20, logic_summary="simple concat"),
+        ]
+        inv.get_summary.return_value = {
+            "total_derived_fields": 2,
+            "metrics_count": 1,
+            "dimensions_count": 1,
+            "complexity": {
+                "average": 55.0,
+                "max": 90.0,
+                "high_complexity_count": 1,
+                "elevated_complexity_count": 0,
+            },
+        }
+        return inv
+
+    def test_display_with_segments_inventory(self, capsys):
+        seg_inv = self._make_segments_inventory()
+        result = display_inventory_summary(
+            data_view_id="dv_test",
+            data_view_name="Test DV",
+            segments_inventory=seg_inv,
+            output_format="console",
+        )
+
+        assert "inventories" in result
+        assert "segments" in result["inventories"]
+
+        captured = capsys.readouterr()
+        assert "Segments" in captured.out
+        assert "Total:" in captured.out
+
+    def test_display_with_calculated_inventory(self, capsys):
+        calc_inv = self._make_calculated_inventory()
+        result = display_inventory_summary(
+            data_view_id="dv_test",
+            data_view_name="Test DV",
+            calculated_inventory=calc_inv,
+            output_format="console",
+        )
+
+        assert "calculated_metrics" in result["inventories"]
+
+        captured = capsys.readouterr()
+        assert "Calculated Metrics" in captured.out
+
+    def test_display_with_derived_inventory(self, capsys):
+        derived_inv = self._make_derived_inventory()
+        result = display_inventory_summary(
+            data_view_id="dv_test",
+            data_view_name="Test DV",
+            derived_inventory=derived_inv,
+            output_format="console",
+        )
+
+        assert "derived_fields" in result["inventories"]
+
+        captured = capsys.readouterr()
+        assert "Derived Fields" in captured.out
+
+    def test_display_all_inventories(self, capsys):
+        seg_inv = self._make_segments_inventory()
+        calc_inv = self._make_calculated_inventory()
+        derived_inv = self._make_derived_inventory()
+
+        result = display_inventory_summary(
+            data_view_id="dv_test",
+            data_view_name="Test DV",
+            segments_inventory=seg_inv,
+            calculated_inventory=calc_inv,
+            derived_inventory=derived_inv,
+            output_format="console",
+        )
+
+        assert "segments" in result["inventories"]
+        assert "calculated_metrics" in result["inventories"]
+        assert "derived_fields" in result["inventories"]
+
+    def test_display_high_complexity_items_collected(self, capsys):
+        seg_inv = self._make_segments_inventory()
+        calc_inv = self._make_calculated_inventory()
+        derived_inv = self._make_derived_inventory()
+
+        result = display_inventory_summary(
+            data_view_id="dv_test",
+            data_view_name="Test DV",
+            segments_inventory=seg_inv,
+            calculated_inventory=calc_inv,
+            derived_inventory=derived_inv,
+            output_format="console",
+        )
+
+        # High complexity items should be collected (score >= 70)
+        assert len(result["high_complexity_items"]) == 3  # DF1=90, Seg A=80, RPV=75
+        # Should be sorted by complexity descending
+        scores = [item["complexity"] for item in result["high_complexity_items"]]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_display_quiet_mode_suppresses_output(self, capsys):
+        seg_inv = self._make_segments_inventory()
+
+        result = display_inventory_summary(
+            data_view_id="dv_test",
+            data_view_name="Test DV",
+            segments_inventory=seg_inv,
+            output_format="console",
+            quiet=True,
+        )
+
+        captured = capsys.readouterr()
+        assert captured.out == ""
+
+        # Result dict should still be populated
+        assert "segments" in result["inventories"]
+
+    def test_display_json_output(self, tmp_path, capsys):
+        seg_inv = self._make_segments_inventory()
+
+        summary = display_inventory_summary(
+            data_view_id="dv_test",
+            data_view_name="Test DV",
+            segments_inventory=seg_inv,
+            output_format="json",
+            output_dir=str(tmp_path),
+        )
+        assert summary["data_view_id"] == "dv_test"
+
+        # Should have created a JSON file
+        json_files = [f for f in os.listdir(str(tmp_path)) if f.endswith(".json")]
+        assert len(json_files) == 1
+
+    def test_display_all_format_creates_json_and_console(self, tmp_path, capsys):
+        seg_inv = self._make_segments_inventory()
+
+        summary = display_inventory_summary(
+            data_view_id="dv_test",
+            data_view_name="Test DV",
+            segments_inventory=seg_inv,
+            output_format="all",
+            output_dir=str(tmp_path),
+        )
+        assert summary["data_view_id"] == "dv_test"
+
+        captured = capsys.readouterr()
+        assert "Segments" in captured.out
+
+        json_files = [f for f in os.listdir(str(tmp_path)) if f.endswith(".json")]
+        assert len(json_files) == 1
+
+    def test_display_custom_inventory_order(self, capsys):
+        seg_inv = self._make_segments_inventory()
+        calc_inv = self._make_calculated_inventory()
+        derived_inv = self._make_derived_inventory()
+
+        summary = display_inventory_summary(
+            data_view_id="dv_test",
+            data_view_name="Test DV",
+            segments_inventory=seg_inv,
+            calculated_inventory=calc_inv,
+            derived_inventory=derived_inv,
+            output_format="console",
+            inventory_order=["derived", "segments", "calculated"],
+        )
+        assert summary["data_view_id"] == "dv_test"
+
+        captured = capsys.readouterr()
+        # All three should be present
+        assert "Derived Fields" in captured.out
+        assert "Segments" in captured.out
+        assert "Calculated Metrics" in captured.out
+
+        # Check order: derived should appear before segments
+        idx_derived = captured.out.index("Derived Fields")
+        idx_segments = captured.out.index("Segments")
+        idx_calc = captured.out.index("Calculated Metrics")
+        assert idx_derived < idx_segments < idx_calc
+
+    def test_display_no_inventories_returns_empty(self):
+        result = display_inventory_summary(
+            data_view_id="dv_test",
+            data_view_name="Test DV",
+            output_format="console",
+            quiet=True,
+        )
+
+        assert result["inventories"] == {}
+        assert result["high_complexity_items"] == []
+
+    def test_display_segments_governance_fields(self, capsys):
+        seg_inv = self._make_segments_inventory()
+
+        result = display_inventory_summary(
+            data_view_id="dv_test",
+            data_view_name="Test DV",
+            segments_inventory=seg_inv,
+            output_format="console",
+        )
+        assert result is not None
+
+        captured = capsys.readouterr()
+        assert "Approved:" in captured.out
+        assert "Shared:" in captured.out
+        assert "Tagged:" in captured.out
+        assert "Containers:" in captured.out
+
+    def test_display_calculated_governance_fields(self, capsys):
+        calc_inv = self._make_calculated_inventory()
+
+        result = display_inventory_summary(
+            data_view_id="dv_test",
+            data_view_name="Test DV",
+            calculated_inventory=calc_inv,
+            output_format="console",
+        )
+        assert result is not None
+
+        captured = capsys.readouterr()
+        assert "Approved:" in captured.out
+        assert "Shared:" in captured.out
+
+    def test_display_complexity_warning_shown(self, capsys):
+        seg_inv = self._make_segments_inventory()
+
+        result = display_inventory_summary(
+            data_view_id="dv_test",
+            data_view_name="Test DV",
+            segments_inventory=seg_inv,
+            output_format="console",
+        )
+        assert result is not None
+
+        captured = capsys.readouterr()
+        # High complexity count >= 1 so warning should appear
+        assert "High (>=75):" in captured.out
+
+    def test_display_derived_metrics_dimensions_counts(self, capsys):
+        derived_inv = self._make_derived_inventory()
+
+        result = display_inventory_summary(
+            data_view_id="dv_test",
+            data_view_name="Test DV",
+            derived_inventory=derived_inv,
+            output_format="console",
+        )
+        assert result is not None
+
+        captured = capsys.readouterr()
+        assert "Metrics:" in captured.out
+        assert "Dimensions:" in captured.out
+
+
+# ==================== Console output: inventory summary counts in SUMMARY ====================
+
+
+class TestConsoleSummaryInventoryRows:
+    """Test the SUMMARY table rows for inventory in console output (lines 3048-3097)."""
+
+    def test_summary_table_calc_metrics_added_colored(self):
+        """When calc_metrics_added > 0, it should appear in green (or plain with color off)."""
+        result = _make_diff_result_with_inventory()
+        output = write_diff_console_output(result, use_color=False)
+
+        # Should contain the calc metrics line with counts
+        assert "+2" in output  # calc_metrics_added
+        assert "~1" in output  # calc_metrics_modified
+
+    def test_summary_table_segments_row_present(self):
+        result = _make_diff_result_with_inventory()
+        output = write_diff_console_output(result, use_color=False)
+
+        # Segments row should show counts
+        lines = output.split("\n")
+        segments_lines = [line for line in lines if "Segments" in line and "8" in line]
+        assert len(segments_lines) >= 1  # At least the summary table row
+
+    def test_summary_table_no_inventory_when_counts_zero(self):
+        """When all inventory counts are 0, inventory section should not appear in summary."""
+        summary = DiffSummary(
+            source_metrics_count=5,
+            target_metrics_count=5,
+            metrics_unchanged=5,
+            source_dimensions_count=3,
+            target_dimensions_count=3,
+            dimensions_unchanged=3,
+        )
+        result = DiffResult(
+            summary=summary,
+            metadata_diff=_make_metadata(),
+            metric_diffs=[
+                ComponentDiff(id="m1", name="M1", change_type=ChangeType.UNCHANGED),
+            ],
+            dimension_diffs=[
+                ComponentDiff(id="d1", name="D1", change_type=ChangeType.UNCHANGED),
+            ],
+            generated_at="2025-01-15 12:00:00",
+            tool_version="3.2.8",
+        )
+        output = write_diff_console_output(result, use_color=False)
+
+        # INVENTORY header should not appear
+        assert "INVENTORY CHANGES" not in output
+
+
+# ==================== Side-by-side with inventory ====================
+
+
+class TestSideBySideWithInventory:
+    """Test side-by-side display mode with inventory data present."""
+
+    def test_side_by_side_console_with_inventory(self):
+        result = _make_diff_result_with_inventory()
+        output = write_diff_console_output(result, side_by_side=True, use_color=False)
+
+        # Should still contain inventory section
+        assert "INVENTORY CHANGES" in output
+        # Modified metric should get side-by-side treatment
+        assert "Before" in output or "After" in output
+
+
+# ==================== Edge cases ====================
+
+
+class TestInventoryEdgeCases:
+    """Edge cases for inventory diff output."""
+
+    def test_empty_inventory_lists(self):
+        """Empty inventory diff lists (not None) with zero counts should not show inventory section."""
+        summary = _make_summary_with_inventory(
+            source_calc_metrics_count=0,
+            target_calc_metrics_count=0,
+            calc_metrics_added=0,
+            calc_metrics_removed=0,
+            calc_metrics_modified=0,
+            calc_metrics_unchanged=0,
+            source_segments_count=0,
+            target_segments_count=0,
+            segments_added=0,
+            segments_removed=0,
+            segments_modified=0,
+            segments_unchanged=0,
+        )
+        result = _make_diff_result_with_inventory(
+            calc_metrics_diffs=[],
+            segments_diffs=[],
+            summary=summary,
+        )
+        output = write_diff_console_output(result, use_color=False)
+
+        # has_inventory_diffs should be False since both lists are empty
+        # (empty list is falsy in Python, so has_inventory_diffs returns False)
+        assert "INVENTORY CHANGES" not in output
+
+    def test_inventory_with_none_changed_fields(self):
+        """InventoryItemDiff with changed_fields=None for MODIFIED type."""
+        diff = InventoryItemDiff(
+            id="cm1",
+            name="Test",
+            change_type=ChangeType.MODIFIED,
+            inventory_type="calculated_metric",
+        )
+        # __post_init__ sets changed_fields to {}
+        detail = _get_inventory_change_detail(diff)
+        assert detail == ""
+
+    def test_large_number_of_inventory_diffs_json(self, tmp_path):
+        """Test with many inventory diffs to ensure JSON handles them."""
+        many_diffs = [
+            InventoryItemDiff(
+                id=f"cm{i}",
+                name=f"Metric {i}",
+                change_type=ChangeType.ADDED if i % 3 == 0 else ChangeType.MODIFIED,
+                inventory_type="calculated_metric",
+                changed_fields={"field": ("old", "new")} if i % 3 != 0 else None,
+            )
+            for i in range(50)
+        ]
+        result = _make_diff_result_with_inventory(calc_metrics_diffs=many_diffs)
+        logger = _make_logger()
+
+        json_file = write_diff_json_output(result, "test_diff", str(tmp_path), logger)
+
+        with open(json_file) as f:
+            data = json.load(f)
+
+        assert len(data["calculated_metrics_diffs"]) == 50
+
+    def test_inventory_diff_with_none_values_in_changed_fields(self):
+        """Test that None values in changed_fields are handled gracefully."""
+        diff = InventoryItemDiff(
+            id="cm1",
+            name="Test",
+            change_type=ChangeType.MODIFIED,
+            inventory_type="calculated_metric",
+            changed_fields={"description": (None, "new desc")},
+        )
+        detail = _get_inventory_change_detail(diff)
+        assert "(empty)" in detail
+        assert "new desc" in detail
+
+    def test_console_output_total_line_includes_inventory(self):
+        """Total line at footer should account for inventory changes."""
+        result = _make_diff_result_with_inventory()
+        output = write_diff_console_output(result, use_color=False)
+
+        # total_added from summary includes inventory
+        # metrics_added=2, dims_added=3, calc_added=2, seg_added=1 = 8 total added
+        assert "8 added" in output

--- a/tests/test_diff_inventory_output.py
+++ b/tests/test_diff_inventory_output.py
@@ -288,8 +288,8 @@ class TestConsoleOutputWithInventory:
         output = write_diff_console_output(result, use_color=False)
 
         assert "CALCULATED METRICS" in output
-        # Should not have SEGMENTS section in inventory changes
-        assert "SEGMENTS" not in output or output.index("CALCULATED METRICS") < output.rindex("=")
+        # Should not have SEGMENTS section when segments_diffs is None
+        assert "SEGMENTS" not in output
 
     def test_console_output_only_segments_no_calc_metrics(self):
         """Test output when only segments_diffs is present, no calc metrics."""
@@ -946,8 +946,9 @@ class TestGetInventoryChangeDetail:
             changed_fields={"field": (long_val, "short")},
         )
         detail = _get_inventory_change_detail(diff, truncate=True)
-        # Truncated to max_len=30 by default
-        assert len(detail) < len(long_val) + 50  # rough check
+        # Value should be truncated to max_len=30 — full 100-char value must not appear
+        assert long_val not in detail
+        assert "x" * 30 in detail
 
     def test_no_truncation(self):
         long_val = "x" * 100
@@ -1396,8 +1397,9 @@ class TestSideBySideWithInventory:
 
         # Should still contain inventory section
         assert "INVENTORY CHANGES" in output
-        # Modified metric should get side-by-side treatment
-        assert "Before" in output or "After" in output
+        # Source/target labels should appear in side-by-side columns
+        assert "Before" in output
+        assert "After" in output
 
 
 # ==================== Edge cases ====================

--- a/tests/test_e2e_integration.py
+++ b/tests/test_e2e_integration.py
@@ -91,7 +91,7 @@ def e2e_metrics_df():
                 "title": "Cart Additions",
                 "description": "Items added to cart",
             },
-        ]
+        ],
     )
 
 
@@ -142,7 +142,7 @@ def e2e_dimensions_df():
                 "title": "Operating System",
                 "description": 'OS with <special> & "chars"',  # Special chars
             },
-        ]
+        ],
     )
 
 

--- a/tests/test_early_exit.py
+++ b/tests/test_early_exit.py
@@ -130,7 +130,7 @@ class TestValidDataContinuesAllChecks:
                 "name": ["Metric 1", "Metric 2", "Metric 3"],
                 "type": ["int", "currency", "int"],
                 "description": ["Desc 1", "Desc 2", "Desc 3"],
-            }
+            },
         )
 
         dq_checker.check_all_quality_issues_optimized(df_valid, "Metrics", ["id", "name", "type"], ["id", "name"])
@@ -152,7 +152,7 @@ class TestValidDataContinuesAllChecks:
                 "name": ["Duplicate", "Duplicate", "Unique"],
                 "type": ["int", "currency", "int"],
                 "description": ["Desc", "", "Another desc"],  # Empty description
-            }
+            },
         )
 
         dq_checker.check_all_quality_issues_optimized(df_with_issues, "Metrics", ["id", "name", "type"], ["id", "name"])
@@ -186,7 +186,7 @@ class TestBackwardCompatibility:
                 "name": ["Dup", "Dup", "Valid", "Missing Desc"],
                 "type": ["int", "int", "currency", "int"],
                 "description": ["Desc 1", "Desc 2", "Desc 3", ""],
-            }
+            },
         )
 
         dq_checker.check_all_quality_issues_optimized(df, "Metrics", ["id", "name", "type"], ["id", "name"])
@@ -237,7 +237,10 @@ class TestPerformanceImprovement:
 
         start = time.time()
         dq_checker.check_all_quality_issues_optimized(
-            df_large_invalid, "Metrics", ["id", "name", "type"], ["id", "name"]
+            df_large_invalid,
+            "Metrics",
+            ["id", "name", "type"],
+            ["id", "name"],
         )
         duration = time.time() - start
 
@@ -262,7 +265,7 @@ class TestPerformanceImprovement:
                 "name": [f"Metric {i}" for i in range(1000)],
                 "type": ["int"] * 1000,
                 "description": [f"Description {i}" for i in range(1000)],
-            }
+            },
         )
 
         import time

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -69,7 +69,10 @@ class TestCustomExceptions:
     def test_configuration_error(self):
         """Test ConfigurationError"""
         error = ConfigurationError(
-            "Missing credentials", config_file="config.json", field="client_id", details="Field is empty"
+            "Missing credentials",
+            config_file="config.json",
+            field="client_id",
+            details="Field is empty",
         )
         assert error.config_file == "config.json"
         assert error.field == "client_id"
@@ -99,7 +102,10 @@ class TestCustomExceptions:
     def test_validation_error(self):
         """Test ValidationError"""
         error = ValidationError(
-            "Data quality check failed", item_type="Metrics", issue_count=5, details="Found 5 critical issues"
+            "Data quality check failed",
+            item_type="Metrics",
+            issue_count=5,
+            details="Found 5 critical issues",
         )
         assert error.item_type == "Metrics"
         assert error.issue_count == 5
@@ -107,7 +113,10 @@ class TestCustomExceptions:
     def test_output_error(self):
         """Test OutputError"""
         error = OutputError(
-            "Failed to write file", output_path="/tmp/output.xlsx", output_format="excel", details="Permission denied"
+            "Failed to write file",
+            output_path="/tmp/output.xlsx",
+            output_format="excel",
+            details="Permission denied",
         )
         assert error.output_path == "/tmp/output.xlsx"
         assert error.output_format == "excel"
@@ -518,7 +527,7 @@ class TestDataFrameColumnHandling:
                 "type": ["int", "currency"],
                 "extra_col": ["a", "b"],
                 "another_extra": [1, 2],
-            }
+            },
         )
 
         # Should handle extra columns gracefully
@@ -588,7 +597,7 @@ def sample_metrics_df():
             "name": ["Metric 1", "Metric 2", "Metric 3"],
             "type": ["int", "currency", "percent"],
             "description": ["First metric", None, "Third metric"],
-        }
+        },
     )
 
 
@@ -601,5 +610,5 @@ def sample_dimensions_df():
             "name": ["Dimension 1", "Dimension 2", "Dimension 3"],
             "type": ["string", "string", "string"],
             "description": ["First dimension", "Second dimension", None],
-        }
+        },
     )

--- a/tests/test_env_credentials.py
+++ b/tests/test_env_credentials.py
@@ -145,7 +145,7 @@ class TestCredentialResolverFallbacks:
                     "client_id": "a" * 32,
                     "secret": "b" * 32,
                     "scopes": "openid",
-                }
+                },
             ),
             encoding="utf-8",
         )

--- a/tests/test_error_messages.py
+++ b/tests/test_error_messages.py
@@ -79,7 +79,8 @@ class TestErrorMessageHelper:
     def test_invalid_json_config_message(self):
         """Test invalid JSON config error message"""
         msg = ErrorMessageHelper.get_config_error_message(
-            "invalid_json", details="Line 5, Column 12: Unterminated string"
+            "invalid_json",
+            details="Line 5, Column 12: Unterminated string",
         )
         assert "Invalid JSON" in msg
         assert "Line 5, Column 12" in msg

--- a/tests/test_excel_formatting.py
+++ b/tests/test_excel_formatting.py
@@ -33,7 +33,7 @@ def sample_metrics_df():
             {"name": "Metric 1", "type": "calculated", "id": "m1", "title": "Title 1", "description": "Desc 1"},
             {"name": "Metric 2", "type": "standard", "id": "m2", "title": "Title 2", "description": "Desc 2"},
             {"name": "Metric 3", "type": "calculated", "id": "m3", "title": "Title 3", "description": "Desc 3"},
-        ]
+        ],
     )
 
 
@@ -44,7 +44,7 @@ def sample_dimensions_df():
         [
             {"name": "Dimension 1", "type": "string", "id": "d1", "title": "Title 1", "description": "Desc 1"},
             {"name": "Dimension 2", "type": "string", "id": "d2", "title": "Title 2", "description": "Desc 2"},
-        ]
+        ],
     )
 
 
@@ -85,7 +85,7 @@ def sample_data_quality_df():
                 "Issue": "Minor issue",
                 "Details": "Details here",
             },
-        ]
+        ],
     )
 
 
@@ -93,7 +93,7 @@ def sample_data_quality_df():
 def sample_metadata_df():
     """Sample metadata DataFrame"""
     return pd.DataFrame(
-        {"Property": ["Generated At", "Data View ID", "Total Metrics"], "Value": ["2024-01-01", "dv_test", "100"]}
+        {"Property": ["Generated At", "Data View ID", "Total Metrics"], "Value": ["2024-01-01", "dv_test", "100"]},
     )
 
 
@@ -194,7 +194,7 @@ class TestApplyExcelFormattingIntegration:
         """Test formatting with Unicode characters"""
         output_file = tmp_path / "test_output.xlsx"
         unicode_df = pd.DataFrame(
-            [{"name": "Test \u00e9\u00e8\u00ea\u00eb", "description": "\u4e2d\u6587\u6d4b\u8bd5"}]
+            [{"name": "Test \u00e9\u00e8\u00ea\u00eb", "description": "\u4e2d\u6587\u6d4b\u8bd5"}],
         )
 
         with pd.ExcelWriter(str(output_file), engine="xlsxwriter") as writer:
@@ -212,7 +212,7 @@ class TestApplyExcelFormattingMetricsSheet:
 
         # DataFrame with columns not in preferred order
         df = pd.DataFrame(
-            [{"id": "m1", "type": "calculated", "name": "Metric 1", "title": "Title 1", "description": "Desc 1"}]
+            [{"id": "m1", "type": "calculated", "name": "Metric 1", "title": "Title 1", "description": "Desc 1"}],
         )
 
         with pd.ExcelWriter(str(output_file), engine="xlsxwriter") as writer:
@@ -242,7 +242,7 @@ class TestApplyExcelFormattingDimensionsSheet:
         output_file = tmp_path / "test_output.xlsx"
 
         df = pd.DataFrame(
-            [{"id": "d1", "type": "string", "name": "Dimension 1", "title": "Title 1", "description": "Desc 1"}]
+            [{"id": "d1", "type": "string", "name": "Dimension 1", "title": "Title 1", "description": "Desc 1"}],
         )
 
         with pd.ExcelWriter(str(output_file), engine="xlsxwriter") as writer:
@@ -314,7 +314,7 @@ class TestApplyExcelFormattingDataQualitySheet:
                     "Issue": "I5",
                     "Details": "D5",
                 },
-            ]
+            ],
         )
 
         with pd.ExcelWriter(str(output_file), engine="xlsxwriter") as writer:
@@ -335,8 +335,8 @@ class TestApplyExcelFormattingDataQualitySheet:
                     "Item Name": "T1",
                     "Issue": "I1",
                     "Details": "D1",
-                }
-            ]
+                },
+            ],
         )
 
         with pd.ExcelWriter(str(output_file), engine="xlsxwriter") as writer:
@@ -458,7 +458,13 @@ class TestApplyExcelFormattingMultipleSheets:
     """Tests for formatting multiple sheets"""
 
     def test_formats_all_sheet_types(
-        self, mock_logger, tmp_path, sample_metrics_df, sample_dimensions_df, sample_data_quality_df, sample_metadata_df
+        self,
+        mock_logger,
+        tmp_path,
+        sample_metrics_df,
+        sample_dimensions_df,
+        sample_data_quality_df,
+        sample_metadata_df,
     ):
         """Test formatting all sheet types in one workbook"""
         output_file = tmp_path / "test_output.xlsx"

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -146,7 +146,11 @@ class TestOutputError:
     def test_all_params(self):
         orig = PermissionError("denied")
         err = OutputError(
-            "write failed", output_path="/tmp/out.xlsx", output_format="excel", details="denied", original_error=orig
+            "write failed",
+            output_path="/tmp/out.xlsx",
+            output_format="excel",
+            details="denied",
+            original_error=orig,
         )
         assert err.output_path == "/tmp/out.xlsx"
         assert err.output_format == "excel"

--- a/tests/test_generator_coverage.py
+++ b/tests/test_generator_coverage.py
@@ -631,7 +631,7 @@ class TestBuildQualityReportDataframe:
                 "Item Name": "x",
                 "Issue": "bad",
                 "Details": "d",
-            }
+            },
         ]
         df = _build_quality_report_dataframe(issues)
         # Preferred columns come first, then extras

--- a/tests/test_generator_interactive_and_console.py
+++ b/tests/test_generator_interactive_and_console.py
@@ -195,10 +195,12 @@ def test_run_org_report_all_formats_branch(tmp_path: Path, rich_org_report_resul
         patch("cja_auto_sdr.generator.write_org_report_console") as mock_console,
         patch("cja_auto_sdr.generator.write_org_report_json", return_value=str(tmp_path / "report.json")) as mock_json,
         patch(
-            "cja_auto_sdr.generator.write_org_report_excel", return_value=str(tmp_path / "report.xlsx")
+            "cja_auto_sdr.generator.write_org_report_excel",
+            return_value=str(tmp_path / "report.xlsx"),
         ) as mock_excel,
         patch(
-            "cja_auto_sdr.generator.write_org_report_markdown", return_value=str(tmp_path / "report.md")
+            "cja_auto_sdr.generator.write_org_report_markdown",
+            return_value=str(tmp_path / "report.md"),
         ) as mock_markdown,
         patch("cja_auto_sdr.generator.write_org_report_html", return_value=str(tmp_path / "report.html")) as mock_html,
         patch("cja_auto_sdr.generator.write_org_report_csv", return_value=str(tmp_path / "report_csv")) as mock_csv,
@@ -297,26 +299,27 @@ def test_run_org_report_reports_alias_and_individual_format_branches(tmp_path: P
     with ExitStack() as stack:
         stack.enter_context(
             patch(
-                "cja_auto_sdr.generator.configure_cjapy", return_value=(True, "mock", {"org_id": "test_org@AdobeOrg"})
-            )
+                "cja_auto_sdr.generator.configure_cjapy",
+                return_value=(True, "mock", {"org_id": "test_org@AdobeOrg"}),
+            ),
         )
         mock_cjapy = stack.enter_context(patch("cja_auto_sdr.generator.cjapy"))
         mock_analyzer_cls = stack.enter_context(patch("cja_auto_sdr.generator.OrgComponentAnalyzer"))
         stack.enter_context(patch("cja_auto_sdr.generator.write_org_report_console", return_value=None))
         stack.enter_context(
-            patch("cja_auto_sdr.generator.write_org_report_json", return_value=str(tmp_path / "report.json"))
+            patch("cja_auto_sdr.generator.write_org_report_json", return_value=str(tmp_path / "report.json")),
         )
         stack.enter_context(
-            patch("cja_auto_sdr.generator.write_org_report_excel", return_value=str(tmp_path / "report.xlsx"))
+            patch("cja_auto_sdr.generator.write_org_report_excel", return_value=str(tmp_path / "report.xlsx")),
         )
         stack.enter_context(
-            patch("cja_auto_sdr.generator.write_org_report_markdown", return_value=str(tmp_path / "report.md"))
+            patch("cja_auto_sdr.generator.write_org_report_markdown", return_value=str(tmp_path / "report.md")),
         )
         stack.enter_context(
-            patch("cja_auto_sdr.generator.write_org_report_html", return_value=str(tmp_path / "report.html"))
+            patch("cja_auto_sdr.generator.write_org_report_html", return_value=str(tmp_path / "report.html")),
         )
         stack.enter_context(
-            patch("cja_auto_sdr.generator.write_org_report_csv", return_value=str(tmp_path / "report_csv"))
+            patch("cja_auto_sdr.generator.write_org_report_csv", return_value=str(tmp_path / "report_csv")),
         )
         stack.enter_context(patch("cja_auto_sdr.generator.build_org_step_summary", return_value="summary"))
         stack.enter_context(patch("cja_auto_sdr.generator.append_github_step_summary"))
@@ -479,7 +482,9 @@ def test_run_org_report_org_stats_json_stdout_branch(tmp_path: Path, capsys, ric
 
 
 def test_org_report_renderers_core_min_count_and_unnamed_component_branches(
-    tmp_path: Path, capsys, rich_org_report_result
+    tmp_path: Path,
+    capsys,
+    rich_org_report_result,
 ):
     result = rich_org_report_result
     result.parameters.core_min_count = 3
@@ -663,7 +668,7 @@ def test_recommendation_context_and_normalization_helpers():
     assert "raw text recommendation" in normalized["reason"]
 
     flattened = generator._flatten_recommendation_for_tabular(
-        {"type": "naming", "severity": "MEDIUM", "reason": "Use one style", "custom_field": {"x": 1}}
+        {"type": "naming", "severity": "MEDIUM", "reason": "Use one style", "custom_field": {"x": 1}},
     )
     assert flattened["Severity"] == "medium"
     assert "custom_field" in flattened["Extra Details"]

--- a/tests/test_git_integration.py
+++ b/tests/test_git_integration.py
@@ -153,7 +153,10 @@ class TestSaveGitFriendlySnapshot:
     def test_sanitizes_data_view_name_for_directory(self, tmp_path):
         """Test that special characters in name are sanitized."""
         snapshot = DataViewSnapshot(
-            data_view_id="dv_12345", data_view_name="Test / Data View: With <Special> Chars!", metrics=[], dimensions=[]
+            data_view_id="dv_12345",
+            data_view_name="Test / Data View: With <Special> Chars!",
+            metrics=[],
+            dimensions=[],
         )
 
         saved_files = save_git_friendly_snapshot(snapshot, tmp_path)
@@ -220,7 +223,10 @@ class TestSaveGitFriendlySnapshot:
     def test_no_inventory_files_when_not_present(self, tmp_path):
         """Test that inventory files are not created when data not present."""
         snapshot = DataViewSnapshot(
-            data_view_id="dv_12345", data_view_name="Test", metrics=[{"id": "cm1"}], dimensions=[{"id": "dim1"}]
+            data_view_id="dv_12345",
+            data_view_name="Test",
+            metrics=[{"id": "cm1"}],
+            dimensions=[{"id": "dim1"}],
         )
 
         saved_files = save_git_friendly_snapshot(snapshot, tmp_path)
@@ -277,7 +283,10 @@ class TestGenerateGitCommitMessage:
     def test_basic_message_structure(self):
         """Test that commit message has correct structure."""
         message = generate_git_commit_message(
-            data_view_id="dv_12345", data_view_name="Test Data View", metrics_count=10, dimensions_count=5
+            data_view_id="dv_12345",
+            data_view_name="Test Data View",
+            metrics_count=10,
+            dimensions_count=5,
         )
 
         assert "[dv_12345]" in message
@@ -334,7 +343,11 @@ class TestGenerateGitCommitMessage:
         mock_diff.summary = mock_summary
 
         message = generate_git_commit_message(
-            data_view_id="dv_12345", data_view_name="Test", metrics_count=10, dimensions_count=5, diff_result=mock_diff
+            data_view_id="dv_12345",
+            data_view_name="Test",
+            metrics_count=10,
+            dimensions_count=5,
+            diff_result=mock_diff,
         )
 
         assert "Changes:" in message
@@ -441,7 +454,11 @@ class TestGitCommitSnapshot:
         test_file.write_text('{"test": "data"}')
 
         success, result = git_commit_snapshot(
-            snapshot_dir=tmp_path, data_view_id="dv_12345", data_view_name="Test", metrics_count=1, dimensions_count=1
+            snapshot_dir=tmp_path,
+            data_view_id="dv_12345",
+            data_view_name="Test",
+            metrics_count=1,
+            dimensions_count=1,
         )
 
         assert success is True
@@ -449,7 +466,10 @@ class TestGitCommitSnapshot:
 
         # Verify commit exists
         log_result = subprocess.run(
-            ["git", "log", "--oneline", "-1"], cwd=str(tmp_path), capture_output=True, text=True
+            ["git", "log", "--oneline", "-1"],
+            cwd=str(tmp_path),
+            capture_output=True,
+            text=True,
         )
         assert "dv_12345" in log_result.stdout
 
@@ -468,7 +488,11 @@ class TestGitCommitSnapshot:
 
         # Try to commit again without changes
         success, result = git_commit_snapshot(
-            snapshot_dir=tmp_path, data_view_id="dv_12345", data_view_name="Test", metrics_count=1, dimensions_count=1
+            snapshot_dir=tmp_path,
+            data_view_id="dv_12345",
+            data_view_name="Test",
+            metrics_count=1,
+            dimensions_count=1,
         )
 
         assert success is True
@@ -477,7 +501,11 @@ class TestGitCommitSnapshot:
     def test_fails_for_non_git_directory(self, tmp_path):
         """Test that function fails for non-Git directory."""
         success, result = git_commit_snapshot(
-            snapshot_dir=tmp_path, data_view_id="dv_12345", data_view_name="Test", metrics_count=1, dimensions_count=1
+            snapshot_dir=tmp_path,
+            data_view_id="dv_12345",
+            data_view_name="Test",
+            metrics_count=1,
+            dimensions_count=1,
         )
 
         assert success is False
@@ -505,7 +533,10 @@ class TestGitCommitSnapshot:
         )
 
         log_result = subprocess.run(
-            ["git", "log", "--oneline", "-1"], cwd=str(tmp_path), capture_output=True, text=True
+            ["git", "log", "--oneline", "-1"],
+            cwd=str(tmp_path),
+            capture_output=True,
+            text=True,
         )
         assert "Custom commit message" in log_result.stdout
 

--- a/tests/test_lock_backend_edge_cases.py
+++ b/tests/test_lock_backend_edge_cases.py
@@ -1168,7 +1168,9 @@ class TestIsFcntlLockActiveEwouldblock:
 
 class TestFcntlAcquireResultOpenFails:
     def test_open_lock_file_returns_none_yields_contended(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """When _open_lock_file returns (None, False), acquire_result returns CONTENDED."""
         from cja_auto_sdr.core.locks.backends import AcquireStatus
@@ -1285,7 +1287,9 @@ class TestFcntlReleaseEdgeCases:
 
 class TestLeaseAcquireErrorPropagation:
     def test_acquire_raises_when_acquire_result_has_error(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """When acquire_result returns non-ACQUIRED with error, acquire() raises it."""
         from cja_auto_sdr.core.locks.backends import AcquireResult, AcquireStatus
@@ -1296,14 +1300,17 @@ class TestLeaseAcquireErrorPropagation:
             backend,
             "acquire_result",
             lambda lock_path, stale_threshold_seconds: AcquireResult(
-                status=AcquireStatus.METADATA_ERROR, error=test_error
+                status=AcquireStatus.METADATA_ERROR,
+                error=test_error,
             ),
         )
         with pytest.raises(OSError, match="disk error"):
             backend.acquire(tmp_path / "lock", stale_threshold_seconds=10)
 
     def test_acquire_returns_none_when_contended_no_error(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """When acquire_result returns CONTENDED with no error, acquire() returns None."""
         from cja_auto_sdr.core.locks.backends import AcquireResult, AcquireStatus

--- a/tests/test_lock_manager.py
+++ b/tests/test_lock_manager.py
@@ -155,7 +155,9 @@ class TestLockManagerAcquire:
     def test_contended_returns_false(self, tmp_path):
         mgr = self._make_manager(tmp_path)
         with patch.object(
-            LockManager, "_acquire_with_result", return_value=AcquireResult(status=AcquireStatus.CONTENDED)
+            LockManager,
+            "_acquire_with_result",
+            return_value=AcquireResult(status=AcquireStatus.CONTENDED),
         ):
             assert mgr.acquire() is False
             assert mgr.acquired is False
@@ -201,7 +203,9 @@ class TestLockManagerAcquire:
         mock_backend.requires_heartbeat = False
         mgr = self._make_manager(tmp_path, mock_backend)
         with patch.object(
-            LockManager, "_acquire_with_result", return_value=AcquireResult(status=AcquireStatus.BACKEND_UNAVAILABLE)
+            LockManager,
+            "_acquire_with_result",
+            return_value=AcquireResult(status=AcquireStatus.BACKEND_UNAVAILABLE),
         ):
             with pytest.raises(LockBackendUnavailableError, match="lock backend unavailable"):
                 mgr.acquire()
@@ -220,7 +224,9 @@ class TestLockManagerAcquire:
     def test_metadata_error_without_error_returns_false(self, tmp_path):
         mgr = self._make_manager(tmp_path)
         with patch.object(
-            LockManager, "_acquire_with_result", return_value=AcquireResult(status=AcquireStatus.METADATA_ERROR)
+            LockManager,
+            "_acquire_with_result",
+            return_value=AcquireResult(status=AcquireStatus.METADATA_ERROR),
         ):
             assert mgr.acquire() is False
 

--- a/tests/test_malformed_api_responses.py
+++ b/tests/test_malformed_api_responses.py
@@ -57,7 +57,13 @@ def _apply(func):
 
 
 def _setup_mocks(
-    mock_setup_logging, mock_init_cja, mock_validate_dv, mock_fetcher_class, metrics_df, dimensions_df, dataview_info
+    mock_setup_logging,
+    mock_init_cja,
+    mock_validate_dv,
+    mock_fetcher_class,
+    metrics_df,
+    dimensions_df,
+    dataview_info,
 ):
     logger = logging.getLogger("malformed_test")
     logger.handlers = []
@@ -242,8 +248,8 @@ class TestMalformedDataFrameSchemas:
                         "description": "d",
                         "unknown_field": "xyz",
                         "another_new_field": 42,
-                    }
-                ]
+                    },
+                ],
             ),
             pd.DataFrame([{"id": "d1", "name": "D1", "type": "string", "title": "D1", "description": "d"}]),
             {"id": "dv_test", "name": "Test DV", "owner": {"name": "Owner"}},
@@ -281,7 +287,7 @@ class TestMalformedDataFrameSchemas:
                     {"id": "d1", "name": "D1", "type": "string", "title": "D1", "description": None},
                     {"id": "d2", "name": "D2", "type": "string", "title": "D2", "description": None},
                     {"id": "d3", "name": "D3", "type": "string", "title": "D3", "description": None},
-                ]
+                ],
             ),
             {"id": "dv_test", "name": "Test DV", "owner": {"name": "Owner"}},
         )
@@ -316,7 +322,7 @@ class TestMalformedDataFrameSchemas:
                 [
                     {"id": "m1", "name": "M1", "type": "int", "title": "M1", "description": {"nested": "dict"}},
                     {"id": 12345, "name": "M2", "type": "int", "title": "M2", "description": ["a", "list"]},
-                ]
+                ],
             ),
             pd.DataFrame([{"id": "d1", "name": "D1", "type": "string", "title": "D1", "description": "d"}]),
             {"id": "dv_test", "name": "Test DV", "owner": {"name": "Owner"}},
@@ -589,7 +595,7 @@ class TestDataQualityCheckerMalformedInput:
                 "name": ["Metric 1", np.nan],
                 "type": ["int", "int"],
                 "description": [np.nan, "desc"],
-            }
+            },
         )
         checker.check_all_quality_issues_optimized(df, "Metrics", ["id", "name", "type"], ["id", "name", "description"])
         assert len(checker.issues) > 0
@@ -605,7 +611,7 @@ class TestDataQualityCheckerMalformedInput:
                 "name": ["A" * 10000],  # 10KB string
                 "type": ["int"],
                 "description": ["B" * 50000],  # 50KB string
-            }
+            },
         )
         checker.check_all_quality_issues_optimized(df, "Metrics", ["id", "name", "type"], ["id", "name", "description"])
         # Should not crash or hang

--- a/tests/test_name_resolution.py
+++ b/tests/test_name_resolution.py
@@ -119,7 +119,9 @@ class TestDataViewNameResolution:
         mock_cjapy.importConfigFile.return_value = None
 
         ids, name_map = resolve_data_view_names(
-            ["dv_prod123", "Test Environment", "dv_stage789"], "config.json", self.logger
+            ["dv_prod123", "Test Environment", "dv_stage789"],
+            "config.json",
+            self.logger,
         )
 
         assert len(ids) == 3

--- a/tests/test_optimized_validation.py
+++ b/tests/test_optimized_validation.py
@@ -27,7 +27,10 @@ class TestOptimizedValidation:
 
         empty_df = pd.DataFrame()
         validator.check_all_quality_issues_optimized(
-            empty_df, "Metrics", ["id", "name", "type"], ["id", "name", "description"]
+            empty_df,
+            "Metrics",
+            ["id", "name", "type"],
+            ["id", "name", "description"],
         )
 
         issues_df = validator.get_issues_dataframe()
@@ -55,15 +58,18 @@ class TestOptimizedValidation:
                             "type": "calculated",
                             "title": "Duplicate Metric",
                             "description": "Duplicate",
-                        }
-                    ]
+                        },
+                    ],
                 ),
             ],
             ignore_index=True,
         )
 
         validator.check_all_quality_issues_optimized(
-            duplicate_df, "Metrics", ["id", "name", "type"], ["id", "name", "description"]
+            duplicate_df,
+            "Metrics",
+            ["id", "name", "type"],
+            ["id", "name", "description"],
         )
 
         issues_df = validator.get_issues_dataframe()
@@ -78,7 +84,10 @@ class TestOptimizedValidation:
         validator = DataQualityChecker(logger)
 
         validator.check_all_quality_issues_optimized(
-            sample_metrics_df, "Metrics", ["id", "name", "type"], ["id", "name", "description"]
+            sample_metrics_df,
+            "Metrics",
+            ["id", "name", "type"],
+            ["id", "name", "description"],
         )
 
         issues_df = validator.get_issues_dataframe()
@@ -95,7 +104,10 @@ class TestOptimizedValidation:
         validator = DataQualityChecker(logger)
 
         validator.check_all_quality_issues_optimized(
-            sample_metrics_df, "Metrics", ["id", "name", "type"], ["id", "name", "description"]
+            sample_metrics_df,
+            "Metrics",
+            ["id", "name", "type"],
+            ["id", "name", "description"],
         )
 
         issues_df = validator.get_issues_dataframe()
@@ -115,12 +127,15 @@ class TestOptimizedValidation:
                     "id": "metric1",
                     "name": "Test Metric",
                     # Missing 'type' field
-                }
-            ]
+                },
+            ],
         )
 
         validator.check_all_quality_issues_optimized(
-            incomplete_df, "Metrics", ["id", "name", "type"], ["id", "name", "description"]
+            incomplete_df,
+            "Metrics",
+            ["id", "name", "type"],
+            ["id", "name", "description"],
         )
 
         issues_df = validator.get_issues_dataframe()
@@ -143,11 +158,14 @@ class TestOptimizedValidation:
                 {"id": None, "name": "Test 1", "type": "metric", "description": "Desc 1"},
                 {"id": "", "name": "Test 2", "type": "metric", "description": "Desc 2"},
                 {"id": "valid_id", "name": "Test 3", "type": "metric", "description": "Desc 3"},
-            ]
+            ],
         )
 
         validator.check_all_quality_issues_optimized(
-            df_with_invalid_ids, "Metrics", ["id", "name", "type"], ["id", "name", "description"]
+            df_with_invalid_ids,
+            "Metrics",
+            ["id", "name", "type"],
+            ["id", "name", "description"],
         )
 
         issues_df = validator.get_issues_dataframe()
@@ -166,7 +184,10 @@ class TestOptimizedValidation:
         validator = DataQualityChecker(logger)
 
         validator.check_all_quality_issues_optimized(
-            sample_metrics_df, "Metrics", ["id", "name", "type"], ["id", "name", "description"]
+            sample_metrics_df,
+            "Metrics",
+            ["id", "name", "type"],
+            ["id", "name", "description"],
         )
 
         issues_df = validator.get_issues_dataframe()
@@ -182,7 +203,10 @@ class TestOptimizedValidation:
         validator = DataQualityChecker(logger)
 
         validator.check_all_quality_issues_optimized(
-            sample_metrics_df, "Metrics", ["id", "name", "type"], ["id", "name", "description"]
+            sample_metrics_df,
+            "Metrics",
+            ["id", "name", "type"],
+            ["id", "name", "description"],
         )
 
         issues_df = validator.get_issues_dataframe()
@@ -213,7 +237,10 @@ class TestOptimizedVsOriginalValidation:
         # Run optimized validation
         validator_optimized = DataQualityChecker(logger)
         validator_optimized.check_all_quality_issues_optimized(
-            sample_metrics_df, "Metrics", ["id", "name", "type"], ["id", "name", "description"]
+            sample_metrics_df,
+            "Metrics",
+            ["id", "name", "type"],
+            ["id", "name", "description"],
         )
 
         optimized_issues = validator_optimized.get_issues_dataframe()
@@ -244,7 +271,10 @@ class TestOptimizedVsOriginalValidation:
         # Run optimized validation
         validator_optimized = DataQualityChecker(logger)
         validator_optimized.check_all_quality_issues_optimized(
-            sample_dimensions_df, "Dimensions", ["id", "name", "type"], ["id", "name", "description"]
+            sample_dimensions_df,
+            "Dimensions",
+            ["id", "name", "type"],
+            ["id", "name", "description"],
         )
 
         optimized_issues = validator_optimized.get_issues_dataframe()
@@ -265,7 +295,10 @@ class TestOptimizedVsOriginalValidation:
         # Run optimized validation
         validator_optimized = DataQualityChecker(logger)
         validator_optimized.check_all_quality_issues_optimized(
-            empty_df, "Metrics", ["id", "name", "type"], ["id", "name", "description"]
+            empty_df,
+            "Metrics",
+            ["id", "name", "type"],
+            ["id", "name", "description"],
         )
         optimized_issues = validator_optimized.get_issues_dataframe()
 
@@ -293,7 +326,7 @@ class TestOptimizedValidationPerformance:
                 "type": ["metric" if i % 2 == 0 else "calculated" for i in range(size)],
                 "description": [f"Description {i}" if i % 3 != 0 else None for i in range(size)],
                 "title": [f"Title {i}" for i in range(size)],
-            }
+            },
         )
 
         # Run multiple iterations to get stable timing
@@ -317,7 +350,10 @@ class TestOptimizedValidationPerformance:
             start = time.time()
             validator_optimized = DataQualityChecker(logger)
             validator_optimized.check_all_quality_issues_optimized(
-                df, "Metrics", ["id", "name", "type"], ["id", "name", "description", "title"]
+                df,
+                "Metrics",
+                ["id", "name", "type"],
+                ["id", "name", "description", "title"],
             )
             optimized_times.append(time.time() - start)
 
@@ -364,7 +400,7 @@ class TestOptimizedValidationPerformance:
                     "type": ["metric"] * size,
                     "description": [f"Desc {i}" if i % 2 == 0 else None for i in range(size)],
                     "title": [f"Title {i}" for i in range(size)],
-                }
+                },
             )
 
             # Run 3 times and take median to reduce variance
@@ -386,7 +422,10 @@ class TestOptimizedValidationPerformance:
                 start = time.time()
                 validator_optimized = DataQualityChecker(logger)
                 validator_optimized.check_all_quality_issues_optimized(
-                    df, "Metrics", ["id", "name", "type"], ["id", "name", "description"]
+                    df,
+                    "Metrics",
+                    ["id", "name", "type"],
+                    ["id", "name", "description"],
                 )
                 opt_times.append(time.time() - start)
 
@@ -399,7 +438,7 @@ class TestOptimizedValidationPerformance:
             print(
                 f"  Size {size}: Original={times_original[i]:.4f}s, "
                 f"Optimized={times_optimized[i]:.4f}s, "
-                f"Improvement={improvement:.1f}%"
+                f"Improvement={improvement:.1f}%",
             )
 
         print("\n  Note: Performance benefits increase with:")
@@ -430,7 +469,10 @@ class TestEdgeCases:
 
         # Should not crash
         validator.check_all_quality_issues_optimized(
-            df, "Metrics", ["id", "name", "type"], ["id", "name", "description"]
+            df,
+            "Metrics",
+            ["id", "name", "type"],
+            ["id", "name", "description"],
         )
 
         issues_df = validator.get_issues_dataframe()
@@ -447,11 +489,14 @@ class TestEdgeCases:
                 "name": [None, None, None],
                 "type": [None, None, None],
                 "description": [None, None, None],
-            }
+            },
         )
 
         validator.check_all_quality_issues_optimized(
-            df, "Metrics", ["id", "name", "type"], ["id", "name", "description"]
+            df,
+            "Metrics",
+            ["id", "name", "type"],
+            ["id", "name", "description"],
         )
 
         issues_df = validator.get_issues_dataframe()
@@ -468,11 +513,14 @@ class TestEdgeCases:
             [
                 {"id": "id_1", "name": "Test & Special <> Chars", "type": "metric", "description": "Desc"},
                 {"id": "id_2", "name": "Test & Special <> Chars", "type": "metric", "description": "Desc"},  # Duplicate
-            ]
+            ],
         )
 
         validator.check_all_quality_issues_optimized(
-            df, "Metrics", ["id", "name", "type"], ["id", "name", "description"]
+            df,
+            "Metrics",
+            ["id", "name", "type"],
+            ["id", "name", "description"],
         )
 
         issues_df = validator.get_issues_dataframe()

--- a/tests/test_org_analyzer_coverage.py
+++ b/tests/test_org_analyzer_coverage.py
@@ -158,7 +158,7 @@ class TestListAndFilterDataViews:
             [
                 {"id": "dv1", "name": "Alpha"},
                 {"id": "dv2", "name": "Beta"},
-            ]
+            ],
         )
         mock_cja.getDataViews.return_value = df
         analyzer = _make_analyzer(mock_cja, logger)
@@ -870,7 +870,9 @@ class TestRunAnalysisImplFeatureFlags:
 
         patches = [
             patch.object(
-                analyzer, "_list_and_filter_data_views", return_value=([{"id": "dv1"}, {"id": "dv2"}], False, 2)
+                analyzer,
+                "_list_and_filter_data_views",
+                return_value=([{"id": "dv1"}, {"id": "dv2"}], False, 2),
             ),
             patch.object(analyzer, "_fetch_all_data_views", return_value=summaries),
             patch.object(analyzer, "_check_memory_warning"),
@@ -1201,7 +1203,10 @@ class TestCachePaths:
         analyzer = _make_analyzer(mock_cja, logger, config=config)
 
         cached_summary = DataViewSummary(
-            data_view_id="dv1", data_view_name="Cached DV", metric_count=5, dimension_count=3
+            data_view_id="dv1",
+            data_view_name="Cached DV",
+            metric_count=5,
+            dimension_count=3,
         )
         mock_cache = MagicMock()
         mock_cache.get.return_value = cached_summary
@@ -2131,13 +2136,13 @@ class TestFetchDataViewComponentsNames:
             {
                 "id": ["m1", "m2"],
                 "name": ["Revenue", "Page Views"],
-            }
+            },
         )
         mock_cja.getDimensions.return_value = pd.DataFrame(
             {
                 "id": ["d1"],
                 "name": ["Browser"],
-            }
+            },
         )
 
         dv = {"id": "dv_test", "name": "Test DV"}
@@ -2161,7 +2166,7 @@ class TestFetchDataViewComponentsNames:
             {
                 "id": ["d1", "d2"],
                 "name": ["Browser", "Country"],
-            }
+            },
         )
 
         dv = {"id": "dv_test", "name": "Test DV"}

--- a/tests/test_org_report.py
+++ b/tests/test_org_report.py
@@ -489,7 +489,7 @@ class TestAnalyzerLockIntegration:
             side_effect=[
                 None,
                 LockOwnershipLostError("/tmp/test.lock", reason="heartbeat metadata write failed"),
-            ]
+            ],
         )
 
         data_views = [
@@ -561,7 +561,7 @@ class TestAnalyzerLockIntegration:
             side_effect=[
                 None,
                 LockOwnershipLostError("/tmp/test.lock", reason="heartbeat metadata write failed"),
-            ]
+            ],
         )
 
         data_views = [
@@ -662,7 +662,10 @@ class TestDataViewSummary:
     def test_all_component_ids(self):
         """Test all_component_ids property"""
         summary = DataViewSummary(
-            data_view_id="dv_123", data_view_name="Test DV", metric_ids={"m1", "m2"}, dimension_ids={"d1", "d2", "d3"}
+            data_view_id="dv_123",
+            data_view_name="Test DV",
+            metric_ids={"m1", "m2"},
+            dimension_ids={"d1", "d2", "d3"},
         )
         assert summary.all_component_ids == {"m1", "m2", "d1", "d2", "d3"}
 
@@ -830,13 +833,13 @@ class TestOrgComponentAnalyzer:
             [
                 {"id": "m_derived", "name": "Derived Metric", "sourceFieldType": "derived"},
                 {"id": "m_standard", "name": "Standard Metric", "sourceFieldType": "field"},
-            ]
+            ],
         )
         mock_cja.getDimensions.return_value = pd.DataFrame(
             [
                 {"id": "d_derived", "name": "Derived Dimension", "sourceFieldType": "derived"},
                 {"id": "d_standard", "name": "Standard Dimension", "sourceFieldType": "custom"},
-            ]
+            ],
         )
 
         summary = analyzer._fetch_data_view_components({"id": "dv_1", "name": "DV 1"})
@@ -992,7 +995,9 @@ class TestOrgComponentAnalyzer:
 
         with (
             patch.object(
-                analyzer, "_list_and_filter_data_views", return_value=([{"id": "dv_1", "name": "DV 1"}], False, 1)
+                analyzer,
+                "_list_and_filter_data_views",
+                return_value=([{"id": "dv_1", "name": "DV 1"}], False, 1),
             ),
             patch.object(
                 analyzer,
@@ -1154,7 +1159,7 @@ class TestOrgComponentAnalyzer:
                 {"id": "dv_2", "name": "Test DV"},
                 {"id": "dv_3", "name": "Prod Analytics"},
                 {"id": "dv_4", "name": "Dev Sandbox"},
-            ]
+            ],
         )
 
         config = OrgReportConfig(filter_pattern="Prod.*")
@@ -1176,7 +1181,7 @@ class TestOrgComponentAnalyzer:
                 {"id": "dv_2", "name": "Test DV"},
                 {"id": "dv_3", "name": "Prod Analytics"},
                 {"id": "dv_4", "name": "Dev Sandbox"},
-            ]
+            ],
         )
 
         config = OrgReportConfig(exclude_pattern="Test|Dev")
@@ -1258,7 +1263,7 @@ class TestOrgComponentAnalyzer:
                 dimension_count=5,
                 modified="2000-01-01T00:00:00Z",
                 has_description=True,
-            )
+            ),
         ]
 
         recommendations = analyzer._generate_recommendations(
@@ -1345,7 +1350,10 @@ class TestOutputWriters:
                 "d2": ComponentInfo("d2", "dimension", data_views={"dv_2"}),
             },
             distribution=ComponentDistribution(
-                core_metrics=["m1"], core_dimensions=["d1"], isolated_metrics=["m2"], isolated_dimensions=["d2"]
+                core_metrics=["m1"],
+                core_dimensions=["d1"],
+                isolated_metrics=["m2"],
+                isolated_dimensions=["d2"],
             ),
             similarity_pairs=[SimilarityPair("dv_1", "Production DV", "dv_2", "Staging DV", 0.6, 2, 4)],
             recommendations=[{"type": "test_recommendation", "severity": "low", "reason": "Test reason"}],
@@ -1512,7 +1520,7 @@ class TestOutputWriters:
                 "data_view_2_name": "Staging `Copy`",
                 "similarity": 0.95,
                 "drift_count": 7,
-            }
+            },
         ]
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -1537,7 +1545,7 @@ class TestOutputWriters:
                 "data_view": "dv_1",
                 "data_view_name": "Prod Main",
                 "isolated_count": 42,
-            }
+            },
         ]
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -1562,7 +1570,7 @@ class TestOutputWriters:
                 "severity": "CRITICAL",
                 "reason": "Includes non-serializable value",
                 "extra_timestamp": datetime(2024, 1, 15, 12, 0, 0),
-            }
+            },
         ]
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -1591,7 +1599,7 @@ class TestOutputWriters:
                 "data_view_2_name": "Staging",
                 "similarity": 0.95,
                 "drift_count": 7,
-            }
+            },
         ]
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -1620,7 +1628,7 @@ class TestOutputWriters:
                 "data_view_2": "dv_2",
                 "data_view_2_name": "Staging",
                 "similarity": 0.95,
-            }
+            },
         ]
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -2134,7 +2142,7 @@ class TestLargeOrgScaling:
                     dimension_count=len(dims),
                     metric_names=metric_names,
                     dimension_names=dim_names,
-                )
+                ),
             )
 
         # Build the index
@@ -2169,19 +2177,25 @@ class TestLargeOrgScaling:
         # Core: in 60% of DVs (120+ DVs)
         for i in range(25):
             component_index[f"m_core_{i}"] = ComponentInfo(
-                f"m_core_{i}", "metric", data_views={f"dv_{j}" for j in range(120)}
+                f"m_core_{i}",
+                "metric",
+                data_views={f"dv_{j}" for j in range(120)},
             )
 
         # Common: in 30% of DVs (60 DVs)
         for i in range(50):
             component_index[f"d_common_{i}"] = ComponentInfo(
-                f"d_common_{i}", "dimension", data_views={f"dv_{j}" for j in range(60)}
+                f"d_common_{i}",
+                "dimension",
+                data_views={f"dv_{j}" for j in range(60)},
             )
 
         # Limited: in 5% of DVs (10 DVs)
         for i in range(100):
             component_index[f"m_limited_{i}"] = ComponentInfo(
-                f"m_limited_{i}", "metric", data_views={f"dv_{j}" for j in range(10)}
+                f"m_limited_{i}",
+                "metric",
+                data_views={f"dv_{j}" for j in range(10)},
             )
 
         # Isolated: in 1 DV each
@@ -2228,7 +2242,7 @@ class TestLargeOrgScaling:
                     data_view_name=f"DV {i}",
                     metric_ids=metrics,
                     dimension_ids=dims,
-                )
+                ),
             )
 
         pairs = analyzer._compute_similarity_matrix(summaries)
@@ -2296,7 +2310,10 @@ class TestLargeOrgScaling:
         component_index = {}
         for i in range(300):
             component_index[f"metric_{i}"] = ComponentInfo(
-                f"metric_{i}", "metric", name=f"Metric Name {i}", data_views={f"dv_{j}" for j in range(min(i + 1, 100))}
+                f"metric_{i}",
+                "metric",
+                name=f"Metric Name {i}",
+                data_views={f"dv_{j}" for j in range(min(i + 1, 100))},
             )
         for i in range(200):
             component_index[f"dim_{i}"] = ComponentInfo(
@@ -2366,7 +2383,12 @@ class TestOutputPathWithFormatAliases:
             parameters=OrgReportConfig(core_threshold=0.5, overlap_threshold=0.8),
             data_view_summaries=[
                 DataViewSummary(
-                    "dv_1", "DV 1", metric_ids={"m1"}, dimension_ids={"d1"}, metric_count=1, dimension_count=1
+                    "dv_1",
+                    "DV 1",
+                    metric_ids={"m1"},
+                    dimension_ids={"d1"},
+                    metric_count=1,
+                    dimension_count=1,
                 ),
             ],
             component_index={
@@ -2626,7 +2648,12 @@ class TestOrgReportOutputHandling:
             parameters=OrgReportConfig(core_threshold=0.5, overlap_threshold=0.8),
             data_view_summaries=[
                 DataViewSummary(
-                    "dv_1", "DV 1", metric_ids={"m1"}, dimension_ids={"d1"}, metric_count=1, dimension_count=1
+                    "dv_1",
+                    "DV 1",
+                    metric_ids={"m1"},
+                    dimension_ids={"d1"},
+                    metric_count=1,
+                    dimension_count=1,
                 ),
             ],
             component_index={
@@ -2720,7 +2747,8 @@ class TestOrgReportOutputHandling:
         """CSV org-report should error on stdout since it writes multiple files."""
         with (
             patch(
-                "cja_auto_sdr.generator.configure_cjapy", return_value=(True, "ok", {"org_id": "org_123"})
+                "cja_auto_sdr.generator.configure_cjapy",
+                return_value=(True, "ok", {"org_id": "org_123"}),
             ) as mock_configure,
             patch("cja_auto_sdr.generator.cjapy.CJA", return_value=Mock()),
             patch("cja_auto_sdr.generator.OrgComponentAnalyzer") as mock_analyzer,
@@ -2747,7 +2775,8 @@ class TestOrgReportOutputHandling:
         """Markdown org-report should fail fast when stdout is requested."""
         with (
             patch(
-                "cja_auto_sdr.generator.configure_cjapy", return_value=(True, "ok", {"org_id": "org_123"})
+                "cja_auto_sdr.generator.configure_cjapy",
+                return_value=(True, "ok", {"org_id": "org_123"}),
             ) as mock_configure,
             patch("cja_auto_sdr.generator.cjapy.CJA", return_value=Mock()),
             patch("cja_auto_sdr.generator.OrgComponentAnalyzer") as mock_analyzer,
@@ -2774,7 +2803,8 @@ class TestOrgReportOutputHandling:
         """Format aliases should fail fast when stdout is requested."""
         with (
             patch(
-                "cja_auto_sdr.generator.configure_cjapy", return_value=(True, "ok", {"org_id": "org_123"})
+                "cja_auto_sdr.generator.configure_cjapy",
+                return_value=(True, "ok", {"org_id": "org_123"}),
             ) as mock_configure,
             patch("cja_auto_sdr.generator.cjapy.CJA", return_value=Mock()),
             patch("cja_auto_sdr.generator.OrgComponentAnalyzer") as mock_analyzer,
@@ -2801,7 +2831,8 @@ class TestOrgReportOutputHandling:
         """--format all should fail fast when stdout is requested."""
         with (
             patch(
-                "cja_auto_sdr.generator.configure_cjapy", return_value=(True, "ok", {"org_id": "org_123"})
+                "cja_auto_sdr.generator.configure_cjapy",
+                return_value=(True, "ok", {"org_id": "org_123"}),
             ) as mock_configure,
             patch("cja_auto_sdr.generator.cjapy.CJA", return_value=Mock()),
             patch("cja_auto_sdr.generator.OrgComponentAnalyzer") as mock_analyzer,
@@ -2828,7 +2859,8 @@ class TestOrgReportOutputHandling:
         """Unknown org-report format should fail before any API/configuration work."""
         with (
             patch(
-                "cja_auto_sdr.generator.configure_cjapy", return_value=(True, "ok", {"org_id": "org_123"})
+                "cja_auto_sdr.generator.configure_cjapy",
+                return_value=(True, "ok", {"org_id": "org_123"}),
             ) as mock_configure,
             patch("cja_auto_sdr.generator.cjapy.CJA", return_value=Mock()),
             patch("cja_auto_sdr.generator.OrgComponentAnalyzer") as mock_analyzer,
@@ -3056,7 +3088,10 @@ class TestNamingAudit:
         component_index = {
             "metric_20240101": ComponentInfo("metric_20240101", "metric", name="metric_20240101", data_views={"dv_1"}),
             "metric_2024-01-15": ComponentInfo(
-                "metric_2024-01-15", "metric", name="metric_2024-01-15", data_views={"dv_1"}
+                "metric_2024-01-15",
+                "metric",
+                name="metric_2024-01-15",
+                data_views={"dv_1"},
             ),
             "current_metric": ComponentInfo("current_metric", "metric", name="current_metric", data_views={"dv_1"}),
         }
@@ -3220,7 +3255,7 @@ class TestOrgReportComparison:
                     "jaccard_similarity": 0.95,
                     "shared_components": 10,
                     "union_size": 12,
-                }
+                },
             ],
         }
 
@@ -3275,7 +3310,7 @@ class TestOrgReportComparison:
                     "jaccard_similarity": 0.95,
                     "shared_components": 10,
                     "union_size": 12,
-                }
+                },
             ],
         }
 
@@ -3318,7 +3353,7 @@ class TestOrgReportComparison:
                     only_in_dv2=[],
                     only_in_dv1_names=None,
                     only_in_dv2_names=None,
-                )
+                ),
             ],
             recommendations=[],
             duration=1.0,
@@ -3342,7 +3377,7 @@ class TestOrgReportComparison:
                     "jaccard_similarity": 0.95,
                     "shared_components": 10,
                     "union_size": 12,
-                }
+                },
             ],
         }
 
@@ -3680,7 +3715,10 @@ class TestMemoryWarning:
         # Create a component index with known sizes
         component_index = {
             f"metric/comp_{i}": ComponentInfo(
-                f"metric/comp_{i}", "metric", name=f"Component {i}", data_views={f"dv_{j}" for j in range(10)}
+                f"metric/comp_{i}",
+                "metric",
+                name=f"Component {i}",
+                data_views={f"dv_{j}" for j in range(10)},
             )
             for i in range(100)
         }
@@ -3972,7 +4010,7 @@ class TestSmartCacheInvalidation:
             # Pass data view list with different modification timestamp
             # (batch optimization: uses modified from the list, not individual API calls)
             to_fetch, valid_summaries, valid_count, stale_count = analyzer._validate_cache_entries(
-                [{"id": "dv_1", "name": "DV 1", "modified": "2024-01-16T10:00:00Z"}]
+                [{"id": "dv_1", "name": "DV 1", "modified": "2024-01-16T10:00:00Z"}],
             )
 
             # Should detect stale entry and need to re-fetch
@@ -4051,7 +4089,7 @@ class TestSmartCacheInvalidation:
             # Pass data view list with same modification timestamp
             # (batch optimization: uses modified from the list, not individual API calls)
             to_fetch, valid_summaries, valid_count, stale_count = analyzer._validate_cache_entries(
-                [{"id": "dv_1", "name": "DV 1", "modified": "2024-01-15T10:00:00Z"}]
+                [{"id": "dv_1", "name": "DV 1", "modified": "2024-01-15T10:00:00Z"}],
             )
 
             # Should detect valid entry and use cache
@@ -4093,7 +4131,7 @@ class TestSmartCacheInvalidation:
 
             # Pass data view WITHOUT modification timestamp (some API responses omit this)
             to_fetch, valid_summaries, valid_count, stale_count = analyzer._validate_cache_entries(
-                [{"id": "dv_1", "name": "DV 1"}]  # No 'modified' or 'modifiedDate' field
+                [{"id": "dv_1", "name": "DV 1"}],  # No 'modified' or 'modifiedDate' field
             )
 
             # Should treat missing timestamp as stale to honor --validate-cache guarantee

--- a/tests/test_org_report_integration.py
+++ b/tests/test_org_report_integration.py
@@ -67,7 +67,7 @@ def create_mock_metrics(dv_id: str, count: int = 10, overlap_ids: list | None = 
                 "name": f"Metric {metric_id}",
                 "type": "standard",
                 "sourceFieldType": "field",
-            }
+            },
         )
 
     # Add unique metrics for this DV
@@ -78,7 +78,7 @@ def create_mock_metrics(dv_id: str, count: int = 10, overlap_ids: list | None = 
                 "name": f"Metric {i} for {dv_id}",
                 "type": "standard",
                 "sourceFieldType": "field",
-            }
+            },
         )
 
     return pd.DataFrame(metrics)
@@ -106,7 +106,7 @@ def create_mock_dimensions(dv_id: str, count: int = 10, overlap_ids: list | None
                 "name": f"Dimension {dim_id}",
                 "type": "standard",
                 "sourceFieldType": "field",
-            }
+            },
         )
 
     # Add unique dimensions for this DV
@@ -117,7 +117,7 @@ def create_mock_dimensions(dv_id: str, count: int = 10, overlap_ids: list | None
                 "name": f"Dimension {i} for {dv_id}",
                 "type": "standard",
                 "sourceFieldType": "field",
-            }
+            },
         )
 
     return pd.DataFrame(dimensions)

--- a/tests/test_output_content_validation.py
+++ b/tests/test_output_content_validation.py
@@ -38,7 +38,7 @@ def rich_data_dict():
         "Metadata": pd.DataFrame(
             {
                 "Property": ["Generated At", "Data View ID", "Tool Version", "Total Metrics"],
-                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.2.8", 3],
+                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.2.9", 3],
             },
         ),
         "Data Quality": pd.DataFrame(
@@ -104,7 +104,7 @@ def rich_metadata_dict():
         "Generated At": "2025-01-15 10:30:00 PST",
         "Data View ID": "dv_content_test",
         "Data View Name": "Test DataView",
-        "Tool Version": "3.2.8",
+        "Tool Version": "3.2.9",
         "Metrics Count": "3",
         "Dimensions Count": "4",
     }
@@ -224,7 +224,7 @@ class TestJSONContentValidation:
             data = json.load(f)
 
         assert data["metadata"]["Data View ID"] == "dv_content_test"
-        assert data["metadata"]["Tool Version"] == "3.2.8"
+        assert data["metadata"]["Tool Version"] == "3.2.9"
 
 
 # ===================================================================

--- a/tests/test_output_content_validation.py
+++ b/tests/test_output_content_validation.py
@@ -39,7 +39,7 @@ def rich_data_dict():
             {
                 "Property": ["Generated At", "Data View ID", "Tool Version", "Total Metrics"],
                 "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.2.8", 3],
-            }
+            },
         ),
         "Data Quality": pd.DataFrame(
             [
@@ -67,20 +67,20 @@ def rich_data_dict():
                     "Issue": "No description",
                     "Details": "Consider adding",
                 },
-            ]
+            ],
         ),
         "DataView Details": pd.DataFrame(
             {
                 "Property": ["Name", "ID", "Owner"],
                 "Value": ["Test DataView", "dv_content_test", "Test Owner"],
-            }
+            },
         ),
         "Metrics": pd.DataFrame(
             [
                 {"id": "m1", "name": "Page Views", "type": "int", "description": "Total page views"},
                 {"id": "m2", "name": "Revenue", "type": "currency", "description": None},
                 {"id": "m3", "name": "Bounce Rate", "type": "percent", "description": ""},
-            ]
+            ],
         ),
         "Dimensions": pd.DataFrame(
             [
@@ -93,7 +93,7 @@ def rich_data_dict():
                     "type": "string",
                     "description": 'Contains "quotes" & <angles>',
                 },
-            ]
+            ],
         ),
     }
 
@@ -393,8 +393,8 @@ class TestMarkdownContentValidation:
         logger = logging.getLogger("md_test")
         data_dict = {
             "Metrics": pd.DataFrame(
-                [{"id": "m1", "name": "Rate | Percentage", "type": "int", "description": "Has | pipe"}]
-            )
+                [{"id": "m1", "name": "Rate | Percentage", "type": "int", "description": "Has | pipe"}],
+            ),
         }
         path = write_markdown_output(data_dict, rich_metadata_dict, "test", str(tmp_path), logger)
 

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -95,8 +95,8 @@ class TestCSVOutput:
 
         data_dict = {
             "Test Data": pd.DataFrame(
-                [{"name": "Test, with comma", "value": "Line\nbreak"}, {"name": 'Quote "test"', "value": "Normal"}]
-            )
+                [{"name": "Test, with comma", "value": "Line\nbreak"}, {"name": 'Quote "test"', "value": "Normal"}],
+            ),
         }
 
         output_path = write_csv_output(data_dict, "test", str(tmp_path), logger)
@@ -175,8 +175,11 @@ class TestJSONOutput:
 
         data_dict = {
             "Metrics": pd.DataFrame(
-                [{"id": "1", "name": "Test", "description": None}, {"id": "2", "name": "Test2", "description": "Valid"}]
-            )
+                [
+                    {"id": "1", "name": "Test", "description": None},
+                    {"id": "2", "name": "Test2", "description": "Valid"},
+                ],
+            ),
         }
 
         output_path = write_json_output(data_dict, sample_metadata_dict, "test", str(tmp_path), logger)
@@ -288,8 +291,8 @@ class TestHTMLOutput:
                     {"Severity": "CRITICAL", "Issue": "Critical issue", "Details": "Test"},
                     {"Severity": "HIGH", "Issue": "High issue", "Details": "Test"},
                     {"Severity": "MEDIUM", "Issue": "Medium issue", "Details": "Test"},
-                ]
-            )
+                ],
+            ),
         }
 
         output_path = write_html_output(data_dict, sample_metadata_dict, "test", str(tmp_path), logger)
@@ -311,8 +314,8 @@ class TestHTMLOutput:
                 [
                     {"Severity": "CRITICAL", "Issue": "Critical issue", "Details": "Test"},
                     {"Severity": "HIGH", "Issue": "High issue", "Details": "Test"},
-                ]
-            )
+                ],
+            ),
         }
 
         output_path = write_html_output(data_dict, sample_metadata_dict, "test", str(tmp_path), logger)
@@ -439,7 +442,7 @@ class TestEdgeCases:
         logger = logging.getLogger("test")
 
         data_dict = {
-            "Unicode": pd.DataFrame([{"name": "测试数据", "value": "Tëst"}, {"name": "Тест", "value": "مرحبا"}])
+            "Unicode": pd.DataFrame([{"name": "测试数据", "value": "Tëst"}, {"name": "Тест", "value": "مرحبا"}]),
         }
         metadata_dict = {"key": "日本語"}
 
@@ -468,7 +471,7 @@ class TestEdgeCases:
                 "id": [f"id_{i}" for i in range(1000)],
                 "name": [f"Name {i}" for i in range(1000)],
                 "value": list(range(1000)),
-            }
+            },
         )
 
         data_dict = {"LargeData": large_df}
@@ -497,7 +500,11 @@ class TestMarkdownOutput:
         logger = logging.getLogger("test")
 
         output_path = write_markdown_output(
-            sample_data_dict, sample_metadata_dict, "test_dataview", str(tmp_path), logger
+            sample_data_dict,
+            sample_metadata_dict,
+            "test_dataview",
+            str(tmp_path),
+            logger,
         )
 
         # Check file was created
@@ -509,7 +516,11 @@ class TestMarkdownOutput:
         logger = logging.getLogger("test")
 
         output_path = write_markdown_output(
-            sample_data_dict, sample_metadata_dict, "test_dataview", str(tmp_path), logger
+            sample_data_dict,
+            sample_metadata_dict,
+            "test_dataview",
+            str(tmp_path),
+            logger,
         )
 
         with open(output_path, encoding="utf-8") as f:
@@ -528,7 +539,11 @@ class TestMarkdownOutput:
         logger = logging.getLogger("test")
 
         output_path = write_markdown_output(
-            sample_data_dict, sample_metadata_dict, "test_dataview", str(tmp_path), logger
+            sample_data_dict,
+            sample_metadata_dict,
+            "test_dataview",
+            str(tmp_path),
+            logger,
         )
 
         with open(output_path, encoding="utf-8") as f:
@@ -545,8 +560,8 @@ class TestMarkdownOutput:
 
         data_dict = {
             "Test Data": pd.DataFrame(
-                [{"name": "Test | with pipe", "value": "Has `backtick`"}, {"name": "Normal", "value": "Normal"}]
-            )
+                [{"name": "Test | with pipe", "value": "Has `backtick`"}, {"name": "Normal", "value": "Normal"}],
+            ),
         }
         metadata_dict = {"key": "value"}
 
@@ -564,7 +579,11 @@ class TestMarkdownOutput:
         logger = logging.getLogger("test")
 
         output_path = write_markdown_output(
-            sample_data_dict, sample_metadata_dict, "test_dataview", str(tmp_path), logger
+            sample_data_dict,
+            sample_metadata_dict,
+            "test_dataview",
+            str(tmp_path),
+            logger,
         )
 
         with open(output_path, encoding="utf-8") as f:
@@ -601,7 +620,11 @@ class TestMarkdownOutput:
         logger = logging.getLogger("test")
 
         output_path = write_markdown_output(
-            sample_data_dict, sample_metadata_dict, "test_dataview", str(tmp_path), logger
+            sample_data_dict,
+            sample_metadata_dict,
+            "test_dataview",
+            str(tmp_path),
+            logger,
         )
 
         with open(output_path, encoding="utf-8") as f:
@@ -630,7 +653,7 @@ class TestMarkdownOutput:
         logger = logging.getLogger("test")
 
         data_dict = {
-            "Unicode": pd.DataFrame([{"name": "测试数据", "value": "Tëst"}, {"name": "Тест", "value": "مرحبا"}])
+            "Unicode": pd.DataFrame([{"name": "测试数据", "value": "Tëst"}, {"name": "Тест", "value": "مرحبا"}]),
         }
         metadata_dict = {"key": "日本語"}
 
@@ -666,7 +689,11 @@ class TestMarkdownOutput:
         logger = logging.getLogger("test")
 
         output_path = write_markdown_output(
-            sample_data_dict, sample_metadata_dict, "test_dataview", str(tmp_path), logger
+            sample_data_dict,
+            sample_metadata_dict,
+            "test_dataview",
+            str(tmp_path),
+            logger,
         )
 
         with open(output_path, encoding="utf-8") as f:
@@ -682,7 +709,11 @@ class TestMarkdownOutput:
         logger = logging.getLogger("test")
 
         output_path = write_markdown_output(
-            sample_data_dict, sample_metadata_dict, "test_dataview", str(tmp_path), logger
+            sample_data_dict,
+            sample_metadata_dict,
+            "test_dataview",
+            str(tmp_path),
+            logger,
         )
 
         with open(output_path, encoding="utf-8") as f:
@@ -696,7 +727,11 @@ class TestMarkdownOutput:
         logger = logging.getLogger("test")
 
         output_path = write_markdown_output(
-            sample_data_dict, sample_metadata_dict, "test_dataview", str(tmp_path), logger
+            sample_data_dict,
+            sample_metadata_dict,
+            "test_dataview",
+            str(tmp_path),
+            logger,
         )
 
         with open(output_path, encoding="utf-8") as f:

--- a/tests/test_parallel_api_fetcher.py
+++ b/tests/test_parallel_api_fetcher.py
@@ -48,7 +48,7 @@ def sample_metrics_data():
         [
             {"id": "metric1", "name": "Metric 1", "type": "calculated", "description": "Test"},
             {"id": "metric2", "name": "Metric 2", "type": "standard", "description": "Test 2"},
-        ]
+        ],
     )
 
 
@@ -59,7 +59,7 @@ def sample_dimensions_data():
         [
             {"id": "dim1", "name": "Dimension 1", "type": "string", "description": "Test"},
             {"id": "dim2", "name": "Dimension 2", "type": "string", "description": "Test 2"},
-        ]
+        ],
     )
 
 
@@ -365,7 +365,12 @@ class TestParallelAPIFetcherFetchDimensions:
 
     @patch("cja_auto_sdr.api.fetch.make_api_call_with_retry")
     def test_fetch_dimensions_success(
-        self, mock_api_call, mock_cja, mock_logger, mock_perf_tracker, sample_dimensions_data
+        self,
+        mock_api_call,
+        mock_cja,
+        mock_logger,
+        mock_perf_tracker,
+        sample_dimensions_data,
     ):
         """Test successful dimensions fetching"""
         mock_api_call.return_value = sample_dimensions_data
@@ -413,7 +418,12 @@ class TestParallelAPIFetcherFetchDataviewInfo:
 
     @patch("cja_auto_sdr.api.fetch.make_api_call_with_retry")
     def test_fetch_dataview_info_success(
-        self, mock_api_call, mock_cja, mock_logger, mock_perf_tracker, sample_dataview_info
+        self,
+        mock_api_call,
+        mock_cja,
+        mock_logger,
+        mock_perf_tracker,
+        sample_dataview_info,
     ):
         """Test successful dataview info fetching"""
         mock_api_call.return_value = sample_dataview_info
@@ -545,7 +555,13 @@ class TestParallelAPIFetcherLogging:
     @patch("cja_auto_sdr.api.fetch.make_api_call_with_retry")
     @patch("cja_auto_sdr.api.fetch.tqdm")
     def test_logs_completion_summary(
-        self, mock_tqdm, mock_api_call, mock_cja, mock_logger, mock_perf_tracker, sample_metrics_data
+        self,
+        mock_tqdm,
+        mock_api_call,
+        mock_cja,
+        mock_logger,
+        mock_perf_tracker,
+        sample_metrics_data,
     ):
         """Test that completion summary is logged"""
         mock_pbar = MagicMock()

--- a/tests/test_parallel_validation.py
+++ b/tests/test_parallel_validation.py
@@ -29,10 +29,16 @@ class TestParallelValidation:
         # Sequential validation
         sequential_checker = DataQualityChecker(logger)
         sequential_checker.check_all_quality_issues_optimized(
-            sample_metrics_df, "Metrics", ["id", "name", "type"], ["id", "name", "description"]
+            sample_metrics_df,
+            "Metrics",
+            ["id", "name", "type"],
+            ["id", "name", "description"],
         )
         sequential_checker.check_all_quality_issues_optimized(
-            sample_dimensions_df, "Dimensions", ["id", "name", "type"], ["id", "name", "description"]
+            sample_dimensions_df,
+            "Dimensions",
+            ["id", "name", "type"],
+            ["id", "name", "description"],
         )
         sequential_issues = sorted(sequential_checker.issues, key=lambda x: (x["Type"], x["Item Name"]))
 
@@ -100,13 +106,13 @@ class TestParallelValidation:
             [
                 {"id": "m1", "name": "dup_metric", "type": "metric", "title": "Metric One", "description": ""},
                 {"id": "", "name": "dup_metric", "type": "metric", "title": None, "description": ""},
-            ]
+            ],
         )
         dimensions_df = pd.DataFrame(
             [
                 {"id": "d1", "name": "dimension_a", "type": "dimension", "title": "Dim A", "description": ""},
                 {"id": "d2", "name": "dimension_b", "type": "dimension", "title": "Dim B", "description": ""},
-            ]
+            ],
         )
 
         required_fields = ["id", "name", "type"]
@@ -149,10 +155,16 @@ class TestParallelValidation:
             seq_checker = DataQualityChecker(logger)
             seq_start = time.time()
             seq_checker.check_all_quality_issues_optimized(
-                large_metrics_df, "Metrics", ["id", "name", "type"], ["id", "name", "description"]
+                large_metrics_df,
+                "Metrics",
+                ["id", "name", "type"],
+                ["id", "name", "description"],
             )
             seq_checker.check_all_quality_issues_optimized(
-                large_dimensions_df, "Dimensions", ["id", "name", "type"], ["id", "name", "description"]
+                large_dimensions_df,
+                "Dimensions",
+                ["id", "name", "type"],
+                ["id", "name", "description"],
             )
             seq_times.append(time.time() - seq_start)
 
@@ -265,7 +277,7 @@ class TestParallelValidationIntegration:
                 {"id": "m2", "name": "Metric 2", "type": "calculated", "description": ""},  # Missing description
                 {"id": "m3", "name": "Metric 1", "type": "calculated", "description": "Duplicate name"},  # Duplicate
                 {"id": "", "name": "Metric 4", "type": "calculated", "description": "Invalid ID"},  # Invalid ID
-            ]
+            ],
         )
 
         dimensions_with_issues = pd.DataFrame(
@@ -273,7 +285,7 @@ class TestParallelValidationIntegration:
                 {"id": "d1", "name": "Dimension 1", "type": "string", "description": "Valid dimension"},
                 {"id": "d2", "name": "Dimension 2", "type": "string", "description": None},  # Null description
                 {"id": "d3", "name": "Dimension 1", "type": "string", "description": "Duplicate"},  # Duplicate
-            ]
+            ],
         )
 
         checker.check_all_parallel(

--- a/tests/test_process_single_dataview.py
+++ b/tests/test_process_single_dataview.py
@@ -62,7 +62,7 @@ def sample_metrics_df():
                 "description": "Test metric 2",
                 "title": "Metric 2",
             },
-        ]
+        ],
     )
 
 
@@ -79,7 +79,7 @@ def sample_dimensions_df():
                 "description": "Test dim 2",
                 "title": "Dimension 2",
             },
-        ]
+        ],
     )
 
 
@@ -137,7 +137,7 @@ class TestProcessSingleDataviewSuccess:
         mock_dq_checker = Mock()
         mock_dq_checker.issues = []
         mock_dq_checker.get_issues_dataframe.return_value = pd.DataFrame(
-            columns=["Severity", "Category", "Type", "Item Name", "Issue", "Details"]
+            columns=["Severity", "Category", "Type", "Item Name", "Issue", "Details"],
         )
         mock_dq_checker_class.return_value = mock_dq_checker
 
@@ -147,7 +147,9 @@ class TestProcessSingleDataviewSuccess:
         mock_excel_writer.return_value.__exit__ = Mock(return_value=False)
 
         result = process_single_dataview(
-            data_view_id="dv_test_12345", config_file=mock_config_file, output_dir=temp_output_dir
+            data_view_id="dv_test_12345",
+            config_file=mock_config_file,
+            output_dir=temp_output_dir,
         )
 
         assert result.success is True
@@ -193,7 +195,7 @@ class TestProcessSingleDataviewSuccess:
         mock_dq_checker = Mock()
         mock_dq_checker.issues = []
         mock_dq_checker.get_issues_dataframe.return_value = pd.DataFrame(
-            columns=["Severity", "Category", "Type", "Item Name", "Issue", "Details"]
+            columns=["Severity", "Category", "Type", "Item Name", "Issue", "Details"],
         )
         mock_dq_checker_class.return_value = mock_dq_checker
 
@@ -225,7 +227,9 @@ class TestProcessSingleDataviewFailures:
         mock_init_cja.return_value = None
 
         result = process_single_dataview(
-            data_view_id="dv_test_12345", config_file=mock_config_file, output_dir=temp_output_dir
+            data_view_id="dv_test_12345",
+            config_file=mock_config_file,
+            output_dir=temp_output_dir,
         )
 
         assert result.success is False
@@ -235,7 +239,12 @@ class TestProcessSingleDataviewFailures:
     @patch("cja_auto_sdr.generator.initialize_cja")
     @patch("cja_auto_sdr.generator.validate_data_view")
     def test_data_view_validation_failure(
-        self, mock_validate_dv, mock_init_cja, mock_setup_logging, mock_config_file, temp_output_dir
+        self,
+        mock_validate_dv,
+        mock_init_cja,
+        mock_setup_logging,
+        mock_config_file,
+        temp_output_dir,
     ):
         """Test handling of data view validation failure"""
         mock_logger = Mock()
@@ -245,7 +254,9 @@ class TestProcessSingleDataviewFailures:
         mock_validate_dv.return_value = False
 
         result = process_single_dataview(
-            data_view_id="dv_invalid", config_file=mock_config_file, output_dir=temp_output_dir
+            data_view_id="dv_invalid",
+            config_file=mock_config_file,
+            output_dir=temp_output_dir,
         )
 
         assert result.success is False
@@ -278,7 +289,9 @@ class TestProcessSingleDataviewFailures:
         mock_fetcher_class.return_value = mock_fetcher
 
         result = process_single_dataview(
-            data_view_id="dv_test_12345", config_file=mock_config_file, output_dir=temp_output_dir
+            data_view_id="dv_test_12345",
+            config_file=mock_config_file,
+            output_dir=temp_output_dir,
         )
 
         assert result.success is False
@@ -319,14 +332,16 @@ class TestProcessSingleDataviewFailures:
         mock_dq_checker = Mock()
         mock_dq_checker.issues = []
         mock_dq_checker.get_issues_dataframe.return_value = pd.DataFrame(
-            columns=["Severity", "Category", "Type", "Item Name", "Issue", "Details"]
+            columns=["Severity", "Category", "Type", "Item Name", "Issue", "Details"],
         )
         mock_dq_checker_class.return_value = mock_dq_checker
 
         mock_excel_writer.side_effect = PermissionError("File is open")
 
         result = process_single_dataview(
-            data_view_id="dv_test_12345", config_file=mock_config_file, output_dir=temp_output_dir
+            data_view_id="dv_test_12345",
+            config_file=mock_config_file,
+            output_dir=temp_output_dir,
         )
 
         assert result.success is False
@@ -370,14 +385,17 @@ class TestProcessSingleDataviewOutputFormats:
         mock_dq_checker = Mock()
         mock_dq_checker.issues = []
         mock_dq_checker.get_issues_dataframe.return_value = pd.DataFrame(
-            columns=["Severity", "Category", "Type", "Item Name", "Issue", "Details"]
+            columns=["Severity", "Category", "Type", "Item Name", "Issue", "Details"],
         )
         mock_dq_checker_class.return_value = mock_dq_checker
 
         mock_write_csv.return_value = f"{temp_output_dir}/test_csv"
 
         result = process_single_dataview(
-            data_view_id="dv_test_12345", config_file=mock_config_file, output_dir=temp_output_dir, output_format="csv"
+            data_view_id="dv_test_12345",
+            config_file=mock_config_file,
+            output_dir=temp_output_dir,
+            output_format="csv",
         )
 
         assert result.success is True
@@ -417,14 +435,17 @@ class TestProcessSingleDataviewOutputFormats:
         mock_dq_checker = Mock()
         mock_dq_checker.issues = []
         mock_dq_checker.get_issues_dataframe.return_value = pd.DataFrame(
-            columns=["Severity", "Category", "Type", "Item Name", "Issue", "Details"]
+            columns=["Severity", "Category", "Type", "Item Name", "Issue", "Details"],
         )
         mock_dq_checker_class.return_value = mock_dq_checker
 
         mock_write_json.return_value = f"{temp_output_dir}/test.json"
 
         result = process_single_dataview(
-            data_view_id="dv_test_12345", config_file=mock_config_file, output_dir=temp_output_dir, output_format="json"
+            data_view_id="dv_test_12345",
+            config_file=mock_config_file,
+            output_dir=temp_output_dir,
+            output_format="json",
         )
 
         assert result.success is True
@@ -464,14 +485,17 @@ class TestProcessSingleDataviewOutputFormats:
         mock_dq_checker = Mock()
         mock_dq_checker.issues = []
         mock_dq_checker.get_issues_dataframe.return_value = pd.DataFrame(
-            columns=["Severity", "Category", "Type", "Item Name", "Issue", "Details"]
+            columns=["Severity", "Category", "Type", "Item Name", "Issue", "Details"],
         )
         mock_dq_checker_class.return_value = mock_dq_checker
 
         mock_write_html.return_value = f"{temp_output_dir}/test.html"
 
         result = process_single_dataview(
-            data_view_id="dv_test_12345", config_file=mock_config_file, output_dir=temp_output_dir, output_format="html"
+            data_view_id="dv_test_12345",
+            config_file=mock_config_file,
+            output_dir=temp_output_dir,
+            output_format="html",
         )
 
         assert result.success is True
@@ -511,7 +535,7 @@ class TestProcessSingleDataviewOutputFormats:
         mock_dq_checker = Mock()
         mock_dq_checker.issues = []
         mock_dq_checker.get_issues_dataframe.return_value = pd.DataFrame(
-            columns=["Severity", "Category", "Type", "Item Name", "Issue", "Details"]
+            columns=["Severity", "Category", "Type", "Item Name", "Issue", "Details"],
         )
         mock_dq_checker_class.return_value = mock_dq_checker
 
@@ -572,7 +596,7 @@ class TestProcessSingleDataviewCaching:
         mock_dq_checker = Mock()
         mock_dq_checker.issues = []
         mock_dq_checker.get_issues_dataframe.return_value = pd.DataFrame(
-            columns=["Severity", "Category", "Type", "Item Name", "Issue", "Details"]
+            columns=["Severity", "Category", "Type", "Item Name", "Issue", "Details"],
         )
         mock_dq_checker_class.return_value = mock_dq_checker
 
@@ -633,7 +657,7 @@ class TestProcessSingleDataviewCaching:
         mock_dq_checker = Mock()
         mock_dq_checker.issues = []
         mock_dq_checker.get_issues_dataframe.return_value = pd.DataFrame(
-            columns=["Severity", "Category", "Type", "Item Name", "Issue", "Details"]
+            columns=["Severity", "Category", "Type", "Item Name", "Issue", "Details"],
         )
         mock_dq_checker_class.return_value = mock_dq_checker
 
@@ -660,7 +684,10 @@ class TestProcessSingleDataviewWorker:
     def test_worker_unpacks_args(self, mock_process):
         """Test that worker correctly unpacks arguments"""
         expected_result = ProcessingResult(
-            data_view_id="dv_test_12345", data_view_name="Test", success=True, duration=1.0
+            data_view_id="dv_test_12345",
+            data_view_name="Test",
+            success=True,
+            duration=1.0,
         )
         mock_process.return_value = expected_result
 
@@ -750,7 +777,7 @@ class TestProcessSingleDataviewFilenaming:
         mock_dq_checker = Mock()
         mock_dq_checker.issues = []
         mock_dq_checker.get_issues_dataframe.return_value = pd.DataFrame(
-            columns=["Severity", "Category", "Type", "Item Name", "Issue", "Details"]
+            columns=["Severity", "Category", "Type", "Item Name", "Issue", "Details"],
         )
         mock_dq_checker_class.return_value = mock_dq_checker
 
@@ -759,7 +786,9 @@ class TestProcessSingleDataviewFilenaming:
         mock_excel_writer.return_value.__exit__ = Mock(return_value=False)
 
         result = process_single_dataview(
-            data_view_id="dv_test_12345", config_file=mock_config_file, output_dir=temp_output_dir
+            data_view_id="dv_test_12345",
+            config_file=mock_config_file,
+            output_dir=temp_output_dir,
         )
 
         assert result.success is True
@@ -808,7 +837,7 @@ class TestProcessSingleDataviewMaxIssues:
         mock_dq_checker = Mock()
         mock_dq_checker.issues = []
         mock_dq_checker.get_issues_dataframe.return_value = pd.DataFrame(
-            columns=["Severity", "Category", "Type", "Item Name", "Issue", "Details"]
+            columns=["Severity", "Category", "Type", "Item Name", "Issue", "Details"],
         )
         mock_dq_checker_class.return_value = mock_dq_checker
 
@@ -817,7 +846,10 @@ class TestProcessSingleDataviewMaxIssues:
         mock_excel_writer.return_value.__exit__ = Mock(return_value=False)
 
         result = process_single_dataview(
-            data_view_id="dv_test_12345", config_file=mock_config_file, output_dir=temp_output_dir, max_issues=10
+            data_view_id="dv_test_12345",
+            config_file=mock_config_file,
+            output_dir=temp_output_dir,
+            max_issues=10,
         )
 
         assert result.success is True
@@ -931,7 +963,7 @@ class TestProcessSingleDataviewMaxIssues:
         mock_dq_checker.issues = []
         mock_dq_checker.check_all_parallel.side_effect = RuntimeError("unexpected validation failure")
         mock_dq_checker.get_issues_dataframe.return_value = pd.DataFrame(
-            columns=["Severity", "Category", "Type", "Item Name", "Issue", "Details"]
+            columns=["Severity", "Category", "Type", "Item Name", "Issue", "Details"],
         )
         mock_dq_checker_class.return_value = mock_dq_checker
 

--- a/tests/test_profile_management.py
+++ b/tests/test_profile_management.py
@@ -10,14 +10,12 @@ Covers uncovered lines in generator.py:
 
 import json
 import os
-import sys
 import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from cja_auto_sdr.generator import (
     add_profile_interactive,
     import_profile_non_interactive,

--- a/tests/test_profile_management.py
+++ b/tests/test_profile_management.py
@@ -1,0 +1,787 @@
+"""Tests for profile management operations: interactive creation, import, test, show.
+
+Covers uncovered lines in generator.py:
+- add_profile_interactive (lines 1378-1465)
+- import_profile / load_profile_import_source (lines 1524-1543, 1565-1579, 1606-1611)
+- profile operations (lines 1662-1664, 1681)
+- test_profile (lines 1713-1789)
+- show_profile extended paths (lines 1880-1928)
+"""
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from cja_auto_sdr.generator import (
+    add_profile_interactive,
+    import_profile_non_interactive,
+    load_profile_import_source,
+    show_profile,
+)
+from cja_auto_sdr.generator import test_profile as run_test_profile
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+VALID_CREDENTIALS = {
+    "org_id": "ABC123@AdobeOrg",
+    "client_id": "1234567890abcdef1234567890abcdef",
+    "secret": "abcdefghijklmnop1234567890abcdef",
+    "scopes": "openid,AdobeID,read_organizations",
+}
+
+
+def _write_config_json(profile_dir: Path, config: dict | None = None) -> None:
+    """Write a config.json inside *profile_dir* (creating dirs as needed)."""
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    (profile_dir / "config.json").write_text(json.dumps(config or VALID_CREDENTIALS))
+
+
+def _write_dotenv(profile_dir: Path, content: str) -> None:
+    """Write a .env inside *profile_dir* (creating dirs as needed)."""
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    (profile_dir / ".env").write_text(content)
+
+
+# ===========================================================================
+# add_profile_interactive
+# ===========================================================================
+
+
+class TestAddProfileInteractive:
+    """Tests for the interactive profile creation wizard."""
+
+    def test_invalid_profile_name(self, capsys):
+        """Invalid profile name should return False immediately."""
+        result = add_profile_interactive("bad name!")
+        assert result is False
+        captured = capsys.readouterr()
+        assert "Error" in captured.out
+
+    def test_existing_profile_overwrite_declined(self, tmp_path, capsys):
+        """Declining overwrite of existing profile returns False."""
+        profile_dir = tmp_path / "orgs" / "existing"
+        _write_config_json(profile_dir)
+
+        with (
+            patch("cja_auto_sdr.generator.get_profile_path", return_value=profile_dir),
+            patch("builtins.input", return_value="n"),
+        ):
+            result = add_profile_interactive("existing")
+
+        assert result is False
+        captured = capsys.readouterr()
+        assert "already exists" in captured.out
+        assert "Aborted" in captured.out
+
+    def test_existing_profile_overwrite_accepted(self, tmp_path, capsys):
+        """Accepting overwrite proceeds with profile creation flow."""
+        profile_dir = tmp_path / "orgs" / "existing"
+        _write_config_json(profile_dir)
+
+        inputs = iter(["y", "NewOrg@AdobeOrg", "new_client_id", "openid,AdobeID"])
+
+        with (
+            patch("cja_auto_sdr.generator.get_profile_path", return_value=profile_dir),
+            patch("builtins.input", side_effect=inputs),
+            patch("getpass.getpass", return_value="new_secret_value"),
+        ):
+            result = add_profile_interactive("existing")
+
+        assert result is True
+        captured = capsys.readouterr()
+        assert "created successfully" in captured.out
+
+        # Verify config written
+        config = json.loads((profile_dir / "config.json").read_text())
+        assert config["org_id"] == "NewOrg@AdobeOrg"
+        assert config["client_id"] == "new_client_id"
+        assert config["secret"] == "new_secret_value"
+        assert config["scopes"] == "openid,AdobeID"
+
+    def test_successful_creation_new_profile(self, tmp_path, capsys):
+        """Full happy-path creation of a brand new profile."""
+        profile_dir = tmp_path / "orgs" / "new-profile"
+
+        inputs = iter(["MyOrg@AdobeOrg", "my_client_id", "openid"])
+
+        with (
+            patch("cja_auto_sdr.generator.get_profile_path", return_value=profile_dir),
+            patch("builtins.input", side_effect=inputs),
+            patch("getpass.getpass", return_value="my_secret"),
+        ):
+            result = add_profile_interactive("new-profile")
+
+        assert result is True
+        captured = capsys.readouterr()
+        assert "CREATING PROFILE: new-profile" in captured.out
+        assert "created successfully" in captured.out
+        assert "profile-test" in captured.out
+
+        config = json.loads((profile_dir / "config.json").read_text())
+        assert config["org_id"] == "MyOrg@AdobeOrg"
+
+    def test_empty_org_id_aborts(self, tmp_path, capsys):
+        """Empty organization ID causes early exit."""
+        profile_dir = tmp_path / "orgs" / "empty-org"
+
+        with (
+            patch("cja_auto_sdr.generator.get_profile_path", return_value=profile_dir),
+            patch("builtins.input", return_value=""),
+        ):
+            result = add_profile_interactive("empty-org")
+
+        assert result is False
+        captured = capsys.readouterr()
+        assert "Organization ID is required" in captured.out
+
+    def test_empty_client_id_aborts(self, tmp_path, capsys):
+        """Empty client ID causes early exit."""
+        profile_dir = tmp_path / "orgs" / "empty-cid"
+        inputs = iter(["MyOrg@AdobeOrg", ""])
+
+        with (
+            patch("cja_auto_sdr.generator.get_profile_path", return_value=profile_dir),
+            patch("builtins.input", side_effect=inputs),
+        ):
+            result = add_profile_interactive("empty-cid")
+
+        assert result is False
+        captured = capsys.readouterr()
+        assert "Client ID is required" in captured.out
+
+    def test_empty_secret_aborts(self, tmp_path, capsys):
+        """Empty client secret causes early exit."""
+        profile_dir = tmp_path / "orgs" / "empty-secret"
+        inputs = iter(["MyOrg@AdobeOrg", "my_client_id"])
+
+        with (
+            patch("cja_auto_sdr.generator.get_profile_path", return_value=profile_dir),
+            patch("builtins.input", side_effect=inputs),
+            patch("getpass.getpass", return_value=""),
+        ):
+            result = add_profile_interactive("empty-secret")
+
+        assert result is False
+        captured = capsys.readouterr()
+        assert "Client Secret is required" in captured.out
+
+    def test_empty_scopes_aborts(self, tmp_path, capsys):
+        """Empty scopes causes early exit."""
+        profile_dir = tmp_path / "orgs" / "empty-scopes"
+        inputs = iter(["MyOrg@AdobeOrg", "my_client_id", ""])
+
+        with (
+            patch("cja_auto_sdr.generator.get_profile_path", return_value=profile_dir),
+            patch("builtins.input", side_effect=inputs),
+            patch("getpass.getpass", return_value="my_secret"),
+        ):
+            result = add_profile_interactive("empty-scopes")
+
+        assert result is False
+        captured = capsys.readouterr()
+        assert "OAuth Scopes are required" in captured.out
+
+    def test_keyboard_interrupt_aborts(self, tmp_path, capsys):
+        """KeyboardInterrupt during input aborts gracefully."""
+        profile_dir = tmp_path / "orgs" / "interrupted"
+
+        with (
+            patch("cja_auto_sdr.generator.get_profile_path", return_value=profile_dir),
+            patch("builtins.input", side_effect=KeyboardInterrupt),
+        ):
+            result = add_profile_interactive("interrupted")
+
+        assert result is False
+        captured = capsys.readouterr()
+        assert "Aborted" in captured.out
+
+    def test_eoferror_aborts(self, tmp_path, capsys):
+        """EOFError during input aborts gracefully."""
+        profile_dir = tmp_path / "orgs" / "eof"
+
+        with (
+            patch("cja_auto_sdr.generator.get_profile_path", return_value=profile_dir),
+            patch("builtins.input", side_effect=EOFError),
+        ):
+            result = add_profile_interactive("eof")
+
+        assert result is False
+        captured = capsys.readouterr()
+        assert "Aborted" in captured.out
+
+    def test_getpass_warning_aborts(self, tmp_path, capsys):
+        """GetPassWarning should cause graceful abort with guidance."""
+        import getpass
+
+        profile_dir = tmp_path / "orgs" / "no-tty"
+        inputs = iter(["MyOrg@AdobeOrg", "my_client_id"])
+
+        with (
+            patch("cja_auto_sdr.generator.get_profile_path", return_value=profile_dir),
+            patch("builtins.input", side_effect=inputs),
+            patch("getpass.getpass", side_effect=getpass.GetPassWarning("no tty")),
+        ):
+            result = add_profile_interactive("no-tty")
+
+        assert result is False
+        captured = capsys.readouterr()
+        assert "Cannot securely read secret" in captured.out
+
+    def test_mkdir_failure(self, tmp_path, capsys):
+        """OSError during directory creation returns False."""
+        profile_dir = tmp_path / "orgs" / "bad-dir"
+
+        with (
+            patch("cja_auto_sdr.generator.get_profile_path", return_value=profile_dir),
+            patch.object(Path, "exists", return_value=False),
+            patch.object(Path, "mkdir", side_effect=OSError("Permission denied")),
+        ):
+            result = add_profile_interactive("bad-dir")
+
+        assert result is False
+        captured = capsys.readouterr()
+        assert "Error creating profile directory" in captured.out
+
+    def test_config_write_failure(self, tmp_path, capsys):
+        """OSError during config.json write returns False."""
+        profile_dir = tmp_path / "orgs" / "write-fail"
+        # Do NOT create the directory — let the function create it, so it
+        # does not trigger the "already exists" overwrite prompt.
+
+        inputs = iter(["MyOrg@AdobeOrg", "my_client_id", "openid"])
+
+        with (
+            patch("cja_auto_sdr.generator.get_profile_path", return_value=profile_dir),
+            patch("builtins.input", side_effect=inputs),
+            patch("getpass.getpass", return_value="my_secret"),
+            patch("os.open", side_effect=OSError("Disk full")),
+        ):
+            result = add_profile_interactive("write-fail")
+
+        assert result is False
+        captured = capsys.readouterr()
+        assert "Error writing config file" in captured.out
+
+
+# ===========================================================================
+# load_profile_import_source — directory mode
+# ===========================================================================
+
+
+class TestLoadProfileImportSourceDirectory:
+    """Tests for importing from a directory containing config.json / .env files."""
+
+    def test_directory_with_config_json_only(self, tmp_path):
+        """Directory with only config.json should load credentials."""
+        source_dir = tmp_path / "source"
+        _write_config_json(source_dir, VALID_CREDENTIALS)
+
+        result = load_profile_import_source(source_dir)
+        assert result["org_id"] == VALID_CREDENTIALS["org_id"]
+        assert result["client_id"] == VALID_CREDENTIALS["client_id"]
+
+    def test_directory_with_dotenv_only(self, tmp_path):
+        """Directory with only .env should load credentials."""
+        source_dir = tmp_path / "source"
+        source_dir.mkdir(parents=True)
+        _write_dotenv(
+            source_dir,
+            "ORG_ID=Test@AdobeOrg\nCLIENT_ID=abcd1234\nSECRET=secret_val\nSCOPES=openid",
+        )
+
+        result = load_profile_import_source(source_dir)
+        assert result["org_id"] == "Test@AdobeOrg"
+        assert result["client_id"] == "abcd1234"
+
+    def test_directory_with_both_config_and_env(self, tmp_path):
+        """.env values should override config.json when both present."""
+        source_dir = tmp_path / "source"
+        _write_config_json(source_dir, VALID_CREDENTIALS)
+        _write_dotenv(source_dir, "ORG_ID=Override@AdobeOrg")
+
+        result = load_profile_import_source(source_dir)
+        assert result["org_id"] == "Override@AdobeOrg"
+        # Other fields from config.json should still be present
+        assert result["client_id"] == VALID_CREDENTIALS["client_id"]
+
+    def test_directory_empty_raises_valueerror(self, tmp_path):
+        """Empty directory should raise ValueError."""
+        source_dir = tmp_path / "empty_source"
+        source_dir.mkdir(parents=True)
+
+        with pytest.raises(ValueError, match="No credentials found"):
+            load_profile_import_source(source_dir)
+
+    def test_directory_not_found_raises_filenotfounderror(self, tmp_path):
+        """Non-existent directory should raise FileNotFoundError."""
+        with pytest.raises(FileNotFoundError, match="Source not found"):
+            load_profile_import_source(tmp_path / "nonexistent")
+
+    def test_directory_with_nested_credentials_key(self, tmp_path):
+        """config.json with top-level 'credentials' dict should be unwrapped."""
+        source_dir = tmp_path / "nested"
+        source_dir.mkdir(parents=True)
+        config = {"credentials": VALID_CREDENTIALS}
+        (source_dir / "config.json").write_text(json.dumps(config))
+
+        result = load_profile_import_source(source_dir)
+        assert result["org_id"] == VALID_CREDENTIALS["org_id"]
+
+    def test_directory_config_json_invalid_type(self, tmp_path):
+        """config.json that's not a dict should raise ValueError."""
+        source_dir = tmp_path / "bad_config"
+        source_dir.mkdir(parents=True)
+        (source_dir / "config.json").write_text(json.dumps(["not", "a", "dict"]))
+
+        with pytest.raises(ValueError, match="expected JSON object"):
+            load_profile_import_source(source_dir)
+
+    def test_json_file_with_credentials_key(self, tmp_path):
+        """JSON file with 'credentials' key should unwrap."""
+        source = tmp_path / "wrapped.json"
+        source.write_text(json.dumps({"credentials": VALID_CREDENTIALS}))
+
+        result = load_profile_import_source(source)
+        assert result["org_id"] == VALID_CREDENTIALS["org_id"]
+
+    def test_json_file_invalid_type(self, tmp_path):
+        """JSON file that's not a dict should raise ValueError."""
+        source = tmp_path / "bad.json"
+        source.write_text(json.dumps("just a string"))
+
+        with pytest.raises(ValueError, match="must be an object"):
+            load_profile_import_source(source)
+
+    def test_env_file_with_no_recognized_fields(self, tmp_path):
+        """Env file with no recognized fields should raise ValueError."""
+        source = tmp_path / "empty.env"
+        source.write_text("# only a comment\n")
+
+        with pytest.raises(ValueError, match="No supported credential fields"):
+            load_profile_import_source(source)
+
+
+# ===========================================================================
+# import_profile_non_interactive — extended paths
+# ===========================================================================
+
+
+class TestImportProfileNonInteractiveExtended:
+    """Extended tests for non-interactive import covering validation, errors."""
+
+    def test_invalid_name_rejects(self, capsys):
+        """Invalid profile name should be rejected."""
+        result = import_profile_non_interactive("bad name!", "/some/file.json")
+        assert result is False
+        captured = capsys.readouterr()
+        assert "Error" in captured.out
+
+    def test_source_file_not_found(self, tmp_path, capsys):
+        """Non-existent source file returns False with error message."""
+        profile_dir = tmp_path / "orgs" / "test-profile"
+
+        with patch("cja_auto_sdr.generator.get_profile_path", return_value=profile_dir):
+            result = import_profile_non_interactive("test-profile", tmp_path / "missing.json")
+
+        assert result is False
+        captured = capsys.readouterr()
+        assert "Error loading profile import source" in captured.out
+
+    def test_overwrite_existing_profile(self, tmp_path, capsys):
+        """Overwrite=True should replace an existing profile."""
+        source = tmp_path / "credentials.json"
+        source.write_text(json.dumps(VALID_CREDENTIALS))
+
+        profile_dir = tmp_path / "orgs" / "existing"
+        _write_config_json(profile_dir, {"org_id": "Old@AdobeOrg", "client_id": "old", "secret": "old"})
+
+        with patch("cja_auto_sdr.generator.get_profile_path", return_value=profile_dir):
+            result = import_profile_non_interactive("existing", source, overwrite=True)
+
+        assert result is True
+        config = json.loads((profile_dir / "config.json").read_text())
+        assert config["org_id"] == VALID_CREDENTIALS["org_id"]
+
+    def test_overwrite_warns_about_existing_dotenv(self, tmp_path, capsys):
+        """Overwrite with existing .env should warn about potential conflicts."""
+        source = tmp_path / "credentials.json"
+        source.write_text(json.dumps(VALID_CREDENTIALS))
+
+        profile_dir = tmp_path / "orgs" / "with-env"
+        _write_config_json(profile_dir, {"org_id": "Old@AdobeOrg", "client_id": "old", "secret": "old"})
+        _write_dotenv(profile_dir, "ORG_ID=EnvOrg@AdobeOrg")
+
+        with patch("cja_auto_sdr.generator.get_profile_path", return_value=profile_dir):
+            result = import_profile_non_interactive("with-env", source, overwrite=True)
+
+        assert result is True
+        captured = capsys.readouterr()
+        assert "Warning" in captured.out
+        assert ".env" in captured.out
+
+    def test_write_oserror(self, tmp_path, capsys):
+        """OSError during config write returns False."""
+        source = tmp_path / "credentials.json"
+        source.write_text(json.dumps(VALID_CREDENTIALS))
+
+        profile_dir = tmp_path / "orgs" / "bad-write"
+
+        with (
+            patch("cja_auto_sdr.generator.get_profile_path", return_value=profile_dir),
+            patch("os.open", side_effect=OSError("Permission denied")),
+        ):
+            result = import_profile_non_interactive("bad-write", source)
+
+        assert result is False
+        captured = capsys.readouterr()
+        assert "Error writing profile config" in captured.out
+
+    def test_validation_failure(self, tmp_path, capsys):
+        """Credentials that fail strict validation should be rejected."""
+        source = tmp_path / "credentials.json"
+        source.write_text(
+            json.dumps(
+                {
+                    "org_id": "not_adobe_format",
+                    "client_id": "x",
+                    "secret": "y",
+                    "scopes": "openid",
+                },
+            ),
+        )
+
+        profile_dir = tmp_path / "orgs" / "bad-creds"
+
+        with patch("cja_auto_sdr.generator.get_profile_path", return_value=profile_dir):
+            result = import_profile_non_interactive("bad-creds", source)
+
+        assert result is False
+        captured = capsys.readouterr()
+        assert "failed validation" in captured.out
+
+    def test_success_message_includes_source_and_location(self, tmp_path, capsys):
+        """Successful import prints source path and profile location."""
+        source = tmp_path / "credentials.json"
+        source.write_text(json.dumps(VALID_CREDENTIALS))
+
+        profile_dir = tmp_path / "orgs" / "new-import"
+
+        with patch("cja_auto_sdr.generator.get_profile_path", return_value=profile_dir):
+            result = import_profile_non_interactive("new-import", source)
+
+        assert result is True
+        captured = capsys.readouterr()
+        assert "imported successfully" in captured.out
+        assert "Source:" in captured.out
+        assert "Location:" in captured.out
+        assert "profile-test" in captured.out
+
+
+# ===========================================================================
+# test_profile — connectivity test
+# ===========================================================================
+
+
+class TestTestProfile:
+    """Tests for the profile connectivity test function."""
+
+    def test_profile_not_found(self, tmp_path, capsys):
+        """Non-existent profile should fail with FAILED message."""
+        nonexistent = tmp_path / "orgs" / "nonexistent"
+
+        with patch("cja_auto_sdr.generator.get_profile_path", return_value=nonexistent):
+            result = run_test_profile("nonexistent")
+
+        assert result is False
+        captured = capsys.readouterr()
+        assert "FAILED" in captured.out
+
+    def test_profile_config_error(self, tmp_path, capsys):
+        """Profile with config error should fail with FAILED message."""
+        profile_dir = tmp_path / "orgs" / "bad-config"
+        profile_dir.mkdir(parents=True)
+        # Empty directory = no config files => ProfileConfigError
+
+        with patch("cja_auto_sdr.generator.get_profile_path", return_value=profile_dir):
+            result = run_test_profile("bad-config")
+
+        assert result is False
+        captured = capsys.readouterr()
+        assert "FAILED" in captured.out
+
+    def test_successful_api_connection(self, tmp_path, capsys):
+        """Successful API test should return True with SUCCESS."""
+        profile_dir = tmp_path / "orgs" / "good"
+        _write_config_json(profile_dir)
+
+        mock_cja_instance = MagicMock()
+        mock_cja_instance.getDataViews.return_value = [
+            {"id": "dv1", "name": "DataView 1"},
+            {"id": "dv2", "name": "DataView 2"},
+        ]
+
+        with (
+            patch("cja_auto_sdr.generator.get_profile_path", return_value=profile_dir),
+            patch("cja_auto_sdr.generator.cjapy") as mock_cjapy,
+            patch("cja_auto_sdr.generator.ConfigValidator") as mock_validator,
+        ):
+            mock_cjapy.CJA.return_value = mock_cja_instance
+            mock_validator.validate_all.return_value = []
+            result = run_test_profile("good")
+
+        assert result is True
+        captured = capsys.readouterr()
+        assert "TESTING PROFILE: good" in captured.out
+        assert "Profile found and loaded" in captured.out
+        assert "Credential validation: OK" in captured.out
+        assert "API connection: SUCCESS" in captured.out
+        assert "Data views accessible: 2" in captured.out
+        assert "Profile test: PASSED" in captured.out
+
+    def test_api_connection_with_none_dataviews(self, tmp_path, capsys):
+        """API returning None for data views should still pass."""
+        profile_dir = tmp_path / "orgs" / "none-dv"
+        _write_config_json(profile_dir)
+
+        mock_cja_instance = MagicMock()
+        mock_cja_instance.getDataViews.return_value = None
+
+        with (
+            patch("cja_auto_sdr.generator.get_profile_path", return_value=profile_dir),
+            patch("cja_auto_sdr.generator.cjapy") as mock_cjapy,
+            patch("cja_auto_sdr.generator.ConfigValidator") as mock_validator,
+        ):
+            mock_cjapy.CJA.return_value = mock_cja_instance
+            mock_validator.validate_all.return_value = []
+            result = run_test_profile("none-dv")
+
+        assert result is True
+        captured = capsys.readouterr()
+        assert "no data views found" in captured.out
+        assert "Profile test: PASSED" in captured.out
+
+    def test_api_connection_failure(self, tmp_path, capsys):
+        """API connection failure should return False with helpful message."""
+        profile_dir = tmp_path / "orgs" / "api-fail"
+        _write_config_json(profile_dir)
+
+        with (
+            patch("cja_auto_sdr.generator.get_profile_path", return_value=profile_dir),
+            patch("cja_auto_sdr.generator.cjapy") as mock_cjapy,
+            patch("cja_auto_sdr.generator.ConfigValidator") as mock_validator,
+        ):
+            mock_cjapy.importConfigFile.side_effect = Exception("Connection refused")
+            mock_validator.validate_all.return_value = []
+            result = run_test_profile("api-fail")
+
+        assert result is False
+        captured = capsys.readouterr()
+        assert "API connection: FAILED" in captured.out
+        assert "Connection refused" in captured.out
+        assert "Profile test: FAILED" in captured.out
+        assert "Common issues:" in captured.out
+
+    def test_validation_warnings_displayed(self, tmp_path, capsys):
+        """Validation warnings should be displayed but not block the test."""
+        profile_dir = tmp_path / "orgs" / "warnings"
+        _write_config_json(profile_dir)
+
+        mock_cja_instance = MagicMock()
+        mock_cja_instance.getDataViews.return_value = []
+
+        with (
+            patch("cja_auto_sdr.generator.get_profile_path", return_value=profile_dir),
+            patch("cja_auto_sdr.generator.cjapy") as mock_cjapy,
+            patch("cja_auto_sdr.generator.ConfigValidator") as mock_validator,
+        ):
+            mock_cjapy.CJA.return_value = mock_cja_instance
+            mock_validator.validate_all.return_value = ["org_id format looks unusual"]
+            result = run_test_profile("warnings")
+
+        assert result is True
+        captured = capsys.readouterr()
+        assert "Credential validation: WARNINGS" in captured.out
+        assert "org_id format looks unusual" in captured.out
+
+    def test_cja_constructor_failure(self, tmp_path, capsys):
+        """CJA() constructor exception should be caught."""
+        profile_dir = tmp_path / "orgs" / "cja-fail"
+        _write_config_json(profile_dir)
+
+        with (
+            patch("cja_auto_sdr.generator.get_profile_path", return_value=profile_dir),
+            patch("cja_auto_sdr.generator.cjapy") as mock_cjapy,
+            patch("cja_auto_sdr.generator.ConfigValidator") as mock_validator,
+        ):
+            mock_cjapy.importConfigFile.return_value = None
+            mock_cjapy.CJA.side_effect = Exception("Auth failed: invalid credentials")
+            mock_validator.validate_all.return_value = []
+            result = run_test_profile("cja-fail")
+
+        assert result is False
+        captured = capsys.readouterr()
+        assert "FAILED" in captured.out
+        assert "invalid credentials" in captured.out
+
+    def test_temp_file_cleaned_up_on_success(self, tmp_path):
+        """Temp config file should be cleaned up after successful test."""
+        profile_dir = tmp_path / "orgs" / "cleanup"
+        _write_config_json(profile_dir)
+
+        mock_cja_instance = MagicMock()
+        mock_cja_instance.getDataViews.return_value = [{"id": "dv1"}]
+
+        created_files = []
+        original_named_temp = tempfile.NamedTemporaryFile
+
+        def tracking_temp(**kwargs):
+            f = original_named_temp(**kwargs)
+            created_files.append(f.name)
+            return f
+
+        with (
+            patch("cja_auto_sdr.generator.get_profile_path", return_value=profile_dir),
+            patch("cja_auto_sdr.generator.cjapy") as mock_cjapy,
+            patch("cja_auto_sdr.generator.ConfigValidator") as mock_validator,
+            patch("cja_auto_sdr.generator.tempfile.NamedTemporaryFile", side_effect=tracking_temp),
+        ):
+            mock_cjapy.CJA.return_value = mock_cja_instance
+            mock_validator.validate_all.return_value = []
+            run_test_profile("cleanup")
+
+        # Temp file should have been unlinked
+        for path in created_files:
+            assert not os.path.exists(path), f"Temp file not cleaned up: {path}"
+
+
+# ===========================================================================
+# show_profile — extended paths
+# ===========================================================================
+
+
+class TestShowProfileExtended:
+    """Extended show_profile tests covering error branches and display details."""
+
+    def test_show_profile_config_error(self, tmp_path, capsys):
+        """ProfileConfigError path should print error and return False."""
+        profile_dir = tmp_path / "orgs" / "bad-config"
+        profile_dir.mkdir(parents=True)
+        # Empty dir triggers ProfileConfigError
+
+        with patch("cja_auto_sdr.generator.get_profile_path", return_value=profile_dir):
+            result = show_profile("bad-config")
+
+        assert result is False
+        captured = capsys.readouterr()
+        assert "Error" in captured.out
+
+    def test_show_profile_not_found(self, tmp_path, capsys):
+        """ProfileNotFoundError path should print error and return False."""
+        nonexistent = tmp_path / "orgs" / "missing"
+
+        with patch("cja_auto_sdr.generator.get_profile_path", return_value=nonexistent):
+            result = show_profile("missing")
+
+        assert result is False
+        captured = capsys.readouterr()
+        assert "Error" in captured.out
+
+    def test_show_profile_with_both_sources(self, tmp_path, capsys):
+        """Profile with config.json and .env should list both sources."""
+        profile_dir = tmp_path / "orgs" / "both-sources"
+        _write_config_json(profile_dir)
+        _write_dotenv(profile_dir, "ORG_ID=Test@AdobeOrg")
+
+        with patch("cja_auto_sdr.generator.get_profile_path", return_value=profile_dir):
+            result = show_profile("both-sources")
+
+        assert result is True
+        captured = capsys.readouterr()
+        assert "config.json" in captured.out
+        assert ".env" in captured.out
+        assert "Sources:" in captured.out
+
+    def test_show_profile_masks_sensitive_fields(self, tmp_path, capsys):
+        """Sensitive fields (client_id, secret) should be masked in output."""
+        profile_dir = tmp_path / "orgs" / "masked"
+        _write_config_json(
+            profile_dir,
+            {
+                "org_id": "ShowOrg@AdobeOrg",
+                "client_id": "1234567890abcdef1234567890abcdef",
+                "secret": "secret_value_that_is_long_enough",
+                "scopes": "openid,AdobeID",
+            },
+        )
+
+        with patch("cja_auto_sdr.generator.get_profile_path", return_value=profile_dir):
+            result = show_profile("masked")
+
+        assert result is True
+        captured = capsys.readouterr()
+        # org_id is NOT sensitive, should appear in full
+        assert "ShowOrg@AdobeOrg" in captured.out
+        # scopes is NOT sensitive, should appear in full
+        assert "openid,AdobeID" in captured.out
+        # The full secret should NOT appear
+        assert "secret_value_that_is_long_enough" not in captured.out
+        # The full client_id should NOT appear
+        assert "1234567890abcdef1234567890abcdef" not in captured.out
+        # But partial display should appear (first 4 chars)
+        assert "1234" in captured.out
+
+    def test_show_profile_displays_banner(self, tmp_path, capsys):
+        """show_profile should display a banner with profile name."""
+        profile_dir = tmp_path / "orgs" / "banner-test"
+        _write_config_json(profile_dir)
+
+        with patch("cja_auto_sdr.generator.get_profile_path", return_value=profile_dir):
+            result = show_profile("banner-test")
+
+        assert result is True
+        captured = capsys.readouterr()
+        assert "PROFILE: banner-test" in captured.out
+        assert "Location:" in captured.out
+        assert "Credentials:" in captured.out
+
+    def test_show_profile_with_sandbox(self, tmp_path, capsys):
+        """Profile with sandbox field should display it."""
+        profile_dir = tmp_path / "orgs" / "sandbox-test"
+        creds = dict(VALID_CREDENTIALS)
+        creds["sandbox"] = "prod"
+        _write_config_json(profile_dir, creds)
+
+        with patch("cja_auto_sdr.generator.get_profile_path", return_value=profile_dir):
+            result = show_profile("sandbox-test")
+
+        assert result is True
+        captured = capsys.readouterr()
+        assert "sandbox" in captured.out
+        assert "prod" in captured.out
+
+    def test_show_profile_env_only(self, tmp_path, capsys):
+        """Profile with only .env should list only .env as source."""
+        profile_dir = tmp_path / "orgs" / "env-only"
+        profile_dir.mkdir(parents=True)
+        _write_dotenv(
+            profile_dir,
+            "ORG_ID=Env@AdobeOrg\nCLIENT_ID=env_client_1234567890ab\nSECRET=env_secret_1234567890ab\nSCOPES=openid",
+        )
+
+        with patch("cja_auto_sdr.generator.get_profile_path", return_value=profile_dir):
+            result = show_profile("env-only")
+
+        assert result is True
+        captured = capsys.readouterr()
+        assert ".env" in captured.out
+        # Should NOT mention config.json in sources
+        # (It may mention it elsewhere as "Sources: .env")
+        assert "Env@AdobeOrg" in captured.out

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -447,8 +447,8 @@ class TestProfileImport:
                     "clientId": "1234567890abcdef1234567890abcdef",
                     "client_secret": "abcdefghijklmnop1234567890",
                     "scopes": "openid,AdobeID,read_organizations",
-                }
-            )
+                },
+            ),
         )
 
         credentials = load_profile_import_source(source)
@@ -466,8 +466,8 @@ class TestProfileImport:
                     "CLIENT_ID=1234567890abcdef1234567890abcdef",
                     "SECRET=abcdefghijklmnop1234567890",
                     "SCOPES=openid,AdobeID",
-                ]
-            )
+                ],
+            ),
         )
 
         credentials = load_profile_import_source(source)
@@ -486,8 +486,8 @@ class TestProfileImport:
                     "client_id": "1234567890abcdef1234567890abcdef",
                     "secret": "abcdefghijklmnop1234567890",
                     "scopes": "openid,AdobeID",
-                }
-            )
+                },
+            ),
         )
 
         profile_dir = tmp_path / "orgs" / "client-a"
@@ -511,8 +511,8 @@ class TestProfileImport:
                     "org_id": "new@AdobeOrg",
                     "client_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                     "secret": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-                }
-            )
+                },
+            ),
         )
 
         profile_dir = tmp_path / "orgs" / "client-a"
@@ -524,8 +524,8 @@ class TestProfileImport:
                     "org_id": "existing@AdobeOrg",
                     "client_id": "existing_client",
                     "secret": "existing_secret",
-                }
-            )
+                },
+            ),
         )
 
         with patch("cja_auto_sdr.generator.get_profile_path", return_value=profile_dir):
@@ -544,8 +544,8 @@ class TestProfileImport:
                     "client_id": "1234567890abcdef1234567890abcdef",
                     "secret": "abcdefghijklmnop1234567890",
                     "scopes": "openid,AdobeID",
-                }
-            )
+                },
+            ),
         )
 
         profile_dir = tmp_path / "orgs" / "client-a"

--- a/tests/test_quality_policy_and_run_summary.py
+++ b/tests/test_quality_policy_and_run_summary.py
@@ -267,7 +267,9 @@ class TestApplyQualityPolicyDefaults:
         args = argparse.Namespace(fail_on_quality="HIGH", quality_report=None)
         policy = {"fail_on_quality": "LOW"}
         applied = apply_quality_policy_defaults(
-            args, policy, argv=["cja_auto_sdr", "--fail-on-quality", "HIGH", "dv_123"]
+            args,
+            policy,
+            argv=["cja_auto_sdr", "--fail-on-quality", "HIGH", "dv_123"],
         )
         # CLI flag was specified so policy should NOT override
         assert args.fail_on_quality == "HIGH"

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -186,7 +186,7 @@ class TestMakeApiCallWithRetry:
     def test_api_call_with_retry(self):
         """Test API call retries on network error"""
         mock_api = Mock(
-            side_effect=[ConnectionError("Network error"), ConnectionError("Network error"), {"data": "success"}]
+            side_effect=[ConnectionError("Network error"), ConnectionError("Network error"), {"data": "success"}],
         )
 
         with patch("time.sleep"):  # Skip actual delays

--- a/tests/test_shared_cache.py
+++ b/tests/test_shared_cache.py
@@ -45,7 +45,7 @@ def sample_metrics_df():
             "name": ["Metric One", "Metric Two", "Metric Three"],
             "type": ["calculated", "standard", "calculated"],
             "description": ["First metric", "Second metric", "Third metric"],
-        }
+        },
     )
 
 
@@ -58,7 +58,7 @@ def sample_dimensions_df():
             "name": ["Dimension One", "Dimension Two"],
             "type": ["standard", "standard"],
             "description": ["First dimension", "Second dimension"],
-        }
+        },
     )
 
 
@@ -70,7 +70,10 @@ class TestSharedValidationCacheBasics:
         cache = SharedValidationCache(max_size=100, ttl_seconds=3600)
 
         result, cache_key = cache.get(
-            sample_metrics_df, "Metrics", ["id", "name", "type"], ["id", "name", "description"]
+            sample_metrics_df,
+            "Metrics",
+            ["id", "name", "type"],
+            ["id", "name", "description"],
         )
 
         assert result is None
@@ -87,19 +90,30 @@ class TestSharedValidationCacheBasics:
 
         # First call - miss
         result, cache_key = cache.get(
-            sample_metrics_df, "Metrics", ["id", "name", "type"], ["id", "name", "description"]
+            sample_metrics_df,
+            "Metrics",
+            ["id", "name", "type"],
+            ["id", "name", "description"],
         )
         assert result is None
 
         # Store result
         issues = [{"severity": "LOW", "message": "Test issue"}]
         cache.put(
-            sample_metrics_df, "Metrics", ["id", "name", "type"], ["id", "name", "description"], issues, cache_key
+            sample_metrics_df,
+            "Metrics",
+            ["id", "name", "type"],
+            ["id", "name", "description"],
+            issues,
+            cache_key,
         )
 
         # Second call - hit
         result2, _cache_key2 = cache.get(
-            sample_metrics_df, "Metrics", ["id", "name", "type"], ["id", "name", "description"]
+            sample_metrics_df,
+            "Metrics",
+            ["id", "name", "type"],
+            ["id", "name", "description"],
         )
 
         assert result2 is not None

--- a/tests/test_snapshot_commands.py
+++ b/tests/test_snapshot_commands.py
@@ -1,0 +1,1462 @@
+"""Tests for snapshot creation, comparison, and name resolution commands.
+
+Covers:
+- handle_snapshot_command (lines 12593-12678)
+- handle_diff_snapshot_command (lines 12991-13373)
+- handle_compare_snapshots_command (lines 13376-13605)
+- Snapshot dispatch and name resolution in main() (lines 14263-14786)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cja_auto_sdr.diff.models import (
+    DataViewSnapshot,
+    DiffResult,
+    DiffSummary,
+    MetadataDiff,
+)
+from cja_auto_sdr.generator import (
+    _known_long_options,
+    handle_compare_snapshots_command,
+    handle_diff_snapshot_command,
+    handle_snapshot_command,
+    resolve_data_view_names,
+)
+from cja_auto_sdr.generator import (
+    parse_arguments as _real_parse_arguments,
+)
+
+# Warm the lru_cache on _known_long_options before any @patch on parse_arguments
+# can interfere.  The cached frozenset is used by _cli_option_value /
+# _cli_option_specified inside main() and _main_impl().
+_known_long_options()
+
+# ==================== Helpers ====================
+
+
+def _make_snapshot(**overrides) -> DataViewSnapshot:
+    """Build a minimal DataViewSnapshot with sensible defaults."""
+    defaults = {
+        "data_view_id": "dv_test",
+        "data_view_name": "Test DV",
+        "owner": "owner@test.com",
+        "description": "desc",
+        "metrics": [{"id": "m1", "name": "Metric A"}],
+        "dimensions": [{"id": "d1", "name": "Dim A"}],
+        "created_at": "2025-06-01T00:00:00+00:00",
+    }
+    defaults.update(overrides)
+    return DataViewSnapshot(**defaults)
+
+
+def _make_diff_result(has_changes: bool = False, change_pct: float = 0.0) -> DiffResult:
+    """Build a minimal DiffResult for mocking."""
+    summary = DiffSummary(
+        source_metrics_count=10,
+        target_metrics_count=10,
+        source_dimensions_count=5,
+        target_dimensions_count=5,
+        metrics_added=1 if has_changes else 0,
+    )
+    metadata = MetadataDiff(
+        source_name="Source DV",
+        target_name="Target DV",
+        source_id="dv_src",
+        target_id="dv_tgt",
+    )
+    return DiffResult(
+        summary=summary,
+        metadata_diff=metadata,
+        metric_diffs=[],
+        dimension_diffs=[],
+    )
+
+
+def _write_snapshot_file(path, snapshot: DataViewSnapshot | None = None):
+    """Write a snapshot JSON to disk."""
+    if snapshot is None:
+        snapshot = _make_snapshot()
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(snapshot.to_dict(), f)
+
+
+# ==================== handle_snapshot_command ====================
+
+
+class TestHandleSnapshotCommand:
+    """Tests for handle_snapshot_command — snapshot creation flow."""
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_successful_snapshot_creation(self, mock_configure, mock_cjapy, tmp_path, capsys):
+        """Snapshot creation succeeds and writes file."""
+        mock_configure.return_value = (True, "config", None)
+        mock_cja = MagicMock()
+        mock_cjapy.CJA.return_value = mock_cja
+        mock_cja.getDataView.return_value = {
+            "name": "My Data View",
+            "owner": {"name": "admin"},
+            "description": "A test data view",
+        }
+        mock_cja.getMetrics.return_value = MagicMock(
+            empty=False, to_dict=MagicMock(return_value=[{"id": "m1", "name": "M1"}])
+        )
+        mock_cja.getDimensions.return_value = MagicMock(
+            empty=False, to_dict=MagicMock(return_value=[{"id": "d1", "name": "D1"}])
+        )
+
+        out_file = str(tmp_path / "snap.json")
+        result = handle_snapshot_command(
+            data_view_id="dv_123",
+            snapshot_file=out_file,
+            config_file="config.json",
+            quiet=False,
+        )
+
+        assert result is True
+        assert os.path.exists(out_file)
+
+        with open(out_file, encoding="utf-8") as f:
+            data = json.load(f)
+        assert data["data_view_id"] == "dv_123"
+        assert data["data_view_name"] == "My Data View"
+
+        captured = capsys.readouterr()
+        assert "SNAPSHOT CREATED SUCCESSFULLY" in captured.out
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_snapshot_quiet_mode(self, mock_configure, mock_cjapy, tmp_path, capsys):
+        """Quiet mode suppresses progress output."""
+        mock_configure.return_value = (True, "config", None)
+        mock_cja = MagicMock()
+        mock_cjapy.CJA.return_value = mock_cja
+        mock_cja.getDataView.return_value = {"name": "DV", "owner": "o", "description": ""}
+        mock_cja.getMetrics.return_value = MagicMock(empty=False, to_dict=MagicMock(return_value=[]))
+        mock_cja.getDimensions.return_value = MagicMock(empty=False, to_dict=MagicMock(return_value=[]))
+
+        out_file = str(tmp_path / "snap.json")
+        result = handle_snapshot_command(
+            data_view_id="dv_123",
+            snapshot_file=out_file,
+            quiet=True,
+        )
+
+        assert result is True
+        captured = capsys.readouterr()
+        assert "SNAPSHOT CREATED SUCCESSFULLY" not in captured.out
+        assert "CREATING DATA VIEW SNAPSHOT" not in captured.out
+
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_configuration_failure(self, mock_configure, tmp_path, capsys):
+        """Returns False when CJA configuration fails."""
+        mock_configure.return_value = (False, "Missing credentials", None)
+
+        out_file = str(tmp_path / "snap.json")
+        result = handle_snapshot_command(
+            data_view_id="dv_123",
+            snapshot_file=out_file,
+        )
+
+        assert result is False
+        captured = capsys.readouterr()
+        assert "Configuration failed" in captured.err
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_snapshot_with_inventory_flags(self, mock_configure, mock_cjapy, tmp_path, capsys):
+        """Snapshot creation includes inventory info in banner."""
+        mock_configure.return_value = (True, "config", None)
+        mock_cja = MagicMock()
+        mock_cjapy.CJA.return_value = mock_cja
+        mock_cja.getDataView.return_value = {"name": "DV", "owner": "o", "description": ""}
+        mock_cja.getMetrics.return_value = MagicMock(
+            empty=False, to_dict=MagicMock(return_value=[{"id": "m1", "name": "M1"}])
+        )
+        mock_cja.getDimensions.return_value = MagicMock(empty=False, to_dict=MagicMock(return_value=[]))
+
+        out_file = str(tmp_path / "snap.json")
+        result = handle_snapshot_command(
+            data_view_id="dv_123",
+            snapshot_file=out_file,
+            include_calculated_metrics=True,
+            include_segments=True,
+        )
+
+        assert result is True
+        captured = capsys.readouterr()
+        assert "calculated metrics" in captured.out
+        assert "segments" in captured.out
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_snapshot_general_exception(self, mock_configure, mock_cjapy, tmp_path, capsys):
+        """Returns False on unexpected exception."""
+        mock_configure.return_value = (True, "config", None)
+        mock_cjapy.CJA.side_effect = RuntimeError("API down")
+
+        out_file = str(tmp_path / "snap.json")
+        result = handle_snapshot_command(
+            data_view_id="dv_123",
+            snapshot_file=out_file,
+        )
+
+        assert result is False
+        captured = capsys.readouterr()
+        assert "Failed to create snapshot" in captured.err
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_snapshot_with_profile(self, mock_configure, mock_cjapy, tmp_path):
+        """Profile parameter is passed to configure_cjapy."""
+        mock_configure.return_value = (True, "config", None)
+        mock_cja = MagicMock()
+        mock_cjapy.CJA.return_value = mock_cja
+        mock_cja.getDataView.return_value = {"name": "DV", "owner": "o", "description": ""}
+        mock_cja.getMetrics.return_value = MagicMock(empty=False, to_dict=MagicMock(return_value=[]))
+        mock_cja.getDimensions.return_value = MagicMock(empty=False, to_dict=MagicMock(return_value=[]))
+
+        out_file = str(tmp_path / "snap.json")
+        handle_snapshot_command(
+            data_view_id="dv_123",
+            snapshot_file=out_file,
+            profile="staging",
+        )
+
+        mock_configure.assert_called_once_with(
+            profile="staging", config_file="config.json", logger=mock_configure.call_args[1]["logger"]
+        )
+
+
+# ==================== handle_compare_snapshots_command ====================
+
+
+class TestHandleCompareSnapshotsCommand:
+    """Tests for handle_compare_snapshots_command — offline snapshot comparison."""
+
+    def test_compare_identical_snapshots(self, tmp_path, capsys):
+        """Comparing identical snapshots reports no changes."""
+        source = _make_snapshot(data_view_id="dv_A", data_view_name="DV A")
+        target = _make_snapshot(data_view_id="dv_B", data_view_name="DV B")
+
+        src_file = str(tmp_path / "source.json")
+        tgt_file = str(tmp_path / "target.json")
+        _write_snapshot_file(src_file, source)
+        _write_snapshot_file(tgt_file, target)
+
+        success, _has_changes, _exit_code = handle_compare_snapshots_command(
+            source_file=src_file,
+            target_file=tgt_file,
+            quiet=True,
+            quiet_diff=True,
+        )
+
+        assert success is True
+
+    def test_compare_snapshots_file_not_found(self, tmp_path, capsys):
+        """Returns failure when snapshot file is missing."""
+        src_file = str(tmp_path / "source.json")
+        _write_snapshot_file(src_file)
+
+        success, _has_changes, _exit_code = handle_compare_snapshots_command(
+            source_file=src_file,
+            target_file=str(tmp_path / "nonexistent.json"),
+            quiet=True,
+        )
+
+        assert success is False
+        captured = capsys.readouterr()
+        assert "Snapshot file not found" in captured.err
+
+    def test_compare_snapshots_invalid_file(self, tmp_path, capsys):
+        """Returns failure for invalid snapshot file (missing snapshot_version)."""
+        src_file = str(tmp_path / "source.json")
+        _write_snapshot_file(src_file)
+
+        invalid_file = str(tmp_path / "invalid.json")
+        with open(invalid_file, "w", encoding="utf-8") as f:
+            json.dump({"not_a_snapshot": True}, f)
+
+        success, _has_changes, _exit_code = handle_compare_snapshots_command(
+            source_file=src_file,
+            target_file=invalid_file,
+            quiet=True,
+        )
+
+        assert success is False
+        captured = capsys.readouterr()
+        assert "Invalid snapshot file" in captured.err
+
+    def test_compare_snapshots_with_banner(self, tmp_path, capsys):
+        """Non-quiet mode prints comparison banner."""
+        source = _make_snapshot(data_view_id="dv_A", data_view_name="DV A")
+        target = _make_snapshot(data_view_id="dv_B", data_view_name="DV B")
+
+        src_file = str(tmp_path / "source.json")
+        tgt_file = str(tmp_path / "target.json")
+        _write_snapshot_file(src_file, source)
+        _write_snapshot_file(tgt_file, target)
+
+        success, _has_changes, _exit_code = handle_compare_snapshots_command(
+            source_file=src_file,
+            target_file=tgt_file,
+            quiet=False,
+            quiet_diff=False,
+            output_format="console",
+            no_color=True,
+        )
+
+        assert success is True
+        captured = capsys.readouterr()
+        assert "COMPARING TWO SNAPSHOTS" in captured.out
+        assert "Source:" in captured.out
+        assert "Target:" in captured.out
+
+    def test_compare_snapshots_reverse_diff(self, tmp_path, capsys):
+        """Reverse diff swaps source and target."""
+        source = _make_snapshot(
+            data_view_id="dv_A",
+            data_view_name="DV A",
+            metrics=[{"id": "m1", "name": "Metric A"}],
+        )
+        target = _make_snapshot(
+            data_view_id="dv_B",
+            data_view_name="DV B",
+            metrics=[{"id": "m1", "name": "Metric A"}, {"id": "m2", "name": "Metric B"}],
+        )
+
+        src_file = str(tmp_path / "source.json")
+        tgt_file = str(tmp_path / "target.json")
+        _write_snapshot_file(src_file, source)
+        _write_snapshot_file(tgt_file, target)
+
+        success, _has_changes, _exit_code = handle_compare_snapshots_command(
+            source_file=src_file,
+            target_file=tgt_file,
+            reverse_diff=True,
+            quiet=False,
+            quiet_diff=False,
+            output_format="console",
+            no_color=True,
+        )
+
+        assert success is True
+        captured = capsys.readouterr()
+        assert "(Reversed comparison)" in captured.out
+
+    def test_compare_snapshots_custom_labels(self, tmp_path, capsys):
+        """Custom labels appear in comparison output."""
+        source = _make_snapshot(data_view_id="dv_A", data_view_name="DV A")
+        target = _make_snapshot(data_view_id="dv_B", data_view_name="DV B")
+
+        src_file = str(tmp_path / "source.json")
+        tgt_file = str(tmp_path / "target.json")
+        _write_snapshot_file(src_file, source)
+        _write_snapshot_file(tgt_file, target)
+
+        success, _, _ = handle_compare_snapshots_command(
+            source_file=src_file,
+            target_file=tgt_file,
+            labels=("Baseline", "Current"),
+            quiet=False,
+            quiet_diff=False,
+            output_format="console",
+            no_color=True,
+        )
+
+        assert success is True
+        captured = capsys.readouterr()
+        assert "Baseline" in captured.out
+        assert "Current" in captured.out
+
+    def test_compare_snapshots_warn_threshold_exceeded(self, tmp_path, capsys):
+        """Exit code 3 when change percentage exceeds warn threshold."""
+        source = _make_snapshot(
+            data_view_id="dv_A",
+            data_view_name="DV A",
+            metrics=[{"id": f"m{i}", "name": f"M{i}"} for i in range(10)],
+        )
+        # Target is missing all metrics -> 100% change
+        target = _make_snapshot(
+            data_view_id="dv_B",
+            data_view_name="DV B",
+            metrics=[],
+        )
+
+        src_file = str(tmp_path / "source.json")
+        tgt_file = str(tmp_path / "target.json")
+        _write_snapshot_file(src_file, source)
+        _write_snapshot_file(tgt_file, target)
+
+        success, has_changes, exit_code = handle_compare_snapshots_command(
+            source_file=src_file,
+            target_file=tgt_file,
+            warn_threshold=5.0,
+            quiet=True,
+            quiet_diff=False,
+            output_format="console",
+            no_color=True,
+        )
+
+        assert success is True
+        assert has_changes is True
+        assert exit_code == 3
+
+    def test_compare_snapshots_diff_output_to_file(self, tmp_path, capsys):
+        """--diff-output writes content to a file."""
+        source = _make_snapshot(data_view_id="dv_A", data_view_name="DV A")
+        target = _make_snapshot(data_view_id="dv_B", data_view_name="DV B")
+
+        src_file = str(tmp_path / "source.json")
+        tgt_file = str(tmp_path / "target.json")
+        diff_out = str(tmp_path / "diff_output.txt")
+        _write_snapshot_file(src_file, source)
+        _write_snapshot_file(tgt_file, target)
+
+        success, _, _ = handle_compare_snapshots_command(
+            source_file=src_file,
+            target_file=tgt_file,
+            diff_output=diff_out,
+            quiet=False,
+            quiet_diff=False,
+            output_format="console",
+            no_color=True,
+        )
+
+        assert success is True
+        assert os.path.exists(diff_out)
+
+    def test_compare_snapshots_general_exception(self, tmp_path, capsys):
+        """General exception returns failure tuple."""
+        src_file = str(tmp_path / "source.json")
+        # Write a valid JSON that will cause a downstream error
+        with open(src_file, "w", encoding="utf-8") as f:
+            json.dump({"snapshot_version": "1.0", "data_view_id": "dv_A", "data_view_name": "A"}, f)
+
+        tgt_file = str(tmp_path / "target.json")
+        with open(tgt_file, "w", encoding="utf-8") as f:
+            f.write("this is not json")
+
+        success, _has_changes, _exit_code = handle_compare_snapshots_command(
+            source_file=src_file,
+            target_file=tgt_file,
+            quiet=True,
+        )
+
+        assert success is False
+
+    def test_compare_snapshots_inventory_cross_dv_error(self, tmp_path, capsys):
+        """Inventory comparison fails when snapshots are from different data views."""
+        source = _make_snapshot(
+            data_view_id="dv_A",
+            data_view_name="DV A",
+            calculated_metrics_inventory=[],
+        )
+        target = _make_snapshot(
+            data_view_id="dv_B",
+            data_view_name="DV B",
+            calculated_metrics_inventory=[],
+        )
+
+        src_file = str(tmp_path / "source.json")
+        tgt_file = str(tmp_path / "target.json")
+        _write_snapshot_file(src_file, source)
+        _write_snapshot_file(tgt_file, target)
+
+        success, _has_changes, _exit_code = handle_compare_snapshots_command(
+            source_file=src_file,
+            target_file=tgt_file,
+            include_calc_metrics=True,
+            quiet=True,
+        )
+
+        assert success is False
+        captured = capsys.readouterr()
+        assert "Inventory comparison requires snapshots from the same data view" in captured.err
+
+    def test_compare_snapshots_quiet_diff_suppresses_output(self, tmp_path, capsys):
+        """quiet_diff suppresses comparison output but still returns results."""
+        source = _make_snapshot(data_view_id="dv_A", data_view_name="DV A")
+        target = _make_snapshot(data_view_id="dv_B", data_view_name="DV B")
+
+        src_file = str(tmp_path / "source.json")
+        tgt_file = str(tmp_path / "target.json")
+        _write_snapshot_file(src_file, source)
+        _write_snapshot_file(tgt_file, target)
+
+        success, _, _ = handle_compare_snapshots_command(
+            source_file=src_file,
+            target_file=tgt_file,
+            quiet=True,
+            quiet_diff=True,
+        )
+
+        assert success is True
+        captured = capsys.readouterr()
+        # quiet_diff means no diff output, and quiet means no banner
+        assert "COMPARING TWO SNAPSHOTS" not in captured.out
+
+    def test_compare_snapshots_same_dv_with_inventory(self, tmp_path, capsys):
+        """Inventory comparison works when snapshots are from the same data view."""
+        source = _make_snapshot(
+            data_view_id="dv_A",
+            data_view_name="DV A",
+            calculated_metrics_inventory=[
+                {"metric_id": "cm1", "metric_name": "Calc A"},
+            ],
+        )
+        target = _make_snapshot(
+            data_view_id="dv_A",
+            data_view_name="DV A",
+            calculated_metrics_inventory=[
+                {"metric_id": "cm1", "metric_name": "Calc A Modified"},
+                {"metric_id": "cm2", "metric_name": "Calc B"},
+            ],
+        )
+
+        src_file = str(tmp_path / "source.json")
+        tgt_file = str(tmp_path / "target.json")
+        _write_snapshot_file(src_file, source)
+        _write_snapshot_file(tgt_file, target)
+
+        success, _has_changes, _exit_code = handle_compare_snapshots_command(
+            source_file=src_file,
+            target_file=tgt_file,
+            include_calc_metrics=True,
+            quiet=True,
+            quiet_diff=True,
+        )
+
+        assert success is True
+
+    def test_compare_snapshots_non_console_format(self, tmp_path, capsys):
+        """Non-console output format shows 'Diff report generated successfully'."""
+        source = _make_snapshot(data_view_id="dv_A", data_view_name="DV A")
+        target = _make_snapshot(data_view_id="dv_B", data_view_name="DV B")
+
+        src_file = str(tmp_path / "source.json")
+        tgt_file = str(tmp_path / "target.json")
+        _write_snapshot_file(src_file, source)
+        _write_snapshot_file(tgt_file, target)
+
+        success, _, _ = handle_compare_snapshots_command(
+            source_file=src_file,
+            target_file=tgt_file,
+            quiet=False,
+            quiet_diff=False,
+            output_format="json",
+            output_dir=str(tmp_path),
+            no_color=True,
+        )
+
+        assert success is True
+        captured = capsys.readouterr()
+        assert "Diff report generated successfully" in captured.out
+
+
+# ==================== handle_diff_snapshot_command ====================
+
+
+class TestHandleDiffSnapshotCommand:
+    """Tests for handle_diff_snapshot_command — compare live DV against snapshot."""
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_successful_diff_snapshot(self, mock_configure, mock_cjapy, tmp_path, capsys):
+        """Diff against snapshot succeeds end-to-end."""
+        mock_configure.return_value = (True, "config", None)
+        mock_cja = MagicMock()
+        mock_cjapy.CJA.return_value = mock_cja
+        mock_cja.getDataView.return_value = {
+            "name": "Test DV",
+            "owner": {"name": "admin"},
+            "description": "desc",
+        }
+        mock_cja.getMetrics.return_value = MagicMock(
+            empty=False, to_dict=MagicMock(return_value=[{"id": "m1", "name": "Metric A"}])
+        )
+        mock_cja.getDimensions.return_value = MagicMock(
+            empty=False, to_dict=MagicMock(return_value=[{"id": "d1", "name": "Dim A"}])
+        )
+
+        snap_file = str(tmp_path / "baseline.json")
+        _write_snapshot_file(snap_file)
+
+        success, _has_changes, _exit_code = handle_diff_snapshot_command(
+            data_view_id="dv_test",
+            snapshot_file=snap_file,
+            quiet=True,
+            quiet_diff=True,
+        )
+
+        assert success is True
+
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_diff_snapshot_config_failure(self, mock_configure, tmp_path, capsys):
+        """Returns failure when CJA configuration fails."""
+        mock_configure.return_value = (False, "No credentials", None)
+
+        snap_file = str(tmp_path / "baseline.json")
+        _write_snapshot_file(snap_file)
+
+        success, _has_changes, _exit_code = handle_diff_snapshot_command(
+            data_view_id="dv_test",
+            snapshot_file=snap_file,
+            quiet=False,
+            quiet_diff=False,
+        )
+
+        assert success is False
+        captured = capsys.readouterr()
+        assert "Configuration failed" in captured.err
+
+    def test_diff_snapshot_file_not_found(self, tmp_path, capsys):
+        """Returns failure when snapshot file does not exist."""
+        success, _has_changes, _exit_code = handle_diff_snapshot_command(
+            data_view_id="dv_test",
+            snapshot_file=str(tmp_path / "nonexistent.json"),
+            quiet=True,
+        )
+
+        assert success is False
+        captured = capsys.readouterr()
+        assert "Snapshot file not found" in captured.err
+
+    def test_diff_snapshot_invalid_file(self, tmp_path, capsys):
+        """Returns failure for invalid snapshot file."""
+        invalid_file = str(tmp_path / "bad.json")
+        with open(invalid_file, "w", encoding="utf-8") as f:
+            json.dump({"no_version": True}, f)
+
+        success, _has_changes, _exit_code = handle_diff_snapshot_command(
+            data_view_id="dv_test",
+            snapshot_file=invalid_file,
+            quiet=True,
+        )
+
+        assert success is False
+        captured = capsys.readouterr()
+        assert "Invalid snapshot file" in captured.err
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_diff_snapshot_with_banner(self, mock_configure, mock_cjapy, tmp_path, capsys):
+        """Non-quiet mode prints comparison banner."""
+        mock_configure.return_value = (True, "config", None)
+        mock_cja = MagicMock()
+        mock_cjapy.CJA.return_value = mock_cja
+        mock_cja.getDataView.return_value = {
+            "name": "DV",
+            "owner": "o",
+            "description": "",
+        }
+        mock_cja.getMetrics.return_value = MagicMock(empty=False, to_dict=MagicMock(return_value=[]))
+        mock_cja.getDimensions.return_value = MagicMock(empty=False, to_dict=MagicMock(return_value=[]))
+
+        snap_file = str(tmp_path / "baseline.json")
+        _write_snapshot_file(snap_file)
+
+        success, _, _ = handle_diff_snapshot_command(
+            data_view_id="dv_test",
+            snapshot_file=snap_file,
+            quiet=False,
+            quiet_diff=False,
+            output_format="console",
+            no_color=True,
+        )
+
+        assert success is True
+        captured = capsys.readouterr()
+        assert "COMPARING DATA VIEW AGAINST SNAPSHOT" in captured.out
+        assert "dv_test" in captured.out
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_diff_snapshot_reverse_diff(self, mock_configure, mock_cjapy, tmp_path, capsys):
+        """Reverse diff prints indicator and swaps source/target."""
+        mock_configure.return_value = (True, "config", None)
+        mock_cja = MagicMock()
+        mock_cjapy.CJA.return_value = mock_cja
+        mock_cja.getDataView.return_value = {
+            "name": "DV",
+            "owner": "o",
+            "description": "",
+        }
+        mock_cja.getMetrics.return_value = MagicMock(empty=False, to_dict=MagicMock(return_value=[]))
+        mock_cja.getDimensions.return_value = MagicMock(empty=False, to_dict=MagicMock(return_value=[]))
+
+        snap_file = str(tmp_path / "baseline.json")
+        _write_snapshot_file(snap_file)
+
+        success, _, _ = handle_diff_snapshot_command(
+            data_view_id="dv_test",
+            snapshot_file=snap_file,
+            reverse_diff=True,
+            quiet=False,
+            quiet_diff=False,
+            output_format="console",
+            no_color=True,
+        )
+
+        assert success is True
+        captured = capsys.readouterr()
+        assert "(Reversed comparison)" in captured.out
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_diff_snapshot_missing_inventory(self, mock_configure, mock_cjapy, tmp_path, capsys):
+        """Returns failure when requesting inventory diff but snapshot lacks inventory data."""
+        mock_configure.return_value = (True, "config", None)
+
+        # Snapshot without inventory data
+        snap = _make_snapshot(data_view_id="dv_test")
+        snap_file = str(tmp_path / "baseline.json")
+        _write_snapshot_file(snap_file, snap)
+
+        success, _, _ = handle_diff_snapshot_command(
+            data_view_id="dv_test",
+            snapshot_file=snap_file,
+            include_calc_metrics=True,
+            quiet=True,
+        )
+
+        assert success is False
+        captured = capsys.readouterr()
+        assert "snapshot missing requested data" in captured.err
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_diff_snapshot_auto_snapshot(self, mock_configure, mock_cjapy, tmp_path, capsys):
+        """Auto-snapshot saves current state to snapshot directory."""
+        mock_configure.return_value = (True, "config", None)
+        mock_cja = MagicMock()
+        mock_cjapy.CJA.return_value = mock_cja
+        mock_cja.getDataView.return_value = {
+            "name": "Test DV",
+            "owner": "o",
+            "description": "",
+        }
+        mock_cja.getMetrics.return_value = MagicMock(
+            empty=False, to_dict=MagicMock(return_value=[{"id": "m1", "name": "M1"}])
+        )
+        mock_cja.getDimensions.return_value = MagicMock(empty=False, to_dict=MagicMock(return_value=[]))
+
+        snap_file = str(tmp_path / "baseline.json")
+        _write_snapshot_file(snap_file)
+        snapshot_dir = str(tmp_path / "auto_snapshots")
+
+        success, _, _ = handle_diff_snapshot_command(
+            data_view_id="dv_test",
+            snapshot_file=snap_file,
+            auto_snapshot=True,
+            snapshot_dir=snapshot_dir,
+            quiet=False,
+            quiet_diff=False,
+            output_format="console",
+            no_color=True,
+        )
+
+        assert success is True
+        assert os.path.isdir(snapshot_dir)
+
+        # Check auto-saved snapshot exists
+        files = os.listdir(snapshot_dir)
+        assert len(files) >= 1
+        assert any(f.endswith(".json") for f in files)
+
+        captured = capsys.readouterr()
+        assert "Auto-saved current state" in captured.out
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_diff_snapshot_auto_prune(self, mock_configure, mock_cjapy, tmp_path, capsys):
+        """Auto-prune with retention deletes old snapshots."""
+        mock_configure.return_value = (True, "config", None)
+        mock_cja = MagicMock()
+        mock_cjapy.CJA.return_value = mock_cja
+        mock_cja.getDataView.return_value = {
+            "name": "Test DV",
+            "owner": "o",
+            "description": "",
+        }
+        mock_cja.getMetrics.return_value = MagicMock(empty=False, to_dict=MagicMock(return_value=[]))
+        mock_cja.getDimensions.return_value = MagicMock(empty=False, to_dict=MagicMock(return_value=[]))
+
+        snap_file = str(tmp_path / "baseline.json")
+        _write_snapshot_file(snap_file)
+        snapshot_dir = str(tmp_path / "auto_snapshots")
+        os.makedirs(snapshot_dir)
+
+        # Pre-populate with old snapshots for the same data view
+        for i in range(5):
+            old_snap = _make_snapshot(
+                data_view_id="dv_test",
+                created_at=f"2025-01-{10 + i:02d}T00:00:00+00:00",
+            )
+            old_file = os.path.join(snapshot_dir, f"dv_test_2025010{i}_000000.json")
+            _write_snapshot_file(old_file, old_snap)
+
+        success, _, _ = handle_diff_snapshot_command(
+            data_view_id="dv_test",
+            snapshot_file=snap_file,
+            auto_snapshot=True,
+            snapshot_dir=snapshot_dir,
+            keep_last=2,
+            keep_last_specified=True,
+            quiet=False,
+            quiet_diff=False,
+            output_format="console",
+            no_color=True,
+        )
+
+        assert success is True
+        captured = capsys.readouterr()
+        assert "Retention policy" in captured.out
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_diff_snapshot_warn_threshold(self, mock_configure, mock_cjapy, tmp_path, capsys):
+        """Warn threshold triggers exit code 3."""
+        mock_configure.return_value = (True, "config", None)
+        mock_cja = MagicMock()
+        mock_cjapy.CJA.return_value = mock_cja
+        mock_cja.getDataView.return_value = {
+            "name": "Test DV",
+            "owner": "o",
+            "description": "",
+        }
+        # Return no metrics from live view, but snapshot has many
+        mock_cja.getMetrics.return_value = MagicMock(empty=True, to_dict=MagicMock(return_value=[]))
+        mock_cja.getDimensions.return_value = MagicMock(empty=True, to_dict=MagicMock(return_value=[]))
+
+        snap = _make_snapshot(
+            data_view_id="dv_test",
+            metrics=[{"id": f"m{i}", "name": f"M{i}"} for i in range(10)],
+            dimensions=[{"id": f"d{i}", "name": f"D{i}"} for i in range(5)],
+        )
+        snap_file = str(tmp_path / "baseline.json")
+        _write_snapshot_file(snap_file, snap)
+
+        success, has_changes, exit_code = handle_diff_snapshot_command(
+            data_view_id="dv_test",
+            snapshot_file=snap_file,
+            warn_threshold=5.0,
+            quiet=True,
+            quiet_diff=False,
+            output_format="console",
+            no_color=True,
+        )
+
+        assert success is True
+        assert has_changes is True
+        assert exit_code == 3
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_diff_snapshot_diff_output_to_file(self, mock_configure, mock_cjapy, tmp_path, capsys):
+        """--diff-output writes output to specified file."""
+        mock_configure.return_value = (True, "config", None)
+        mock_cja = MagicMock()
+        mock_cjapy.CJA.return_value = mock_cja
+        mock_cja.getDataView.return_value = {
+            "name": "Test DV",
+            "owner": "o",
+            "description": "",
+        }
+        mock_cja.getMetrics.return_value = MagicMock(
+            empty=False, to_dict=MagicMock(return_value=[{"id": "m1", "name": "M1"}])
+        )
+        mock_cja.getDimensions.return_value = MagicMock(
+            empty=False, to_dict=MagicMock(return_value=[{"id": "d1", "name": "D1"}])
+        )
+
+        snap_file = str(tmp_path / "baseline.json")
+        _write_snapshot_file(snap_file)
+        diff_out = str(tmp_path / "diff.txt")
+
+        success, _, _ = handle_diff_snapshot_command(
+            data_view_id="dv_test",
+            snapshot_file=snap_file,
+            diff_output=diff_out,
+            quiet=False,
+            quiet_diff=False,
+            output_format="console",
+            no_color=True,
+        )
+
+        assert success is True
+        assert os.path.exists(diff_out)
+        captured = capsys.readouterr()
+        assert "Diff output written to" in captured.out
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_diff_snapshot_non_console_format(self, mock_configure, mock_cjapy, tmp_path, capsys):
+        """Non-console format shows success message."""
+        mock_configure.return_value = (True, "config", None)
+        mock_cja = MagicMock()
+        mock_cjapy.CJA.return_value = mock_cja
+        mock_cja.getDataView.return_value = {
+            "name": "DV",
+            "owner": "o",
+            "description": "",
+        }
+        mock_cja.getMetrics.return_value = MagicMock(empty=False, to_dict=MagicMock(return_value=[]))
+        mock_cja.getDimensions.return_value = MagicMock(empty=False, to_dict=MagicMock(return_value=[]))
+
+        snap_file = str(tmp_path / "baseline.json")
+        _write_snapshot_file(snap_file)
+
+        success, _, _ = handle_diff_snapshot_command(
+            data_view_id="dv_test",
+            snapshot_file=snap_file,
+            quiet=False,
+            quiet_diff=False,
+            output_format="json",
+            output_dir=str(tmp_path),
+            no_color=True,
+        )
+
+        assert success is True
+        captured = capsys.readouterr()
+        assert "Diff report generated successfully" in captured.out
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_diff_snapshot_inventory_included_in_banner(self, mock_configure, mock_cjapy, tmp_path, capsys):
+        """Inventory flags appear in the banner."""
+        mock_configure.return_value = (True, "config", None)
+        mock_cja = MagicMock()
+        mock_cjapy.CJA.return_value = mock_cja
+        mock_cja.getDataView.return_value = {
+            "name": "DV",
+            "owner": "o",
+            "description": "",
+        }
+        mock_cja.getMetrics.return_value = MagicMock(empty=False, to_dict=MagicMock(return_value=[]))
+        mock_cja.getDimensions.return_value = MagicMock(empty=False, to_dict=MagicMock(return_value=[]))
+
+        snap = _make_snapshot(
+            data_view_id="dv_test",
+            calculated_metrics_inventory=[],
+            segments_inventory=[],
+        )
+        snap_file = str(tmp_path / "baseline.json")
+        _write_snapshot_file(snap_file, snap)
+
+        success, _, _ = handle_diff_snapshot_command(
+            data_view_id="dv_test",
+            snapshot_file=snap_file,
+            include_calc_metrics=True,
+            include_segments=True,
+            quiet=False,
+            quiet_diff=False,
+            output_format="console",
+            no_color=True,
+        )
+
+        assert success is True
+        captured = capsys.readouterr()
+        assert "calculated metrics" in captured.out
+        assert "segments" in captured.out
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_diff_snapshot_general_exception(self, mock_configure, mock_cjapy, tmp_path, capsys):
+        """General exception returns failure tuple."""
+        mock_configure.return_value = (True, "config", None)
+        mock_cjapy.CJA.side_effect = RuntimeError("Unexpected failure")
+
+        snap_file = str(tmp_path / "baseline.json")
+        _write_snapshot_file(snap_file)
+
+        success, _has_changes, _exit_code = handle_diff_snapshot_command(
+            data_view_id="dv_test",
+            snapshot_file=snap_file,
+            quiet=True,
+        )
+
+        assert success is False
+        captured = capsys.readouterr()
+        assert "Failed to compare against snapshot" in captured.err
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_diff_snapshot_auto_snapshot_with_date_retention(self, mock_configure, mock_cjapy, tmp_path, capsys):
+        """Auto-snapshot with date-based retention (keep_since)."""
+        mock_configure.return_value = (True, "config", None)
+        mock_cja = MagicMock()
+        mock_cjapy.CJA.return_value = mock_cja
+        mock_cja.getDataView.return_value = {
+            "name": "Test DV",
+            "owner": "o",
+            "description": "",
+        }
+        mock_cja.getMetrics.return_value = MagicMock(empty=False, to_dict=MagicMock(return_value=[]))
+        mock_cja.getDimensions.return_value = MagicMock(empty=False, to_dict=MagicMock(return_value=[]))
+
+        snap_file = str(tmp_path / "baseline.json")
+        _write_snapshot_file(snap_file)
+        snapshot_dir = str(tmp_path / "auto_snapshots")
+
+        success, _, _ = handle_diff_snapshot_command(
+            data_view_id="dv_test",
+            snapshot_file=snap_file,
+            auto_snapshot=True,
+            snapshot_dir=snapshot_dir,
+            keep_since="7d",
+            keep_since_specified=True,
+            quiet=True,
+            quiet_diff=True,
+        )
+
+        assert success is True
+        assert os.path.isdir(snapshot_dir)
+
+
+# ==================== Snapshot name resolution ====================
+
+
+class TestSnapshotNameResolution:
+    """Tests for name resolution in snapshot dispatch paths."""
+
+    @patch("cja_auto_sdr.generator.get_cached_data_views")
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_resolve_data_view_id_passthrough(self, mock_configure, mock_cjapy, mock_cache):
+        """Data view IDs (starting with dv_) pass through unchanged."""
+        mock_configure.return_value = (True, "config", None)
+        mock_cjapy.CJA.return_value = MagicMock()
+        mock_cache.return_value = [{"id": "dv_12345", "name": "Test DV"}]
+
+        resolved, name_map = resolve_data_view_names(
+            ["dv_12345"],
+            config_file="config.json",
+        )
+
+        assert resolved == ["dv_12345"]
+        assert name_map == {}
+
+    @patch("cja_auto_sdr.generator.get_cached_data_views")
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_resolve_name_to_id(self, mock_configure, mock_cjapy, mock_cache):
+        """Data view name resolves to ID via API lookup."""
+        mock_configure.return_value = (True, "config", None)
+        mock_cjapy.CJA.return_value = MagicMock()
+        mock_cache.return_value = [
+            {"id": "dv_found", "name": "Production Analytics"},
+            {"id": "dv_other", "name": "Staging Analytics"},
+        ]
+
+        resolved, name_map = resolve_data_view_names(
+            ["Production Analytics"],
+            config_file="config.json",
+        )
+
+        assert "dv_found" in resolved
+        assert "Production Analytics" in name_map
+
+    @patch("cja_auto_sdr.generator.get_cached_data_views")
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_resolve_name_not_found(self, mock_configure, mock_cjapy, mock_cache):
+        """Unresolvable name results in empty list."""
+        mock_configure.return_value = (True, "config", None)
+        mock_cjapy.CJA.return_value = MagicMock()
+        mock_cache.return_value = [
+            {"id": "dv_1", "name": "Other DV"},
+        ]
+
+        resolved, _name_map = resolve_data_view_names(
+            ["NonexistentDV"],
+            config_file="config.json",
+            suggest_similar=False,
+        )
+
+        assert "NonexistentDV" not in list(resolved)
+
+    @patch("cja_auto_sdr.generator.get_cached_data_views")
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_resolve_multiple_identifiers_mixed(self, mock_configure, mock_cjapy, mock_cache):
+        """Mix of IDs and names resolves correctly."""
+        mock_configure.return_value = (True, "config", None)
+        mock_cjapy.CJA.return_value = MagicMock()
+        mock_cache.return_value = [
+            {"id": "dv_direct_id", "name": "Direct DV"},
+            {"id": "dv_name_resolved", "name": "My DV"},
+        ]
+
+        resolved, _name_map = resolve_data_view_names(
+            ["dv_direct_id", "My DV"],
+            config_file="config.json",
+        )
+
+        assert "dv_direct_id" in resolved
+        assert "dv_name_resolved" in resolved
+
+    def test_resolve_with_invalid_match_mode(self):
+        """Invalid match_mode raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid match_mode"):
+            resolve_data_view_names(
+                ["dv_123"],
+                config_file="config.json",
+                match_mode="invalid_mode",
+            )
+
+
+# ==================== Main dispatch snapshot paths ====================
+
+
+class TestMainSnapshotDispatch:
+    """Tests for main() dispatch paths for snapshot-related commands."""
+
+    @pytest.fixture(autouse=True)
+    def _no_cli_option_scan(self, monkeypatch):
+        monkeypatch.setattr("cja_auto_sdr.generator._cli_option_value", lambda *_a, **_kw: None)
+
+    @staticmethod
+    def _make_compare_args(**overrides):
+        """Build a Namespace with all args main() expects for --compare-snapshots."""
+        args = _real_parse_arguments(["--compare-snapshots", "source.json", "target.json", "--quiet"])
+        for k, v in overrides.items():
+            setattr(args, k, v)
+        return args
+
+    @patch("cja_auto_sdr.generator.handle_compare_snapshots_command")
+    @patch("cja_auto_sdr.generator.parse_arguments")
+    def test_main_compare_snapshots_success_no_changes(self, mock_parse, mock_compare):
+        """main() dispatches --compare-snapshots and exits 0 on no changes."""
+        from cja_auto_sdr.generator import main
+
+        mock_parse.return_value = self._make_compare_args()
+        mock_compare.return_value = (True, False, None)
+
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+        assert exc_info.value.code == 0
+
+    @patch("cja_auto_sdr.generator.handle_compare_snapshots_command")
+    @patch("cja_auto_sdr.generator.parse_arguments")
+    def test_main_compare_snapshots_with_changes(self, mock_parse, mock_compare):
+        """main() exits 2 when compare-snapshots detects changes."""
+        from cja_auto_sdr.generator import main
+
+        mock_parse.return_value = self._make_compare_args()
+        mock_compare.return_value = (True, True, None)
+
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+        assert exc_info.value.code == 2
+
+    @patch("cja_auto_sdr.generator.handle_compare_snapshots_command")
+    @patch("cja_auto_sdr.generator.parse_arguments")
+    def test_main_compare_snapshots_threshold_exit_3(self, mock_parse, mock_compare):
+        """main() exits 3 when warn threshold exceeded."""
+        from cja_auto_sdr.generator import main
+
+        mock_parse.return_value = self._make_compare_args(warn_threshold=5.0)
+        mock_compare.return_value = (True, True, 3)
+
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+        assert exc_info.value.code == 3
+
+    @patch("cja_auto_sdr.generator.handle_compare_snapshots_command")
+    @patch("cja_auto_sdr.generator.parse_arguments")
+    def test_main_compare_snapshots_failure_exit_1(self, mock_parse, mock_compare):
+        """main() exits 1 when compare-snapshots fails."""
+        from cja_auto_sdr.generator import main
+
+        mock_parse.return_value = self._make_compare_args()
+        mock_compare.return_value = (False, False, None)
+
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+        assert exc_info.value.code == 1
+
+    @patch("cja_auto_sdr.generator.parse_arguments")
+    def test_main_compare_snapshots_metrics_dimensions_conflict(self, mock_parse, capsys):
+        """main() rejects --metrics-only + --dimensions-only with --compare-snapshots."""
+        from cja_auto_sdr.generator import main
+
+        mock_parse.return_value = self._make_compare_args(metrics_only=True, dimensions_only=True)
+
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "Cannot use both --metrics-only and --dimensions-only" in captured.err
+
+    @patch("cja_auto_sdr.generator.parse_arguments")
+    def test_main_compare_snapshots_inventory_only_rejected(self, mock_parse, capsys):
+        """main() rejects --inventory-only with --compare-snapshots."""
+        from cja_auto_sdr.generator import main
+
+        mock_parse.return_value = self._make_compare_args(inventory_only=True)
+
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "--inventory-only is only available in SDR mode" in captured.err
+
+
+# ==================== Snapshot dispatch for --snapshot mode ====================
+
+
+class TestMainSnapshotMode:
+    """Tests for main() --snapshot dispatch with name resolution."""
+
+    @pytest.fixture(autouse=True)
+    def _no_cli_option_scan(self, monkeypatch):
+        monkeypatch.setattr("cja_auto_sdr.generator._cli_option_value", lambda *_a, **_kw: None)
+
+    @staticmethod
+    def _make_snapshot_args(**overrides):
+        args = _real_parse_arguments(["--snapshot", "./snap.json", "dv_1"])
+        for k, v in overrides.items():
+            setattr(args, k, v)
+        return args
+
+    @patch("cja_auto_sdr.generator.handle_snapshot_command")
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    @patch("cja_auto_sdr.generator.parse_arguments")
+    def test_snapshot_requires_one_data_view(self, mock_parse, mock_resolve, mock_handle, capsys):
+        """--snapshot with multiple data views exits with error."""
+        from cja_auto_sdr.generator import main
+
+        mock_parse.return_value = self._make_snapshot_args(data_views=["dv_1", "dv_2"])
+
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "--snapshot requires exactly 1 data view" in captured.err
+
+    @patch("cja_auto_sdr.generator.handle_snapshot_command")
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    @patch("cja_auto_sdr.generator.parse_arguments")
+    def test_snapshot_include_derived_rejected(self, mock_parse, mock_resolve, mock_handle, capsys):
+        """--include-derived with --snapshot is rejected."""
+        from cja_auto_sdr.generator import main
+
+        mock_parse.return_value = self._make_snapshot_args(include_derived_inventory=True)
+
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "--include-derived cannot be used with --snapshot" in captured.err
+
+
+# ==================== Snapshot dispatch for --diff-snapshot mode ====================
+
+
+class TestMainDiffSnapshotMode:
+    """Tests for main() --diff-snapshot dispatch with name resolution."""
+
+    @pytest.fixture(autouse=True)
+    def _no_cli_option_scan(self, monkeypatch):
+        monkeypatch.setattr("cja_auto_sdr.generator._cli_option_value", lambda *_a, **_kw: None)
+
+    @staticmethod
+    def _make_diff_snap_args(**overrides):
+        args = _real_parse_arguments(["--diff-snapshot", "./baseline.json", "dv_1"])
+        for k, v in overrides.items():
+            setattr(args, k, v)
+        return args
+
+    @patch("cja_auto_sdr.generator.handle_diff_snapshot_command")
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    @patch("cja_auto_sdr.generator.parse_arguments")
+    def test_diff_snapshot_requires_one_data_view(self, mock_parse, mock_resolve, mock_handle, capsys):
+        """--diff-snapshot with multiple data views exits with error."""
+        from cja_auto_sdr.generator import main
+
+        mock_parse.return_value = self._make_diff_snap_args(data_views=["dv_1", "dv_2"])
+
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "--diff-snapshot requires exactly 1 data view" in captured.err
+
+    @patch("cja_auto_sdr.generator.handle_diff_snapshot_command")
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    @patch("cja_auto_sdr.generator.parse_arguments")
+    def test_diff_snapshot_metrics_dimensions_conflict(self, mock_parse, mock_resolve, mock_handle, capsys):
+        """--metrics-only + --dimensions-only with --diff-snapshot is rejected."""
+        from cja_auto_sdr.generator import main
+
+        mock_parse.return_value = self._make_diff_snap_args(metrics_only=True, dimensions_only=True)
+
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "Cannot use both --metrics-only and --dimensions-only" in captured.err
+
+    @patch("cja_auto_sdr.generator.handle_diff_snapshot_command")
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    @patch("cja_auto_sdr.generator.parse_arguments")
+    def test_diff_snapshot_inventory_only_rejected(self, mock_parse, mock_resolve, mock_handle, capsys):
+        """--inventory-only with --diff-snapshot is rejected."""
+        from cja_auto_sdr.generator import main
+
+        mock_parse.return_value = self._make_diff_snap_args(inventory_only=True)
+
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "--inventory-only is only available in SDR mode" in captured.err
+
+    @patch("cja_auto_sdr.generator.handle_diff_snapshot_command")
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    @patch("cja_auto_sdr.generator.parse_arguments")
+    def test_diff_snapshot_name_resolution_failure(self, mock_parse, mock_resolve, mock_handle, capsys):
+        """Unresolvable data view name exits with error."""
+        from cja_auto_sdr.generator import main
+
+        mock_parse.return_value = self._make_diff_snap_args(data_views=["My DV"])
+        mock_resolve.return_value = ([], {})
+
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "Could not resolve data view" in captured.err
+
+    @patch("cja_auto_sdr.generator.prompt_for_selection")
+    @patch("cja_auto_sdr.generator.handle_diff_snapshot_command")
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    @patch("cja_auto_sdr.generator.parse_arguments")
+    def test_diff_snapshot_ambiguous_name_no_selection(
+        self, mock_parse, mock_resolve, mock_handle, mock_prompt, capsys
+    ):
+        """Ambiguous name resolution with no interactive selection exits with error."""
+        from cja_auto_sdr.generator import main
+
+        mock_parse.return_value = self._make_diff_snap_args(data_views=["My DV"])
+        mock_resolve.return_value = (["dv_1", "dv_2"], {"My DV": ["dv_1", "dv_2"]})
+        mock_prompt.return_value = None
+
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "ambiguous" in captured.err.lower()
+
+    @patch("cja_auto_sdr.generator.prompt_for_selection")
+    @patch("cja_auto_sdr.generator.handle_diff_snapshot_command")
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    @patch("cja_auto_sdr.generator.parse_arguments")
+    def test_diff_snapshot_ambiguous_name_selection_succeeds(
+        self,
+        mock_parse,
+        mock_resolve,
+        mock_handle,
+        mock_prompt,
+    ):
+        """Ambiguous name resolved via interactive selection."""
+        from cja_auto_sdr.generator import main
+
+        mock_parse.return_value = self._make_diff_snap_args(data_views=["My DV"], quiet=True)
+        mock_resolve.return_value = (["dv_1", "dv_2"], {"My DV": ["dv_1", "dv_2"]})
+        mock_prompt.return_value = "dv_1"
+        mock_handle.return_value = (True, False, None)
+
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+        assert exc_info.value.code == 0
+        mock_handle.assert_called_once()
+
+
+# ==================== Compare-with-prev dispatch ====================
+
+
+class TestMainCompareWithPrevMode:
+    """Tests for main() --compare-with-prev dispatch."""
+
+    @pytest.fixture(autouse=True)
+    def _no_cli_option_scan(self, monkeypatch):
+        monkeypatch.setattr("cja_auto_sdr.generator._cli_option_value", lambda *_a, **_kw: None)
+
+    @staticmethod
+    def _make_cwp_args(**overrides):
+        args = _real_parse_arguments(["--compare-with-prev", "dv_1"])
+        for k, v in overrides.items():
+            setattr(args, k, v)
+        return args
+
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    @patch("cja_auto_sdr.generator.parse_arguments")
+    def test_compare_with_prev_requires_one_data_view(self, mock_parse, mock_resolve, capsys):
+        """--compare-with-prev with multiple data views exits with error."""
+        from cja_auto_sdr.generator import main
+
+        mock_parse.return_value = self._make_cwp_args(data_views=["dv_1", "dv_2"])
+
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "--compare-with-prev requires exactly 1 data view" in captured.err
+
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    @patch("cja_auto_sdr.generator.parse_arguments")
+    def test_compare_with_prev_inventory_only_rejected(self, mock_parse, mock_resolve, capsys):
+        """--inventory-only with --compare-with-prev is rejected."""
+        from cja_auto_sdr.generator import main
+
+        mock_parse.return_value = self._make_cwp_args(inventory_only=True)
+
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "--inventory-only is only available in SDR mode" in captured.err
+
+    @patch("cja_auto_sdr.generator.SnapshotManager")
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    @patch("cja_auto_sdr.generator.parse_arguments")
+    def test_compare_with_prev_no_previous_snapshot(self, mock_parse, mock_resolve, mock_sm, capsys):
+        """No previous snapshot exits with guidance message."""
+        from cja_auto_sdr.generator import main
+
+        mock_parse.return_value = self._make_cwp_args()
+        mock_resolve.return_value = (["dv_1"], {})
+        mock_sm_instance = MagicMock()
+        mock_sm.return_value = mock_sm_instance
+        mock_sm_instance.get_most_recent_snapshot.return_value = None
+
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "No previous snapshots found" in captured.err

--- a/tests/test_snapshot_commands.py
+++ b/tests/test_snapshot_commands.py
@@ -32,9 +32,11 @@ from cja_auto_sdr.generator import (
     parse_arguments as _real_parse_arguments,
 )
 
-# Warm the lru_cache on _known_long_options before any @patch on parse_arguments
-# can interfere.  The cached frozenset is used by _cli_option_value /
-# _cli_option_specified inside main() and _main_impl().
+# _known_long_options() internally calls parse_arguments(return_parser=True).
+# When tests @patch parse_arguments, that internal call would return a MagicMock
+# instead of a real parser, breaking _cli_option_value / _cli_option_specified.
+# Pre-populating the lru_cache here avoids that — the real frozenset is cached
+# once and reused across all tests regardless of patches.
 _known_long_options()
 
 # ==================== Helpers ====================

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -681,8 +681,8 @@ class TestConfigValidation:
                     "org_id": "test_org",
                     "client_id": "test_client",
                     # Missing other required fields
-                }
-            )
+                },
+            ),
         )
 
         # Should fail when required fields are missing
@@ -864,12 +864,15 @@ class TestValidationSchema:
                 "name": ["Metric 1", "Metric 2"],
                 "type": ["int", "currency"],
                 "description": ["Desc 1", "Desc 2"],
-            }
+            },
         )
 
         # Use VALIDATION_SCHEMA values directly
         checker.check_all_quality_issues_optimized(
-            df, "Metrics", VALIDATION_SCHEMA["required_metric_fields"], VALIDATION_SCHEMA["critical_fields"]
+            df,
+            "Metrics",
+            VALIDATION_SCHEMA["required_metric_fields"],
+            VALIDATION_SCHEMA["critical_fields"],
         )
 
         # Should have no critical issues for valid data

--- a/tests/test_ux_features.py
+++ b/tests/test_ux_features.py
@@ -344,11 +344,11 @@ class TestCombinedFeatures:
 class TestVersionUpdated:
     """Test that version is correct"""
 
-    def test_version_is_3_2_8(self):
-        """Test that version is 3.2.8"""
+    def test_version_is_3_2_9(self):
+        """Test that version is 3.2.9"""
         from cja_auto_sdr.generator import __version__
 
-        assert __version__ == "3.2.8"
+        assert __version__ == "3.2.9"
 
 
 class TestFormatAutoDetection:

--- a/tests/test_ux_features.py
+++ b/tests/test_ux_features.py
@@ -1136,7 +1136,10 @@ class TestIncludeAllInventory:
     @patch("cja_auto_sdr.generator.SnapshotManager")
     @patch("cja_auto_sdr.generator.resolve_data_view_names")
     def test_include_all_inventory_expands_for_compare_with_prev_mode(
-        self, mock_resolve, mock_snapshot_manager_cls, mock_handle_diff_snapshot
+        self,
+        mock_resolve,
+        mock_snapshot_manager_cls,
+        mock_handle_diff_snapshot,
     ):
         """Test include-all enables calculated+segments for --compare-with-prev mode."""
         from cja_auto_sdr.generator import main
@@ -1174,7 +1177,11 @@ class TestProcessingResultInventory:
         from cja_auto_sdr.generator import ProcessingResult
 
         result = ProcessingResult(
-            data_view_id="dv_test", data_view_name="Test", success=True, duration=1.0, segments_count=10
+            data_view_id="dv_test",
+            data_view_name="Test",
+            success=True,
+            duration=1.0,
+            segments_count=10,
         )
         assert result.has_inventory is True
 
@@ -1183,7 +1190,11 @@ class TestProcessingResultInventory:
         from cja_auto_sdr.generator import ProcessingResult
 
         result = ProcessingResult(
-            data_view_id="dv_test", data_view_name="Test", success=True, duration=1.0, calculated_metrics_count=5
+            data_view_id="dv_test",
+            data_view_name="Test",
+            success=True,
+            duration=1.0,
+            calculated_metrics_count=5,
         )
         assert result.has_inventory is True
 
@@ -1192,7 +1203,11 @@ class TestProcessingResultInventory:
         from cja_auto_sdr.generator import ProcessingResult
 
         result = ProcessingResult(
-            data_view_id="dv_test", data_view_name="Test", success=True, duration=1.0, derived_fields_count=15
+            data_view_id="dv_test",
+            data_view_name="Test",
+            success=True,
+            duration=1.0,
+            derived_fields_count=15,
         )
         assert result.has_inventory is True
 

--- a/tests/test_validation_cache.py
+++ b/tests/test_validation_cache.py
@@ -31,7 +31,10 @@ class TestValidationCache:
         cache = ValidationCache(max_size=100, ttl_seconds=3600)
 
         result, cache_key = cache.get(
-            sample_metrics_df, "Metrics", ["id", "name", "type"], ["id", "name", "description"]
+            sample_metrics_df,
+            "Metrics",
+            ["id", "name", "type"],
+            ["id", "name", "description"],
         )
 
         assert result is None
@@ -48,14 +51,20 @@ class TestValidationCache:
 
         # First call - should validate and cache
         checker.check_all_quality_issues_optimized(
-            sample_metrics_df, "Metrics", ["id", "name", "type"], ["id", "name", "description"]
+            sample_metrics_df,
+            "Metrics",
+            ["id", "name", "type"],
+            ["id", "name", "description"],
         )
         first_issues = checker.issues.copy()
 
         # Second call - should use cache
         checker2 = DataQualityChecker(logger, validation_cache=cache)
         checker2.check_all_quality_issues_optimized(
-            sample_metrics_df, "Metrics", ["id", "name", "type"], ["id", "name", "description"]
+            sample_metrics_df,
+            "Metrics",
+            ["id", "name", "type"],
+            ["id", "name", "description"],
         )
         second_issues = checker2.issues
 
@@ -96,7 +105,11 @@ class TestValidationCache:
 
             # Store result
             cache.put(
-                sample_metrics_df, "Metrics", ["id", "name", "type"], ["id", "name", "description"], [{"test": "issue"}]
+                sample_metrics_df,
+                "Metrics",
+                ["id", "name", "type"],
+                ["id", "name", "description"],
+                [{"test": "issue"}],
             )
 
             # Should be cached immediately
@@ -157,7 +170,10 @@ class TestValidationCache:
             try:
                 c = DataQualityChecker(logger, validation_cache=cache)
                 c.check_all_quality_issues_optimized(
-                    sample_metrics_df, "Metrics", ["id", "name", "type"], ["id", "name", "description"]
+                    sample_metrics_df,
+                    "Metrics",
+                    ["id", "name", "type"],
+                    ["id", "name", "description"],
                 )
                 results.append(c.issues)
             except Exception as e:
@@ -195,14 +211,20 @@ class TestValidationCache:
 
         # First call
         checker.check_all_quality_issues_optimized(
-            empty_df, "Metrics", ["id", "name", "type"], ["id", "name", "description"]
+            empty_df,
+            "Metrics",
+            ["id", "name", "type"],
+            ["id", "name", "description"],
         )
         first_issues = checker.issues.copy()
 
         # Second call - should use cache
         checker2 = DataQualityChecker(logger, validation_cache=cache)
         checker2.check_all_quality_issues_optimized(
-            empty_df, "Metrics", ["id", "name", "type"], ["id", "name", "description"]
+            empty_df,
+            "Metrics",
+            ["id", "name", "type"],
+            ["id", "name", "description"],
         )
         second_issues = checker2.issues
 
@@ -224,14 +246,20 @@ class TestValidationCache:
 
         # First call
         checker.check_all_quality_issues_optimized(
-            bad_df, "Metrics", ["id", "name", "type"], ["id", "name", "description"]
+            bad_df,
+            "Metrics",
+            ["id", "name", "type"],
+            ["id", "name", "description"],
         )
         first_issues = checker.issues.copy()
 
         # Second call - should use cache
         checker2 = DataQualityChecker(logger, validation_cache=cache)
         checker2.check_all_quality_issues_optimized(
-            bad_df, "Metrics", ["id", "name", "type"], ["id", "name", "description"]
+            bad_df,
+            "Metrics",
+            ["id", "name", "type"],
+            ["id", "name", "description"],
         )
         second_issues = checker2.issues
 
@@ -281,7 +309,10 @@ class TestValidationCache:
         for _ in range(10):
             checker_no_cache.issues = []  # Reset
             checker_no_cache.check_all_quality_issues_optimized(
-                sample_metrics_df, "Metrics", ["id", "name", "type"], ["id", "name", "description"]
+                sample_metrics_df,
+                "Metrics",
+                ["id", "name", "type"],
+                ["id", "name", "description"],
             )
         time_no_cache = time.time() - start
 
@@ -291,14 +322,17 @@ class TestValidationCache:
         for _ in range(10):
             checker_with_cache.issues = []  # Reset
             checker_with_cache.check_all_quality_issues_optimized(
-                sample_metrics_df, "Metrics", ["id", "name", "type"], ["id", "name", "description"]
+                sample_metrics_df,
+                "Metrics",
+                ["id", "name", "type"],
+                ["id", "name", "description"],
             )
         time_with_cache = time.time() - start
 
         # Cache should be faster (at least 5% improvement)
         improvement = (time_no_cache - time_with_cache) / time_no_cache * 100
         print(
-            f"\nPerformance: no_cache={time_no_cache:.3f}s, with_cache={time_with_cache:.3f}s, improvement={improvement:.1f}%"
+            f"\nPerformance: no_cache={time_no_cache:.3f}s, with_cache={time_with_cache:.3f}s, improvement={improvement:.1f}%",
         )
 
         # Should be at least 5% faster (conservative for small datasets on slow CI runners)
@@ -355,7 +389,7 @@ class TestValidationCache:
                 "id": ["m1", "m3"],  # Changed m2 to m3
                 "name": ["Metric 1", "Metric 3"],
                 "type": ["int", "currency"],
-            }
+            },
         )
 
         # Should be cache miss
@@ -409,14 +443,20 @@ class TestValidationCache:
         # With cache disabled (None)
         checker = DataQualityChecker(logger, validation_cache=None)
         checker.check_all_quality_issues_optimized(
-            sample_metrics_df, "Metrics", ["id", "name", "type"], ["id", "name", "description"]
+            sample_metrics_df,
+            "Metrics",
+            ["id", "name", "type"],
+            ["id", "name", "description"],
         )
         issues_no_cache = checker.issues
 
         # Without specifying cache at all (default behavior)
         checker2 = DataQualityChecker(logger)
         checker2.check_all_quality_issues_optimized(
-            sample_metrics_df, "Metrics", ["id", "name", "type"], ["id", "name", "description"]
+            sample_metrics_df,
+            "Metrics",
+            ["id", "name", "type"],
+            ["id", "name", "description"],
         )
         issues_default = checker2.issues
 
@@ -430,7 +470,10 @@ class TestValidationCache:
 
         # Get returns (None, cache_key) on miss
         result, cache_key = cache.get(
-            sample_metrics_df, "Metrics", ["id", "name", "type"], ["id", "name", "description"]
+            sample_metrics_df,
+            "Metrics",
+            ["id", "name", "type"],
+            ["id", "name", "description"],
         )
         assert result is None
         assert cache_key is not None
@@ -449,7 +492,10 @@ class TestValidationCache:
 
         # Get should now return the cached issues
         cached_result, _ = cache.get(
-            sample_metrics_df, "Metrics", ["id", "name", "type"], ["id", "name", "description"]
+            sample_metrics_df,
+            "Metrics",
+            ["id", "name", "type"],
+            ["id", "name", "description"],
         )
         assert cached_result is not None
         assert len(cached_result) == 1

--- a/uv.lock
+++ b/uv.lock
@@ -107,6 +107,7 @@ full = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "openpyxl" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
@@ -130,6 +131,7 @@ provides-extras = ["clustering", "completion", "env", "full"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "openpyxl", specifier = ">=3.1.0" },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "pytest-cov", specifier = ">=4.1.0" },
     { name = "ruff", specifier = ">=0.9.0" },
@@ -253,6 +255,15 @@ wheels = [
 ]
 
 [[package]]
+name = "et-xmlfile"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -297,6 +308,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/23/12/8b5fc6b9c487a09a7957188e0943c9ff08432c65e34567cabc1623b03a51/numpy-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:5de60946f14ebe15e713a6f22850c2372fa72f4ff9a432ab44aa90edcadaa65a", size = 6152482, upload-time = "2026-01-10T06:44:36.798Z" },
     { url = "https://files.pythonhosted.org/packages/00/a5/9f8ca5856b8940492fc24fbe13c1bc34d65ddf4079097cf9e53164d094e1/numpy-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:8f085da926c0d491ffff3096f91078cc97ea67e7e6b65e490bc8dcda65663be2", size = 12627117, upload-time = "2026-01-10T06:44:38.828Z" },
     { url = "https://files.pythonhosted.org/packages/ad/0d/eca3d962f9eef265f01a8e0d20085c6dd1f443cbffc11b6dede81fd82356/numpy-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:6436cffb4f2bf26c974344439439c95e152c9a527013f26b3577be6c2ca64295", size = 10667121, upload-time = "2026-01-10T06:44:41.644Z" },
+]
+
+[[package]]
+name = "openpyxl"
+version = "3.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "et-xmlfile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- **Ruff rule expansion**: 25 → 41 active rule sets (16 new: FLY, FA, YTT, PD, SLOT, ICN, EXE, INT, NPY, AIR, ASYNC, INP, ERA, Q, COM, TCH); auto-fixed ~938 trailing comma violations
- **Coverage push**: 85% → 92% via 258 new tests across 4 new test files
- **CI gate raised**: `--cov-fail-under` 85% → 90%
- **Version bump**: 3.2.8 → 3.2.9

## New test files
| File | Tests | Coverage area |
|------|-------|---------------|
| `test_diff_inventory_output.py` | 88 | Inventory diff output across all formats (console, JSON, HTML, Excel, MD, CSV, PR comment) |
| `test_cli_command_handlers.py` | 69 | CLI dispatch for --stats, --org-report, --list-snapshots, --prune-snapshots, diff config unpacking |
| `test_profile_management.py` | 45 | Interactive profile creation, import, test, show |
| `test_snapshot_commands.py` | 56 | Snapshot creation, comparison, name resolution |

## Test plan
- [x] `uv run ruff check src/ tests/` — zero violations
- [x] `uv run ruff format --check src/ tests/` — all formatted
- [x] `uv run pytest tests/ --cov=cja_auto_sdr --cov-fail-under=90` — 3,928 passed, 7 skipped, 92% coverage
- [x] `uv run python scripts/check_version_sync.py` — all version refs match 3.2.9