### PR TITLE
v3.3.2: Discovery Inspection Commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - All five commands support `--format console/json/csv`, `--output`, and `--profile` for multi-org workflows
 - Graceful degradation: `--describe-dataview` shows "N/A" for component counts when API permissions are limited
 - **Terminal-aware text wrapping**: All five discovery inspection commands now wrap long text (e.g. descriptions) at the terminal width instead of overflowing horizontally
+- **Shared discovery normalization helpers**: Extracted common owner/date/component normalization into reusable core utilities
+
+### Fixed
+- **Name resolution efficiency**: `--describe-dataview` now calls `getDataView()` (single) instead of `getDataViews()` (all) to avoid an expensive API round-trip
+- **Not-found exit code**: `--describe-dataview` returns exit code 1 with a machine-readable `error_type=not_found` on stderr when the requested resource is missing
+- **NaN/NA identity handling**: Discovery inspection commands no longer crash on `pd.NA`, `pd.NaT`, or `float('nan')` values in API payloads; these are coerced to display-safe placeholders
+- **Table wrapping edge cases**: Fixed column-width calculation when non-last columns already exceed terminal width
+- **Hidden component consistency**: Component counts now consistently exclude hidden items across all five inspection commands
+- **Ignored-option warnings**: Commands that don't support `--filter`/`--sort`/`--limit` now warn when those flags are passed instead of silently ignoring them
+
+### Changed
+- **Canonical data view names**: Inspection output now uses the API-returned data view name rather than the user-supplied input, ensuring consistent display
+- **Owner/date alias normalization**: List commands normalize variant field names (e.g. `ownerFullName` vs `owner`) to stable column headers across different API response shapes
+- **JSON output contracts**: Hardened JSON envelopes across discovery and snapshot commands to guarantee consistent key ordering and type contracts
+- **Typed error handling**: Dataview lookup errors now raise typed exceptions with structured diagnostics instead of generic strings
 
 ## [3.3.1] - 2026-02-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Data View Name Resolution**: All five inspection commands accept data view names in addition to IDs (`dv_...`), matching the diff mode pattern. Names are resolved via the API with `--name-match` support (exact, insensitive, fuzzy). Ambiguous names prompt for interactive disambiguation.
 - All five commands support `--format table/json/csv`, `--output`, and `--profile` for multi-org workflows
 - Graceful degradation: `--describe-dataview` shows "N/A" for component counts when API permissions are limited
+- **Terminal-aware text wrapping**: All five discovery inspection commands now wrap long text (e.g. descriptions) at the terminal width instead of overflowing horizontally
 
 ## [3.3.1] - 2026-02-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Discovery Inspection Commands**: Five new commands for drilling into individual data view resources without generating a full SDR:
+  - `--describe-dataview <ID>` — Show detailed metadata and component counts (metrics, dimensions, segments, calculated metrics)
+  - `--list-metrics <ID>` — List all metrics in a data view with `--filter`/`--sort`/`--limit` support
+  - `--list-dimensions <ID>` — List all dimensions in a data view with `--filter`/`--sort`/`--limit` support
+  - `--list-segments <ID>` — List all segments/filters scoped to a data view with owner and governance fields
+  - `--list-calculated-metrics <ID>` — List all calculated metrics with type, polarity, and governance fields
+- All five commands support `--format table/json/csv`, `--output`, and `--profile` for multi-org workflows
+- Graceful degradation: `--describe-dataview` shows "N/A" for component counts when API permissions are limited
+
 ## [3.3.1] - 2026-02-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the CJA SDR Generator project will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.3.2] - 2026-02-20
 
 ### Added
 - **Discovery Inspection Commands**: Five new commands for drilling into individual data view resources without generating a full SDR:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Discovery Inspection Commands**: Five new commands for drilling into individual data view resources without generating a full SDR:
-  - `--describe-dataview <ID>` — Show detailed metadata and component counts (metrics, dimensions, segments, calculated metrics)
-  - `--list-metrics <ID>` — List all metrics in a data view with `--filter`/`--sort`/`--limit` support
-  - `--list-dimensions <ID>` — List all dimensions in a data view with `--filter`/`--sort`/`--limit` support
-  - `--list-segments <ID>` — List all segments/filters scoped to a data view with owner and governance fields
-  - `--list-calculated-metrics <ID>` — List all calculated metrics with type, polarity, and governance fields
+  - `--describe-dataview <ID_OR_NAME>` — Show detailed metadata and component counts (metrics, dimensions, segments, calculated metrics)
+  - `--list-metrics <ID_OR_NAME>` — List all metrics in a data view with `--filter`/`--sort`/`--limit` support
+  - `--list-dimensions <ID_OR_NAME>` — List all dimensions in a data view with `--filter`/`--sort`/`--limit` support
+  - `--list-segments <ID_OR_NAME>` — List all segments/filters scoped to a data view with owner and governance fields
+  - `--list-calculated-metrics <ID_OR_NAME>` — List all calculated metrics with type, polarity, and governance fields
+- **Data View Name Resolution**: All five inspection commands accept data view names in addition to IDs (`dv_...`), matching the diff mode pattern. Names are resolved via the API with `--name-match` support (exact, insensitive, fuzzy). Ambiguous names prompt for interactive disambiguation.
 - All five commands support `--format table/json/csv`, `--output`, and `--profile` for multi-org workflows
 - Graceful degradation: `--describe-dataview` shows "N/A" for component counts when API permissions are limited
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Discovery Inspection Commands**: Five new commands for drilling into individual data view resources without generating a full SDR:
   - `--describe-dataview <ID_OR_NAME>` — Show detailed metadata and component counts (metrics, dimensions, segments, calculated metrics)
-  - `--list-metrics <ID_OR_NAME>` — List all metrics in a data view with `--filter`/`--sort`/`--limit` support
-  - `--list-dimensions <ID_OR_NAME>` — List all dimensions in a data view with `--filter`/`--sort`/`--limit` support
+  - `--list-metrics <ID_OR_NAME>` — List all metrics in a data view with `--filter`/`--exclude`/`--sort`/`--limit` support
+  - `--list-dimensions <ID_OR_NAME>` — List all dimensions in a data view with `--filter`/`--exclude`/`--sort`/`--limit` support
   - `--list-segments <ID_OR_NAME>` — List all segments/filters scoped to a data view with owner and governance fields
   - `--list-calculated-metrics <ID_OR_NAME>` — List all calculated metrics with type, polarity, and governance fields
 - **Data View Name Resolution**: All five inspection commands accept data view names in addition to IDs (`dv_...`), matching the diff mode pattern. Names are resolved via the API with `--name-match` support (exact, insensitive, fuzzy). Ambiguous names prompt for interactive disambiguation.
-- All five commands support `--format table/json/csv`, `--output`, and `--profile` for multi-org workflows
+- All five commands support `--format console/json/csv`, `--output`, and `--profile` for multi-org workflows
 - Graceful degradation: `--describe-dataview` shows "N/A" for component counts when API permissions are limited
 - **Terminal-aware text wrapping**: All five discovery inspection commands now wrap long text (e.g. descriptions) at the terminal width instead of overflowing horizontally
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ CJA SDR Generator - A tool for generating Solution Design Reference (SDR) docume
 
 - Package manager: uv
 - Entry point: `cja_auto_sdr` command (via pyproject.toml scripts)
-- Current version: v3.3.1
+- Current version: v3.3.2
 - Main script: `generator.py` (~10k lines) — subpackages use lazy forwarding via `make_getattr()` in `core/lazy.py`
 
 ## CI & Quality

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (4,859+ tests)
+├── tests/                     # Test suite (4,862+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (4,862+ tests)
+├── tests/                     # Test suite (4,870+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (4,850+ tests)
+├── tests/                     # Test suite (4,859+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (4,838+ tests)
+├── tests/                     # Test suite (4,850+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ A **Solution Design Reference** is the essential documentation that bridges your
 | | Profile Testing | Validate credentials with `--profile-test` before use |
 | **Developer UX** | Quick Stats Mode | Get metrics/dimensions count instantly with `--stats` (no full report) |
 | | Connection & Dataset Discovery | `--list-connections` and `--list-datasets` for infrastructure inventory |
+| | Discovery Inspection | Drill into a data view's metrics, dimensions, segments, and calculated metrics |
 | | Machine-Readable Discovery | `--list-dataviews --format json` for scripting integration |
 | | Dry-Run Mode | Test configuration without generating reports |
 | | Color-Coded Output | Global color controls via `--no-color`, `NO_COLOR`, and `FORCE_COLOR` |
@@ -259,6 +260,8 @@ cja_auto_sdr "Production Analytics"
 | Inspect a data view | `cja_auto_sdr --describe-dataview dv_abc123` |
 | List metrics (with filter) | `cja_auto_sdr --list-metrics dv_abc123 --filter revenue` |
 | List dimensions as CSV | `cja_auto_sdr --list-dimensions dv_abc123 --format csv --output dims.csv` |
+| List segments | `cja_auto_sdr --list-segments dv_abc123` |
+| List calculated metrics | `cja_auto_sdr --list-calculated-metrics dv_abc123 --format json` |
 | Validate config only | `cja_auto_sdr --validate-config` |
 | **Diff Comparison** (default: console output) | |
 | Compare two Data Views | `cja_auto_sdr --diff dv_1 dv_2` |

--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (4,708+ tests)
+├── tests/                     # Test suite (4,745+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (4,774+ tests)
+├── tests/                     # Test suite (4,819+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (4,769+ tests)
+├── tests/                     # Test suite (4,774+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (4,819+ tests)
+├── tests/                     # Test suite (4,834+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (4,870+ tests)
+├── tests/                     # Test suite (4,881+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (4,837+ tests)
+├── tests/                     # Test suite (4,838+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ cja_auto_sdr "Production Analytics"
 | Interactive Data View selection | `cja_auto_sdr --interactive` |
 | Pipe to other tools | `cja_auto_sdr --list-dataviews --output - \| jq '.dataViews[]'` |
 | Inspect a data view | `cja_auto_sdr --describe-dataview dv_abc123` |
+| Inspect by name | `cja_auto_sdr --describe-dataview "Production Web Data"` |
 | List metrics (with filter) | `cja_auto_sdr --list-metrics dv_abc123 --filter revenue` |
 | List dimensions as CSV | `cja_auto_sdr --list-dimensions dv_abc123 --format csv --output dims.csv` |
 | List segments | `cja_auto_sdr --list-segments dv_abc123` |
@@ -408,7 +409,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (4,745+ tests)
+├── tests/                     # Test suite (4,756+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (4,756+ tests)
+├── tests/                     # Test suite (4,769+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (4,834+ tests)
+├── tests/                     # Test suite (4,837+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -256,6 +256,9 @@ cja_auto_sdr "Production Analytics"
 | List as JSON (for scripting) | `cja_auto_sdr --list-dataviews --format json` |
 | Interactive Data View selection | `cja_auto_sdr --interactive` |
 | Pipe to other tools | `cja_auto_sdr --list-dataviews --output - \| jq '.dataViews[]'` |
+| Inspect a data view | `cja_auto_sdr --describe-dataview dv_abc123` |
+| List metrics (with filter) | `cja_auto_sdr --list-metrics dv_abc123 --filter revenue` |
+| List dimensions as CSV | `cja_auto_sdr --list-dimensions dv_abc123 --format csv --output dims.csv` |
 | Validate config only | `cja_auto_sdr --validate-config` |
 | **Diff Comparison** (default: console output) | |
 | Compare two Data Views | `cja_auto_sdr --diff dv_1 dv_2` |

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -644,6 +644,8 @@ cja_auto_sdr --list-metrics "Prod Web" --name-match fuzzy
 > **Name resolution:** You can pass a data view name instead of an ID. Use `--name-match` to control matching mode (exact, insensitive, fuzzy). If a name matches multiple views, you'll be prompted to choose one interactively.
 >
 > **Filter/Sort/Limit/Exclude:** All list commands (`--list-metrics`, `--list-dimensions`, `--list-segments`, `--list-calculated-metrics`) support `--filter`, `--exclude`, `--sort`, and `--limit`. `--describe-dataview` does not (it returns a single resource).
+>
+> **Table column scope:** For readability, table output for `--list-segments` omits `tags`, `created`, and `modified`; table output for `--list-calculated-metrics` omits `precision`, `tags`, `created`, and `modified`. Use JSON/CSV for the full field set.
 
 ### Quick Statistics
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -15,6 +15,7 @@ Complete command-line interface documentation for the CJA SDR Generator.
   - [Configuration](#configuration)
   - [Profile Management](#profile-management)
   - [Validation & Testing](#validation--testing)
+  - [Discovery Inspection](#discovery-inspection)
   - [Caching](#caching)
   - [Retry Configuration](#retry-configuration)
   - [Diff Comparison](#diff-comparison)
@@ -27,6 +28,7 @@ Complete command-line interface documentation for the CJA SDR Generator.
   - [Single Data View](#single-data-view)
   - [Multiple Data Views](#multiple-data-views)
   - [Discovery Commands](#discovery-commands)
+  - [Discovery Inspection Commands](#discovery-inspection-commands)
   - [Quick Statistics](#quick-statistics)
   - [Interactive Data View Selection](#interactive-data-view-selection)
   - [Auto-Open Generated Files](#auto-open-generated-files)
@@ -215,6 +217,22 @@ cja_auto_sdr --list-dataviews
 | `--sort FIELD` | Sort discovery output by field (prefix `-` for descending), e.g. `--sort name` or `--sort=-id` | - |
 | `-i, --interactive` | Launch interactive mode for guided SDR generation. Walks through: data view selection, output format, and inventory options. Ideal for new users | False |
 | `--sample-config` | Generate sample config file and exit | False |
+
+### Discovery Inspection
+
+Drill into individual data view resources. These commands let you inspect a single data view's metadata, metrics, dimensions, segments, and calculated metrics without generating a full SDR report.
+
+| Option | Argument | Description |
+|--------|----------|-------------|
+| `--describe-dataview` | `DATA_VIEW_ID` | Show detailed metadata and component counts for a single data view |
+| `--list-metrics` | `DATA_VIEW_ID` | List all metrics in a data view |
+| `--list-dimensions` | `DATA_VIEW_ID` | List all dimensions in a data view |
+| `--list-segments` | `DATA_VIEW_ID` | List all segments/filters scoped to a data view |
+| `--list-calculated-metrics` | `DATA_VIEW_ID` | List all calculated metrics for a data view |
+
+> **Mutual exclusivity:** These commands are mutually exclusive with each other and with all other discovery commands (`--list-dataviews`, `--list-connections`, `--list-datasets`).
+>
+> **Filter/Sort/Limit:** `--list-metrics`, `--list-dimensions`, `--list-segments`, and `--list-calculated-metrics` support `--filter`, `--sort`, and `--limit` for filtering, ordering, and limiting results. `--describe-dataview` does not support these options (it returns a single resource).
 
 ### Caching
 
@@ -567,6 +585,53 @@ cja_auto_sdr dv_12345 --dry-run
 > **Note:** `--list-connections` requires the API service account to be a CJA Product Admin for full connection details (names, owners, datasets). Without admin privileges, the tool falls back to showing connection IDs derived from data views.
 >
 > **Discovery Filters:** All discovery commands support `--filter`, `--exclude`, `--limit`, and `--sort` for filtering, limiting, and ordering results.
+
+### Discovery Inspection Commands
+
+```bash
+# Inspect a single data view (metadata, component counts, owner, dates)
+cja_auto_sdr --describe-dataview dv_abc123
+
+# Describe data view as JSON (for scripting)
+cja_auto_sdr --describe-dataview dv_abc123 --format json
+
+# List all metrics in a data view
+cja_auto_sdr --list-metrics dv_abc123
+
+# Filter metrics by name pattern
+cja_auto_sdr --list-metrics dv_abc123 --filter "revenue"
+
+# Sort metrics by name (descending)
+cja_auto_sdr --list-metrics dv_abc123 --sort=-name
+
+# List all dimensions in a data view
+cja_auto_sdr --list-dimensions dv_abc123
+
+# Export dimensions to CSV file
+cja_auto_sdr --list-dimensions dv_abc123 --format csv --output dims.csv
+
+# List first 20 dimensions
+cja_auto_sdr --list-dimensions dv_abc123 --limit 20
+
+# List all segments/filters scoped to a data view
+cja_auto_sdr --list-segments dv_abc123
+
+# List segments as JSON
+cja_auto_sdr --list-segments dv_abc123 --format json
+
+# List calculated metrics for a data view
+cja_auto_sdr --list-calculated-metrics dv_abc123
+
+# Find calculated metrics matching a pattern
+cja_auto_sdr --list-calculated-metrics dv_abc123 --filter "percent"
+
+# Use with a profile
+cja_auto_sdr --profile client-a --list-metrics dv_abc123
+```
+
+> **Note:** Discovery inspection commands are mutually exclusive with each other and with `--list-dataviews`, `--list-connections`, and `--list-datasets`.
+>
+> **Filter/Sort/Limit:** All list commands (`--list-metrics`, `--list-dimensions`, `--list-segments`, `--list-calculated-metrics`) support `--filter`, `--sort`, and `--limit`. `--describe-dataview` does not (it returns a single resource).
 
 ### Quick Statistics
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -224,12 +224,14 @@ Drill into individual data view resources. These commands let you inspect a sing
 
 | Option | Argument | Description |
 |--------|----------|-------------|
-| `--describe-dataview` | `DATA_VIEW_ID` | Show detailed metadata and component counts for a single data view |
-| `--list-metrics` | `DATA_VIEW_ID` | List all metrics in a data view |
-| `--list-dimensions` | `DATA_VIEW_ID` | List all dimensions in a data view |
-| `--list-segments` | `DATA_VIEW_ID` | List all segments/filters scoped to a data view |
-| `--list-calculated-metrics` | `DATA_VIEW_ID` | List all calculated metrics for a data view |
+| `--describe-dataview` | `DATA_VIEW_ID_OR_NAME` | Show detailed metadata and component counts for a single data view |
+| `--list-metrics` | `DATA_VIEW_ID_OR_NAME` | List all metrics in a data view |
+| `--list-dimensions` | `DATA_VIEW_ID_OR_NAME` | List all dimensions in a data view |
+| `--list-segments` | `DATA_VIEW_ID_OR_NAME` | List all segments/filters scoped to a data view |
+| `--list-calculated-metrics` | `DATA_VIEW_ID_OR_NAME` | List all calculated metrics for a data view |
 
+> **Name resolution:** These commands accept a data view ID (`dv_...`) or a data view name. When a name is provided, it is resolved via the API. Use `--name-match` to control matching (exact, insensitive, or fuzzy). If a name matches multiple data views, you will be prompted to select one interactively.
+>
 > **Mutual exclusivity:** These commands are mutually exclusive with each other and with all other discovery commands (`--list-dataviews`, `--list-connections`, `--list-datasets`).
 >
 > **Filter/Sort/Limit:** `--list-metrics`, `--list-dimensions`, `--list-segments`, and `--list-calculated-metrics` support `--filter`, `--sort`, and `--limit` for filtering, ordering, and limiting results. `--describe-dataview` does not support these options (it returns a single resource).
@@ -627,9 +629,17 @@ cja_auto_sdr --list-calculated-metrics dv_abc123 --filter "percent"
 
 # Use with a profile
 cja_auto_sdr --profile client-a --list-metrics dv_abc123
+
+# Use a data view name instead of ID
+cja_auto_sdr --describe-dataview "Production Web Data"
+
+# Name with fuzzy matching
+cja_auto_sdr --list-metrics "Prod Web" --name-match fuzzy
 ```
 
 > **Note:** Discovery inspection commands are mutually exclusive with each other and with `--list-dataviews`, `--list-connections`, and `--list-datasets`.
+>
+> **Name resolution:** You can pass a data view name instead of an ID. Use `--name-match` to control matching mode (exact, insensitive, fuzzy). If a name matches multiple views, you'll be prompted to choose one interactively.
 >
 > **Filter/Sort/Limit:** All list commands (`--list-metrics`, `--list-dimensions`, `--list-segments`, `--list-calculated-metrics`) support `--filter`, `--sort`, and `--limit`. `--describe-dataview` does not (it returns a single resource).
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -127,8 +127,8 @@ cja-auto-sdr [OPTIONS] DATA_VIEW_ID_OR_NAME [...]
 
 **Format Availability by Mode:**
 
-| Format | SDR Generation | Diff Comparison | Org-Wide Analysis | Discovery Commands |
-|--------|----------------|-----------------|-------------------|--------------------|
+| Format | SDR Generation | Diff Comparison | Org-Wide Analysis | Discovery |
+|--------|----------------|-----------------|-------------------|-----------|
 | `excel` | ✓ (default) | ✓ | ✓ | ✗ |
 | `csv` | ✓ | ✓ | ✓ | ✓ |
 | `json` | ✓ | ✓ | ✓ | ✓ |
@@ -137,7 +137,9 @@ cja-auto-sdr [OPTIONS] DATA_VIEW_ID_OR_NAME [...]
 | `console` | ✗ | ✓ (default) | ✓ (default) | ✓ (default) |
 | `all` | ✓ | ✓ | ✓ | ✗ |
 
-> **Note:** Console format is only supported for diff comparison and org-wide analysis. Using `--format console` with SDR generation will show an error with suggested alternatives.
+> **Note:** The Discovery column covers both discovery commands (`--list-dataviews`, `--list-connections`, `--list-datasets`) and discovery inspection commands (`--describe-dataview`, `--list-metrics`, `--list-dimensions`, `--list-segments`, `--list-calculated-metrics`). All share the same format support.
+>
+> **Note:** Console format is supported for diff comparison, org-wide analysis, and discovery. Using `--format console` with SDR generation will show an error with suggested alternatives.
 >
 > **Note:** In diff and org-wide modes, `--format all` includes console output (displayed in terminal) in addition to all file formats.
 
@@ -234,7 +236,7 @@ Drill into individual data view resources. These commands let you inspect a sing
 >
 > **Mutual exclusivity:** These commands are mutually exclusive with each other and with all other discovery commands (`--list-dataviews`, `--list-connections`, `--list-datasets`).
 >
-> **Filter/Sort/Limit:** `--list-metrics`, `--list-dimensions`, `--list-segments`, and `--list-calculated-metrics` support `--filter`, `--sort`, and `--limit` for filtering, ordering, and limiting results. `--describe-dataview` does not support these options (it returns a single resource).
+> **Filter/Sort/Limit/Exclude:** `--list-metrics`, `--list-dimensions`, `--list-segments`, and `--list-calculated-metrics` support `--filter`, `--exclude`, `--sort`, and `--limit` for filtering, ordering, and limiting results. `--describe-dataview` does not support these options (it returns a single resource).
 
 ### Caching
 
@@ -586,7 +588,7 @@ cja_auto_sdr dv_12345 --dry-run
 >
 > **Note:** `--list-connections` requires the API service account to be a CJA Product Admin for full connection details (names, owners, datasets). Without admin privileges, the tool falls back to showing connection IDs derived from data views.
 >
-> **Discovery Filters:** All discovery commands support `--filter`, `--exclude`, `--limit`, and `--sort` for filtering, limiting, and ordering results.
+> **Discovery Filters:** `--list-dataviews`, `--list-connections`, and `--list-datasets` support `--filter`, `--exclude`, `--limit`, and `--sort` for filtering, limiting, and ordering results.
 
 ### Discovery Inspection Commands
 
@@ -641,7 +643,7 @@ cja_auto_sdr --list-metrics "Prod Web" --name-match fuzzy
 >
 > **Name resolution:** You can pass a data view name instead of an ID. Use `--name-match` to control matching mode (exact, insensitive, fuzzy). If a name matches multiple views, you'll be prompted to choose one interactively.
 >
-> **Filter/Sort/Limit:** All list commands (`--list-metrics`, `--list-dimensions`, `--list-segments`, `--list-calculated-metrics`) support `--filter`, `--sort`, and `--limit`. `--describe-dataview` does not (it returns a single resource).
+> **Filter/Sort/Limit/Exclude:** All list commands (`--list-metrics`, `--list-dimensions`, `--list-segments`, `--list-calculated-metrics`) support `--filter`, `--exclude`, `--sort`, and `--limit`. `--describe-dataview` does not (it returns a single resource).
 
 ### Quick Statistics
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -913,7 +913,7 @@ cja_auto_sdr --list-dataviews --log-level DEBUG
 At launch, the tool logs a diagnostic line containing the tool version, Python version, platform, active log level, and inferred run mode (batch, single, or discovery). This appears automatically at `INFO` level and is useful for troubleshooting environment issues in CI/CD logs or support requests:
 
 ```text
-CJA SDR Generator v3.3.1 | Python 3.14.2 | darwin | log_level=INFO | mode=single
+CJA SDR Generator v3.3.2 | Python 3.14.2 | darwin | log_level=INFO | mode=single
 ```
 
 ### Structured JSON Logging

--- a/docs/OUTPUT_FORMATS.md
+++ b/docs/OUTPUT_FORMATS.md
@@ -11,13 +11,13 @@ The tool supports multiple output formats beyond Excel, providing flexible integ
 | **JSON** | Hierarchical structured data | APIs, automation, integration with tools |
 | **HTML** | Professional web-ready report | Web viewing, sharing, presentations |
 | **Markdown** (.md) | GitHub/Confluence compatible tables | Documentation, version control, PRs |
-| **Console** | Terminal output with ASCII formatting | Quick review, diff comparison, org-wide analysis |
+| **Console** | Terminal output with ASCII formatting | Quick review, diff comparison, org-wide analysis, discovery |
 | **All** | Generate all formats simultaneously (includes console in diff/org-wide modes) | Complete documentation package |
 
 ### Format Availability by Mode
 
-| Format | SDR Generation | Diff Comparison | Org-Wide Analysis | Discovery Inspection |
-|--------|----------------|-----------------|-------------------|----------------------|
+| Format | SDR Generation | Diff Comparison | Org-Wide Analysis | Discovery |
+|--------|----------------|-----------------|-------------------|-----------|
 | Excel | ✓ (default) | ✓ | ✓ | ✗ |
 | CSV | ✓ | ✓ | ✓ | ✓ |
 | JSON | ✓ | ✓ | ✓ | ✓ |
@@ -26,7 +26,7 @@ The tool supports multiple output formats beyond Excel, providing flexible integ
 | Console/Table | ✗ | ✓ (default) | ✓ (default) | ✓ (default) |
 | All | ✓ | ✓ | ✓ | ✗ |
 
-> **Discovery Inspection** commands (`--describe-dataview`, `--list-metrics`, `--list-dimensions`, `--list-segments`, `--list-calculated-metrics`) output table (console), JSON, or CSV. They do not generate file-based formats like Excel, HTML, or Markdown.
+> The Discovery column covers both discovery commands (`--list-dataviews`, `--list-connections`, `--list-datasets`) and discovery inspection commands (`--describe-dataview`, `--list-metrics`, `--list-dimensions`, `--list-segments`, `--list-calculated-metrics`). All output console (table), JSON, or CSV. They do not generate file-based formats like Excel, HTML, or Markdown.
 
 ### Format Aliases (introduced in v3.2.0)
 

--- a/docs/OUTPUT_FORMATS.md
+++ b/docs/OUTPUT_FORMATS.md
@@ -16,15 +16,17 @@ The tool supports multiple output formats beyond Excel, providing flexible integ
 
 ### Format Availability by Mode
 
-| Format | SDR Generation | Diff Comparison | Org-Wide Analysis |
-|--------|----------------|-----------------|-------------------|
-| Excel | ✓ (default) | ✓ | ✓ |
-| CSV | ✓ | ✓ | ✓ |
-| JSON | ✓ | ✓ | ✓ |
-| HTML | ✓ | ✓ | ✓ |
-| Markdown | ✓ | ✓ | ✓ |
-| Console | ✗ | ✓ (default) | ✓ (default) |
-| All | ✓ | ✓ | ✓ |
+| Format | SDR Generation | Diff Comparison | Org-Wide Analysis | Discovery Inspection |
+|--------|----------------|-----------------|-------------------|----------------------|
+| Excel | ✓ (default) | ✓ | ✓ | ✗ |
+| CSV | ✓ | ✓ | ✓ | ✓ |
+| JSON | ✓ | ✓ | ✓ | ✓ |
+| HTML | ✓ | ✓ | ✓ | ✗ |
+| Markdown | ✓ | ✓ | ✓ | ✗ |
+| Console/Table | ✗ | ✓ (default) | ✓ (default) | ✓ (default) |
+| All | ✓ | ✓ | ✓ | ✗ |
+
+> **Discovery Inspection** commands (`--describe-dataview`, `--list-metrics`, `--list-dimensions`, `--list-segments`, `--list-calculated-metrics`) output table (console), JSON, or CSV. They do not generate file-based formats like Excel, HTML, or Markdown.
 
 ### Format Aliases (introduced in v3.2.0)
 

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -400,6 +400,19 @@ uv run cja_auto_sdr --list-datasets
 
 This is useful for understanding which datasets feed into which data views before generating an SDR.
 
+You can also drill into individual data view components without generating a full SDR:
+
+```bash
+# Inspect a data view's metadata and component counts
+uv run cja_auto_sdr --describe-dataview dv_677ea9291244fd082f02dd42
+
+# Browse metrics, dimensions, segments, or calculated metrics
+uv run cja_auto_sdr --list-metrics dv_677ea9291244fd082f02dd42 --filter "revenue"
+uv run cja_auto_sdr --list-segments dv_677ea9291244fd082f02dd42
+```
+
+See [CLI Reference](CLI_REFERENCE.md#discovery-inspection) for the full set of inspection commands.
+
 > **Note:** Full connection details require the API service account to be a CJA Product Admin. If you only see connection IDs (like `dg_...`) instead of names, see [Troubleshooting](TROUBLESHOOTING.md#connections-api-returns-empty-results) for how to grant the technical account admin rights.
 
 ### 4.3 Choose a Data View

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -203,7 +203,7 @@ This command:
 
 ```bash
 $ uv run cja_auto_sdr -V
-cja_auto_sdr 3.3.1
+cja_auto_sdr 3.3.2
 ```
 
 > **Important:** All commands in this guide assume you're in the `cja_auto_sdr` directory. If you see "command not found", make sure you're in the right directory and have run `uv sync`.

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -10,6 +10,7 @@ Single-page command cheat sheet for CJA SDR Generator v3.3.2.
 | **Diff Comparison** | Compare two data views or snapshots to identify changes | Side-by-side comparison showing added, removed, and modified components |
 | **Org-Wide Analysis** | Analyze component usage across all data views in an organization | Distribution reports, similarity matrix, governance recommendations |
 | **Discovery** | List data views, connections, and datasets in your CJA org | Console table, JSON, or CSV output |
+| **Discovery Inspection** | Drill into a data view's metrics, dimensions, segments, and calculated metrics | Console table, JSON, or CSV output |
 
 **SDR Generation** creates a Solution Design Reference—a comprehensive inventory of all components in a data view. Use this for documentation, audits, and onboarding.
 
@@ -18,6 +19,8 @@ Single-page command cheat sheet for CJA SDR Generator v3.3.2.
 **Org-Wide Analysis** examines all accessible data views to identify core components, detect duplicates, and provide governance insights. Use this for audits, standardization, and understanding your analytics landscape.
 
 **Discovery** lists the CJA infrastructure: data views, connections, and their backing datasets. Use this for onboarding, infrastructure audits, and understanding the data pipeline before generating SDRs.
+
+**Discovery Inspection** drills into a single data view's components without generating a full SDR. Use this for quick audits, pre-SDR exploration, and verifying component availability.
 
 ## Running Commands
 
@@ -364,6 +367,8 @@ cja_auto_sdr --list-dataviews  # Uses client-a
 | `markdown` | ✅ | ✅ | ✅ | ❌ | Documentation-ready |
 | `console` | ❌ | ✅ (default) | ✅ (default) | ✅ (default) | Terminal output |
 | `all` | ✅ | ✅ | ✅ | ❌ | All formats |
+
+> Discovery column covers both discovery commands (`--list-dataviews`, etc.) and inspection commands (`--describe-dataview`, `--list-metrics`, etc.).
 
 ### Format Aliases (Shortcuts)
 

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -118,6 +118,12 @@ cja_auto_sdr --list-metrics dv_abc123 --sort name --limit 20
 
 # Pipe to jq for scripting
 cja_auto_sdr --list-dimensions dv_abc123 --format json --output - | jq '.[].name'
+
+# Use a data view name instead of ID
+cja_auto_sdr --describe-dataview "Production Web Data"
+
+# Name with fuzzy matching
+cja_auto_sdr --list-metrics "Prod Web" --name-match fuzzy
 ```
 
 ## Diff Comparison Commands (Diff Mode)

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Quick Reference Card
 
-Single-page command cheat sheet for CJA SDR Generator v3.3.1.
+Single-page command cheat sheet for CJA SDR Generator v3.3.2.
 
 ## Four Main Modes
 

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -95,6 +95,31 @@ cja_auto_sdr dv_12345 --quality-report json --output quality_issues.json
 
 > **Quality constraints:** `--fail-on-quality` and `--quality-report` are SDR-only and cannot be used with `--skip-validation`.
 
+## Discovery Inspection Commands
+
+```bash
+# Inspect a data view (metadata, component counts, owner, dates)
+cja_auto_sdr --describe-dataview dv_abc123
+
+# Browse metrics (with filter)
+cja_auto_sdr --list-metrics dv_abc123 --filter revenue
+
+# Export dimensions to CSV
+cja_auto_sdr --list-dimensions dv_abc123 --format csv --output dims.csv
+
+# List segments as JSON
+cja_auto_sdr --list-segments dv_abc123 --format json
+
+# Find calculated metrics by pattern
+cja_auto_sdr --list-calculated-metrics dv_abc123 --filter percent
+
+# Sort and limit results
+cja_auto_sdr --list-metrics dv_abc123 --sort name --limit 20
+
+# Pipe to jq for scripting
+cja_auto_sdr --list-dimensions dv_abc123 --format json --output - | jq '.[].name'
+```
+
 ## Diff Comparison Commands (Diff Mode)
 
 ```bash

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -14,6 +14,7 @@ Common scenarios and recommended practices for the CJA SDR Generator.
   - [Compliance Documentation](#compliance-documentation)
   - [Migration Planning](#migration-planning)
   - [Connection & Dataset Discovery](#connection--dataset-discovery)
+  - [Discovery Inspection](#discovery-inspection)
   - [Data View Drift Detection (CI/CD)](#data-view-drift-detection-cicd)
   - [Automated Audit Trail](#automated-audit-trail)
   - [Multi-Organization Management](#multi-organization-management)
@@ -205,6 +206,47 @@ done
 ```
 
 > **Note:** Full connection details (names, owners, dataset names) require the API service account to be a CJA Product Admin. Without admin privileges, the tool shows connection IDs derived from data views. See [Troubleshooting](TROUBLESHOOTING.md#connections-api-returns-empty-results) for setup instructions.
+
+### Discovery Inspection
+
+Drill into a single data view's components without generating a full SDR:
+- Quick-check what metrics, dimensions, segments, or calculated metrics exist
+- Pre-SDR exploration to verify a data view has the expected components
+- Filter and sort component lists to find specific items
+- Export component inventories for stakeholder review or automation
+
+**Best for:** Pre-SDR exploration, quick component audits, CI validation, data view onboarding
+
+```bash
+# Describe a data view — metadata and component counts at a glance
+cja_auto_sdr --describe-dataview dv_abc123
+
+# Use a data view name instead of an ID
+cja_auto_sdr --describe-dataview "Production Web Data"
+
+# List all metrics, filtered to revenue-related
+cja_auto_sdr --list-metrics dv_abc123 --filter revenue
+
+# Export dimensions as CSV for spreadsheet review
+cja_auto_sdr --list-dimensions dv_abc123 --format csv --output dims.csv
+
+# List segments with owner and governance info
+cja_auto_sdr --list-segments dv_abc123
+
+# Export calculated metrics as JSON for programmatic use
+cja_auto_sdr --list-calculated-metrics dv_abc123 --format json --output calcs.json
+
+# Combine filter, sort, and limit
+cja_auto_sdr --list-dimensions dv_abc123 --filter "evar|prop" --sort name --limit 20
+
+# Exclude test components
+cja_auto_sdr --list-metrics dv_abc123 --exclude "test|debug"
+
+# Fuzzy name matching across organizations
+cja_auto_sdr --list-metrics "Prod Web" --name-match fuzzy --profile client-a
+```
+
+> **Note:** All five inspection commands support `--format console/json/csv`, `--output`, `--profile`, and `--name-match`. The four list commands also support `--filter`, `--exclude`, `--sort`, and `--limit`. See [CLI Reference](CLI_REFERENCE.md#discovery-inspection) for full details.
 
 ### Data View Drift Detection (CI/CD)
 

--- a/src/cja_auto_sdr/cli/parser.py
+++ b/src/cja_auto_sdr/cli/parser.py
@@ -484,28 +484,28 @@ Requirements:
         "--list-metrics",
         type=str,
         metavar="DATA_VIEW_ID_OR_NAME",
-        help="List all metrics in a data view (supports --filter, --sort, --limit). Accepts a data view ID (dv_...) or name. Honors --name-match.",
+        help="List all metrics in a data view (supports --filter, --exclude, --sort, --limit). Accepts a data view ID (dv_...) or name. Honors --name-match.",
     )
 
     discovery_mx.add_argument(
         "--list-dimensions",
         type=str,
         metavar="DATA_VIEW_ID_OR_NAME",
-        help="List all dimensions in a data view (supports --filter, --sort, --limit). Accepts a data view ID (dv_...) or name. Honors --name-match.",
+        help="List all dimensions in a data view (supports --filter, --exclude, --sort, --limit). Accepts a data view ID (dv_...) or name. Honors --name-match.",
     )
 
     discovery_mx.add_argument(
         "--list-segments",
         type=str,
         metavar="DATA_VIEW_ID_OR_NAME",
-        help="List all segments/filters scoped to a data view (supports --filter, --sort, --limit). Accepts a data view ID (dv_...) or name. Honors --name-match.",
+        help="List all segments/filters scoped to a data view (supports --filter, --exclude, --sort, --limit). Accepts a data view ID (dv_...) or name. Honors --name-match.",
     )
 
     discovery_mx.add_argument(
         "--list-calculated-metrics",
         type=str,
         metavar="DATA_VIEW_ID_OR_NAME",
-        help="List all calculated metrics for a data view (supports --filter, --sort, --limit). Accepts a data view ID (dv_...) or name. Honors --name-match.",
+        help="List all calculated metrics for a data view (supports --filter, --exclude, --sort, --limit). Accepts a data view ID (dv_...) or name. Honors --name-match.",
     )
 
     parser.add_argument(

--- a/src/cja_auto_sdr/cli/parser.py
+++ b/src/cja_auto_sdr/cli/parser.py
@@ -476,36 +476,36 @@ Requirements:
     discovery_mx.add_argument(
         "--describe-dataview",
         type=str,
-        metavar="DATA_VIEW_ID",
-        help="Show detailed metadata and component counts for a single data view",
+        metavar="DATA_VIEW_ID_OR_NAME",
+        help="Show detailed metadata and component counts for a single data view. Accepts a data view ID (dv_...) or name. Honors --name-match.",
     )
 
     discovery_mx.add_argument(
         "--list-metrics",
         type=str,
-        metavar="DATA_VIEW_ID",
-        help="List all metrics in a data view (supports --filter, --sort, --limit)",
+        metavar="DATA_VIEW_ID_OR_NAME",
+        help="List all metrics in a data view (supports --filter, --sort, --limit). Accepts a data view ID (dv_...) or name. Honors --name-match.",
     )
 
     discovery_mx.add_argument(
         "--list-dimensions",
         type=str,
-        metavar="DATA_VIEW_ID",
-        help="List all dimensions in a data view (supports --filter, --sort, --limit)",
+        metavar="DATA_VIEW_ID_OR_NAME",
+        help="List all dimensions in a data view (supports --filter, --sort, --limit). Accepts a data view ID (dv_...) or name. Honors --name-match.",
     )
 
     discovery_mx.add_argument(
         "--list-segments",
         type=str,
-        metavar="DATA_VIEW_ID",
-        help="List all segments/filters scoped to a data view (supports --filter, --sort, --limit)",
+        metavar="DATA_VIEW_ID_OR_NAME",
+        help="List all segments/filters scoped to a data view (supports --filter, --sort, --limit). Accepts a data view ID (dv_...) or name. Honors --name-match.",
     )
 
     discovery_mx.add_argument(
         "--list-calculated-metrics",
         type=str,
-        metavar="DATA_VIEW_ID",
-        help="List all calculated metrics for a data view (supports --filter, --sort, --limit)",
+        metavar="DATA_VIEW_ID_OR_NAME",
+        help="List all calculated metrics for a data view (supports --filter, --sort, --limit). Accepts a data view ID (dv_...) or name. Honors --name-match.",
     )
 
     parser.add_argument(

--- a/src/cja_auto_sdr/cli/parser.py
+++ b/src/cja_auto_sdr/cli/parser.py
@@ -473,6 +473,41 @@ Requirements:
         help="List all data views with their backing connections and datasets, then exit",
     )
 
+    discovery_mx.add_argument(
+        "--describe-dataview",
+        type=str,
+        metavar="DATA_VIEW_ID",
+        help="Show detailed metadata and component counts for a single data view",
+    )
+
+    discovery_mx.add_argument(
+        "--list-metrics",
+        type=str,
+        metavar="DATA_VIEW_ID",
+        help="List all metrics in a data view (supports --filter, --sort, --limit)",
+    )
+
+    discovery_mx.add_argument(
+        "--list-dimensions",
+        type=str,
+        metavar="DATA_VIEW_ID",
+        help="List all dimensions in a data view (supports --filter, --sort, --limit)",
+    )
+
+    discovery_mx.add_argument(
+        "--list-segments",
+        type=str,
+        metavar="DATA_VIEW_ID",
+        help="List all segments/filters scoped to a data view (supports --filter, --sort, --limit)",
+    )
+
+    discovery_mx.add_argument(
+        "--list-calculated-metrics",
+        type=str,
+        metavar="DATA_VIEW_ID",
+        help="List all calculated metrics for a data view (supports --filter, --sort, --limit)",
+    )
+
     parser.add_argument(
         "--sort",
         type=str,

--- a/src/cja_auto_sdr/core/discovery_normalization.py
+++ b/src/cja_auto_sdr/core/discovery_normalization.py
@@ -1,0 +1,188 @@
+"""Shared normalization helpers for discovery and inspection command payloads."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+import pandas as pd
+
+_NULL_LIKE_TEXT_VALUES = frozenset({"<na>", "n/a", "nan", "none", "null"})
+_OWNER_FIELD_PRIORITY = ("name", "fullName", "full_name", "ownerFullName", "login", "email", "imsUserId", "id")
+_OWNER_ALIAS_FIELDS = ("ownerFullName", "ownerName", "owner_name", "owner_full_name")
+_TAG_NAME_FIELDS = ("name", "label", "title", "id")
+
+
+def _is_na_like(value: Any) -> bool:
+    """Return True when pandas recognizes the value as missing."""
+    try:
+        is_na = pd.isna(value)
+    except TypeError, ValueError:
+        return False
+
+    if isinstance(is_na, bool):
+        return is_na
+    if hasattr(is_na, "all"):
+        try:
+            return bool(is_na.all())
+        except TypeError, ValueError:
+            return False
+    return False
+
+
+def is_missing_value(
+    value: Any,
+    *,
+    treat_blank_string: bool = False,
+    treat_null_like_strings: bool = False,
+) -> bool:
+    """Return True when a value should be treated as missing for display logic."""
+    if value is None or _is_na_like(value):
+        return True
+
+    if isinstance(value, str):
+        text = value.strip()
+        if treat_blank_string and not text:
+            return True
+        if treat_null_like_strings and text.casefold() in _NULL_LIKE_TEXT_VALUES:
+            return True
+
+    return False
+
+
+def normalize_display_text(
+    value: Any,
+    *,
+    default: str = "",
+    treat_null_like_strings: bool = False,
+) -> str:
+    """Normalize arbitrary values to display-safe text."""
+    if is_missing_value(
+        value,
+        treat_blank_string=True,
+        treat_null_like_strings=treat_null_like_strings,
+    ):
+        return default
+    text = str(value).strip()
+    if treat_null_like_strings and text.casefold() in _NULL_LIKE_TEXT_VALUES:
+        return default
+    return text or default
+
+
+def pick_first_present_value(
+    candidates: Iterable[Any],
+    *,
+    treat_blank_string: bool = True,
+    treat_null_like_strings: bool = False,
+) -> Any | None:
+    """Return the first non-missing candidate value."""
+    for candidate in candidates:
+        if is_missing_value(
+            candidate,
+            treat_blank_string=treat_blank_string,
+            treat_null_like_strings=treat_null_like_strings,
+        ):
+            continue
+        return candidate
+    return None
+
+
+def pick_first_present_text(
+    candidates: Iterable[Any],
+    *,
+    default: str = "",
+    treat_null_like_strings: bool = False,
+) -> str:
+    """Return normalized text for the first non-missing candidate."""
+    candidate = pick_first_present_value(
+        candidates,
+        treat_blank_string=True,
+        treat_null_like_strings=treat_null_like_strings,
+    )
+    if candidate is None:
+        return default
+    return normalize_display_text(
+        candidate,
+        default=default,
+        treat_null_like_strings=treat_null_like_strings,
+    )
+
+
+def extract_owner_name(
+    owner_data: Any,
+    *,
+    default: str = "N/A",
+) -> str:
+    """Extract a displayable owner name from heterogenous API owner payloads."""
+    if isinstance(owner_data, Mapping):
+        for key in _OWNER_FIELD_PRIORITY:
+            owner_name = normalize_display_text(
+                owner_data.get(key),
+                default="",
+                treat_null_like_strings=True,
+            )
+            if owner_name:
+                return owner_name
+        return default
+    return normalize_display_text(
+        owner_data,
+        default=default,
+        treat_null_like_strings=True,
+    )
+
+
+def extract_owner_name_from_record(
+    record: Mapping[str, Any],
+    *,
+    default: str = "N/A",
+) -> str:
+    """Extract owner name from record-level aliases used by API endpoints."""
+    owner_name = extract_owner_name(record.get("owner"), default=default)
+    if owner_name != default:
+        return owner_name
+
+    for key in _OWNER_ALIAS_FIELDS:
+        alias_name = normalize_display_text(
+            record.get(key),
+            default="",
+            treat_null_like_strings=True,
+        )
+        if alias_name:
+            return alias_name
+    return default
+
+
+def extract_tags(tags_data: Any) -> list[str]:
+    """Extract normalized tag names from API tags payloads."""
+    if is_missing_value(tags_data):
+        return []
+
+    if isinstance(tags_data, Mapping):
+        raw_tags: list[Any] = [tags_data]
+    elif isinstance(tags_data, (list, tuple, set)):
+        raw_tags = list(tags_data)
+    else:
+        raw_tags = [tags_data]
+
+    tags: list[str] = []
+    for tag in raw_tags:
+        if is_missing_value(tag):
+            continue
+
+        if isinstance(tag, Mapping):
+            normalized = pick_first_present_text(
+                (tag.get(key) for key in _TAG_NAME_FIELDS),
+                default="",
+                treat_null_like_strings=True,
+            )
+        else:
+            normalized = normalize_display_text(
+                tag,
+                default="",
+                treat_null_like_strings=True,
+            )
+
+        if normalized:
+            tags.append(normalized)
+    return tags
+

--- a/src/cja_auto_sdr/core/discovery_normalization.py
+++ b/src/cja_auto_sdr/core/discovery_normalization.py
@@ -185,4 +185,3 @@ def extract_tags(tags_data: Any) -> list[str]:
         if normalized:
             tags.append(normalized)
     return tags
-

--- a/src/cja_auto_sdr/core/discovery_payloads.py
+++ b/src/cja_auto_sdr/core/discovery_payloads.py
@@ -1,0 +1,169 @@
+"""Discovery payload classification for data-view inspection commands."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+import pandas as pd
+
+EXPLICIT_ERROR_KEYS = frozenset({"error", "errorcode", "errordescription", "error_description"})
+STATUS_KEYS = frozenset({"statuscode", "status_code", "status"})
+ERROR_TEXT_KEYS = frozenset({"message", "detail", "title"})
+COMPONENT_SEQUENCE_KEYS = ("content", "items", "results", "data", "rows")
+
+
+class PayloadKind(Enum):
+    """Normalized classification for discovery API payloads."""
+
+    DATA = "data"
+    EMPTY = "empty"
+    ERROR = "error"
+    INVALID = "invalid"
+
+
+@dataclass(frozen=True)
+class PayloadAssessment:
+    """Normalized payload assessment used by discovery list/describe commands."""
+
+    kind: PayloadKind
+    rows: list[dict[str, Any]]
+    reason: str
+    raw_type: str
+
+
+def normalized_payload_keys(payload: Mapping[str, Any]) -> set[str]:
+    """Return normalized dictionary keys for payload-shape checks."""
+    return {str(key).strip().casefold() for key in payload}
+
+
+def _has_identity_value(payload: Mapping[str, Any], identity_keys: tuple[str, ...]) -> bool:
+    for key in identity_keys:
+        value = payload.get(key)
+        if value is None:
+            continue
+        if isinstance(value, str):
+            if value.strip():
+                return True
+            continue
+        if bool(value):
+            return True
+    return False
+
+
+def _schema_indicates_error(keys: set[str], *, has_identity: bool) -> bool:
+    if not keys:
+        return True
+    if keys & EXPLICIT_ERROR_KEYS:
+        return True
+    if has_identity:
+        return False
+    return bool(keys & STATUS_KEYS) and bool(keys & ERROR_TEXT_KEYS)
+
+
+def looks_like_error_payload(payload: Mapping[str, Any], *, identity_keys: tuple[str, ...] = ("id", "name")) -> bool:
+    """Return True when object keys match an API-error-like shape."""
+    keys = normalized_payload_keys(payload)
+    has_identity = _has_identity_value(payload, identity_keys)
+    return _schema_indicates_error(keys, has_identity=has_identity)
+
+
+def is_dataview_error_payload(payload: Mapping[str, Any]) -> bool:
+    """Return True when getDataView payload appears to be an API error object."""
+    return looks_like_error_payload(payload, identity_keys=("id", "name"))
+
+
+def extract_component_sequence(payload: Mapping[str, Any]) -> list[Any] | None:
+    """Extract list-like component rows from common API envelope shapes."""
+    for key in COMPONENT_SEQUENCE_KEYS:
+        if key not in payload:
+            continue
+        value = payload.get(key)
+        if value is None:
+            return []
+        if isinstance(value, pd.DataFrame):
+            return value.to_dict("records")
+        if isinstance(value, (list, tuple, set)):
+            return list(value)
+        if isinstance(value, Mapping):
+            nested = extract_component_sequence(value)
+            if nested is not None:
+                return nested
+        return []
+    return None
+
+
+def looks_like_component_error_payload(payload: Mapping[str, Any]) -> bool:
+    """Return True when a component row payload matches an API error shape."""
+    return looks_like_error_payload(payload, identity_keys=("id", "name"))
+
+
+def _empty_dataframe_schema_is_error(frame: pd.DataFrame) -> bool:
+    return _schema_indicates_error({str(column).strip().casefold() for column in frame.columns}, has_identity=False)
+
+
+def assess_component_payload(raw_payload: Any) -> PayloadAssessment:
+    """Classify mixed component payload shapes into DATA/EMPTY/ERROR/INVALID."""
+    raw_type = type(raw_payload).__name__
+
+    if raw_payload is None:
+        return PayloadAssessment(PayloadKind.EMPTY, [], "none_payload", raw_type)
+
+    if isinstance(raw_payload, pd.DataFrame):
+        if raw_payload.empty:
+            if len(raw_payload.columns) == 0:
+                return PayloadAssessment(PayloadKind.EMPTY, [], "empty_dataframe_no_columns", raw_type)
+            if _empty_dataframe_schema_is_error(raw_payload):
+                return PayloadAssessment(PayloadKind.ERROR, [], "empty_dataframe_error_schema", raw_type)
+            return PayloadAssessment(PayloadKind.EMPTY, [], "empty_dataframe_rows", raw_type)
+        return assess_component_payload(raw_payload.to_dict("records"))
+
+    if isinstance(raw_payload, Mapping):
+        if normalized_payload_keys(raw_payload) & EXPLICIT_ERROR_KEYS:
+            return PayloadAssessment(PayloadKind.ERROR, [], "object_explicit_error_shape", raw_type)
+        extracted_rows = extract_component_sequence(raw_payload)
+        if extracted_rows is not None:
+            return assess_component_payload(extracted_rows)
+        if looks_like_component_error_payload(raw_payload):
+            return PayloadAssessment(PayloadKind.ERROR, [], "object_error_shape", raw_type)
+        return PayloadAssessment(PayloadKind.DATA, [dict(raw_payload)], "single_object_row", raw_type)
+
+    if isinstance(raw_payload, (list, tuple, set)):
+        rows = list(raw_payload)
+        if not rows:
+            return PayloadAssessment(PayloadKind.EMPTY, [], "empty_sequence", raw_type)
+
+        dict_rows = [dict(row) for row in rows if isinstance(row, Mapping)]
+
+        if not dict_rows:
+            return PayloadAssessment(PayloadKind.INVALID, [], "non_mapping_sequence_rows", raw_type)
+
+        if any(looks_like_component_error_payload(row) for row in dict_rows):
+            return PayloadAssessment(PayloadKind.ERROR, [], "error_row_detected", raw_type)
+
+        return PayloadAssessment(PayloadKind.DATA, dict_rows, "mapping_rows", raw_type)
+
+    return PayloadAssessment(PayloadKind.INVALID, [], "unsupported_payload_type", raw_type)
+
+
+def coerce_component_rows_or_none(raw_payload: Any) -> list[dict[str, Any]] | None:
+    """Normalize component payloads into row dicts, or None when invalid/error."""
+    assessment = assess_component_payload(raw_payload)
+    if assessment.kind in {PayloadKind.DATA, PayloadKind.EMPTY}:
+        return assessment.rows
+    return None
+
+
+def is_component_error_payload(raw_payload: Any) -> bool:
+    """Return True when a component payload is assessed as an API error."""
+    return assess_component_payload(raw_payload).kind is PayloadKind.ERROR
+
+
+def count_component_items_or_na(raw_payload: Any) -> int | str:
+    """Return component count or 'N/A' when payload is unavailable/invalid."""
+    assessment = assess_component_payload(raw_payload)
+    if assessment.kind in {PayloadKind.ERROR, PayloadKind.INVALID}:
+        return "N/A"
+    return len(assessment.rows)

--- a/src/cja_auto_sdr/core/discovery_payloads.py
+++ b/src/cja_auto_sdr/core/discovery_payloads.py
@@ -9,6 +9,8 @@ from typing import Any
 
 import pandas as pd
 
+from cja_auto_sdr.core.discovery_normalization import is_missing_value
+
 EXPLICIT_ERROR_KEYS = frozenset({"error", "errorcode", "errordescription", "error_description"})
 STATUS_KEYS = frozenset({"statuscode", "status_code", "status"})
 ERROR_TEXT_KEYS = frozenset({"message", "detail", "title"})
@@ -39,17 +41,13 @@ def normalized_payload_keys(payload: Mapping[str, Any]) -> set[str]:
     return {str(key).strip().casefold() for key in payload}
 
 
-def _has_identity_value(payload: Mapping[str, Any], identity_keys: tuple[str, ...]) -> bool:
+def has_identity_value(payload: Mapping[str, Any], identity_keys: tuple[str, ...]) -> bool:
+    """Return True when any identity key has a non-missing value."""
     for key in identity_keys:
         value = payload.get(key)
-        if value is None:
+        if is_missing_value(value, treat_blank_string=True, treat_null_like_strings=True):
             continue
-        if isinstance(value, str):
-            if value.strip():
-                return True
-            continue
-        if bool(value):
-            return True
+        return True
     return False
 
 
@@ -66,7 +64,7 @@ def _schema_indicates_error(keys: set[str], *, has_identity: bool) -> bool:
 def looks_like_error_payload(payload: Mapping[str, Any], *, identity_keys: tuple[str, ...] = ("id", "name")) -> bool:
     """Return True when object keys match an API-error-like shape."""
     keys = normalized_payload_keys(payload)
-    has_identity = _has_identity_value(payload, identity_keys)
+    has_identity = has_identity_value(payload, identity_keys)
     return _schema_indicates_error(keys, has_identity=has_identity)
 
 

--- a/src/cja_auto_sdr/core/version.py
+++ b/src/cja_auto_sdr/core/version.py
@@ -1,3 +1,3 @@
 """Version information for CJA Auto SDR."""
 
-__version__ = "3.3.1"
+__version__ = "3.3.2"

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -92,6 +92,24 @@ from cja_auto_sdr.core.constants import (
     infer_format_from_path,
     should_generate_format,
 )
+from cja_auto_sdr.core.discovery_normalization import (
+    extract_owner_name as _extract_owner_name_normalized,
+)
+from cja_auto_sdr.core.discovery_normalization import (
+    extract_owner_name_from_record as _extract_owner_name_from_record_normalized,
+)
+from cja_auto_sdr.core.discovery_normalization import (
+    extract_tags as _extract_tags_normalized,
+)
+from cja_auto_sdr.core.discovery_normalization import (
+    is_missing_value as _is_missing_discovery_value,
+)
+from cja_auto_sdr.core.discovery_normalization import (
+    normalize_display_text as _normalize_display_text,
+)
+from cja_auto_sdr.core.discovery_normalization import (
+    pick_first_present_text as _pick_first_present_text,
+)
 from cja_auto_sdr.core.discovery_payloads import (
     PayloadKind as _PayloadKind,
 )
@@ -7477,24 +7495,40 @@ def _extract_dataset_info(dataset: Any) -> dict:
         Dict with 'id' and 'name' keys (values may be 'N/A' if not found)
     """
     if not isinstance(dataset, dict):
-        return {"id": str(dataset) if dataset else "N/A", "name": "N/A"}
+        # Preserve previous fallback semantics for scalar falsey values while
+        # avoiding ambiguous truthiness checks on pandas missing scalars.
+        if _is_missing_discovery_value(dataset, treat_blank_string=True, treat_null_like_strings=True):
+            return {"id": "N/A", "name": "N/A"}
+        if isinstance(dataset, (bool, int, float)) and not dataset:
+            return {"id": "N/A", "name": "N/A"}
+        return {"id": _normalize_display_text(dataset, default="N/A"), "name": "N/A"}
 
     # Try common ID field names (prefer canonical/camelCase, keep snake_case for compatibility)
-    ds_id = (
-        dataset.get("id") or dataset.get("datasetId") or dataset.get("dataSetId") or dataset.get("dataset_id") or "N/A"
+    ds_id = _pick_first_present_text(
+        (
+            dataset.get("id"),
+            dataset.get("datasetId"),
+            dataset.get("dataSetId"),
+            dataset.get("dataset_id"),
+        ),
+        default="N/A",
+        treat_null_like_strings=True,
     )
 
     # Try common name field names
-    ds_name = (
-        dataset.get("name")
-        or dataset.get("datasetName")
-        or dataset.get("dataSetName")
-        or dataset.get("dataset_name")
-        or dataset.get("title")
-        or "N/A"
+    ds_name = _pick_first_present_text(
+        (
+            dataset.get("name"),
+            dataset.get("datasetName"),
+            dataset.get("dataSetName"),
+            dataset.get("dataset_name"),
+            dataset.get("title"),
+        ),
+        default="N/A",
+        treat_null_like_strings=True,
     )
 
-    return {"id": str(ds_id), "name": str(ds_name)}
+    return {"id": ds_id, "name": ds_name}
 
 
 # ==================== LIST HELPERS ====================
@@ -7614,43 +7648,21 @@ def _extract_owner_name(owner_data: Any) -> str:
     - Connections may return ``{"imsUserId": "ABC@AdobeID"}``
     - Some endpoints return ``None`` or a bare string.
     """
-    if owner_data is None:
-        return "N/A"
-    if isinstance(owner_data, str):
-        return owner_data or "N/A"
-    if isinstance(owner_data, dict):
-        for key in ("name", "fullName", "full_name", "ownerFullName", "login", "email", "imsUserId", "id"):
-            val = owner_data.get(key)
-            if val:
-                return str(val)
-        return "N/A"
-    return str(owner_data) or "N/A"
+    return _extract_owner_name_normalized(owner_data, default="N/A")
 
 
 def _normalize_optional_text(value: Any, *, default: str = "") -> str:
     """Normalize optional display values, handling None/NaN and whitespace."""
-    if value is None:
-        return default
-    try:
-        if pd.isna(value):
-            return default
-    except TypeError, ValueError:
-        pass
-    text = str(value).strip()
-    return text or default
+    return _normalize_display_text(
+        value,
+        default=default,
+        treat_null_like_strings=True,
+    )
 
 
 def _extract_owner_name_from_record(record: dict[str, Any]) -> str:
     """Extract owner name from record-level owner aliases used by CJA endpoints."""
-    owner_name = _extract_owner_name(record.get("owner"))
-    if owner_name != "N/A":
-        return owner_name
-
-    for key in ("ownerFullName", "ownerName", "owner_name", "owner_full_name"):
-        alias_name = _normalize_optional_text(record.get(key))
-        if alias_name:
-            return alias_name
-    return "N/A"
+    return _extract_owner_name_from_record_normalized(record, default="N/A")
 
 
 def _extract_timestamp_from_record(record: dict[str, Any], field: str) -> str:
@@ -8026,8 +8038,8 @@ def _fetch_dataviews(
         display_data = []
         for dv in available_dvs:
             if isinstance(dv, dict):
-                dv_id = dv.get("id", "N/A")
-                dv_name = dv.get("name", "N/A")
+                dv_id = _normalize_optional_text(dv.get("id"), default="N/A")
+                dv_name = _normalize_optional_text(dv.get("name"), default="N/A")
                 owner_name = _extract_owner_name(dv.get("owner"))
                 display_data.append({"id": dv_id, "name": dv_name, "owner": owner_name})
 
@@ -8195,13 +8207,13 @@ def _fetch_describe_dataview(
     def _inner(cja: Any, _is_machine_readable: bool) -> str | None:
         raw_dv = _require_accessible_dataview(cja, data_view_id)
 
-        dv_id = raw_dv.get("id", data_view_id)
-        dv_name = raw_dv.get("name", "N/A")
+        dv_id = _normalize_optional_text(raw_dv.get("id"), default=data_view_id)
+        dv_name = _normalize_optional_text(raw_dv.get("name"), default="N/A")
         owner_name = _extract_owner_name(raw_dv.get("owner"))
         description = raw_dv.get("description", "")
-        connection_id = raw_dv.get("parentDataGroupId", "N/A")
-        created = raw_dv.get("created", "N/A")
-        modified = raw_dv.get("modified", "N/A")
+        connection_id = _normalize_optional_text(raw_dv.get("parentDataGroupId"), default="N/A")
+        created = _normalize_optional_text(raw_dv.get("created"), default="N/A")
+        modified = _normalize_optional_text(raw_dv.get("modified"), default="N/A")
 
         def _safe_count(api_call: Callable, *args: Any, **kwargs: Any) -> int | str:
             """Call an API method and return the item count, or 'N/A' on failure."""
@@ -8341,10 +8353,7 @@ def _resolve_dataview_name(cja: Any, data_view_id: str) -> str:
     Raises DiscoveryNotFoundError if the data view is missing or inaccessible.
     """
     raw_dv = _require_accessible_dataview(cja, data_view_id)
-    raw_name = raw_dv.get("name")
-    if raw_name is None:
-        return "Unknown"
-    normalized_name = str(raw_name).strip()
+    normalized_name = _normalize_optional_text(raw_dv.get("name"), default="")
     return normalized_name or "Unknown"
 
 
@@ -8379,8 +8388,8 @@ def _fetch_metrics_list(
 
         display_data = [
             {
-                "id": m.get("id", "N/A"),
-                "name": m.get("name", "N/A"),
+                "id": _normalize_optional_text(m.get("id"), default="N/A"),
+                "name": _normalize_optional_text(m.get("name"), default="N/A"),
                 "type": m.get("type", "N/A"),
                 "description": m.get("description", ""),
             }
@@ -8488,8 +8497,8 @@ def _fetch_dimensions_list(
 
         display_data = [
             {
-                "id": d.get("id", "N/A"),
-                "name": d.get("name", "N/A"),
+                "id": _normalize_optional_text(d.get("id"), default="N/A"),
+                "name": _normalize_optional_text(d.get("name"), default="N/A"),
                 "type": d.get("type", "N/A"),
                 "description": d.get("description", ""),
             }
@@ -8609,13 +8618,12 @@ def _fetch_segments_list(
         for item in raw_segments:
             if not isinstance(item, dict):
                 continue
-            raw_tags = item.get("tags") or []
-            tags = [t.get("name", str(t)) if isinstance(t, dict) else str(t) for t in raw_tags]
+            tags = _extract_tags_normalized(item.get("tags"))
             approved_raw = item.get("approved")
             display_data.append(
                 {
-                    "id": item.get("id", "N/A"),
-                    "name": item.get("name", "N/A"),
+                    "id": _normalize_optional_text(item.get("id"), default="N/A"),
+                    "name": _normalize_optional_text(item.get("name"), default="N/A"),
                     "owner": _extract_owner_name_from_record(item),
                     "description": item.get("description", ""),
                     "approved": approved_raw if isinstance(approved_raw, bool) else None,
@@ -8650,7 +8658,7 @@ def _fetch_segments_list(
             {
                 **row,
                 "approved": _approved_display(row.get("approved")),
-                "tags": ", ".join(row.get("tags") or []),
+                "tags": ", ".join(_extract_tags_normalized(row.get("tags"))),
             }
             for row in display_data
         ]
@@ -8742,13 +8750,12 @@ def _fetch_calculated_metrics_list(
         for item in raw_metrics:
             if not isinstance(item, dict):
                 continue
-            raw_tags = item.get("tags") or []
-            tags = [t.get("name", str(t)) if isinstance(t, dict) else str(t) for t in raw_tags]
+            tags = _extract_tags_normalized(item.get("tags"))
             approved_raw = item.get("approved")
             display_data.append(
                 {
-                    "id": item.get("id", "N/A"),
-                    "name": item.get("name", "N/A"),
+                    "id": _normalize_optional_text(item.get("id"), default="N/A"),
+                    "name": _normalize_optional_text(item.get("name"), default="N/A"),
                     "owner": _extract_owner_name_from_record(item),
                     "description": item.get("description", ""),
                     "type": item.get("type", ""),
@@ -8786,7 +8793,7 @@ def _fetch_calculated_metrics_list(
             {
                 **row,
                 "approved": _approved_display(row.get("approved")),
-                "tags": ", ".join(row.get("tags") or []),
+                "tags": ", ".join(_extract_tags_normalized(row.get("tags"))),
             }
             for row in display_data
         ]
@@ -8881,7 +8888,7 @@ def _fetch_connections(
                 if not isinstance(dv, dict):
                     continue
                 pid = dv.get("parentDataGroupId")
-                if pid is not None and not (isinstance(pid, float) and pd.isna(pid)):
+                if not _is_missing_discovery_value(pid, treat_blank_string=True, treat_null_like_strings=True):
                     conn_ids_from_dvs[pid] = conn_ids_from_dvs.get(pid, 0) + 1
 
             if conn_ids_from_dvs:
@@ -8950,9 +8957,10 @@ def _fetch_connections(
         for conn in connections:
             if not isinstance(conn, dict):
                 continue
-            conn_id = conn.get("id", "N/A")
-            conn_name = conn.get("name", "N/A")
-            owner_name = _extract_owner_name(conn.get("ownerFullName") or conn.get("owner"))
+            conn_id = _normalize_optional_text(conn.get("id"), default="N/A")
+            conn_name = _normalize_optional_text(conn.get("name"), default="N/A")
+            owner_full_name = _normalize_optional_text(conn.get("ownerFullName"), default="")
+            owner_name = owner_full_name or _extract_owner_name(conn.get("owner"))
 
             raw_datasets = conn.get("dataSets", conn.get("datasets", []))
             if not isinstance(raw_datasets, list):
@@ -9080,8 +9088,8 @@ def _fetch_datasets(
         for conn in _extract_connections_list(raw_connections):
             if not isinstance(conn, dict):
                 continue
-            conn_id = conn.get("id", "")
-            conn_name = conn.get("name", "N/A")
+            conn_id = _normalize_optional_text(conn.get("id"), default="")
+            conn_name = _normalize_optional_text(conn.get("name"), default="N/A")
             raw_datasets = conn.get("dataSets", conn.get("datasets", []))
             if not isinstance(raw_datasets, list):
                 raw_datasets = []
@@ -9109,7 +9117,7 @@ def _fetch_datasets(
                 if not isinstance(dv, dict):
                     continue
                 pid = dv.get("parentDataGroupId")
-                if pid is not None and not (isinstance(pid, float) and pd.isna(pid)):
+                if not _is_missing_discovery_value(pid, treat_blank_string=True, treat_null_like_strings=True):
                     _no_conn_details = True
                     break
 
@@ -9120,8 +9128,8 @@ def _fetch_datasets(
         for i, dv in enumerate(available_dvs):
             if not isinstance(dv, dict):
                 continue
-            dv_id = dv.get("id", "N/A")
-            dv_name = dv.get("name", "N/A")
+            dv_id = _normalize_optional_text(dv.get("id"), default="N/A")
+            dv_name = _normalize_optional_text(dv.get("name"), default="N/A")
 
             if not is_machine_readable:
                 print(f"  [{i + 1}/{len(available_dvs)}] {dv_name}...", end="\r")
@@ -9129,7 +9137,7 @@ def _fetch_datasets(
             parent_conn_id = dv.get("parentDataGroupId")
             # DataFrame-backed records can carry missing values as NaN/NA.
             # Normalize to None so machine-readable output emits "N/A", not NaN.
-            if parent_conn_id is not None and pd.isna(parent_conn_id):
+            if _is_missing_discovery_value(parent_conn_id, treat_blank_string=True, treat_null_like_strings=True):
                 parent_conn_id = None
 
             conn_info = conn_map.get(parent_conn_id) if parent_conn_id else None
@@ -9317,8 +9325,8 @@ def interactive_select_dataviews(config_file: str = "config.json", profile: str 
         display_data = []
         for dv in available_dvs:
             if isinstance(dv, dict):
-                dv_id = dv.get("id", "N/A")
-                dv_name = dv.get("name", "N/A")
+                dv_id = _normalize_optional_text(dv.get("id"), default="N/A")
+                dv_name = _normalize_optional_text(dv.get("name"), default="N/A")
                 owner_name = _extract_owner_name(dv.get("owner"))
                 display_data.append({"id": dv_id, "name": dv_name, "owner": owner_name})
 
@@ -9594,8 +9602,8 @@ def interactive_wizard(config_file: str = "config.json", profile: str | None = N
         display_data = []
         for dv in available_dvs:
             if isinstance(dv, dict):
-                dv_id = dv.get("id", "N/A")
-                dv_name = dv.get("name", "N/A")
+                dv_id = _normalize_optional_text(dv.get("id"), default="N/A")
+                dv_name = _normalize_optional_text(dv.get("name"), default="N/A")
                 display_data.append({"id": dv_id, "name": dv_name})
 
         if not display_data:

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -6849,35 +6849,18 @@ def run_dry_run(data_views: list[str], config_file: str, logger: logging.Logger,
                 dv_name = dv_info.get("name", "Unknown")
 
                 # Fetch component counts for predictions
-                metrics_count = 0
-                dimensions_count = 0
-                try:
-                    metrics = make_api_call_with_retry(
-                        cja.getMetrics,
-                        dv_id,
-                        logger=logger,
-                        operation_name=f"getMetrics({dv_id})",
-                    )
-                    if metrics is not None:
-                        metrics_count = len(metrics) if hasattr(metrics, "__len__") else 0
-                except RECOVERABLE_API_EXCEPTIONS as e:
-                    logger.debug(f"Could not fetch metrics count for {dv_id}: {e!s}")
-                except Exception as e:
-                    logger.debug(f"Unexpected metrics count error for {dv_id}: {e!s}", exc_info=True)
-
-                try:
-                    dimensions = make_api_call_with_retry(
-                        cja.getDimensions,
-                        dv_id,
-                        logger=logger,
-                        operation_name=f"getDimensions({dv_id})",
-                    )
-                    if dimensions is not None:
-                        dimensions_count = len(dimensions) if hasattr(dimensions, "__len__") else 0
-                except RECOVERABLE_API_EXCEPTIONS as e:
-                    logger.debug(f"Could not fetch dimensions count for {dv_id}: {e!s}")
-                except Exception as e:
-                    logger.debug(f"Unexpected dimensions count error for {dv_id}: {e!s}", exc_info=True)
+                metrics_count = _count_component_items_for_fetch_spec_with_retry(
+                    cja,
+                    dv_id,
+                    _METRICS_COMPONENT_FETCH_SPEC,
+                    logger=logger,
+                )
+                dimensions_count = _count_component_items_for_fetch_spec_with_retry(
+                    cja,
+                    dv_id,
+                    _DIMENSIONS_COMPONENT_FETCH_SPEC,
+                    logger=logger,
+                )
 
                 total_metrics += metrics_count
                 total_dimensions += dimensions_count
@@ -8254,17 +8237,26 @@ def _fetch_describe_dataview(
         created = dv_metadata["created"]
         modified = dv_metadata["modified"]
 
-        def _safe_count(api_call: Callable, *args: Any, **kwargs: Any) -> int | str:
-            """Call an API method and return the item count, or 'N/A' on failure."""
-            try:
-                return _count_component_items_or_na_from_assessment(api_call(*args, **kwargs))
-            except Exception:
-                return "N/A"
-
-        n_metrics = _safe_count(cja.getMetrics, data_view_id)
-        n_dimensions = _safe_count(cja.getDimensions, data_view_id)
-        n_segments = _safe_count(cja.getFilters, dataIds=data_view_id, full=True)
-        n_calc_metrics = _safe_count(cja.getCalculatedMetrics, dataIds=data_view_id, full=True)
+        n_metrics = _count_component_items_for_fetch_spec(
+            cja,
+            data_view_id,
+            _METRICS_COMPONENT_FETCH_SPEC,
+        )
+        n_dimensions = _count_component_items_for_fetch_spec(
+            cja,
+            data_view_id,
+            _DIMENSIONS_COMPONENT_FETCH_SPEC,
+        )
+        n_segments = _count_component_items_for_fetch_spec(
+            cja,
+            data_view_id,
+            _SEGMENTS_COMPONENT_FETCH_SPEC,
+        )
+        n_calc_metrics = _count_component_items_for_fetch_spec(
+            cja,
+            data_view_id,
+            _CALCULATED_METRICS_COMPONENT_FETCH_SPEC,
+        )
 
         # Compute total only when all counts are numeric
         counts = [n_metrics, n_dimensions, n_segments, n_calc_metrics]
@@ -8413,6 +8405,29 @@ class _ComponentFetchSpec:
     kwargs: dict[str, Any] = field(default_factory=dict)
 
 
+_METRICS_COMPONENT_FETCH_SPEC = _ComponentFetchSpec(
+    method_name="getMetrics",
+    kwargs={"inclType": "hidden", "full": True},
+)
+
+_DIMENSIONS_COMPONENT_FETCH_SPEC = _ComponentFetchSpec(
+    method_name="getDimensions",
+    kwargs={"inclType": "hidden", "full": True},
+)
+
+_SEGMENTS_COMPONENT_FETCH_SPEC = _ComponentFetchSpec(
+    method_name="getFilters",
+    data_view_arg_name="dataIds",
+    kwargs={"full": True},
+)
+
+_CALCULATED_METRICS_COMPONENT_FETCH_SPEC = _ComponentFetchSpec(
+    method_name="getCalculatedMetrics",
+    data_view_arg_name="dataIds",
+    kwargs={"full": True},
+)
+
+
 def _fetch_component_payload(cja: Any, data_view_id: str, fetch_spec: _ComponentFetchSpec) -> Any:
     """Invoke a component-list API call using a declarative fetch spec."""
     fetch_method = getattr(cja, fetch_spec.method_name, None)
@@ -8426,6 +8441,44 @@ def _fetch_component_payload(cja: Any, data_view_id: str, fetch_spec: _Component
         kwargs[fetch_spec.data_view_arg_name] = data_view_id
         return fetch_method(**kwargs)
     return fetch_method(data_view_id, **kwargs)
+
+
+def _count_component_items_for_fetch_spec(cja: Any, data_view_id: str, fetch_spec: _ComponentFetchSpec) -> int | str:
+    """Return a component count for one fetch spec, falling back to 'N/A' on runtime failures."""
+    try:
+        payload = _fetch_component_payload(cja, data_view_id, fetch_spec)
+        return _count_component_items_or_na_from_assessment(payload)
+    except Exception:
+        return "N/A"
+
+
+def _count_component_items_for_fetch_spec_with_retry(
+    cja: Any,
+    data_view_id: str,
+    fetch_spec: _ComponentFetchSpec,
+    *,
+    logger: logging.Logger,
+) -> int:
+    """Return component count via retry-aware fetches, degrading non-fatal issues to zero."""
+    component_label = fetch_spec.method_name
+    try:
+        payload = make_api_call_with_retry(
+            _fetch_component_payload,
+            cja,
+            data_view_id,
+            fetch_spec,
+            logger=logger,
+            operation_name=f"{component_label}({data_view_id})",
+        )
+        count = _count_component_items_or_na_from_assessment(payload)
+        if isinstance(count, int):
+            return count
+        logger.debug("Could not fetch %s count for %s: non-countable payload", component_label, data_view_id)
+    except RECOVERABLE_API_EXCEPTIONS as e:
+        logger.debug("Could not fetch %s count for %s: %s", component_label, data_view_id, e)
+    except Exception as e:
+        logger.debug("Unexpected %s count error for %s: %s", component_label, data_view_id, e, exc_info=True)
+    return 0
 
 
 def _build_component_list_fetcher(
@@ -8576,10 +8629,7 @@ def _fetch_metrics_list(
         table_item_label="metric",
         component_json_key="metrics",
         empty_csv_header="id,name,type,description",
-        fetch_spec=_ComponentFetchSpec(
-            method_name="getMetrics",
-            kwargs={"inclType": "hidden", "full": True},
-        ),
+        fetch_spec=_METRICS_COMPONENT_FETCH_SPEC,
         display_row_builder=_build_metric_display_row,
         searchable_fields=["id", "name", "type", "description"],
         csv_columns=["id", "name", "type", "description"],
@@ -8665,10 +8715,7 @@ def _fetch_dimensions_list(
         table_item_label="dimension",
         component_json_key="dimensions",
         empty_csv_header="id,name,type,description",
-        fetch_spec=_ComponentFetchSpec(
-            method_name="getDimensions",
-            kwargs={"inclType": "hidden", "full": True},
-        ),
+        fetch_spec=_DIMENSIONS_COMPONENT_FETCH_SPEC,
         display_row_builder=_build_dimension_display_row,
         searchable_fields=["id", "name", "type", "description"],
         csv_columns=["id", "name", "type", "description"],
@@ -8776,11 +8823,7 @@ def _fetch_segments_list(
         table_item_label="segment",
         component_json_key="segments",
         empty_csv_header="id,name,owner,approved,description,tags,created,modified",
-        fetch_spec=_ComponentFetchSpec(
-            method_name="getFilters",
-            data_view_arg_name="dataIds",
-            kwargs={"full": True},
-        ),
+        fetch_spec=_SEGMENTS_COMPONENT_FETCH_SPEC,
         display_row_builder=_build_segment_display_row,
         searchable_fields=["id", "name", "owner", "description", "tags"],
         csv_columns=["id", "name", "owner", "approved", "description", "tags", "created", "modified"],
@@ -8876,11 +8919,7 @@ def _fetch_calculated_metrics_list(
         table_item_label="calculated metric",
         component_json_key="calculatedMetrics",
         empty_csv_header="id,name,owner,type,polarity,precision,approved,tags,created,modified,description",
-        fetch_spec=_ComponentFetchSpec(
-            method_name="getCalculatedMetrics",
-            data_view_arg_name="dataIds",
-            kwargs={"full": True},
-        ),
+        fetch_spec=_CALCULATED_METRICS_COMPONENT_FETCH_SPEC,
         display_row_builder=_build_calculated_metric_display_row,
         searchable_fields=["id", "name", "owner", "type", "polarity", "description"],
         csv_columns=[
@@ -10286,15 +10325,18 @@ def _stats_error_row(data_view_id: str, error: Exception) -> dict[str, Any]:
     }
 
 
-def _coerce_stats_component_count(payload: Any) -> int:
-    """Return a safe component count for API payloads with mixed shapes."""
-    if payload is None:
-        return 0
-    if isinstance(payload, pd.DataFrame):
-        return len(payload) if not payload.empty else 0
-    if isinstance(payload, (list, tuple, set, dict)):
-        return len(payload)
-    return 0
+def _require_numeric_component_count_for_stats(
+    cja: cjapy.CJA,
+    data_view_id: str,
+    *,
+    fetch_spec: _ComponentFetchSpec,
+    component_label: str,
+) -> int:
+    """Return a strict numeric component count for stats rows or raise for invalid payloads."""
+    count = _count_component_items_for_fetch_spec(cja, data_view_id, fetch_spec)
+    if isinstance(count, int):
+        return count
+    raise ValueError(f"Failed to retrieve {component_label} for data view '{data_view_id}'")
 
 
 def _collect_stats_row(cja: cjapy.CJA, data_view_id: str) -> dict[str, Any]:
@@ -10302,10 +10344,18 @@ def _collect_stats_row(cja: cjapy.CJA, data_view_id: str) -> dict[str, Any]:
     dv_info = cja.getDataView(data_view_id)
     dv_name = dv_info.get("name", "Unknown") if isinstance(dv_info, dict) else "Unknown"
 
-    metrics_payload = cja.getMetrics(data_view_id)
-    dimensions_payload = cja.getDimensions(data_view_id)
-    metrics_count = _coerce_stats_component_count(metrics_payload)
-    dimensions_count = _coerce_stats_component_count(dimensions_payload)
+    metrics_count = _require_numeric_component_count_for_stats(
+        cja,
+        data_view_id,
+        fetch_spec=_METRICS_COMPONENT_FETCH_SPEC,
+        component_label="metrics",
+    )
+    dimensions_count = _require_numeric_component_count_for_stats(
+        cja,
+        data_view_id,
+        fetch_spec=_DIMENSIONS_COMPONENT_FETCH_SPEC,
+        component_label="dimensions",
+    )
 
     owner_info = dv_info.get("owner", {}) if isinstance(dv_info, dict) else {}
     owner_name = owner_info.get("name", "N/A") if isinstance(owner_info, dict) else "N/A"

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -8231,9 +8231,109 @@ def _normalize_single_dataview_payload(raw_dv: Any) -> dict[str, Any] | None:
     return raw_dv if isinstance(raw_dv, dict) else None
 
 
+_DATAVIEW_LOOKUP_NOT_FOUND_STATUS_CODES = frozenset({403, 404})
+_DATAVIEW_LOOKUP_STATUS_ATTRS = ("status_code", "statusCode", "status", "http_status", "httpStatus", "code")
+_DATAVIEW_LOOKUP_NOT_FOUND_MESSAGE_MARKERS = (
+    "not found",
+    "not_found",
+    "resource_not_found",
+    "forbidden",
+    "no access",
+    "access denied",
+)
+_HTTP_STATUS_CODE_RE = re.compile(r"\b([1-5]\d{2})\b")
+
+
+def _coerce_http_status_code(value: Any) -> int | None:
+    """Best-effort coercion of status-like values into an HTTP status code."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if 100 <= value <= 599 else None
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        if stripped.isdigit():
+            numeric_code = int(stripped)
+            return numeric_code if 100 <= numeric_code <= 599 else None
+        match = _HTTP_STATUS_CODE_RE.search(stripped)
+        if match:
+            numeric_code = int(match.group(1))
+            return numeric_code if 100 <= numeric_code <= 599 else None
+    return None
+
+
+def _iter_error_chain_nodes(error: Exception) -> list[Any]:
+    """Return error/cause/response nodes for robust status-code extraction."""
+    pending: list[Any] = [error]
+    seen: set[int] = set()
+    nodes: list[Any] = []
+    while pending:
+        node = pending.pop()
+        marker = id(node)
+        if marker in seen:
+            continue
+        seen.add(marker)
+        nodes.append(node)
+
+        if isinstance(node, dict):
+            nested = node.get("error")
+            if nested is not None:
+                pending.append(nested)
+            continue
+
+        for attr_name in ("original_error", "__cause__", "__context__", "response"):
+            with contextlib.suppress(Exception):
+                nested = getattr(node, attr_name)
+                if nested is not None:
+                    pending.append(nested)
+    return nodes
+
+
+def _extract_http_status_codes(error: Exception) -> set[int]:
+    """Extract candidate HTTP status codes from nested error objects."""
+    status_codes: set[int] = set()
+    for node in _iter_error_chain_nodes(error):
+        if isinstance(node, dict):
+            for key in _DATAVIEW_LOOKUP_STATUS_ATTRS:
+                code = _coerce_http_status_code(node.get(key))
+                if code is not None:
+                    status_codes.add(code)
+            continue
+
+        for attr_name in _DATAVIEW_LOOKUP_STATUS_ATTRS:
+            with contextlib.suppress(Exception):
+                code = _coerce_http_status_code(getattr(node, attr_name))
+                if code is not None:
+                    status_codes.add(code)
+    return status_codes
+
+
+def _is_inaccessible_dataview_lookup_error(error: Exception) -> bool:
+    """Return True when getDataView failures should map to not_found."""
+    status_codes = _extract_http_status_codes(error)
+    if any(code in _DATAVIEW_LOOKUP_NOT_FOUND_STATUS_CODES for code in status_codes):
+        return True
+
+    # Some APIError paths omit status_code but still include a stable not-found/forbidden marker.
+    if isinstance(error, APIError):
+        normalized_message = str(error).casefold()
+        return any(marker in normalized_message for marker in _DATAVIEW_LOOKUP_NOT_FOUND_MESSAGE_MARKERS)
+
+    return False
+
+
 def _require_accessible_dataview(cja: Any, data_view_id: str) -> dict[str, Any]:
     """Fetch a data view and raise DiscoveryNotFoundError when inaccessible/invalid."""
-    payload = _normalize_single_dataview_payload(cja.getDataView(data_view_id))
+    try:
+        raw_payload = cja.getDataView(data_view_id)
+    except Exception as e:
+        if _is_inaccessible_dataview_lookup_error(e):
+            raise DiscoveryNotFoundError(f"Data view '{data_view_id}' not found") from e
+        raise
+
+    payload = _normalize_single_dataview_payload(raw_payload)
     if payload is None or _is_dataview_error_payload(payload):
         raise DiscoveryNotFoundError(f"Data view '{data_view_id}' not found")
     if not _has_identity_discovery_value(payload, ("id", "name")):

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -8251,6 +8251,143 @@ def list_dimensions(
     )
 
 
+# ==================== LIST SEGMENTS ====================
+
+
+def _approved_display(value: Any) -> str:
+    """Convert an approved flag to a display string."""
+    if value is None:
+        return "N/A"
+    if isinstance(value, bool):
+        return "Yes" if value else "No"
+    return str(value)
+
+
+def _fetch_segments_list(
+    data_view_id: str,
+    output_format: str,
+    filter_pattern: str | None = None,
+    exclude_pattern: str | None = None,
+    limit: int | None = None,
+    sort_expression: str | None = None,
+) -> Callable:
+    """Return a fetch_and_format callback for list_segments."""
+
+    def _inner(cja: Any, is_machine_readable: bool) -> str | None:
+        dv_name = _resolve_dataview_name(cja, data_view_id)
+
+        raw_segments = cja.getFilters(dataIds=data_view_id, full=True)
+
+        if raw_segments is None or (hasattr(raw_segments, "__len__") and len(raw_segments) == 0):
+            if is_machine_readable:
+                if output_format == "json":
+                    return json.dumps(
+                        {"dataViewId": data_view_id, "dataViewName": dv_name, "segments": [], "count": 0},
+                        indent=2,
+                    )
+                return "id,name,owner,approved,description,tags,created,modified\n"
+            return f"\nNo segments found for data view '{data_view_id}'.\n"
+
+        if isinstance(raw_segments, pd.DataFrame):
+            raw_segments = raw_segments.to_dict("records")
+
+        # Build display dicts with native types
+        display_data: list[dict[str, Any]] = []
+        for item in raw_segments:
+            if not isinstance(item, dict):
+                continue
+            raw_tags = item.get("tags") or []
+            tags = [t.get("name", str(t)) if isinstance(t, dict) else str(t) for t in raw_tags]
+            approved_raw = item.get("approved")
+            display_data.append({
+                "id": item.get("id", "N/A"),
+                "name": item.get("name", "N/A"),
+                "owner": _extract_owner_name(item.get("owner")),
+                "description": item.get("description", ""),
+                "approved": approved_raw if isinstance(approved_raw, bool) else None,
+                "tags": tags,
+                "created": item.get("created", ""),
+                "modified": item.get("modified", ""),
+            })
+
+        display_data = _apply_discovery_filters_and_sort(
+            display_data,
+            filter_pattern=filter_pattern,
+            exclude_pattern=exclude_pattern,
+            limit=limit,
+            sort_expression=sort_expression,
+            searchable_fields=["id", "name", "owner", "description", "tags"],
+            default_sort_field="name",
+        )
+
+        if output_format == "json":
+            return _format_as_json({
+                "dataViewId": data_view_id,
+                "dataViewName": dv_name,
+                "segments": display_data,
+                "count": len(display_data),
+            })
+
+        # For table/CSV, convert approved and tags to display strings
+        table_data = [
+            {
+                **row,
+                "approved": _approved_display(row.get("approved")),
+                "tags": ", ".join(row.get("tags") or []),
+            }
+            for row in display_data
+        ]
+
+        if output_format == "csv":
+            return _format_as_csv(
+                ["id", "name", "owner", "approved", "description", "tags", "created", "modified"],
+                table_data,
+            )
+        return _format_as_table(
+            f"Found {len(table_data)} segment(s) in data view '{dv_name}':",
+            table_data,
+            columns=["id", "name", "owner", "approved", "description"],
+            col_labels=["ID", "Name", "Owner", "Approved", "Description"],
+        )
+
+    return _inner
+
+
+def list_segments(
+    data_view_id: str,
+    config_file: str = "config.json",
+    output_format: str = "table",
+    output_file: str | None = None,
+    profile: str | None = None,
+    filter_pattern: str | None = None,
+    exclude_pattern: str | None = None,
+    limit: int | None = None,
+    sort_expression: str | None = None,
+) -> bool:
+    """List all segments (filters) for a given data view."""
+    return _run_list_command(
+        banner_text=f"LISTING SEGMENTS FOR DATA VIEW: {data_view_id}",
+        command_name="list_segments",
+        fetch_and_format=_fetch_segments_list(
+            data_view_id,
+            output_format,
+            filter_pattern=filter_pattern,
+            exclude_pattern=exclude_pattern,
+            limit=limit,
+            sort_expression=sort_expression,
+        ),
+        config_file=config_file,
+        output_format=output_format,
+        output_file=output_file,
+        profile=profile,
+        validate_inputs=lambda: _validate_discovery_query_inputs(
+            filter_pattern=filter_pattern,
+            exclude_pattern=exclude_pattern,
+            limit=limit,
+        ),
+    )
+
+
 # ==================== LIST CONNECTIONS ====================
 
 

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -7590,16 +7590,16 @@ def _emit_output(data: str, output_file: str | None, is_stdout: bool) -> None:
         print(text)
 
 
-# ==================== SHARED DISCOVERY FORMATTERS ====================
+# ==================== SHARED OUTPUT FORMATTERS ====================
 
 
-def _format_as_json(payload: dict) -> str:
-    """Format a discovery result dict as indented JSON."""
+def _format_as_json(payload: dict, *, contract_label: str = "Output") -> str:
+    """Format a result dict as indented JSON with strict contract checks."""
     try:
         return json.dumps(payload, indent=2, allow_nan=False)
     except ValueError as exc:
-        raise DiscoveryOutputContractError(
-            "Discovery output contains non-JSON-compliant values",
+        raise OutputContractError(
+            f"{contract_label} contains non-JSON-compliant values",
         ) from exc
 
 
@@ -7657,6 +7657,14 @@ def _format_as_table(
             lines.append("".join(f"{item.get(col, '')!s:<{w}}" for col, w in zip(columns, widths, strict=True)))
     lines.append("")
     return "\n".join(lines)
+
+
+def _format_discovery_json(payload: dict) -> str:
+    """Format discovery payloads with a discovery-specific contract label."""
+    try:
+        return _format_as_json(payload, contract_label="Discovery output")
+    except OutputContractError as exc:
+        raise DiscoveryOutputContractError(str(exc)) from exc
 
 
 def _extract_owner_name(owner_data: Any) -> str:
@@ -7729,7 +7737,11 @@ class DiscoveryArgumentError(ValueError):
     """Raised when discovery filter/sort arguments are invalid."""
 
 
-class DiscoveryOutputContractError(ValueError):
+class OutputContractError(ValueError):
+    """Raised when machine-readable command output violates JSON contracts."""
+
+
+class DiscoveryOutputContractError(OutputContractError):
     """Raised when machine-readable discovery output violates JSON contracts."""
 
 
@@ -7774,6 +7786,43 @@ def _emit_discovery_error(
 
     stream = sys.stderr if human_to_stderr else sys.stdout
     print(ConsoleColors.error(f"ERROR: {message}"), file=stream)
+
+
+def _emit_output_contract_error(
+    message: str,
+    *,
+    is_machine_readable: bool,
+    human_to_stderr: bool = True,
+) -> None:
+    """Emit output-contract violations using a stable error envelope."""
+    _emit_discovery_error(
+        message,
+        is_machine_readable=is_machine_readable,
+        error_type="output_contract",
+        human_to_stderr=human_to_stderr,
+    )
+
+
+def _emit_json_output(
+    payload: dict[str, Any],
+    *,
+    output_file: str | None,
+    is_stdout: bool,
+    contract_label: str,
+    human_error_to_stderr: bool = True,
+) -> None:
+    """Serialize payload to strict JSON and emit it, exiting cleanly on contract errors."""
+    try:
+        serialized_payload = _format_as_json(payload, contract_label=contract_label)
+    except OutputContractError as exc:
+        _emit_output_contract_error(
+            str(exc),
+            is_machine_readable=_is_machine_readable_output("json", output_file),
+            human_to_stderr=human_error_to_stderr,
+        )
+        raise SystemExit(1) from exc
+
+    _emit_output(serialized_payload, output_file, is_stdout)
 
 
 def _to_numeric_sort_value(value: Any) -> float | None:
@@ -8006,11 +8055,10 @@ def _run_list_command(
         )
         return False
 
-    except DiscoveryOutputContractError as e:
-        _emit_discovery_error(
+    except OutputContractError as e:
+        _emit_output_contract_error(
             str(e),
             is_machine_readable=is_machine_readable,
-            error_type="output_contract",
             human_to_stderr=False,
         )
         return False
@@ -8086,7 +8134,7 @@ def _fetch_dataviews(
         )
 
         if output_format == "json":
-            return _format_as_json({"dataViews": display_data, "count": len(display_data)})
+            return _format_discovery_json({"dataViews": display_data, "count": len(display_data)})
         if output_format == "csv":
             return _format_as_csv(["id", "name", "owner"], display_data)
         table = _format_as_table(
@@ -8282,7 +8330,7 @@ def _fetch_describe_dataview(
                     },
                 }
             }
-            return _format_as_json(payload)
+            return _format_discovery_json(payload)
 
         if output_format == "csv":
             columns = [
@@ -8516,7 +8564,7 @@ def _build_component_list_fetcher(
         if not raw_components:
             if is_machine_readable:
                 if output_format == "json":
-                    return _format_as_json(
+                    return _format_discovery_json(
                         {
                             "dataViewId": data_view_id,
                             "dataViewName": dv_name,
@@ -8539,7 +8587,7 @@ def _build_component_list_fetcher(
         )
 
         if output_format == "json":
-            return _format_as_json(
+            return _format_discovery_json(
                 {
                     "dataViewId": data_view_id,
                     "dataViewName": dv_name,
@@ -9031,7 +9079,7 @@ def _fetch_connections(
                 )
 
                 if output_format == "json":
-                    return _format_as_json(
+                    return _format_discovery_json(
                         {
                             "connections": derived,
                             "count": len(derived),
@@ -9067,7 +9115,7 @@ def _fetch_connections(
             # Genuinely no connections
             if is_machine_readable:
                 if output_format == "json":
-                    return _format_as_json({"connections": [], "count": 0})
+                    return _format_discovery_json({"connections": [], "count": 0})
                 return "connection_id,connection_name,owner,dataset_id,dataset_name\n"
             return "\nNo connections found or no access to any connections.\n"
 
@@ -9105,7 +9153,7 @@ def _fetch_connections(
         )
 
         if output_format == "json":
-            return _format_as_json({"connections": display_data, "count": len(display_data)})
+            return _format_discovery_json({"connections": display_data, "count": len(display_data)})
         if output_format == "csv":
             # Flatten nested datasets: one CSV row per dataset
             flat_rows: list[dict] = []
@@ -9224,7 +9272,7 @@ def _fetch_datasets(
         if not available_dvs:
             if is_machine_readable:
                 if output_format == "json":
-                    return _format_as_json({"dataViews": [], "count": 0})
+                    return _format_discovery_json({"dataViews": [], "count": 0})
                 return "dataview_id,dataview_name,connection_id,connection_name,dataset_id,dataset_name\n"
             return "\nNo data views found or no access to any data views.\n"
 
@@ -9295,7 +9343,7 @@ def _fetch_datasets(
             result_payload["warning"] = _CONN_PERM_WARNING.replace("\n", " ")
 
         if output_format == "json":
-            return _format_as_json(result_payload)
+            return _format_discovery_json(result_payload)
         if output_format == "csv":
             # Flatten nested datasets: one CSV row per dataset per data view
             flat_rows: list[dict] = []
@@ -14352,7 +14400,12 @@ def _main_impl(run_state: dict[str, Any] | None = None):
                 "count": len(snapshots),
                 "snapshots": snapshots,
             }
-            _emit_output(_format_as_json(payload), getattr(args, "output", None), output_to_stdout)
+            _emit_json_output(
+                payload,
+                output_file=getattr(args, "output", None),
+                is_stdout=output_to_stdout,
+                contract_label="Snapshot listing output",
+            )
         elif list_output_format == "csv":
             rows = [
                 {
@@ -14461,7 +14514,12 @@ def _main_impl(run_state: dict[str, Any] | None = None):
                 "target_data_view_ids": target_ids,
                 "retention": {"keep_last": effective_keep_last, "keep_since": effective_keep_since},
             }
-            _emit_output(_format_as_json(payload), getattr(args, "output", None), output_to_stdout)
+            _emit_json_output(
+                payload,
+                output_file=getattr(args, "output", None),
+                is_stdout=output_to_stdout,
+                contract_label="Snapshot prune output",
+            )
         elif prune_output_format == "csv":
             rows = [{"filepath": path} for path in unique_deleted]
             _emit_output(_format_as_csv(["filepath"], rows), getattr(args, "output", None), output_to_stdout)

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -7490,9 +7490,7 @@ def _format_as_table(
             indent = " " * sum(widths[:-1])
             lines.extend(indent + cont for cont in wrapped[1:])
         else:
-            lines.append(
-                "".join(f"{item.get(col, '')!s:<{w}}" for col, w in zip(columns, widths, strict=True))
-            )
+            lines.append("".join(f"{item.get(col, '')!s:<{w}}" for col, w in zip(columns, widths, strict=True)))
     lines.append("")
     return "\n".join(lines)
 

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -7548,6 +7548,10 @@ class DiscoveryArgumentError(ValueError):
     """Raised when discovery filter/sort arguments are invalid."""
 
 
+class DiscoveryNotFoundError(LookupError):
+    """Raised when a requested discovery resource is not found."""
+
+
 _NUMERIC_SORT_VALUE_RE = re.compile(r"^[+-]?(?:\d+(?:\.\d*)?|\.\d+)$")
 
 
@@ -7762,6 +7766,13 @@ def _run_list_command(
 
         return True
 
+    except DiscoveryNotFoundError as e:
+        if is_machine_readable:
+            print(json.dumps({"error": str(e), "error_type": "not_found"}), file=sys.stderr)
+        else:
+            print(ConsoleColors.error(f"ERROR: {e}"))
+        return False
+
     except DiscoveryArgumentError as e:
         if is_machine_readable:
             print(json.dumps({"error": str(e), "error_type": "invalid_arguments"}), file=sys.stderr)
@@ -7910,12 +7921,10 @@ def _fetch_describe_dataview(
 ) -> Callable:
     """Return a fetch_and_format callback for describe_dataview."""
 
-    def _inner(cja: Any, is_machine_readable: bool) -> str | None:
+    def _inner(cja: Any, _is_machine_readable: bool) -> str | None:
         raw_dv = cja.getDataView(data_view_id)
         if raw_dv is None:
-            if is_machine_readable:
-                return json.dumps({"error": f"Data view '{data_view_id}' not found"}, indent=2)
-            return f"\nData view '{data_view_id}' not found.\n"
+            raise DiscoveryNotFoundError(f"Data view '{data_view_id}' not found")
         if isinstance(raw_dv, pd.DataFrame):
             raw_dv = raw_dv.to_dict("records")[0] if len(raw_dv) > 0 else {}
 
@@ -8064,15 +8073,17 @@ def describe_dataview(
 def _resolve_dataview_name(cja: Any, data_view_id: str) -> str:
     """Look up a data view's display name by ID.
 
+    Uses ``getDataView(id)`` to fetch a single resource instead of
+    listing all data views, avoiding an expensive API round-trip.
+
     Returns the name if found, or ``"Unknown"`` on failure.
     """
     with contextlib.suppress(Exception):
-        available_dvs = cja.getDataViews()
-        if isinstance(available_dvs, pd.DataFrame):
-            available_dvs = available_dvs.to_dict("records")
-        for dv in available_dvs or []:
-            if isinstance(dv, dict) and dv.get("id") == data_view_id:
-                return dv.get("name", "Unknown")
+        raw_dv = cja.getDataView(data_view_id)
+        if isinstance(raw_dv, pd.DataFrame):
+            raw_dv = raw_dv.to_dict("records")[0] if len(raw_dv) > 0 else {}
+        if isinstance(raw_dv, dict):
+            return raw_dv.get("name", "Unknown")
     return "Unknown"
 
 

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -8145,6 +8145,112 @@ def list_metrics(
     )
 
 
+# ==================== LIST DIMENSIONS ====================
+
+
+def _fetch_dimensions_list(
+    data_view_id: str,
+    output_format: str,
+    filter_pattern: str | None = None,
+    exclude_pattern: str | None = None,
+    limit: int | None = None,
+    sort_expression: str | None = None,
+) -> Callable:
+    """Return a fetch_and_format callback for list_dimensions."""
+
+    def _inner(cja: Any, is_machine_readable: bool) -> str | None:
+        dv_name = _resolve_dataview_name(cja, data_view_id)
+
+        raw_dimensions = cja.getDimensions(data_view_id, inclType=True, full=True)
+
+        if raw_dimensions is None or (hasattr(raw_dimensions, "__len__") and len(raw_dimensions) == 0):
+            if is_machine_readable:
+                if output_format == "json":
+                    return json.dumps(
+                        {"dataViewId": data_view_id, "dataViewName": dv_name, "dimensions": [], "count": 0},
+                        indent=2,
+                    )
+                return "id,name,type,description\n"
+            return f"\nNo dimensions found for data view '{data_view_id}'.\n"
+
+        if isinstance(raw_dimensions, pd.DataFrame):
+            raw_dimensions = raw_dimensions.to_dict("records")
+
+        display_data = [
+            {
+                "id": d.get("id", "N/A"),
+                "name": d.get("name", "N/A"),
+                "type": d.get("type", "N/A"),
+                "description": d.get("description", ""),
+            }
+            for d in raw_dimensions
+            if isinstance(d, dict)
+        ]
+
+        display_data = _apply_discovery_filters_and_sort(
+            display_data,
+            filter_pattern=filter_pattern,
+            exclude_pattern=exclude_pattern,
+            limit=limit,
+            sort_expression=sort_expression,
+            searchable_fields=["id", "name", "type", "description"],
+            default_sort_field="name",
+        )
+
+        if output_format == "json":
+            return _format_as_json({
+                "dataViewId": data_view_id,
+                "dataViewName": dv_name,
+                "dimensions": display_data,
+                "count": len(display_data),
+            })
+        if output_format == "csv":
+            return _format_as_csv(["id", "name", "type", "description"], display_data)
+        return _format_as_table(
+            f"Found {len(display_data)} dimension(s) in data view '{dv_name}':",
+            display_data,
+            columns=["id", "name", "type", "description"],
+            col_labels=["ID", "Name", "Type", "Description"],
+        )
+
+    return _inner
+
+
+def list_dimensions(
+    data_view_id: str,
+    config_file: str = "config.json",
+    output_format: str = "table",
+    output_file: str | None = None,
+    profile: str | None = None,
+    filter_pattern: str | None = None,
+    exclude_pattern: str | None = None,
+    limit: int | None = None,
+    sort_expression: str | None = None,
+) -> bool:
+    """List all dimensions for a given data view."""
+    return _run_list_command(
+        banner_text=f"LISTING DIMENSIONS FOR DATA VIEW: {data_view_id}",
+        command_name="list_dimensions",
+        fetch_and_format=_fetch_dimensions_list(
+            data_view_id,
+            output_format,
+            filter_pattern=filter_pattern,
+            exclude_pattern=exclude_pattern,
+            limit=limit,
+            sort_expression=sort_expression,
+        ),
+        config_file=config_file,
+        output_format=output_format,
+        output_file=output_file,
+        profile=profile,
+        validate_inputs=lambda: _validate_discovery_query_inputs(
+            filter_pattern=filter_pattern,
+            exclude_pattern=exclude_pattern,
+            limit=limit,
+        ),
+    )
+
+
 # ==================== LIST CONNECTIONS ====================
 
 

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -13508,6 +13508,38 @@ def _main_impl(run_state: dict[str, Any] | None = None):
                 run_state["details"] = {"operation_success": success, "discovery_command": attr}
             sys.exit(0 if success else 1)
 
+    # ID-bearing discovery commands (inspection commands that take a data view ID)
+    _discovery_commands_id = {
+        "describe_dataview": describe_dataview,
+        "list_metrics": list_metrics,
+        "list_dimensions": list_dimensions,
+        "list_segments": list_segments,
+        "list_calculated_metrics": list_calculated_metrics,
+    }
+    for attr, func in _discovery_commands_id.items():
+        resource_id = getattr(args, attr, None)
+        if resource_id:
+            list_format = "table"
+            if args.format in ("json", "csv"):
+                list_format = args.format
+            elif output_to_stdout:
+                list_format = "json"
+            success = func(
+                resource_id,
+                config_file=args.config_file,
+                output_format=list_format,
+                output_file=getattr(args, "output", None),
+                profile=getattr(args, "profile", None),
+                filter_pattern=getattr(args, "org_filter", None),
+                exclude_pattern=getattr(args, "org_exclude", None),
+                limit=getattr(args, "org_limit", None),
+                sort_expression=getattr(args, "discovery_sort", None),
+            )
+            if run_state is not None:
+                run_state["output_format"] = list_format
+                run_state["details"] = {"operation_success": success, "discovery_command": attr}
+            sys.exit(0 if success else 1)
+
     # Handle --config-status mode (no data view required, no API call)
     # --config-json implies --config-status
     if getattr(args, "config_status", False) or getattr(args, "config_json", False):

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -7218,6 +7218,7 @@ class NameResolutionDiagnostics:
 
     error_type: str | None = None
     error_message: str | None = None
+    resolved_name_by_id: dict[str, str] = field(default_factory=dict)
 
 
 type NameResolutionResult = tuple[list[str], dict[str, list[str]]]
@@ -7435,12 +7436,26 @@ def resolve_data_view_names(
 
         if not resolved_ids and unresolved_names:
             unresolved_label = unresolved_names[0]
+            resolved_name_by_id = {
+                resolved_id: id_to_name_lookup[resolved_id]
+                for resolved_id in resolved_ids
+                if resolved_id in id_to_name_lookup
+            }
             resolution_diagnostics = NameResolutionDiagnostics(
                 error_type="not_found",
                 error_message=(
                     f"Could not resolve data view: '{unresolved_label}'. "
                     "Run 'cja_auto_sdr --list-dataviews' to see available names and IDs."
                 ),
+                resolved_name_by_id=resolved_name_by_id,
+            )
+        else:
+            resolution_diagnostics = NameResolutionDiagnostics(
+                resolved_name_by_id={
+                    resolved_id: id_to_name_lookup[resolved_id]
+                    for resolved_id in resolved_ids
+                    if resolved_id in id_to_name_lookup
+                }
             )
         logger.info(f"Resolved {len(identifiers)} identifier(s) to {len(resolved_ids)} data view ID(s)")
         return _build_name_resolution_result(
@@ -8423,13 +8438,13 @@ def describe_dataview(
 
 
 def _resolve_dataview_name(cja: Any, data_view_id: str, *, preferred_name: str | None = None) -> str:
-    """Look up a data view display name, preferring dispatch-resolved names when available."""
-    normalized_preferred = _normalize_optional_text(preferred_name, default="")
-    if normalized_preferred:
-        return normalized_preferred
+    """Look up a canonical data view display name with safe fallback behavior."""
     raw_dv = _require_accessible_dataview(cja, data_view_id)
     normalized_name = _normalize_optional_text(raw_dv.get("name"), default="")
-    return normalized_name or "Unknown"
+    if normalized_name:
+        return normalized_name
+    normalized_preferred = _normalize_optional_text(preferred_name, default="")
+    return normalized_preferred or "Unknown"
 
 
 def _format_governance_rows_for_tabular(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -14072,7 +14087,6 @@ def _main_impl(run_state: dict[str, Any] | None = None):
             if is_data_view_id(resource_id_or_name):
                 resource_id = resource_id_or_name
             else:
-                resolved_resource_name = resource_id_or_name
                 temp_logger = _build_inspection_name_resolution_logger()
                 resolution_result = resolve_data_view_names(
                     [resource_id_or_name],
@@ -14083,6 +14097,7 @@ def _main_impl(run_state: dict[str, Any] | None = None):
                     include_diagnostics=True,
                 )
                 resolved_ids, _, resolution_diagnostics = _coerce_name_resolution_result(resolution_result)
+                resolved_name_by_id = resolution_diagnostics.resolved_name_by_id
                 if not resolved_ids:
                     resolution_error_type = resolution_diagnostics.error_type or "not_found"
                     if resolution_error_type == "not_found":
@@ -14125,6 +14140,7 @@ def _main_impl(run_state: dict[str, Any] | None = None):
                     )
                     if selected:
                         resource_id = selected
+                        resolved_resource_name = resolved_name_by_id.get(resource_id)
                     else:
                         print(
                             ConsoleColors.error(
@@ -14138,6 +14154,7 @@ def _main_impl(run_state: dict[str, Any] | None = None):
                         sys.exit(1)
                 else:
                     resource_id = resolved_ids[0]
+                    resolved_resource_name = resolved_name_by_id.get(resource_id)
 
             if attr == "describe_dataview":
                 success = func(

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -7196,6 +7196,44 @@ def prompt_for_selection(options: list[tuple[str, str]], prompt_text: str) -> st
             return None
 
 
+@dataclass(frozen=True)
+class NameResolutionDiagnostics:
+    """Diagnostic metadata captured during data view name resolution."""
+
+    error_type: str | None = None
+    error_message: str | None = None
+
+
+def _set_name_resolution_diagnostics(
+    logger: logging.Logger | None,
+    diagnostics: NameResolutionDiagnostics,
+) -> None:
+    """Attach name-resolution diagnostics to the logger for caller-side decisions."""
+    if logger is None:
+        return
+    setattr(logger, "_name_resolution_diagnostics", diagnostics)
+
+
+def _get_name_resolution_diagnostics(logger: logging.Logger | None) -> NameResolutionDiagnostics:
+    """Return caller-visible diagnostics produced by resolve_data_view_names."""
+    if logger is None:
+        return NameResolutionDiagnostics()
+    diagnostics = getattr(logger, "_name_resolution_diagnostics", None)
+    if isinstance(diagnostics, NameResolutionDiagnostics):
+        return diagnostics
+    return NameResolutionDiagnostics()
+
+
+def _build_inspection_name_resolution_logger() -> logging.Logger:
+    """Create a muted logger for inspection resolution to keep stderr machine-safe."""
+    logger = logging.getLogger("name_resolution.inspection")
+    logger.setLevel(logging.CRITICAL + 1)
+    logger.propagate = False
+    if not any(isinstance(handler, logging.NullHandler) for handler in logger.handlers):
+        logger.addHandler(logging.NullHandler())
+    return logger
+
+
 def resolve_data_view_names(
     identifiers: list[str],
     config_file: str = "config.json",
@@ -7227,6 +7265,7 @@ def resolve_data_view_names(
     """
     if logger is None:
         logger = logging.getLogger(__name__)
+    _set_name_resolution_diagnostics(logger, NameResolutionDiagnostics())
 
     match_mode = (match_mode or "exact").strip().lower()
     if match_mode not in {"exact", "insensitive", "fuzzy"}:
@@ -7234,13 +7273,19 @@ def resolve_data_view_names(
 
     resolved_ids = []
     name_to_ids_map = {}
+    unresolved_names: list[str] = []
 
     try:
         # Initialize CJA connection
         logger.info(f"Resolving data view identifiers: {identifiers}")
         success, source, credentials = configure_cjapy(profile, config_file, logger)
         if not success:
-            logger.error(f"Failed to configure credentials: {source}")
+            error_message = f"Failed to configure credentials: {source}"
+            logger.error(error_message)
+            _set_name_resolution_diagnostics(
+                logger,
+                NameResolutionDiagnostics(error_type="configuration_error", error_message=error_message),
+            )
             return [], {}
         cja = cjapy.CJA()
 
@@ -7255,7 +7300,12 @@ def resolve_data_view_names(
         available_dvs = get_cached_data_views(cja, cache_key, logger)
 
         if not available_dvs:
-            logger.error("No data views found or no access to any data views")
+            error_message = "No data views found or no access to any data views"
+            logger.error(error_message)
+            _set_name_resolution_diagnostics(
+                logger,
+                NameResolutionDiagnostics(error_type="configuration_error", error_message=error_message),
+            )
             return [], {}
 
         # Build a lookup map: name -> list of IDs
@@ -7321,6 +7371,7 @@ def resolve_data_view_names(
                         logger.info(f"Name '{identifier}' matched {len(matching_ids)} data views: {matching_ids}")
                 else:
                     logger.error(f"Data view name '{identifier}' not found in accessible data views")
+                    unresolved_names.append(identifier)
 
                     if suggest_similar:
                         similar = find_similar_names(identifier, list(name_to_id_lookup.keys()))
@@ -7340,18 +7391,45 @@ def resolve_data_view_names(
                         logger.error("  → Name matching uses fuzzy nearest-match mode")
                     logger.error("  → Run 'cja_auto_sdr --list-dataviews' to see all available names")
 
+        if not resolved_ids and unresolved_names:
+            unresolved_label = unresolved_names[0]
+            _set_name_resolution_diagnostics(
+                logger,
+                NameResolutionDiagnostics(
+                    error_type="not_found",
+                    error_message=(
+                        f"Could not resolve data view: '{unresolved_label}'. "
+                        "Run 'cja_auto_sdr --list-dataviews' to see available names and IDs."
+                    ),
+                ),
+            )
         logger.info(f"Resolved {len(identifiers)} identifier(s) to {len(resolved_ids)} data view ID(s)")
         return resolved_ids, name_to_ids_map
 
     except FileNotFoundError:
-        logger.error(f"Configuration file '{config_file}' not found")
+        error_message = f"Configuration file '{config_file}' not found"
+        logger.error(error_message)
+        _set_name_resolution_diagnostics(
+            logger,
+            NameResolutionDiagnostics(error_type="configuration_error", error_message=error_message),
+        )
         return [], {}
     except RECOVERABLE_API_EXCEPTIONS as e:
-        logger.error(f"Failed to resolve data view names: {e!s}")
+        error_message = f"Failed to resolve data view names: {e!s}"
+        logger.error(error_message)
+        _set_name_resolution_diagnostics(
+            logger,
+            NameResolutionDiagnostics(error_type="connectivity_error", error_message=error_message),
+        )
         return [], {}
     except Exception as e:
-        logger.error(f"Failed to resolve data view names (unexpected): {e!s}")
+        error_message = f"Failed to resolve data view names (unexpected): {e!s}"
+        logger.error(error_message)
         logger.debug("Unexpected error during name resolution", exc_info=True)
+        _set_name_resolution_diagnostics(
+            logger,
+            NameResolutionDiagnostics(error_type="connectivity_error", error_message=error_message),
+        )
         return [], {}
 
 
@@ -7560,6 +7638,42 @@ class DiscoveryNotFoundError(LookupError):
 _NUMERIC_SORT_VALUE_RE = re.compile(r"^[+-]?(?:\d+(?:\.\d*)?|\.\d+)$")
 
 
+def _is_machine_readable_output(output_format: str | None, output_file: str | None = None) -> bool:
+    """Return True when command output is intended for machine consumption."""
+    return output_format in ("json", "csv") or output_file in ("-", "stdout")
+
+
+def _resolve_discovery_output_format(raw_format: str | None, *, output_to_stdout: bool) -> str:
+    """Normalize discovery output format with stdout piping semantics."""
+    if raw_format in ("json", "csv"):
+        return raw_format
+    if output_to_stdout:
+        return "json"
+    return "table"
+
+
+def _emit_discovery_error(
+    message: str,
+    *,
+    is_machine_readable: bool,
+    error_type: str | None = None,
+    additional_fields: dict[str, Any] | None = None,
+    human_to_stderr: bool = False,
+) -> None:
+    """Emit discovery/inspection errors in machine or human-readable form."""
+    if is_machine_readable:
+        payload: dict[str, Any] = {"error": message}
+        if error_type:
+            payload["error_type"] = error_type
+        if additional_fields:
+            payload.update(additional_fields)
+        print(json.dumps(payload), file=sys.stderr)
+        return
+
+    stream = sys.stderr if human_to_stderr else sys.stdout
+    print(ConsoleColors.error(f"ERROR: {message}"), file=stream)
+
+
 def _to_numeric_sort_value(value: Any) -> float | None:
     """Convert a sortable value to float when it is numerically representable."""
     if value is None or isinstance(value, bool):
@@ -7731,7 +7845,7 @@ def _run_list_command(
         True if successful, False otherwise.
     """
     is_stdout = output_file in ("-", "stdout")
-    is_machine_readable = output_format in ("json", "csv") or is_stdout
+    is_machine_readable = _is_machine_readable_output(output_format, output_file)
 
     active_profile = resolve_active_profile(profile)
 
@@ -7755,10 +7869,11 @@ def _run_list_command(
         logger.setLevel(logging.WARNING)
         success, source, _ = configure_cjapy(profile=active_profile, config_file=config_file, logger=logger)
         if not success:
-            if is_machine_readable:
-                print(json.dumps({"error": f"Configuration error: {source}"}), file=sys.stderr)
-            else:
-                print(f"Configuration error: {source}")
+            _emit_discovery_error(
+                f"Configuration error: {source}",
+                is_machine_readable=is_machine_readable,
+                human_to_stderr=False,
+            )
             return False
         cja = cjapy.CJA()
 
@@ -7772,24 +7887,30 @@ def _run_list_command(
         return True
 
     except DiscoveryNotFoundError as e:
-        if is_machine_readable:
-            print(json.dumps({"error": str(e), "error_type": "not_found"}), file=sys.stderr)
-        else:
-            print(ConsoleColors.error(f"ERROR: {e}"))
+        _emit_discovery_error(
+            str(e),
+            is_machine_readable=is_machine_readable,
+            error_type="not_found",
+            human_to_stderr=False,
+        )
         return False
 
     except DiscoveryArgumentError as e:
-        if is_machine_readable:
-            print(json.dumps({"error": str(e), "error_type": "invalid_arguments"}), file=sys.stderr)
-        else:
-            print(ConsoleColors.error(f"ERROR: {e}"))
+        _emit_discovery_error(
+            str(e),
+            is_machine_readable=is_machine_readable,
+            error_type="invalid_arguments",
+            human_to_stderr=False,
+        )
         return False
 
     except FileNotFoundError:
-        if is_machine_readable:
-            print(json.dumps({"error": f"Configuration file '{config_file}' not found"}), file=sys.stderr)
-        else:
-            print(ConsoleColors.error(f"ERROR: Configuration file '{config_file}' not found"))
+        _emit_discovery_error(
+            f"Configuration file '{config_file}' not found",
+            is_machine_readable=is_machine_readable,
+            human_to_stderr=False,
+        )
+        if not is_machine_readable:
             print()
             print("Generate a sample configuration file with:")
             print("  cja_auto_sdr --sample-config")
@@ -7802,10 +7923,11 @@ def _run_list_command(
         raise
 
     except RECOVERABLE_COMMAND_HANDLER_EXCEPTIONS as e:
-        if is_machine_readable:
-            print(json.dumps({"error": f"Failed to connect to CJA API: {e!s}"}), file=sys.stderr)
-        else:
-            print(ConsoleColors.error(f"ERROR: Failed to connect to CJA API: {e!s}"))
+        _emit_discovery_error(
+            f"Failed to connect to CJA API: {e!s}",
+            is_machine_readable=is_machine_readable,
+            human_to_stderr=False,
+        )
         return False
 
 
@@ -13720,11 +13842,7 @@ def _main_impl(run_state: dict[str, Any] | None = None):
     }
     for attr, func in _discovery_commands.items():
         if getattr(args, attr, False):
-            list_format = "table"
-            if args.format in ("json", "csv"):
-                list_format = args.format
-            elif output_to_stdout:
-                list_format = "json"
+            list_format = _resolve_discovery_output_format(args.format, output_to_stdout=output_to_stdout)
             success = func(
                 args.config_file,
                 output_format=list_format,
@@ -13751,12 +13869,14 @@ def _main_impl(run_state: dict[str, Any] | None = None):
     for attr, func in _discovery_commands_id.items():
         resource_id_or_name = getattr(args, attr, None)
         if resource_id_or_name:
+            list_format = _resolve_discovery_output_format(args.format, output_to_stdout=output_to_stdout)
+            is_machine_readable_discovery = _is_machine_readable_output(list_format, getattr(args, "output", None))
             # Resolve name → ID if needed (IDs pass through without API call)
             if is_data_view_id(resource_id_or_name):
                 resource_id = resource_id_or_name
             else:
-                temp_logger = logging.getLogger("name_resolution")
-                temp_logger.setLevel(logging.WARNING)
+                temp_logger = _build_inspection_name_resolution_logger()
+                _set_name_resolution_diagnostics(temp_logger, NameResolutionDiagnostics())
                 resolved_ids, _ = resolve_data_view_names(
                     [resource_id_or_name],
                     args.config_file,
@@ -13765,11 +13885,41 @@ def _main_impl(run_state: dict[str, Any] | None = None):
                     match_mode=getattr(args, "name_match", "exact"),
                 )
                 if not resolved_ids:
-                    _exit_error(
-                        f"Could not resolve data view: '{resource_id_or_name}'\n"
-                        "  Run 'cja_auto_sdr --list-dataviews' to see available names and IDs."
+                    resolution_diagnostics = _get_name_resolution_diagnostics(temp_logger)
+                    resolution_error_type = resolution_diagnostics.error_type or "not_found"
+                    if resolution_error_type == "not_found":
+                        resolution_message = (
+                            f"Could not resolve data view: '{resource_id_or_name}'. "
+                            "Run 'cja_auto_sdr --list-dataviews' to see available names and IDs."
+                        )
+                    else:
+                        resolution_message = (
+                            resolution_diagnostics.error_message
+                            or f"Failed to resolve data view: '{resource_id_or_name}'."
+                        )
+                    _emit_discovery_error(
+                        resolution_message,
+                        is_machine_readable=is_machine_readable_discovery,
+                        error_type=resolution_error_type,
+                        human_to_stderr=True,
                     )
+                    sys.exit(1)
                 if len(resolved_ids) > 1:
+                    if is_machine_readable_discovery:
+                        _emit_discovery_error(
+                            (
+                                f"Name '{resource_id_or_name}' is ambiguous and matches "
+                                f"{len(resolved_ids)} data views. Specify an exact data view ID."
+                            ),
+                            is_machine_readable=True,
+                            error_type="ambiguous_name",
+                            additional_fields={
+                                "data_view_name": resource_id_or_name,
+                                "matches": resolved_ids,
+                            },
+                            human_to_stderr=True,
+                        )
+                        sys.exit(1)
                     options = [(dv_id, f"{resource_id_or_name} ({dv_id})") for dv_id in resolved_ids]
                     selected = prompt_for_selection(
                         options,
@@ -13791,11 +13941,6 @@ def _main_impl(run_state: dict[str, Any] | None = None):
                 else:
                     resource_id = resolved_ids[0]
 
-            list_format = "table"
-            if args.format in ("json", "csv"):
-                list_format = args.format
-            elif output_to_stdout:
-                list_format = "json"
             success = func(
                 resource_id,
                 config_file=args.config_file,

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -7476,7 +7476,8 @@ def _format_as_table(
     term_width = shutil.get_terminal_size().columns
     if sum(widths) > term_width and len(widths) > 1:
         other_width = sum(widths[:-1])
-        widths[-1] = max(term_width - other_width, len(labels[-1]) + 2, 20)
+        if other_width < term_width:
+            widths[-1] = max(term_width - other_width, len(labels[-1]) + 2, 20)
     lines: list[str] = ["", header_line, ""]
     lines.append("".join(f"{lbl:<{w}}" for lbl, w in zip(labels, widths, strict=True)))
     lines.append("-" * min(sum(widths), term_width))
@@ -8002,7 +8003,7 @@ def _fetch_describe_dataview(
 
         # Table output
         term_width = shutil.get_terminal_size().columns
-        rule_width = max(60, term_width)
+        rule_width = term_width
         lines: list[str] = []
         lines.append("")
         lines.append(f"Data View: {dv_name}")

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -92,6 +92,33 @@ from cja_auto_sdr.core.constants import (
     infer_format_from_path,
     should_generate_format,
 )
+from cja_auto_sdr.core.discovery_payloads import (
+    PayloadKind as _PayloadKind,
+)
+from cja_auto_sdr.core.discovery_payloads import (
+    assess_component_payload as _assess_component_payload,
+)
+from cja_auto_sdr.core.discovery_payloads import (
+    coerce_component_rows_or_none as _coerce_component_rows_or_none,
+)
+from cja_auto_sdr.core.discovery_payloads import (
+    count_component_items_or_na as _count_component_items_or_na_from_assessment,
+)
+from cja_auto_sdr.core.discovery_payloads import (
+    extract_component_sequence as _extract_component_sequence_from_payload,
+)
+from cja_auto_sdr.core.discovery_payloads import (
+    is_component_error_payload as _is_component_error_payload_from_assessment,
+)
+from cja_auto_sdr.core.discovery_payloads import (
+    is_dataview_error_payload as _is_dataview_error_payload,
+)
+from cja_auto_sdr.core.discovery_payloads import (
+    looks_like_component_error_payload as _looks_like_component_error_row,
+)
+from cja_auto_sdr.core.discovery_payloads import (
+    normalized_payload_keys as _normalized_payload_keys_set,
+)
 from cja_auto_sdr.core.exceptions import (
     APIError,
     CircuitBreakerOpen,
@@ -7211,7 +7238,7 @@ def _set_name_resolution_diagnostics(
     """Attach name-resolution diagnostics to the logger for caller-side decisions."""
     if logger is None:
         return
-    setattr(logger, "_name_resolution_diagnostics", diagnostics)
+    logger._name_resolution_diagnostics = diagnostics
 
 
 def _get_name_resolution_diagnostics(logger: logging.Logger | None) -> NameResolutionDiagnostics:
@@ -7610,7 +7637,7 @@ def _normalize_optional_text(value: Any, *, default: str = "") -> str:
     except TypeError, ValueError:
         pass
     text = str(value).strip()
-    return text if text else default
+    return text or default
 
 
 def _extract_owner_name_from_record(record: dict[str, Any]) -> str:
@@ -8099,22 +8126,12 @@ def _normalize_single_dataview_payload(raw_dv: Any) -> dict[str, Any] | None:
 
 def _normalized_payload_keys(payload: dict[str, Any]) -> set[str]:
     """Return normalized dictionary keys for payload-shape checks."""
-    return {str(key).strip().casefold() for key in payload}
+    return _normalized_payload_keys_set(payload)
 
 
 def _looks_like_dataview_error_payload(payload: dict[str, Any]) -> bool:
     """Return True when a getDataView payload matches API error object shape."""
-    normalized_keys = _normalized_payload_keys(payload)
-    if not normalized_keys:
-        return True
-
-    explicit_error_keys = {"error", "errorcode", "errordescription", "error_description"}
-    if normalized_keys & explicit_error_keys:
-        return True
-
-    has_identity = bool(payload.get("id")) or bool(payload.get("name"))
-    generic_error_keys = {"statuscode", "status_code", "status", "message", "detail", "title", "type"}
-    return not has_identity and bool(normalized_keys & generic_error_keys)
+    return _is_dataview_error_payload(payload)
 
 
 def _require_accessible_dataview(cja: Any, data_view_id: str) -> dict[str, Any]:
@@ -8127,89 +8144,24 @@ def _require_accessible_dataview(cja: Any, data_view_id: str) -> dict[str, Any]:
     return payload
 
 
-_COMPONENT_SEQUENCE_KEYS = ("content", "items", "results", "data", "rows")
-
-
 def _extract_component_sequence(payload: dict[str, Any]) -> list[Any] | None:
     """Extract list-like component rows from common API envelope shapes."""
-    for key in _COMPONENT_SEQUENCE_KEYS:
-        if key not in payload:
-            continue
-        value = payload.get(key)
-        if value is None:
-            return []
-        if isinstance(value, pd.DataFrame):
-            return value.to_dict("records")
-        if isinstance(value, (list, tuple, set)):
-            return list(value)
-        if isinstance(value, dict):
-            nested = _extract_component_sequence(value)
-            if nested is not None:
-                return nested
-        return []
-    return None
+    return _extract_component_sequence_from_payload(payload)
 
 
 def _looks_like_component_error_payload(payload: dict[str, Any]) -> bool:
     """Return True when a component API payload row matches error object shape."""
-    normalized_keys = _normalized_payload_keys(payload)
-    if not normalized_keys:
-        return True
-
-    explicit_error_keys = {"error", "errorcode", "errordescription", "error_description"}
-    if normalized_keys & explicit_error_keys:
-        return True
-
-    has_component_identity = bool(payload.get("id")) or bool(payload.get("name"))
-    generic_error_keys = {"statuscode", "status_code", "status", "message", "detail", "title", "type"}
-    return not has_component_identity and bool(normalized_keys & generic_error_keys)
+    return _looks_like_component_error_row(payload)
 
 
 def _coerce_component_rows(raw_payload: Any) -> list[Any] | None:
     """Normalize component API payloads into row lists when possible."""
-    if raw_payload is None:
-        return []
-    if isinstance(raw_payload, pd.DataFrame):
-        return raw_payload.to_dict("records")
-    if isinstance(raw_payload, (list, tuple, set)):
-        return list(raw_payload)
-    if isinstance(raw_payload, dict):
-        extracted = _extract_component_sequence(raw_payload)
-        if extracted is not None:
-            return extracted
-        return [raw_payload]
-    return None
+    return _coerce_component_rows_or_none(raw_payload)
 
 
 def _is_component_error_payload(raw_payload: Any) -> bool:
     """Return True when a component API payload appears to be an error object."""
-    if isinstance(raw_payload, pd.DataFrame):
-        # A bare empty frame (no rows, no columns) is a legitimate "no results" shape.
-        if raw_payload.empty and len(raw_payload.columns) == 0:
-            return False
-        if _looks_like_component_error_payload({str(column): None for column in raw_payload.columns}):
-            if raw_payload.empty:
-                return True
-            for row in raw_payload.to_dict("records"):
-                if isinstance(row, dict) and _looks_like_component_error_payload(row):
-                    return True
-        return False
-
-    if isinstance(raw_payload, dict):
-        if _looks_like_component_error_payload(raw_payload):
-            return True
-        extracted = _extract_component_sequence(raw_payload)
-        if extracted is not None:
-            return _is_component_error_payload(extracted)
-        return False
-
-    if isinstance(raw_payload, (list, tuple, set)):
-        rows = list(raw_payload)
-        if not rows:
-            return False
-        return any(isinstance(row, dict) and _looks_like_component_error_payload(row) for row in rows)
-
-    return False
+    return _is_component_error_payload_from_assessment(raw_payload)
 
 
 def _normalize_component_records_or_raise(
@@ -8219,31 +8171,19 @@ def _normalize_component_records_or_raise(
     data_view_id: str,
 ) -> list[dict[str, Any]]:
     """Normalize component payloads to dict rows or fail on error-shaped responses."""
-    if _is_component_error_payload(raw_payload):
+    assessment = _assess_component_payload(raw_payload)
+    if assessment.kind is _PayloadKind.ERROR:
         raise DiscoveryNotFoundError(f"Failed to retrieve {component_label} for data view '{data_view_id}'")
-
-    rows = _coerce_component_rows(raw_payload)
-    if rows is None:
+    if assessment.kind is _PayloadKind.INVALID:
         raise DiscoveryNotFoundError(
             f"Unexpected {component_label} payload type for data view '{data_view_id}'",
         )
-    if not rows:
-        return []
-
-    dict_rows = [row for row in rows if isinstance(row, dict)]
-    if not dict_rows:
-        raise DiscoveryNotFoundError(f"Failed to retrieve {component_label} for data view '{data_view_id}'")
-    return dict_rows
+    return assessment.rows
 
 
 def _count_component_items_or_na(raw_payload: Any) -> int | str:
     """Return component count or 'N/A' when payload is unavailable/invalid."""
-    if _is_component_error_payload(raw_payload):
-        return "N/A"
-    rows = _coerce_component_rows(raw_payload)
-    if rows is None:
-        return "N/A"
-    return len(rows)
+    return _count_component_items_or_na_from_assessment(raw_payload)
 
 
 def _fetch_describe_dataview(

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -7887,6 +7887,143 @@ def list_dataviews(
     )
 
 
+# ==================== DESCRIBE DATA VIEW ====================
+
+
+def _fetch_describe_dataview(
+    data_view_id: str,
+    output_format: str,
+) -> Callable:
+    """Return a fetch_and_format callback for describe_dataview."""
+
+    def _inner(cja: Any, is_machine_readable: bool) -> str | None:
+        raw_dv = cja.getDataView(data_view_id)
+        if raw_dv is None:
+            if is_machine_readable:
+                return json.dumps({"error": f"Data view '{data_view_id}' not found"}, indent=2)
+            return f"\nData view '{data_view_id}' not found.\n"
+        if isinstance(raw_dv, pd.DataFrame):
+            raw_dv = raw_dv.to_dict("records")[0] if len(raw_dv) > 0 else {}
+
+        dv_id = raw_dv.get("id", data_view_id)
+        dv_name = raw_dv.get("name", "N/A")
+        owner_name = _extract_owner_name(raw_dv.get("owner"))
+        description = raw_dv.get("description", "")
+        connection_id = raw_dv.get("parentDataGroupId", "N/A")
+        created = raw_dv.get("created", "N/A")
+        modified = raw_dv.get("modified", "N/A")
+
+        def _safe_count(api_call: Callable, *args: Any, **kwargs: Any) -> int | str:
+            """Call an API method and return the item count, or 'N/A' on failure."""
+            try:
+                result = api_call(*args, **kwargs)
+                if isinstance(result, pd.DataFrame):
+                    return len(result)
+                if isinstance(result, list):
+                    return len(result)
+                return 0
+            except Exception:
+                return "N/A"
+
+        n_metrics = _safe_count(cja.getMetrics, data_view_id)
+        n_dimensions = _safe_count(cja.getDimensions, data_view_id)
+        n_segments = _safe_count(cja.getFilters, dataIds=data_view_id, full=True)
+        n_calc_metrics = _safe_count(cja.getCalculatedMetrics, dataIds=data_view_id, full=True)
+
+        # Compute total only when all counts are numeric
+        counts = [n_metrics, n_dimensions, n_segments, n_calc_metrics]
+        numeric_counts = [c for c in counts if isinstance(c, int)]
+        total = sum(numeric_counts) if len(numeric_counts) == len(counts) else "N/A"
+
+        if output_format == "json":
+            payload = {
+                "dataView": {
+                    "id": dv_id,
+                    "name": dv_name,
+                    "owner": owner_name,
+                    "description": description,
+                    "connectionId": connection_id,
+                    "created": created,
+                    "modified": modified,
+                    "components": {
+                        "dimensions": n_dimensions,
+                        "metrics": n_metrics,
+                        "calculatedMetrics": n_calc_metrics,
+                        "segments": n_segments,
+                        "total": total,
+                    },
+                }
+            }
+            return _format_as_json(payload)
+
+        if output_format == "csv":
+            columns = [
+                "id", "name", "owner", "description", "connection_id",
+                "created", "modified", "dimensions", "metrics",
+                "calculated_metrics", "segments", "total",
+            ]
+            row = {
+                "id": dv_id,
+                "name": dv_name,
+                "owner": owner_name,
+                "description": description,
+                "connection_id": connection_id,
+                "created": created,
+                "modified": modified,
+                "dimensions": n_dimensions,
+                "metrics": n_metrics,
+                "calculated_metrics": n_calc_metrics,
+                "segments": n_segments,
+                "total": total,
+            }
+            return _format_as_csv(columns, [row])
+
+        # Table output
+        lines: list[str] = []
+        lines.append("")
+        lines.append(f"Data View: {dv_name}")
+        lines.append("=" * 60)
+        lines.append(f"  ID:            {dv_id}")
+        lines.append(f"  Owner:         {owner_name}")
+        lines.append(f"  Description:   {description or '(none)'}")
+        lines.append(f"  Connection:    {connection_id}")
+        lines.append(f"  Created:       {created}")
+        lines.append(f"  Modified:      {modified}")
+        lines.append("")
+        lines.append("  Components:")
+        lines.append(f"    Dimensions:          {n_dimensions}")
+        lines.append(f"    Metrics:             {n_metrics}")
+        lines.append(f"    Calculated Metrics:  {n_calc_metrics}")
+        lines.append(f"    Segments:            {n_segments}")
+        lines.append("    ─────────────────────────")
+        lines.append(f"    Total:               {total}")
+        lines.append("=" * 60)
+        lines.append("")
+        return "\n".join(lines)
+
+    return _inner
+
+
+def describe_dataview(
+    data_view_id: str,
+    config_file: str = "config.json",
+    output_format: str = "table",
+    output_file: str | None = None,
+    profile: str | None = None,
+    **_kwargs: Any,
+) -> bool:
+    """Describe a single data view with component counts and exit."""
+    return _run_list_command(
+        banner_text=f"DESCRIBING DATA VIEW: {data_view_id}",
+        command_name="describe_dataview",
+        fetch_and_format=_fetch_describe_dataview(data_view_id, output_format),
+        config_file=config_file,
+        output_format=output_format,
+        output_file=output_file,
+        profile=profile,
+    )
+
+
 # ==================== LIST CONNECTIONS ====================
 
 

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -7592,12 +7592,52 @@ def _extract_owner_name(owner_data: Any) -> str:
     if isinstance(owner_data, str):
         return owner_data or "N/A"
     if isinstance(owner_data, dict):
-        for key in ("name", "login", "email", "imsUserId", "id"):
+        for key in ("name", "fullName", "full_name", "ownerFullName", "login", "email", "imsUserId", "id"):
             val = owner_data.get(key)
             if val:
                 return str(val)
         return "N/A"
     return str(owner_data) or "N/A"
+
+
+def _normalize_optional_text(value: Any, *, default: str = "") -> str:
+    """Normalize optional display values, handling None/NaN and whitespace."""
+    if value is None:
+        return default
+    try:
+        if pd.isna(value):
+            return default
+    except TypeError, ValueError:
+        pass
+    text = str(value).strip()
+    return text if text else default
+
+
+def _extract_owner_name_from_record(record: dict[str, Any]) -> str:
+    """Extract owner name from record-level owner aliases used by CJA endpoints."""
+    owner_name = _extract_owner_name(record.get("owner"))
+    if owner_name != "N/A":
+        return owner_name
+
+    for key in ("ownerFullName", "ownerName", "owner_name", "owner_full_name"):
+        alias_name = _normalize_optional_text(record.get(key))
+        if alias_name:
+            return alias_name
+    return "N/A"
+
+
+def _extract_timestamp_from_record(record: dict[str, Any], field: str) -> str:
+    """Extract created/modified timestamps from common CJA field aliases."""
+    aliases_by_field = {
+        "created": ("created", "createdDate", "createdAt", "created_date"),
+        "modified": ("modified", "modifiedDate", "modifiedAt", "modified_date"),
+    }
+    aliases = aliases_by_field.get(field, (field,))
+    for key in aliases:
+        value = _normalize_optional_text(record.get(key))
+        if value:
+            return value
+    return ""
 
 
 def _extract_connections_list(raw_connections: Any) -> list:
@@ -8636,12 +8676,12 @@ def _fetch_segments_list(
                 {
                     "id": item.get("id", "N/A"),
                     "name": item.get("name", "N/A"),
-                    "owner": _extract_owner_name(item.get("owner")),
+                    "owner": _extract_owner_name_from_record(item),
                     "description": item.get("description", ""),
                     "approved": approved_raw if isinstance(approved_raw, bool) else None,
                     "tags": tags,
-                    "created": item.get("created", ""),
-                    "modified": item.get("modified", ""),
+                    "created": _extract_timestamp_from_record(item, "created"),
+                    "modified": _extract_timestamp_from_record(item, "modified"),
                 }
             )
 
@@ -8769,15 +8809,15 @@ def _fetch_calculated_metrics_list(
                 {
                     "id": item.get("id", "N/A"),
                     "name": item.get("name", "N/A"),
-                    "owner": _extract_owner_name(item.get("owner")),
+                    "owner": _extract_owner_name_from_record(item),
                     "description": item.get("description", ""),
                     "type": item.get("type", ""),
                     "polarity": item.get("polarity", ""),
                     "precision": item.get("precision", 0),
                     "approved": approved_raw if isinstance(approved_raw, bool) else None,
                     "tags": tags,
-                    "created": item.get("created", ""),
-                    "modified": item.get("modified", ""),
+                    "created": _extract_timestamp_from_record(item, "created"),
+                    "modified": _extract_timestamp_from_record(item, "modified"),
                 }
             )
 

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -7958,9 +7958,18 @@ def _fetch_describe_dataview(
 
         if output_format == "csv":
             columns = [
-                "id", "name", "owner", "description", "connection_id",
-                "created", "modified", "dimensions", "metrics",
-                "calculated_metrics", "segments", "total",
+                "id",
+                "name",
+                "owner",
+                "description",
+                "connection_id",
+                "created",
+                "modified",
+                "dimensions",
+                "metrics",
+                "calculated_metrics",
+                "segments",
+                "total",
             ]
             row = {
                 "id": dv_id,
@@ -8092,12 +8101,14 @@ def _fetch_metrics_list(
         )
 
         if output_format == "json":
-            return _format_as_json({
-                "dataViewId": data_view_id,
-                "dataViewName": dv_name,
-                "metrics": display_data,
-                "count": len(display_data),
-            })
+            return _format_as_json(
+                {
+                    "dataViewId": data_view_id,
+                    "dataViewName": dv_name,
+                    "metrics": display_data,
+                    "count": len(display_data),
+                }
+            )
         if output_format == "csv":
             return _format_as_csv(["id", "name", "type", "description"], display_data)
         return _format_as_table(
@@ -8198,12 +8209,14 @@ def _fetch_dimensions_list(
         )
 
         if output_format == "json":
-            return _format_as_json({
-                "dataViewId": data_view_id,
-                "dataViewName": dv_name,
-                "dimensions": display_data,
-                "count": len(display_data),
-            })
+            return _format_as_json(
+                {
+                    "dataViewId": data_view_id,
+                    "dataViewName": dv_name,
+                    "dimensions": display_data,
+                    "count": len(display_data),
+                }
+            )
         if output_format == "csv":
             return _format_as_csv(["id", "name", "type", "description"], display_data)
         return _format_as_table(
@@ -8299,16 +8312,18 @@ def _fetch_segments_list(
             raw_tags = item.get("tags") or []
             tags = [t.get("name", str(t)) if isinstance(t, dict) else str(t) for t in raw_tags]
             approved_raw = item.get("approved")
-            display_data.append({
-                "id": item.get("id", "N/A"),
-                "name": item.get("name", "N/A"),
-                "owner": _extract_owner_name(item.get("owner")),
-                "description": item.get("description", ""),
-                "approved": approved_raw if isinstance(approved_raw, bool) else None,
-                "tags": tags,
-                "created": item.get("created", ""),
-                "modified": item.get("modified", ""),
-            })
+            display_data.append(
+                {
+                    "id": item.get("id", "N/A"),
+                    "name": item.get("name", "N/A"),
+                    "owner": _extract_owner_name(item.get("owner")),
+                    "description": item.get("description", ""),
+                    "approved": approved_raw if isinstance(approved_raw, bool) else None,
+                    "tags": tags,
+                    "created": item.get("created", ""),
+                    "modified": item.get("modified", ""),
+                }
+            )
 
         display_data = _apply_discovery_filters_and_sort(
             display_data,
@@ -8321,12 +8336,14 @@ def _fetch_segments_list(
         )
 
         if output_format == "json":
-            return _format_as_json({
-                "dataViewId": data_view_id,
-                "dataViewName": dv_name,
-                "segments": display_data,
-                "count": len(display_data),
-            })
+            return _format_as_json(
+                {
+                    "dataViewId": data_view_id,
+                    "dataViewName": dv_name,
+                    "segments": display_data,
+                    "count": len(display_data),
+                }
+            )
 
         # For table/CSV, convert approved and tags to display strings
         table_data = [
@@ -8427,19 +8444,21 @@ def _fetch_calculated_metrics_list(
             raw_tags = item.get("tags") or []
             tags = [t.get("name", str(t)) if isinstance(t, dict) else str(t) for t in raw_tags]
             approved_raw = item.get("approved")
-            display_data.append({
-                "id": item.get("id", "N/A"),
-                "name": item.get("name", "N/A"),
-                "owner": _extract_owner_name(item.get("owner")),
-                "description": item.get("description", ""),
-                "type": item.get("type", ""),
-                "polarity": item.get("polarity", ""),
-                "precision": item.get("precision", 0),
-                "approved": approved_raw if isinstance(approved_raw, bool) else None,
-                "tags": tags,
-                "created": item.get("created", ""),
-                "modified": item.get("modified", ""),
-            })
+            display_data.append(
+                {
+                    "id": item.get("id", "N/A"),
+                    "name": item.get("name", "N/A"),
+                    "owner": _extract_owner_name(item.get("owner")),
+                    "description": item.get("description", ""),
+                    "type": item.get("type", ""),
+                    "polarity": item.get("polarity", ""),
+                    "precision": item.get("precision", 0),
+                    "approved": approved_raw if isinstance(approved_raw, bool) else None,
+                    "tags": tags,
+                    "created": item.get("created", ""),
+                    "modified": item.get("modified", ""),
+                }
+            )
 
         display_data = _apply_discovery_filters_and_sort(
             display_data,
@@ -8452,12 +8471,14 @@ def _fetch_calculated_metrics_list(
         )
 
         if output_format == "json":
-            return _format_as_json({
-                "dataViewId": data_view_id,
-                "dataViewName": dv_name,
-                "calculatedMetrics": display_data,
-                "count": len(display_data),
-            })
+            return _format_as_json(
+                {
+                    "dataViewId": data_view_id,
+                    "dataViewName": dv_name,
+                    "calculatedMetrics": display_data,
+                    "count": len(display_data),
+                }
+            )
 
         # For table/CSV, convert approved and tags to display strings
         table_data = [
@@ -8471,7 +8492,19 @@ def _fetch_calculated_metrics_list(
 
         if output_format == "csv":
             return _format_as_csv(
-                ["id", "name", "owner", "type", "polarity", "precision", "approved", "tags", "created", "modified", "description"],
+                [
+                    "id",
+                    "name",
+                    "owner",
+                    "type",
+                    "polarity",
+                    "precision",
+                    "approved",
+                    "tags",
+                    "created",
+                    "modified",
+                    "description",
+                ],
                 table_data,
             )
         return _format_as_table(

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -120,6 +120,9 @@ from cja_auto_sdr.core.discovery_payloads import (
     count_component_items_or_na as _count_component_items_or_na_from_assessment,
 )
 from cja_auto_sdr.core.discovery_payloads import (
+    has_identity_value as _has_identity_discovery_value,
+)
+from cja_auto_sdr.core.discovery_payloads import (
     is_dataview_error_payload as _is_dataview_error_payload,
 )
 from cja_auto_sdr.core.exceptions import (
@@ -8169,7 +8172,7 @@ def _require_accessible_dataview(cja: Any, data_view_id: str) -> dict[str, Any]:
     payload = _normalize_single_dataview_payload(cja.getDataView(data_view_id))
     if payload is None or _is_dataview_error_payload(payload):
         raise DiscoveryNotFoundError(f"Data view '{data_view_id}' not found")
-    if not payload.get("id") and not payload.get("name"):
+    if not _has_identity_discovery_value(payload, ("id", "name")):
         raise DiscoveryNotFoundError(f"Data view '{data_view_id}' not found")
     return payload
 

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -13541,7 +13541,7 @@ def _main_impl(run_state: dict[str, Any] | None = None):
                 run_state["details"] = {"operation_success": success, "discovery_command": attr}
             sys.exit(0 if success else 1)
 
-    # ID-bearing discovery commands (inspection commands that take a data view ID)
+    # ID-bearing discovery commands (inspection commands that take a data view ID or name)
     _discovery_commands_id = {
         "describe_dataview": describe_dataview,
         "list_metrics": list_metrics,
@@ -13550,8 +13550,48 @@ def _main_impl(run_state: dict[str, Any] | None = None):
         "list_calculated_metrics": list_calculated_metrics,
     }
     for attr, func in _discovery_commands_id.items():
-        resource_id = getattr(args, attr, None)
-        if resource_id:
+        resource_id_or_name = getattr(args, attr, None)
+        if resource_id_or_name:
+            # Resolve name → ID if needed (IDs pass through without API call)
+            if is_data_view_id(resource_id_or_name):
+                resource_id = resource_id_or_name
+            else:
+                temp_logger = logging.getLogger("name_resolution")
+                temp_logger.setLevel(logging.WARNING)
+                resolved_ids, _ = resolve_data_view_names(
+                    [resource_id_or_name],
+                    args.config_file,
+                    temp_logger,
+                    profile=getattr(args, "profile", None),
+                    match_mode=getattr(args, "name_match", "exact"),
+                )
+                if not resolved_ids:
+                    _exit_error(
+                        f"Could not resolve data view: '{resource_id_or_name}'\n"
+                        "  Run 'cja_auto_sdr --list-dataviews' to see available names and IDs."
+                    )
+                if len(resolved_ids) > 1:
+                    options = [(dv_id, f"{resource_id_or_name} ({dv_id})") for dv_id in resolved_ids]
+                    selected = prompt_for_selection(
+                        options,
+                        f"Name '{resource_id_or_name}' matches {len(resolved_ids)} data views. Please select one:",
+                    )
+                    if selected:
+                        resource_id = selected
+                    else:
+                        print(
+                            ConsoleColors.error(
+                                f"ERROR: Name '{resource_id_or_name}' is ambiguous — matches {len(resolved_ids)} data views:",
+                            ),
+                            file=sys.stderr,
+                        )
+                        for dv_id in resolved_ids:
+                            print(f"  • {dv_id}", file=sys.stderr)
+                        print("\nPlease specify the exact data view ID instead of the name.", file=sys.stderr)
+                        sys.exit(1)
+                else:
+                    resource_id = resolved_ids[0]
+
             list_format = "table"
             if args.format in ("json", "csv"):
                 list_format = args.format

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -7249,24 +7249,38 @@ class NameResolutionDiagnostics:
     error_message: str | None = None
 
 
-def _set_name_resolution_diagnostics(
-    logger: logging.Logger | None,
+type NameResolutionResult = tuple[list[str], dict[str, list[str]]]
+type NameResolutionResultWithDiagnostics = tuple[list[str], dict[str, list[str]], NameResolutionDiagnostics]
+
+
+def _build_name_resolution_result(
+    resolved_ids: list[str],
+    name_to_ids_map: dict[str, list[str]],
     diagnostics: NameResolutionDiagnostics,
-) -> None:
-    """Attach name-resolution diagnostics to the logger for caller-side decisions."""
-    if logger is None:
-        return
-    logger._name_resolution_diagnostics = diagnostics
+    *,
+    include_diagnostics: bool,
+) -> NameResolutionResult | NameResolutionResultWithDiagnostics:
+    """Return either legacy 2-tuple or extended 3-tuple name-resolution output."""
+    if include_diagnostics:
+        return resolved_ids, name_to_ids_map, diagnostics
+    return resolved_ids, name_to_ids_map
 
 
-def _get_name_resolution_diagnostics(logger: logging.Logger | None) -> NameResolutionDiagnostics:
-    """Return caller-visible diagnostics produced by resolve_data_view_names."""
-    if logger is None:
-        return NameResolutionDiagnostics()
-    diagnostics = getattr(logger, "_name_resolution_diagnostics", None)
+def _coerce_name_resolution_result(
+    result: NameResolutionResult | NameResolutionResultWithDiagnostics,
+) -> NameResolutionResultWithDiagnostics:
+    """Normalize name-resolution return values into a diagnostics-bearing tuple.
+
+    This keeps CLI call sites robust when tests patch resolve_data_view_names with
+    the legacy 2-tuple return shape.
+    """
+    if len(result) == 2:
+        resolved_ids, name_to_ids_map = result
+        return resolved_ids, name_to_ids_map, NameResolutionDiagnostics()
+    resolved_ids, name_to_ids_map, diagnostics = result
     if isinstance(diagnostics, NameResolutionDiagnostics):
-        return diagnostics
-    return NameResolutionDiagnostics()
+        return resolved_ids, name_to_ids_map, diagnostics
+    return resolved_ids, name_to_ids_map, NameResolutionDiagnostics()
 
 
 def _build_inspection_name_resolution_logger() -> logging.Logger:
@@ -7286,7 +7300,8 @@ def resolve_data_view_names(
     suggest_similar: bool = True,
     profile: str | None = None,
     match_mode: str = "exact",
-) -> tuple[list[str], dict[str, list[str]]]:
+    include_diagnostics: bool = False,
+) -> NameResolutionResult | NameResolutionResultWithDiagnostics:
     """
     Resolve data view names to IDs. If an identifier is already an ID, keep it as-is.
     If it's a name, match based on ``match_mode``.
@@ -7304,13 +7319,14 @@ def resolve_data_view_names(
         match_mode: Name matching strategy: exact, insensitive, or fuzzy
 
     Returns:
-        Tuple of (resolved_ids, name_to_ids_map)
+        Tuple of (resolved_ids, name_to_ids_map), optionally with diagnostics when
+        ``include_diagnostics`` is True.
         - resolved_ids: List of all resolved data view IDs
         - name_to_ids_map: Dict mapping names to their resolved IDs (for reporting)
     """
     if logger is None:
         logger = logging.getLogger(__name__)
-    _set_name_resolution_diagnostics(logger, NameResolutionDiagnostics())
+    resolution_diagnostics = NameResolutionDiagnostics()
 
     match_mode = (match_mode or "exact").strip().lower()
     if match_mode not in {"exact", "insensitive", "fuzzy"}:
@@ -7327,11 +7343,16 @@ def resolve_data_view_names(
         if not success:
             error_message = f"Failed to configure credentials: {source}"
             logger.error(error_message)
-            _set_name_resolution_diagnostics(
-                logger,
-                NameResolutionDiagnostics(error_type="configuration_error", error_message=error_message),
+            resolution_diagnostics = NameResolutionDiagnostics(
+                error_type="configuration_error",
+                error_message=error_message,
             )
-            return [], {}
+            return _build_name_resolution_result(
+                [],
+                {},
+                resolution_diagnostics,
+                include_diagnostics=include_diagnostics,
+            )
         cja = cjapy.CJA()
 
         # Get all available data views (with caching)
@@ -7347,11 +7368,16 @@ def resolve_data_view_names(
         if not available_dvs:
             error_message = "No data views found or no access to any data views"
             logger.error(error_message)
-            _set_name_resolution_diagnostics(
-                logger,
-                NameResolutionDiagnostics(error_type="configuration_error", error_message=error_message),
+            resolution_diagnostics = NameResolutionDiagnostics(
+                error_type="configuration_error",
+                error_message=error_message,
             )
-            return [], {}
+            return _build_name_resolution_result(
+                [],
+                {},
+                resolution_diagnostics,
+                include_diagnostics=include_diagnostics,
+            )
 
         # Build a lookup map: name -> list of IDs
         name_to_id_lookup = {}
@@ -7438,44 +7464,61 @@ def resolve_data_view_names(
 
         if not resolved_ids and unresolved_names:
             unresolved_label = unresolved_names[0]
-            _set_name_resolution_diagnostics(
-                logger,
-                NameResolutionDiagnostics(
-                    error_type="not_found",
-                    error_message=(
-                        f"Could not resolve data view: '{unresolved_label}'. "
-                        "Run 'cja_auto_sdr --list-dataviews' to see available names and IDs."
-                    ),
+            resolution_diagnostics = NameResolutionDiagnostics(
+                error_type="not_found",
+                error_message=(
+                    f"Could not resolve data view: '{unresolved_label}'. "
+                    "Run 'cja_auto_sdr --list-dataviews' to see available names and IDs."
                 ),
             )
         logger.info(f"Resolved {len(identifiers)} identifier(s) to {len(resolved_ids)} data view ID(s)")
-        return resolved_ids, name_to_ids_map
+        return _build_name_resolution_result(
+            resolved_ids,
+            name_to_ids_map,
+            resolution_diagnostics,
+            include_diagnostics=include_diagnostics,
+        )
 
     except FileNotFoundError:
         error_message = f"Configuration file '{config_file}' not found"
         logger.error(error_message)
-        _set_name_resolution_diagnostics(
-            logger,
-            NameResolutionDiagnostics(error_type="configuration_error", error_message=error_message),
+        resolution_diagnostics = NameResolutionDiagnostics(
+            error_type="configuration_error",
+            error_message=error_message,
         )
-        return [], {}
+        return _build_name_resolution_result(
+            [],
+            {},
+            resolution_diagnostics,
+            include_diagnostics=include_diagnostics,
+        )
     except RECOVERABLE_API_EXCEPTIONS as e:
         error_message = f"Failed to resolve data view names: {e!s}"
         logger.error(error_message)
-        _set_name_resolution_diagnostics(
-            logger,
-            NameResolutionDiagnostics(error_type="connectivity_error", error_message=error_message),
+        resolution_diagnostics = NameResolutionDiagnostics(
+            error_type="connectivity_error",
+            error_message=error_message,
         )
-        return [], {}
+        return _build_name_resolution_result(
+            [],
+            {},
+            resolution_diagnostics,
+            include_diagnostics=include_diagnostics,
+        )
     except Exception as e:
         error_message = f"Failed to resolve data view names (unexpected): {e!s}"
         logger.error(error_message)
         logger.debug("Unexpected error during name resolution", exc_info=True)
-        _set_name_resolution_diagnostics(
-            logger,
-            NameResolutionDiagnostics(error_type="connectivity_error", error_message=error_message),
+        resolution_diagnostics = NameResolutionDiagnostics(
+            error_type="connectivity_error",
+            error_message=error_message,
         )
-        return [], {}
+        return _build_name_resolution_result(
+            [],
+            {},
+            resolution_diagnostics,
+            include_diagnostics=include_diagnostics,
+        )
 
 
 # ==================== DATASET INFO HELPER ====================
@@ -8609,6 +8652,13 @@ def _approved_display(value: Any) -> str:
     return str(value)
 
 
+def _tags_display(tags: Any) -> str:
+    """Render already-normalized tag lists for table/csv output."""
+    if not isinstance(tags, list):
+        return ""
+    return ", ".join(tag for tag in tags if isinstance(tag, str))
+
+
 def _fetch_segments_list(
     data_view_id: str,
     output_format: str,
@@ -8683,7 +8733,7 @@ def _fetch_segments_list(
             {
                 **row,
                 "approved": _approved_display(row.get("approved")),
-                "tags": ", ".join(_extract_tags_normalized(row.get("tags"))),
+                "tags": _tags_display(row.get("tags")),
             }
             for row in display_data
         ]
@@ -8818,7 +8868,7 @@ def _fetch_calculated_metrics_list(
             {
                 **row,
                 "approved": _approved_display(row.get("approved")),
-                "tags": ", ".join(_extract_tags_normalized(row.get("tags"))),
+                "tags": _tags_display(row.get("tags")),
             }
             for row in display_data
         ]
@@ -13631,6 +13681,35 @@ def handle_compare_snapshots_command(
 # ==================== MAIN FUNCTION ====================
 
 
+def _describe_dataview_ignored_options(args: argparse.Namespace) -> list[str]:
+    """Return discovery filtering options that have no effect on --describe-dataview."""
+    ignored: list[str] = []
+    if getattr(args, "org_filter", None) is not None:
+        ignored.append("--filter")
+    if getattr(args, "org_exclude", None) is not None:
+        ignored.append("--exclude")
+    if getattr(args, "discovery_sort", None) is not None:
+        ignored.append("--sort")
+    if getattr(args, "org_limit", None) is not None:
+        ignored.append("--limit")
+    return ignored
+
+
+def _warn_describe_dataview_ignored_options(args: argparse.Namespace) -> None:
+    """Warn when describe_dataview is invoked with ignored discovery options."""
+    ignored_options = _describe_dataview_ignored_options(args)
+    if not ignored_options:
+        return
+    verb = "is" if len(ignored_options) == 1 else "are"
+    option_label = "option" if len(ignored_options) == 1 else "options"
+    print(
+        ConsoleColors.warning(
+            f"Warning: {', '.join(ignored_options)} {option_label} {verb} ignored with --describe-dataview."
+        ),
+        file=sys.stderr,
+    )
+
+
 def _main_impl(run_state: dict[str, Any] | None = None):
     """Main CLI implementation."""
 
@@ -13884,21 +13963,23 @@ def _main_impl(run_state: dict[str, Any] | None = None):
         if resource_id_or_name:
             list_format = _resolve_discovery_output_format(args.format, output_to_stdout=output_to_stdout)
             is_machine_readable_discovery = _is_machine_readable_output(list_format, getattr(args, "output", None))
+            if attr == "describe_dataview" and not is_machine_readable_discovery:
+                _warn_describe_dataview_ignored_options(args)
             # Resolve name → ID if needed (IDs pass through without API call)
             if is_data_view_id(resource_id_or_name):
                 resource_id = resource_id_or_name
             else:
                 temp_logger = _build_inspection_name_resolution_logger()
-                _set_name_resolution_diagnostics(temp_logger, NameResolutionDiagnostics())
-                resolved_ids, _ = resolve_data_view_names(
+                resolution_result = resolve_data_view_names(
                     [resource_id_or_name],
                     args.config_file,
                     temp_logger,
                     profile=getattr(args, "profile", None),
                     match_mode=getattr(args, "name_match", "exact"),
+                    include_diagnostics=True,
                 )
+                resolved_ids, _, resolution_diagnostics = _coerce_name_resolution_result(resolution_result)
                 if not resolved_ids:
-                    resolution_diagnostics = _get_name_resolution_diagnostics(temp_logger)
                     resolution_error_type = resolution_diagnostics.error_type or "not_found"
                     if resolution_error_type == "not_found":
                         resolution_message = (

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -8388,6 +8388,137 @@ def list_segments(
     )
 
 
+# ==================== LIST CALCULATED METRICS ====================
+
+
+def _fetch_calculated_metrics_list(
+    data_view_id: str,
+    output_format: str,
+    filter_pattern: str | None = None,
+    exclude_pattern: str | None = None,
+    limit: int | None = None,
+    sort_expression: str | None = None,
+) -> Callable:
+    """Return a fetch_and_format callback for list_calculated_metrics."""
+
+    def _inner(cja: Any, is_machine_readable: bool) -> str | None:
+        dv_name = _resolve_dataview_name(cja, data_view_id)
+
+        raw_metrics = cja.getCalculatedMetrics(dataIds=data_view_id, full=True)
+
+        if raw_metrics is None or (hasattr(raw_metrics, "__len__") and len(raw_metrics) == 0):
+            if is_machine_readable:
+                if output_format == "json":
+                    return json.dumps(
+                        {"dataViewId": data_view_id, "dataViewName": dv_name, "calculatedMetrics": [], "count": 0},
+                        indent=2,
+                    )
+                return "id,name,owner,type,polarity,precision,approved,tags,created,modified,description\n"
+            return f"\nNo calculated metrics found for data view '{data_view_id}'.\n"
+
+        if isinstance(raw_metrics, pd.DataFrame):
+            raw_metrics = raw_metrics.to_dict("records")
+
+        # Build display dicts with native types
+        display_data: list[dict[str, Any]] = []
+        for item in raw_metrics:
+            if not isinstance(item, dict):
+                continue
+            raw_tags = item.get("tags") or []
+            tags = [t.get("name", str(t)) if isinstance(t, dict) else str(t) for t in raw_tags]
+            approved_raw = item.get("approved")
+            display_data.append({
+                "id": item.get("id", "N/A"),
+                "name": item.get("name", "N/A"),
+                "owner": _extract_owner_name(item.get("owner")),
+                "description": item.get("description", ""),
+                "type": item.get("type", ""),
+                "polarity": item.get("polarity", ""),
+                "precision": item.get("precision", 0),
+                "approved": approved_raw if isinstance(approved_raw, bool) else None,
+                "tags": tags,
+                "created": item.get("created", ""),
+                "modified": item.get("modified", ""),
+            })
+
+        display_data = _apply_discovery_filters_and_sort(
+            display_data,
+            filter_pattern=filter_pattern,
+            exclude_pattern=exclude_pattern,
+            limit=limit,
+            sort_expression=sort_expression,
+            searchable_fields=["id", "name", "owner", "type", "polarity", "description"],
+            default_sort_field="name",
+        )
+
+        if output_format == "json":
+            return _format_as_json({
+                "dataViewId": data_view_id,
+                "dataViewName": dv_name,
+                "calculatedMetrics": display_data,
+                "count": len(display_data),
+            })
+
+        # For table/CSV, convert approved and tags to display strings
+        table_data = [
+            {
+                **row,
+                "approved": _approved_display(row.get("approved")),
+                "tags": ", ".join(row.get("tags") or []),
+            }
+            for row in display_data
+        ]
+
+        if output_format == "csv":
+            return _format_as_csv(
+                ["id", "name", "owner", "type", "polarity", "precision", "approved", "tags", "created", "modified", "description"],
+                table_data,
+            )
+        return _format_as_table(
+            f"Found {len(table_data)} calculated metric(s) in data view '{dv_name}':",
+            table_data,
+            columns=["id", "name", "owner", "type", "polarity", "approved", "description"],
+            col_labels=["ID", "Name", "Owner", "Type", "Polarity", "Approved", "Description"],
+        )
+
+    return _inner
+
+
+def list_calculated_metrics(
+    data_view_id: str,
+    config_file: str = "config.json",
+    output_format: str = "table",
+    output_file: str | None = None,
+    profile: str | None = None,
+    filter_pattern: str | None = None,
+    exclude_pattern: str | None = None,
+    limit: int | None = None,
+    sort_expression: str | None = None,
+) -> bool:
+    """List all calculated metrics for a given data view."""
+    return _run_list_command(
+        banner_text=f"LISTING CALCULATED METRICS FOR DATA VIEW: {data_view_id}",
+        command_name="list_calculated_metrics",
+        fetch_and_format=_fetch_calculated_metrics_list(
+            data_view_id,
+            output_format,
+            filter_pattern=filter_pattern,
+            exclude_pattern=exclude_pattern,
+            limit=limit,
+            sort_expression=sort_expression,
+        ),
+        config_file=config_file,
+        output_format=output_format,
+        output_file=output_file,
+        profile=profile,
+        validate_inputs=lambda: _validate_discovery_query_inputs(
+            filter_pattern=filter_pattern,
+            exclude_pattern=exclude_pattern,
+            limit=limit,
+        ),
+    )
+
+
 # ==================== LIST CONNECTIONS ====================
 
 

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -7472,12 +7472,27 @@ def _format_as_table(
         max(len(lbl), max((len(str(item.get(col, ""))) for item in items), default=0)) + 2
         for col, lbl in zip(columns, labels, strict=True)
     ]
+    # Constrain total width to terminal so the last column wraps instead of overflowing
+    term_width = shutil.get_terminal_size().columns
+    if sum(widths) > term_width and len(widths) > 1:
+        other_width = sum(widths[:-1])
+        widths[-1] = max(term_width - other_width, len(labels[-1]) + 2, 20)
     lines: list[str] = ["", header_line, ""]
     lines.append("".join(f"{lbl:<{w}}" for lbl, w in zip(labels, widths, strict=True)))
-    lines.append("-" * sum(widths))
-    lines.extend(
-        "".join(f"{item.get(col, '')!s:<{w}}" for col, w in zip(columns, widths, strict=True)) for item in items
-    )
+    lines.append("-" * min(sum(widths), term_width))
+    for item in items:
+        cells = [str(item.get(col, "")) for col in columns]
+        last_text_w = widths[-1] - 2
+        if len(cells[-1]) > last_text_w > 0:
+            wrapped = textwrap.wrap(cells[-1], width=last_text_w) or [""]
+            prefix = "".join(f"{cells[i]:<{widths[i]}}" for i in range(len(columns) - 1))
+            lines.append(prefix + wrapped[0])
+            indent = " " * sum(widths[:-1])
+            lines.extend(indent + cont for cont in wrapped[1:])
+        else:
+            lines.append(
+                "".join(f"{item.get(col, '')!s:<{w}}" for col, w in zip(columns, widths, strict=True))
+            )
     lines.append("")
     return "\n".join(lines)
 
@@ -7988,13 +8003,24 @@ def _fetch_describe_dataview(
             return _format_as_csv(columns, [row])
 
         # Table output
+        term_width = shutil.get_terminal_size().columns
+        rule_width = max(60, term_width)
         lines: list[str] = []
         lines.append("")
         lines.append(f"Data View: {dv_name}")
-        lines.append("=" * 60)
+        lines.append("=" * rule_width)
         lines.append(f"  ID:            {dv_id}")
         lines.append(f"  Owner:         {owner_name}")
-        lines.append(f"  Description:   {description or '(none)'}")
+        desc_text = description or "(none)"
+        desc_prefix = "  Description:   "
+        desc_avail = term_width - len(desc_prefix)
+        if desc_avail > 20 and len(desc_text) > desc_avail:
+            wrapped = textwrap.wrap(desc_text, width=desc_avail)
+            lines.append(desc_prefix + wrapped[0])
+            indent = " " * len(desc_prefix)
+            lines.extend(indent + cont for cont in wrapped[1:])
+        else:
+            lines.append(f"{desc_prefix}{desc_text}")
         lines.append(f"  Connection:    {connection_id}")
         lines.append(f"  Created:       {created}")
         lines.append(f"  Modified:      {modified}")
@@ -8006,7 +8032,7 @@ def _fetch_describe_dataview(
         lines.append(f"    Segments:            {n_segments}")
         lines.append("    ─────────────────────────")
         lines.append(f"    Total:               {total}")
-        lines.append("=" * 60)
+        lines.append("=" * rule_width)
         lines.append("")
         return "\n".join(lines)
 

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -8024,6 +8024,127 @@ def describe_dataview(
     )
 
 
+# ==================== LIST METRICS ====================
+
+
+def _resolve_dataview_name(cja: Any, data_view_id: str) -> str:
+    """Look up a data view's display name by ID.
+
+    Returns the name if found, or ``"Unknown"`` on failure.
+    """
+    with contextlib.suppress(Exception):
+        available_dvs = cja.getDataViews()
+        if isinstance(available_dvs, pd.DataFrame):
+            available_dvs = available_dvs.to_dict("records")
+        for dv in available_dvs or []:
+            if isinstance(dv, dict) and dv.get("id") == data_view_id:
+                return dv.get("name", "Unknown")
+    return "Unknown"
+
+
+def _fetch_metrics_list(
+    data_view_id: str,
+    output_format: str,
+    filter_pattern: str | None = None,
+    exclude_pattern: str | None = None,
+    limit: int | None = None,
+    sort_expression: str | None = None,
+) -> Callable:
+    """Return a fetch_and_format callback for list_metrics."""
+
+    def _inner(cja: Any, is_machine_readable: bool) -> str | None:
+        dv_name = _resolve_dataview_name(cja, data_view_id)
+
+        raw_metrics = cja.getMetrics(data_view_id, inclType=True, full=True)
+
+        if raw_metrics is None or (hasattr(raw_metrics, "__len__") and len(raw_metrics) == 0):
+            if is_machine_readable:
+                if output_format == "json":
+                    return json.dumps(
+                        {"dataViewId": data_view_id, "dataViewName": dv_name, "metrics": [], "count": 0},
+                        indent=2,
+                    )
+                return "id,name,type,description\n"
+            return f"\nNo metrics found for data view '{data_view_id}'.\n"
+
+        if isinstance(raw_metrics, pd.DataFrame):
+            raw_metrics = raw_metrics.to_dict("records")
+
+        display_data = [
+            {
+                "id": m.get("id", "N/A"),
+                "name": m.get("name", "N/A"),
+                "type": m.get("type", "N/A"),
+                "description": m.get("description", ""),
+            }
+            for m in raw_metrics
+            if isinstance(m, dict)
+        ]
+
+        display_data = _apply_discovery_filters_and_sort(
+            display_data,
+            filter_pattern=filter_pattern,
+            exclude_pattern=exclude_pattern,
+            limit=limit,
+            sort_expression=sort_expression,
+            searchable_fields=["id", "name", "type", "description"],
+            default_sort_field="name",
+        )
+
+        if output_format == "json":
+            return _format_as_json({
+                "dataViewId": data_view_id,
+                "dataViewName": dv_name,
+                "metrics": display_data,
+                "count": len(display_data),
+            })
+        if output_format == "csv":
+            return _format_as_csv(["id", "name", "type", "description"], display_data)
+        return _format_as_table(
+            f"Found {len(display_data)} metric(s) in data view '{dv_name}':",
+            display_data,
+            columns=["id", "name", "type", "description"],
+            col_labels=["ID", "Name", "Type", "Description"],
+        )
+
+    return _inner
+
+
+def list_metrics(
+    data_view_id: str,
+    config_file: str = "config.json",
+    output_format: str = "table",
+    output_file: str | None = None,
+    profile: str | None = None,
+    filter_pattern: str | None = None,
+    exclude_pattern: str | None = None,
+    limit: int | None = None,
+    sort_expression: str | None = None,
+) -> bool:
+    """List all metrics for a given data view."""
+    return _run_list_command(
+        banner_text=f"LISTING METRICS FOR DATA VIEW: {data_view_id}",
+        command_name="list_metrics",
+        fetch_and_format=_fetch_metrics_list(
+            data_view_id,
+            output_format,
+            filter_pattern=filter_pattern,
+            exclude_pattern=exclude_pattern,
+            limit=limit,
+            sort_expression=sort_expression,
+        ),
+        config_file=config_file,
+        output_format=output_format,
+        output_file=output_file,
+        profile=profile,
+        validate_inputs=lambda: _validate_discovery_query_inputs(
+            filter_pattern=filter_pattern,
+            exclude_pattern=exclude_pattern,
+            limit=limit,
+        ),
+    )
+
+
 # ==================== LIST CONNECTIONS ====================
 
 

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -7935,9 +7935,14 @@ def _normalize_single_dataview_payload(raw_dv: Any) -> dict[str, Any] | None:
     return raw_dv if isinstance(raw_dv, dict) else None
 
 
+def _normalized_payload_keys(payload: dict[str, Any]) -> set[str]:
+    """Return normalized dictionary keys for payload-shape checks."""
+    return {str(key).strip().casefold() for key in payload}
+
+
 def _looks_like_dataview_error_payload(payload: dict[str, Any]) -> bool:
     """Return True when a getDataView payload matches API error object shape."""
-    normalized_keys = {str(key).strip().casefold() for key in payload}
+    normalized_keys = _normalized_payload_keys(payload)
     if not normalized_keys:
         return True
 
@@ -7960,6 +7965,125 @@ def _require_accessible_dataview(cja: Any, data_view_id: str) -> dict[str, Any]:
     return payload
 
 
+_COMPONENT_SEQUENCE_KEYS = ("content", "items", "results", "data", "rows")
+
+
+def _extract_component_sequence(payload: dict[str, Any]) -> list[Any] | None:
+    """Extract list-like component rows from common API envelope shapes."""
+    for key in _COMPONENT_SEQUENCE_KEYS:
+        if key not in payload:
+            continue
+        value = payload.get(key)
+        if value is None:
+            return []
+        if isinstance(value, pd.DataFrame):
+            return value.to_dict("records")
+        if isinstance(value, (list, tuple, set)):
+            return list(value)
+        if isinstance(value, dict):
+            nested = _extract_component_sequence(value)
+            if nested is not None:
+                return nested
+        return []
+    return None
+
+
+def _looks_like_component_error_payload(payload: dict[str, Any]) -> bool:
+    """Return True when a component API payload row matches error object shape."""
+    normalized_keys = _normalized_payload_keys(payload)
+    if not normalized_keys:
+        return True
+
+    explicit_error_keys = {"error", "errorcode", "errordescription", "error_description"}
+    if normalized_keys & explicit_error_keys:
+        return True
+
+    has_component_identity = bool(payload.get("id")) or bool(payload.get("name"))
+    generic_error_keys = {"statuscode", "status_code", "status", "message", "detail", "title", "type"}
+    return not has_component_identity and bool(normalized_keys & generic_error_keys)
+
+
+def _coerce_component_rows(raw_payload: Any) -> list[Any] | None:
+    """Normalize component API payloads into row lists when possible."""
+    if raw_payload is None:
+        return []
+    if isinstance(raw_payload, pd.DataFrame):
+        return raw_payload.to_dict("records")
+    if isinstance(raw_payload, (list, tuple, set)):
+        return list(raw_payload)
+    if isinstance(raw_payload, dict):
+        extracted = _extract_component_sequence(raw_payload)
+        if extracted is not None:
+            return extracted
+        return [raw_payload]
+    return None
+
+
+def _is_component_error_payload(raw_payload: Any) -> bool:
+    """Return True when a component API payload appears to be an error object."""
+    if isinstance(raw_payload, pd.DataFrame):
+        # A bare empty frame (no rows, no columns) is a legitimate "no results" shape.
+        if raw_payload.empty and len(raw_payload.columns) == 0:
+            return False
+        if _looks_like_component_error_payload({str(column): None for column in raw_payload.columns}):
+            if raw_payload.empty:
+                return True
+            for row in raw_payload.to_dict("records"):
+                if isinstance(row, dict) and _looks_like_component_error_payload(row):
+                    return True
+        return False
+
+    if isinstance(raw_payload, dict):
+        if _looks_like_component_error_payload(raw_payload):
+            return True
+        extracted = _extract_component_sequence(raw_payload)
+        if extracted is not None:
+            return _is_component_error_payload(extracted)
+        return False
+
+    if isinstance(raw_payload, (list, tuple, set)):
+        rows = list(raw_payload)
+        if not rows:
+            return False
+        return any(isinstance(row, dict) and _looks_like_component_error_payload(row) for row in rows)
+
+    return False
+
+
+def _normalize_component_records_or_raise(
+    raw_payload: Any,
+    *,
+    component_label: str,
+    data_view_id: str,
+) -> list[dict[str, Any]]:
+    """Normalize component payloads to dict rows or fail on error-shaped responses."""
+    if _is_component_error_payload(raw_payload):
+        raise DiscoveryNotFoundError(f"Failed to retrieve {component_label} for data view '{data_view_id}'")
+
+    rows = _coerce_component_rows(raw_payload)
+    if rows is None:
+        raise DiscoveryNotFoundError(
+            f"Unexpected {component_label} payload type for data view '{data_view_id}'",
+        )
+    if not rows:
+        return []
+
+    dict_rows = [row for row in rows if isinstance(row, dict)]
+    if not dict_rows:
+        raise DiscoveryNotFoundError(f"Failed to retrieve {component_label} for data view '{data_view_id}'")
+    return dict_rows
+
+
+def _count_component_items_or_na(raw_payload: Any) -> int | str:
+    """Return component count or 'N/A' when payload is unavailable/invalid."""
+    if _is_component_error_payload(raw_payload):
+        return "N/A"
+    rows = _coerce_component_rows(raw_payload)
+    if rows is None:
+        return "N/A"
+    return len(rows)
+
+
 def _fetch_describe_dataview(
     data_view_id: str,
     output_format: str,
@@ -7980,12 +8104,7 @@ def _fetch_describe_dataview(
         def _safe_count(api_call: Callable, *args: Any, **kwargs: Any) -> int | str:
             """Call an API method and return the item count, or 'N/A' on failure."""
             try:
-                result = api_call(*args, **kwargs)
-                if isinstance(result, pd.DataFrame):
-                    return len(result)
-                if isinstance(result, list):
-                    return len(result)
-                return 0
+                return _count_component_items_or_na(api_call(*args, **kwargs))
             except Exception:
                 return "N/A"
 
@@ -8140,9 +8259,13 @@ def _fetch_metrics_list(
     def _inner(cja: Any, is_machine_readable: bool) -> str | None:
         dv_name = _resolve_dataview_name(cja, data_view_id)
 
-        raw_metrics = cja.getMetrics(data_view_id, inclType=True, full=True)
+        raw_metrics = _normalize_component_records_or_raise(
+            cja.getMetrics(data_view_id, inclType=True, full=True),
+            component_label="metrics",
+            data_view_id=data_view_id,
+        )
 
-        if raw_metrics is None or (hasattr(raw_metrics, "__len__") and len(raw_metrics) == 0):
+        if not raw_metrics:
             if is_machine_readable:
                 if output_format == "json":
                     return json.dumps(
@@ -8151,9 +8274,6 @@ def _fetch_metrics_list(
                     )
                 return "id,name,type,description\n"
             return f"\nNo metrics found for data view '{data_view_id}'.\n"
-
-        if isinstance(raw_metrics, pd.DataFrame):
-            raw_metrics = raw_metrics.to_dict("records")
 
         display_data = [
             {
@@ -8248,9 +8368,13 @@ def _fetch_dimensions_list(
     def _inner(cja: Any, is_machine_readable: bool) -> str | None:
         dv_name = _resolve_dataview_name(cja, data_view_id)
 
-        raw_dimensions = cja.getDimensions(data_view_id, inclType=True, full=True)
+        raw_dimensions = _normalize_component_records_or_raise(
+            cja.getDimensions(data_view_id, inclType=True, full=True),
+            component_label="dimensions",
+            data_view_id=data_view_id,
+        )
 
-        if raw_dimensions is None or (hasattr(raw_dimensions, "__len__") and len(raw_dimensions) == 0):
+        if not raw_dimensions:
             if is_machine_readable:
                 if output_format == "json":
                     return json.dumps(
@@ -8259,9 +8383,6 @@ def _fetch_dimensions_list(
                     )
                 return "id,name,type,description\n"
             return f"\nNo dimensions found for data view '{data_view_id}'.\n"
-
-        if isinstance(raw_dimensions, pd.DataFrame):
-            raw_dimensions = raw_dimensions.to_dict("records")
 
         display_data = [
             {
@@ -8365,9 +8486,13 @@ def _fetch_segments_list(
     def _inner(cja: Any, is_machine_readable: bool) -> str | None:
         dv_name = _resolve_dataview_name(cja, data_view_id)
 
-        raw_segments = cja.getFilters(dataIds=data_view_id, full=True)
+        raw_segments = _normalize_component_records_or_raise(
+            cja.getFilters(dataIds=data_view_id, full=True),
+            component_label="segments",
+            data_view_id=data_view_id,
+        )
 
-        if raw_segments is None or (hasattr(raw_segments, "__len__") and len(raw_segments) == 0):
+        if not raw_segments:
             if is_machine_readable:
                 if output_format == "json":
                     return json.dumps(
@@ -8376,9 +8501,6 @@ def _fetch_segments_list(
                     )
                 return "id,name,owner,approved,description,tags,created,modified\n"
             return f"\nNo segments found for data view '{data_view_id}'.\n"
-
-        if isinstance(raw_segments, pd.DataFrame):
-            raw_segments = raw_segments.to_dict("records")
 
         # Build display dicts with native types
         display_data: list[dict[str, Any]] = []
@@ -8497,9 +8619,13 @@ def _fetch_calculated_metrics_list(
     def _inner(cja: Any, is_machine_readable: bool) -> str | None:
         dv_name = _resolve_dataview_name(cja, data_view_id)
 
-        raw_metrics = cja.getCalculatedMetrics(dataIds=data_view_id, full=True)
+        raw_metrics = _normalize_component_records_or_raise(
+            cja.getCalculatedMetrics(dataIds=data_view_id, full=True),
+            component_label="calculated metrics",
+            data_view_id=data_view_id,
+        )
 
-        if raw_metrics is None or (hasattr(raw_metrics, "__len__") and len(raw_metrics) == 0):
+        if not raw_metrics:
             if is_machine_readable:
                 if output_format == "json":
                     return json.dumps(
@@ -8508,9 +8634,6 @@ def _fetch_calculated_metrics_list(
                     )
                 return "id,name,owner,type,polarity,precision,approved,tags,created,modified,description\n"
             return f"\nNo calculated metrics found for data view '{data_view_id}'.\n"
-
-        if isinstance(raw_metrics, pd.DataFrame):
-            raw_metrics = raw_metrics.to_dict("records")
 
         # Build display dicts with native types
         display_data: list[dict[str, Any]] = []

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -8318,7 +8318,7 @@ def _fetch_describe_dataview(
         lines.append("=" * rule_width)
         lines.append(f"  ID:            {dv_id}")
         lines.append(f"  Owner:         {owner_name}")
-        desc_text = description if description else "(none)"
+        desc_text = description or "(none)"
         desc_prefix = "  Description:   "
         desc_avail = term_width - len(desc_prefix)
         if desc_avail > 20 and len(desc_text) > desc_avail:

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -7612,7 +7612,12 @@ def _emit_output(data: str, output_file: str | None, is_stdout: bool) -> None:
 
 def _format_as_json(payload: dict) -> str:
     """Format a discovery result dict as indented JSON."""
-    return json.dumps(payload, indent=2)
+    try:
+        return json.dumps(payload, indent=2, allow_nan=False)
+    except ValueError as exc:
+        raise DiscoveryOutputContractError(
+            "Discovery output contains non-JSON-compliant values",
+        ) from exc
 
 
 def _format_as_csv(columns: list[str], rows: list[dict]) -> str:
@@ -7741,6 +7746,10 @@ class DiscoveryArgumentError(ValueError):
     """Raised when discovery filter/sort arguments are invalid."""
 
 
+class DiscoveryOutputContractError(ValueError):
+    """Raised when machine-readable discovery output violates JSON contracts."""
+
+
 class DiscoveryNotFoundError(LookupError):
     """Raised when a requested discovery resource is not found."""
 
@@ -7777,7 +7786,7 @@ def _emit_discovery_error(
             payload["error_type"] = error_type
         if additional_fields:
             payload.update(additional_fields)
-        print(json.dumps(payload), file=sys.stderr)
+        print(json.dumps(payload, allow_nan=False), file=sys.stderr)
         return
 
     stream = sys.stderr if human_to_stderr else sys.stdout
@@ -8010,6 +8019,15 @@ def _run_list_command(
             str(e),
             is_machine_readable=is_machine_readable,
             error_type="invalid_arguments",
+            human_to_stderr=False,
+        )
+        return False
+
+    except DiscoveryOutputContractError as e:
+        _emit_discovery_error(
+            str(e),
+            is_machine_readable=is_machine_readable,
+            error_type="output_contract",
             human_to_stderr=False,
         )
         return False
@@ -8386,6 +8404,30 @@ def _format_governance_rows_for_tabular(rows: list[dict[str, Any]]) -> list[dict
     ]
 
 
+@dataclass(frozen=True)
+class _ComponentFetchSpec:
+    """Describe how to fetch one component collection for a data view."""
+
+    method_name: str
+    data_view_arg_name: str | None = None
+    kwargs: dict[str, Any] = field(default_factory=dict)
+
+
+def _fetch_component_payload(cja: Any, data_view_id: str, fetch_spec: _ComponentFetchSpec) -> Any:
+    """Invoke a component-list API call using a declarative fetch spec."""
+    fetch_method = getattr(cja, fetch_spec.method_name, None)
+    if not callable(fetch_method):
+        raise DiscoveryNotFoundError(
+            f"CJA client missing expected method '{fetch_spec.method_name}' for data view '{data_view_id}'",
+        )
+
+    kwargs = dict(fetch_spec.kwargs)
+    if fetch_spec.data_view_arg_name:
+        kwargs[fetch_spec.data_view_arg_name] = data_view_id
+        return fetch_method(**kwargs)
+    return fetch_method(data_view_id, **kwargs)
+
+
 def _build_component_list_fetcher(
     *,
     data_view_id: str,
@@ -8399,7 +8441,7 @@ def _build_component_list_fetcher(
     table_item_label: str,
     component_json_key: str,
     empty_csv_header: str,
-    fetch_payload: Callable[[Any, str], Any],
+    fetch_spec: _ComponentFetchSpec,
     display_row_builder: Callable[[dict[str, Any]], dict[str, Any]],
     searchable_fields: list[str],
     csv_columns: list[str],
@@ -8413,7 +8455,7 @@ def _build_component_list_fetcher(
         dv_name = _resolve_dataview_name(cja, data_view_id, preferred_name=data_view_name)
 
         raw_components = _normalize_component_records_or_raise(
-            fetch_payload(cja, data_view_id),
+            _fetch_component_payload(cja, data_view_id, fetch_spec),
             component_label=component_label,
             data_view_id=data_view_id,
         )
@@ -8466,13 +8508,49 @@ def _build_component_list_fetcher(
     return _inner
 
 
+def _normalize_component_text_fields(item: dict[str, Any], *, defaults: dict[str, str]) -> dict[str, str]:
+    """Normalize a component row's text fields with per-field defaults."""
+    return {
+        field_name: _normalize_optional_text(item.get(field_name), default=default_value)
+        for field_name, default_value in defaults.items()
+    }
+
+
+def _normalize_optional_component_int(value: Any, *, default: int = 0) -> int:
+    """Normalize optional integer-ish component values for strict JSON output."""
+    if _is_missing_discovery_value(value, treat_blank_string=True, treat_null_like_strings=True):
+        return default
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if value.is_integer():
+            return int(value)
+        return default
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return default
+        try:
+            return int(stripped)
+        except ValueError:
+            return default
+    return default
+
+
 def _build_metric_display_row(item: dict[str, Any]) -> dict[str, Any]:
     """Normalize one metrics-list row for output."""
     return {
-        "id": _normalize_optional_text(item.get("id"), default="N/A"),
-        "name": _normalize_optional_text(item.get("name"), default="N/A"),
-        "type": item.get("type", "N/A"),
-        "description": item.get("description", ""),
+        **_normalize_component_text_fields(
+            item,
+            defaults={
+                "id": "N/A",
+                "name": "N/A",
+                "type": "N/A",
+                "description": "",
+            },
+        ),
     }
 
 
@@ -8498,7 +8576,10 @@ def _fetch_metrics_list(
         table_item_label="metric",
         component_json_key="metrics",
         empty_csv_header="id,name,type,description",
-        fetch_payload=lambda cja, dv_id: cja.getMetrics(dv_id, inclType=True, full=True),
+        fetch_spec=_ComponentFetchSpec(
+            method_name="getMetrics",
+            kwargs={"inclType": "hidden", "full": True},
+        ),
         display_row_builder=_build_metric_display_row,
         searchable_fields=["id", "name", "type", "description"],
         csv_columns=["id", "name", "type", "description"],
@@ -8550,10 +8631,15 @@ def list_metrics(
 def _build_dimension_display_row(item: dict[str, Any]) -> dict[str, Any]:
     """Normalize one dimensions-list row for output."""
     return {
-        "id": _normalize_optional_text(item.get("id"), default="N/A"),
-        "name": _normalize_optional_text(item.get("name"), default="N/A"),
-        "type": item.get("type", "N/A"),
-        "description": item.get("description", ""),
+        **_normalize_component_text_fields(
+            item,
+            defaults={
+                "id": "N/A",
+                "name": "N/A",
+                "type": "N/A",
+                "description": "",
+            },
+        ),
     }
 
 
@@ -8579,7 +8665,10 @@ def _fetch_dimensions_list(
         table_item_label="dimension",
         component_json_key="dimensions",
         empty_csv_header="id,name,type,description",
-        fetch_payload=lambda cja, dv_id: cja.getDimensions(dv_id, inclType=True, full=True),
+        fetch_spec=_ComponentFetchSpec(
+            method_name="getDimensions",
+            kwargs={"inclType": "hidden", "full": True},
+        ),
         display_row_builder=_build_dimension_display_row,
         searchable_fields=["id", "name", "type", "description"],
         csv_columns=["id", "name", "type", "description"],
@@ -8649,10 +8738,15 @@ def _build_segment_display_row(item: dict[str, Any]) -> dict[str, Any]:
     tags = _extract_tags_normalized(item.get("tags"))
     approved_raw = item.get("approved")
     return {
-        "id": _normalize_optional_text(item.get("id"), default="N/A"),
-        "name": _normalize_optional_text(item.get("name"), default="N/A"),
+        **_normalize_component_text_fields(
+            item,
+            defaults={
+                "id": "N/A",
+                "name": "N/A",
+                "description": "",
+            },
+        ),
         "owner": _extract_owner_name_from_record(item),
-        "description": item.get("description", ""),
         "approved": approved_raw if isinstance(approved_raw, bool) else None,
         "tags": tags,
         "created": _extract_timestamp_from_record(item, "created"),
@@ -8682,7 +8776,11 @@ def _fetch_segments_list(
         table_item_label="segment",
         component_json_key="segments",
         empty_csv_header="id,name,owner,approved,description,tags,created,modified",
-        fetch_payload=lambda cja, dv_id: cja.getFilters(dataIds=dv_id, full=True),
+        fetch_spec=_ComponentFetchSpec(
+            method_name="getFilters",
+            data_view_arg_name="dataIds",
+            kwargs={"full": True},
+        ),
         display_row_builder=_build_segment_display_row,
         searchable_fields=["id", "name", "owner", "description", "tags"],
         csv_columns=["id", "name", "owner", "approved", "description", "tags", "created", "modified"],
@@ -8737,13 +8835,18 @@ def _build_calculated_metric_display_row(item: dict[str, Any]) -> dict[str, Any]
     tags = _extract_tags_normalized(item.get("tags"))
     approved_raw = item.get("approved")
     return {
-        "id": _normalize_optional_text(item.get("id"), default="N/A"),
-        "name": _normalize_optional_text(item.get("name"), default="N/A"),
+        **_normalize_component_text_fields(
+            item,
+            defaults={
+                "id": "N/A",
+                "name": "N/A",
+                "description": "",
+                "type": "",
+                "polarity": "",
+            },
+        ),
         "owner": _extract_owner_name_from_record(item),
-        "description": item.get("description", ""),
-        "type": item.get("type", ""),
-        "polarity": item.get("polarity", ""),
-        "precision": item.get("precision", 0),
+        "precision": _normalize_optional_component_int(item.get("precision"), default=0),
         "approved": approved_raw if isinstance(approved_raw, bool) else None,
         "tags": tags,
         "created": _extract_timestamp_from_record(item, "created"),
@@ -8773,7 +8876,11 @@ def _fetch_calculated_metrics_list(
         table_item_label="calculated metric",
         component_json_key="calculatedMetrics",
         empty_csv_header="id,name,owner,type,polarity,precision,approved,tags,created,modified,description",
-        fetch_payload=lambda cja, dv_id: cja.getCalculatedMetrics(dataIds=dv_id, full=True),
+        fetch_spec=_ComponentFetchSpec(
+            method_name="getCalculatedMetrics",
+            data_view_arg_name="dataIds",
+            kwargs={"full": True},
+        ),
         display_row_builder=_build_calculated_metric_display_row,
         searchable_fields=["id", "name", "owner", "type", "polarity", "description"],
         csv_columns=[

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -117,25 +117,10 @@ from cja_auto_sdr.core.discovery_payloads import (
     assess_component_payload as _assess_component_payload,
 )
 from cja_auto_sdr.core.discovery_payloads import (
-    coerce_component_rows_or_none as _coerce_component_rows_or_none,
-)
-from cja_auto_sdr.core.discovery_payloads import (
     count_component_items_or_na as _count_component_items_or_na_from_assessment,
 )
 from cja_auto_sdr.core.discovery_payloads import (
-    extract_component_sequence as _extract_component_sequence_from_payload,
-)
-from cja_auto_sdr.core.discovery_payloads import (
-    is_component_error_payload as _is_component_error_payload_from_assessment,
-)
-from cja_auto_sdr.core.discovery_payloads import (
     is_dataview_error_payload as _is_dataview_error_payload,
-)
-from cja_auto_sdr.core.discovery_payloads import (
-    looks_like_component_error_payload as _looks_like_component_error_row,
-)
-from cja_auto_sdr.core.discovery_payloads import (
-    normalized_payload_keys as _normalized_payload_keys_set,
 )
 from cja_auto_sdr.core.exceptions import (
     APIError,
@@ -8179,44 +8164,14 @@ def _normalize_single_dataview_payload(raw_dv: Any) -> dict[str, Any] | None:
     return raw_dv if isinstance(raw_dv, dict) else None
 
 
-def _normalized_payload_keys(payload: dict[str, Any]) -> set[str]:
-    """Return normalized dictionary keys for payload-shape checks."""
-    return _normalized_payload_keys_set(payload)
-
-
-def _looks_like_dataview_error_payload(payload: dict[str, Any]) -> bool:
-    """Return True when a getDataView payload matches API error object shape."""
-    return _is_dataview_error_payload(payload)
-
-
 def _require_accessible_dataview(cja: Any, data_view_id: str) -> dict[str, Any]:
     """Fetch a data view and raise DiscoveryNotFoundError when inaccessible/invalid."""
     payload = _normalize_single_dataview_payload(cja.getDataView(data_view_id))
-    if payload is None or _looks_like_dataview_error_payload(payload):
+    if payload is None or _is_dataview_error_payload(payload):
         raise DiscoveryNotFoundError(f"Data view '{data_view_id}' not found")
     if not payload.get("id") and not payload.get("name"):
         raise DiscoveryNotFoundError(f"Data view '{data_view_id}' not found")
     return payload
-
-
-def _extract_component_sequence(payload: dict[str, Any]) -> list[Any] | None:
-    """Extract list-like component rows from common API envelope shapes."""
-    return _extract_component_sequence_from_payload(payload)
-
-
-def _looks_like_component_error_payload(payload: dict[str, Any]) -> bool:
-    """Return True when a component API payload row matches error object shape."""
-    return _looks_like_component_error_row(payload)
-
-
-def _coerce_component_rows(raw_payload: Any) -> list[Any] | None:
-    """Normalize component API payloads into row lists when possible."""
-    return _coerce_component_rows_or_none(raw_payload)
-
-
-def _is_component_error_payload(raw_payload: Any) -> bool:
-    """Return True when a component API payload appears to be an error object."""
-    return _is_component_error_payload_from_assessment(raw_payload)
 
 
 def _normalize_component_records_or_raise(
@@ -8234,11 +8189,6 @@ def _normalize_component_records_or_raise(
             f"Unexpected {component_label} payload type for data view '{data_view_id}'",
         )
     return assessment.rows
-
-
-def _count_component_items_or_na(raw_payload: Any) -> int | str:
-    """Return component count or 'N/A' when payload is unavailable/invalid."""
-    return _count_component_items_or_na_from_assessment(raw_payload)
 
 
 def _normalize_describe_dataview_metadata(raw_dv: dict[str, Any], *, default_id: str) -> dict[str, str]:
@@ -8286,7 +8236,7 @@ def _fetch_describe_dataview(
         def _safe_count(api_call: Callable, *args: Any, **kwargs: Any) -> int | str:
             """Call an API method and return the item count, or 'N/A' on failure."""
             try:
-                return _count_component_items_or_na(api_call(*args, **kwargs))
+                return _count_component_items_or_na_from_assessment(api_call(*args, **kwargs))
             except Exception:
                 return "N/A"
 
@@ -8395,7 +8345,6 @@ def describe_dataview(
     output_format: str = "table",
     output_file: str | None = None,
     profile: str | None = None,
-    **_kwargs: Any,
 ) -> bool:
     """Describe a single data view with component counts and exit."""
     return _run_list_command(
@@ -8412,66 +8361,82 @@ def describe_dataview(
 # ==================== LIST METRICS ====================
 
 
-def _resolve_dataview_name(cja: Any, data_view_id: str) -> str:
-    """Look up a data view's display name by ID.
-
-    Uses ``getDataView(id)`` to fetch a single resource instead of
-    listing all data views, avoiding an expensive API round-trip.
-
-    Raises DiscoveryNotFoundError if the data view is missing or inaccessible.
-    """
+def _resolve_dataview_name(cja: Any, data_view_id: str, *, preferred_name: str | None = None) -> str:
+    """Look up a data view display name, preferring dispatch-resolved names when available."""
+    normalized_preferred = _normalize_optional_text(preferred_name, default="")
+    if normalized_preferred:
+        return normalized_preferred
     raw_dv = _require_accessible_dataview(cja, data_view_id)
     normalized_name = _normalize_optional_text(raw_dv.get("name"), default="")
     return normalized_name or "Unknown"
 
 
-def _fetch_metrics_list(
+def _format_governance_rows_for_tabular(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Convert governance fields into table/csv-friendly strings."""
+    return [
+        {
+            **row,
+            "approved": _approved_display(row.get("approved")),
+            "tags": _tags_display(row.get("tags")),
+        }
+        for row in rows
+    ]
+
+
+def _build_component_list_fetcher(
+    *,
     data_view_id: str,
+    data_view_name: str | None,
     output_format: str,
-    filter_pattern: str | None = None,
-    exclude_pattern: str | None = None,
-    limit: int | None = None,
-    sort_expression: str | None = None,
+    filter_pattern: str | None,
+    exclude_pattern: str | None,
+    limit: int | None,
+    sort_expression: str | None,
+    component_label: str,
+    table_item_label: str,
+    component_json_key: str,
+    empty_csv_header: str,
+    fetch_payload: Callable[[Any, str], Any],
+    display_row_builder: Callable[[dict[str, Any]], dict[str, Any]],
+    searchable_fields: list[str],
+    csv_columns: list[str],
+    table_columns: list[str],
+    table_labels: list[str],
+    table_row_transform: Callable[[list[dict[str, Any]]], list[dict[str, Any]]] | None = None,
 ) -> Callable:
-    """Return a fetch_and_format callback for list_metrics."""
+    """Return a shared fetch-and-format callback for list-* inspection commands."""
 
     def _inner(cja: Any, is_machine_readable: bool) -> str | None:
-        dv_name = _resolve_dataview_name(cja, data_view_id)
+        dv_name = _resolve_dataview_name(cja, data_view_id, preferred_name=data_view_name)
 
-        raw_metrics = _normalize_component_records_or_raise(
-            cja.getMetrics(data_view_id, inclType=True, full=True),
-            component_label="metrics",
+        raw_components = _normalize_component_records_or_raise(
+            fetch_payload(cja, data_view_id),
+            component_label=component_label,
             data_view_id=data_view_id,
         )
 
-        if not raw_metrics:
+        if not raw_components:
             if is_machine_readable:
                 if output_format == "json":
-                    return json.dumps(
-                        {"dataViewId": data_view_id, "dataViewName": dv_name, "metrics": [], "count": 0},
-                        indent=2,
+                    return _format_as_json(
+                        {
+                            "dataViewId": data_view_id,
+                            "dataViewName": dv_name,
+                            component_json_key: [],
+                            "count": 0,
+                        }
                     )
-                return "id,name,type,description\n"
-            return f"\nNo metrics found for data view '{data_view_id}'.\n"
+                return f"{empty_csv_header}\n"
+            return f"\nNo {component_label} found for data view '{data_view_id}'.\n"
 
-        display_data = [
-            {
-                "id": _normalize_optional_text(m.get("id"), default="N/A"),
-                "name": _normalize_optional_text(m.get("name"), default="N/A"),
-                "type": m.get("type", "N/A"),
-                "description": m.get("description", ""),
-            }
-            for m in raw_metrics
-            if isinstance(m, dict)
-        ]
-
+        display_data = [display_row_builder(item) for item in raw_components if isinstance(item, dict)]
         display_data = _apply_discovery_filters_and_sort(
             display_data,
             filter_pattern=filter_pattern,
             exclude_pattern=exclude_pattern,
             limit=limit,
             sort_expression=sort_expression,
-            searchable_fields=["id", "name", "type", "description"],
+            searchable_fields=searchable_fields,
             default_sort_field="name",
         )
 
@@ -8480,20 +8445,63 @@ def _fetch_metrics_list(
                 {
                     "dataViewId": data_view_id,
                     "dataViewName": dv_name,
-                    "metrics": display_data,
+                    component_json_key: display_data,
                     "count": len(display_data),
                 }
             )
+
+        tabular_data = table_row_transform(display_data) if table_row_transform else display_data
         if output_format == "csv":
-            return _format_as_csv(["id", "name", "type", "description"], display_data)
+            return _format_as_csv(csv_columns, tabular_data)
         return _format_as_table(
-            f"Found {len(display_data)} metric(s) in data view '{dv_name}':",
-            display_data,
-            columns=["id", "name", "type", "description"],
-            col_labels=["ID", "Name", "Type", "Description"],
+            f"Found {len(tabular_data)} {table_item_label}(s) in data view '{dv_name}':",
+            tabular_data,
+            columns=table_columns,
+            col_labels=table_labels,
         )
 
     return _inner
+
+
+def _build_metric_display_row(item: dict[str, Any]) -> dict[str, Any]:
+    """Normalize one metrics-list row for output."""
+    return {
+        "id": _normalize_optional_text(item.get("id"), default="N/A"),
+        "name": _normalize_optional_text(item.get("name"), default="N/A"),
+        "type": item.get("type", "N/A"),
+        "description": item.get("description", ""),
+    }
+
+
+def _fetch_metrics_list(
+    data_view_id: str,
+    output_format: str,
+    data_view_name: str | None = None,
+    filter_pattern: str | None = None,
+    exclude_pattern: str | None = None,
+    limit: int | None = None,
+    sort_expression: str | None = None,
+) -> Callable:
+    """Return a fetch_and_format callback for list_metrics."""
+    return _build_component_list_fetcher(
+        data_view_id=data_view_id,
+        data_view_name=data_view_name,
+        output_format=output_format,
+        filter_pattern=filter_pattern,
+        exclude_pattern=exclude_pattern,
+        limit=limit,
+        sort_expression=sort_expression,
+        component_label="metrics",
+        table_item_label="metric",
+        component_json_key="metrics",
+        empty_csv_header="id,name,type,description",
+        fetch_payload=lambda cja, dv_id: cja.getMetrics(dv_id, inclType=True, full=True),
+        display_row_builder=_build_metric_display_row,
+        searchable_fields=["id", "name", "type", "description"],
+        csv_columns=["id", "name", "type", "description"],
+        table_columns=["id", "name", "type", "description"],
+        table_labels=["ID", "Name", "Type", "Description"],
+    )
 
 
 def list_metrics(
@@ -8502,6 +8510,7 @@ def list_metrics(
     output_format: str = "table",
     output_file: str | None = None,
     profile: str | None = None,
+    data_view_name: str | None = None,
     filter_pattern: str | None = None,
     exclude_pattern: str | None = None,
     limit: int | None = None,
@@ -8514,6 +8523,7 @@ def list_metrics(
         fetch_and_format=_fetch_metrics_list(
             data_view_id,
             output_format,
+            data_view_name=data_view_name,
             filter_pattern=filter_pattern,
             exclude_pattern=exclude_pattern,
             limit=limit,
@@ -8534,75 +8544,45 @@ def list_metrics(
 # ==================== LIST DIMENSIONS ====================
 
 
+def _build_dimension_display_row(item: dict[str, Any]) -> dict[str, Any]:
+    """Normalize one dimensions-list row for output."""
+    return {
+        "id": _normalize_optional_text(item.get("id"), default="N/A"),
+        "name": _normalize_optional_text(item.get("name"), default="N/A"),
+        "type": item.get("type", "N/A"),
+        "description": item.get("description", ""),
+    }
+
+
 def _fetch_dimensions_list(
     data_view_id: str,
     output_format: str,
+    data_view_name: str | None = None,
     filter_pattern: str | None = None,
     exclude_pattern: str | None = None,
     limit: int | None = None,
     sort_expression: str | None = None,
 ) -> Callable:
     """Return a fetch_and_format callback for list_dimensions."""
-
-    def _inner(cja: Any, is_machine_readable: bool) -> str | None:
-        dv_name = _resolve_dataview_name(cja, data_view_id)
-
-        raw_dimensions = _normalize_component_records_or_raise(
-            cja.getDimensions(data_view_id, inclType=True, full=True),
-            component_label="dimensions",
-            data_view_id=data_view_id,
-        )
-
-        if not raw_dimensions:
-            if is_machine_readable:
-                if output_format == "json":
-                    return json.dumps(
-                        {"dataViewId": data_view_id, "dataViewName": dv_name, "dimensions": [], "count": 0},
-                        indent=2,
-                    )
-                return "id,name,type,description\n"
-            return f"\nNo dimensions found for data view '{data_view_id}'.\n"
-
-        display_data = [
-            {
-                "id": _normalize_optional_text(d.get("id"), default="N/A"),
-                "name": _normalize_optional_text(d.get("name"), default="N/A"),
-                "type": d.get("type", "N/A"),
-                "description": d.get("description", ""),
-            }
-            for d in raw_dimensions
-            if isinstance(d, dict)
-        ]
-
-        display_data = _apply_discovery_filters_and_sort(
-            display_data,
-            filter_pattern=filter_pattern,
-            exclude_pattern=exclude_pattern,
-            limit=limit,
-            sort_expression=sort_expression,
-            searchable_fields=["id", "name", "type", "description"],
-            default_sort_field="name",
-        )
-
-        if output_format == "json":
-            return _format_as_json(
-                {
-                    "dataViewId": data_view_id,
-                    "dataViewName": dv_name,
-                    "dimensions": display_data,
-                    "count": len(display_data),
-                }
-            )
-        if output_format == "csv":
-            return _format_as_csv(["id", "name", "type", "description"], display_data)
-        return _format_as_table(
-            f"Found {len(display_data)} dimension(s) in data view '{dv_name}':",
-            display_data,
-            columns=["id", "name", "type", "description"],
-            col_labels=["ID", "Name", "Type", "Description"],
-        )
-
-    return _inner
+    return _build_component_list_fetcher(
+        data_view_id=data_view_id,
+        data_view_name=data_view_name,
+        output_format=output_format,
+        filter_pattern=filter_pattern,
+        exclude_pattern=exclude_pattern,
+        limit=limit,
+        sort_expression=sort_expression,
+        component_label="dimensions",
+        table_item_label="dimension",
+        component_json_key="dimensions",
+        empty_csv_header="id,name,type,description",
+        fetch_payload=lambda cja, dv_id: cja.getDimensions(dv_id, inclType=True, full=True),
+        display_row_builder=_build_dimension_display_row,
+        searchable_fields=["id", "name", "type", "description"],
+        csv_columns=["id", "name", "type", "description"],
+        table_columns=["id", "name", "type", "description"],
+        table_labels=["ID", "Name", "Type", "Description"],
+    )
 
 
 def list_dimensions(
@@ -8611,6 +8591,7 @@ def list_dimensions(
     output_format: str = "table",
     output_file: str | None = None,
     profile: str | None = None,
+    data_view_name: str | None = None,
     filter_pattern: str | None = None,
     exclude_pattern: str | None = None,
     limit: int | None = None,
@@ -8623,6 +8604,7 @@ def list_dimensions(
         fetch_and_format=_fetch_dimensions_list(
             data_view_id,
             output_format,
+            data_view_name=data_view_name,
             filter_pattern=filter_pattern,
             exclude_pattern=exclude_pattern,
             limit=limit,
@@ -8659,98 +8641,52 @@ def _tags_display(tags: Any) -> str:
     return ", ".join(tag for tag in tags if isinstance(tag, str))
 
 
+def _build_segment_display_row(item: dict[str, Any]) -> dict[str, Any]:
+    """Normalize one segments-list row for output."""
+    tags = _extract_tags_normalized(item.get("tags"))
+    approved_raw = item.get("approved")
+    return {
+        "id": _normalize_optional_text(item.get("id"), default="N/A"),
+        "name": _normalize_optional_text(item.get("name"), default="N/A"),
+        "owner": _extract_owner_name_from_record(item),
+        "description": item.get("description", ""),
+        "approved": approved_raw if isinstance(approved_raw, bool) else None,
+        "tags": tags,
+        "created": _extract_timestamp_from_record(item, "created"),
+        "modified": _extract_timestamp_from_record(item, "modified"),
+    }
+
+
 def _fetch_segments_list(
     data_view_id: str,
     output_format: str,
+    data_view_name: str | None = None,
     filter_pattern: str | None = None,
     exclude_pattern: str | None = None,
     limit: int | None = None,
     sort_expression: str | None = None,
 ) -> Callable:
     """Return a fetch_and_format callback for list_segments."""
-
-    def _inner(cja: Any, is_machine_readable: bool) -> str | None:
-        dv_name = _resolve_dataview_name(cja, data_view_id)
-
-        raw_segments = _normalize_component_records_or_raise(
-            cja.getFilters(dataIds=data_view_id, full=True),
-            component_label="segments",
-            data_view_id=data_view_id,
-        )
-
-        if not raw_segments:
-            if is_machine_readable:
-                if output_format == "json":
-                    return json.dumps(
-                        {"dataViewId": data_view_id, "dataViewName": dv_name, "segments": [], "count": 0},
-                        indent=2,
-                    )
-                return "id,name,owner,approved,description,tags,created,modified\n"
-            return f"\nNo segments found for data view '{data_view_id}'.\n"
-
-        # Build display dicts with native types
-        display_data: list[dict[str, Any]] = []
-        for item in raw_segments:
-            if not isinstance(item, dict):
-                continue
-            tags = _extract_tags_normalized(item.get("tags"))
-            approved_raw = item.get("approved")
-            display_data.append(
-                {
-                    "id": _normalize_optional_text(item.get("id"), default="N/A"),
-                    "name": _normalize_optional_text(item.get("name"), default="N/A"),
-                    "owner": _extract_owner_name_from_record(item),
-                    "description": item.get("description", ""),
-                    "approved": approved_raw if isinstance(approved_raw, bool) else None,
-                    "tags": tags,
-                    "created": _extract_timestamp_from_record(item, "created"),
-                    "modified": _extract_timestamp_from_record(item, "modified"),
-                }
-            )
-
-        display_data = _apply_discovery_filters_and_sort(
-            display_data,
-            filter_pattern=filter_pattern,
-            exclude_pattern=exclude_pattern,
-            limit=limit,
-            sort_expression=sort_expression,
-            searchable_fields=["id", "name", "owner", "description", "tags"],
-            default_sort_field="name",
-        )
-
-        if output_format == "json":
-            return _format_as_json(
-                {
-                    "dataViewId": data_view_id,
-                    "dataViewName": dv_name,
-                    "segments": display_data,
-                    "count": len(display_data),
-                }
-            )
-
-        # For table/CSV, convert approved and tags to display strings
-        table_data = [
-            {
-                **row,
-                "approved": _approved_display(row.get("approved")),
-                "tags": _tags_display(row.get("tags")),
-            }
-            for row in display_data
-        ]
-
-        if output_format == "csv":
-            return _format_as_csv(
-                ["id", "name", "owner", "approved", "description", "tags", "created", "modified"],
-                table_data,
-            )
-        return _format_as_table(
-            f"Found {len(table_data)} segment(s) in data view '{dv_name}':",
-            table_data,
-            columns=["id", "name", "owner", "approved", "description"],
-            col_labels=["ID", "Name", "Owner", "Approved", "Description"],
-        )
-
-    return _inner
+    return _build_component_list_fetcher(
+        data_view_id=data_view_id,
+        data_view_name=data_view_name,
+        output_format=output_format,
+        filter_pattern=filter_pattern,
+        exclude_pattern=exclude_pattern,
+        limit=limit,
+        sort_expression=sort_expression,
+        component_label="segments",
+        table_item_label="segment",
+        component_json_key="segments",
+        empty_csv_header="id,name,owner,approved,description,tags,created,modified",
+        fetch_payload=lambda cja, dv_id: cja.getFilters(dataIds=dv_id, full=True),
+        display_row_builder=_build_segment_display_row,
+        searchable_fields=["id", "name", "owner", "description", "tags"],
+        csv_columns=["id", "name", "owner", "approved", "description", "tags", "created", "modified"],
+        table_columns=["id", "name", "owner", "approved", "description"],
+        table_labels=["ID", "Name", "Owner", "Approved", "Description"],
+        table_row_transform=_format_governance_rows_for_tabular,
+    )
 
 
 def list_segments(
@@ -8759,6 +8695,7 @@ def list_segments(
     output_format: str = "table",
     output_file: str | None = None,
     profile: str | None = None,
+    data_view_name: str | None = None,
     filter_pattern: str | None = None,
     exclude_pattern: str | None = None,
     limit: int | None = None,
@@ -8771,6 +8708,7 @@ def list_segments(
         fetch_and_format=_fetch_segments_list(
             data_view_id,
             output_format,
+            data_view_name=data_view_name,
             filter_pattern=filter_pattern,
             exclude_pattern=exclude_pattern,
             limit=limit,
@@ -8791,113 +8729,67 @@ def list_segments(
 # ==================== LIST CALCULATED METRICS ====================
 
 
+def _build_calculated_metric_display_row(item: dict[str, Any]) -> dict[str, Any]:
+    """Normalize one calculated-metrics row for output."""
+    tags = _extract_tags_normalized(item.get("tags"))
+    approved_raw = item.get("approved")
+    return {
+        "id": _normalize_optional_text(item.get("id"), default="N/A"),
+        "name": _normalize_optional_text(item.get("name"), default="N/A"),
+        "owner": _extract_owner_name_from_record(item),
+        "description": item.get("description", ""),
+        "type": item.get("type", ""),
+        "polarity": item.get("polarity", ""),
+        "precision": item.get("precision", 0),
+        "approved": approved_raw if isinstance(approved_raw, bool) else None,
+        "tags": tags,
+        "created": _extract_timestamp_from_record(item, "created"),
+        "modified": _extract_timestamp_from_record(item, "modified"),
+    }
+
+
 def _fetch_calculated_metrics_list(
     data_view_id: str,
     output_format: str,
+    data_view_name: str | None = None,
     filter_pattern: str | None = None,
     exclude_pattern: str | None = None,
     limit: int | None = None,
     sort_expression: str | None = None,
 ) -> Callable:
     """Return a fetch_and_format callback for list_calculated_metrics."""
-
-    def _inner(cja: Any, is_machine_readable: bool) -> str | None:
-        dv_name = _resolve_dataview_name(cja, data_view_id)
-
-        raw_metrics = _normalize_component_records_or_raise(
-            cja.getCalculatedMetrics(dataIds=data_view_id, full=True),
-            component_label="calculated metrics",
-            data_view_id=data_view_id,
-        )
-
-        if not raw_metrics:
-            if is_machine_readable:
-                if output_format == "json":
-                    return json.dumps(
-                        {"dataViewId": data_view_id, "dataViewName": dv_name, "calculatedMetrics": [], "count": 0},
-                        indent=2,
-                    )
-                return "id,name,owner,type,polarity,precision,approved,tags,created,modified,description\n"
-            return f"\nNo calculated metrics found for data view '{data_view_id}'.\n"
-
-        # Build display dicts with native types
-        display_data: list[dict[str, Any]] = []
-        for item in raw_metrics:
-            if not isinstance(item, dict):
-                continue
-            tags = _extract_tags_normalized(item.get("tags"))
-            approved_raw = item.get("approved")
-            display_data.append(
-                {
-                    "id": _normalize_optional_text(item.get("id"), default="N/A"),
-                    "name": _normalize_optional_text(item.get("name"), default="N/A"),
-                    "owner": _extract_owner_name_from_record(item),
-                    "description": item.get("description", ""),
-                    "type": item.get("type", ""),
-                    "polarity": item.get("polarity", ""),
-                    "precision": item.get("precision", 0),
-                    "approved": approved_raw if isinstance(approved_raw, bool) else None,
-                    "tags": tags,
-                    "created": _extract_timestamp_from_record(item, "created"),
-                    "modified": _extract_timestamp_from_record(item, "modified"),
-                }
-            )
-
-        display_data = _apply_discovery_filters_and_sort(
-            display_data,
-            filter_pattern=filter_pattern,
-            exclude_pattern=exclude_pattern,
-            limit=limit,
-            sort_expression=sort_expression,
-            searchable_fields=["id", "name", "owner", "type", "polarity", "description"],
-            default_sort_field="name",
-        )
-
-        if output_format == "json":
-            return _format_as_json(
-                {
-                    "dataViewId": data_view_id,
-                    "dataViewName": dv_name,
-                    "calculatedMetrics": display_data,
-                    "count": len(display_data),
-                }
-            )
-
-        # For table/CSV, convert approved and tags to display strings
-        table_data = [
-            {
-                **row,
-                "approved": _approved_display(row.get("approved")),
-                "tags": _tags_display(row.get("tags")),
-            }
-            for row in display_data
-        ]
-
-        if output_format == "csv":
-            return _format_as_csv(
-                [
-                    "id",
-                    "name",
-                    "owner",
-                    "type",
-                    "polarity",
-                    "precision",
-                    "approved",
-                    "tags",
-                    "created",
-                    "modified",
-                    "description",
-                ],
-                table_data,
-            )
-        return _format_as_table(
-            f"Found {len(table_data)} calculated metric(s) in data view '{dv_name}':",
-            table_data,
-            columns=["id", "name", "owner", "type", "polarity", "approved", "description"],
-            col_labels=["ID", "Name", "Owner", "Type", "Polarity", "Approved", "Description"],
-        )
-
-    return _inner
+    return _build_component_list_fetcher(
+        data_view_id=data_view_id,
+        data_view_name=data_view_name,
+        output_format=output_format,
+        filter_pattern=filter_pattern,
+        exclude_pattern=exclude_pattern,
+        limit=limit,
+        sort_expression=sort_expression,
+        component_label="calculated metrics",
+        table_item_label="calculated metric",
+        component_json_key="calculatedMetrics",
+        empty_csv_header="id,name,owner,type,polarity,precision,approved,tags,created,modified,description",
+        fetch_payload=lambda cja, dv_id: cja.getCalculatedMetrics(dataIds=dv_id, full=True),
+        display_row_builder=_build_calculated_metric_display_row,
+        searchable_fields=["id", "name", "owner", "type", "polarity", "description"],
+        csv_columns=[
+            "id",
+            "name",
+            "owner",
+            "type",
+            "polarity",
+            "precision",
+            "approved",
+            "tags",
+            "created",
+            "modified",
+            "description",
+        ],
+        table_columns=["id", "name", "owner", "type", "polarity", "approved", "description"],
+        table_labels=["ID", "Name", "Owner", "Type", "Polarity", "Approved", "Description"],
+        table_row_transform=_format_governance_rows_for_tabular,
+    )
 
 
 def list_calculated_metrics(
@@ -8906,6 +8798,7 @@ def list_calculated_metrics(
     output_format: str = "table",
     output_file: str | None = None,
     profile: str | None = None,
+    data_view_name: str | None = None,
     filter_pattern: str | None = None,
     exclude_pattern: str | None = None,
     limit: int | None = None,
@@ -8918,6 +8811,7 @@ def list_calculated_metrics(
         fetch_and_format=_fetch_calculated_metrics_list(
             data_view_id,
             output_format,
+            data_view_name=data_view_name,
             filter_pattern=filter_pattern,
             exclude_pattern=exclude_pattern,
             limit=limit,
@@ -13965,10 +13859,12 @@ def _main_impl(run_state: dict[str, Any] | None = None):
             is_machine_readable_discovery = _is_machine_readable_output(list_format, getattr(args, "output", None))
             if attr == "describe_dataview" and not is_machine_readable_discovery:
                 _warn_describe_dataview_ignored_options(args)
+            resolved_resource_name: str | None = None
             # Resolve name → ID if needed (IDs pass through without API call)
             if is_data_view_id(resource_id_or_name):
                 resource_id = resource_id_or_name
             else:
+                resolved_resource_name = resource_id_or_name
                 temp_logger = _build_inspection_name_resolution_logger()
                 resolution_result = resolve_data_view_names(
                     [resource_id_or_name],
@@ -14035,17 +13931,28 @@ def _main_impl(run_state: dict[str, Any] | None = None):
                 else:
                     resource_id = resolved_ids[0]
 
-            success = func(
-                resource_id,
-                config_file=args.config_file,
-                output_format=list_format,
-                output_file=getattr(args, "output", None),
-                profile=getattr(args, "profile", None),
-                filter_pattern=getattr(args, "org_filter", None),
-                exclude_pattern=getattr(args, "org_exclude", None),
-                limit=getattr(args, "org_limit", None),
-                sort_expression=getattr(args, "discovery_sort", None),
-            )
+            if attr == "describe_dataview":
+                success = func(
+                    resource_id,
+                    config_file=args.config_file,
+                    output_format=list_format,
+                    output_file=getattr(args, "output", None),
+                    profile=getattr(args, "profile", None),
+                )
+            else:
+                list_kwargs: dict[str, Any] = {
+                    "config_file": args.config_file,
+                    "output_format": list_format,
+                    "output_file": getattr(args, "output", None),
+                    "profile": getattr(args, "profile", None),
+                    "filter_pattern": getattr(args, "org_filter", None),
+                    "exclude_pattern": getattr(args, "org_exclude", None),
+                    "limit": getattr(args, "org_limit", None),
+                    "sort_expression": getattr(args, "discovery_sort", None),
+                }
+                if resolved_resource_name is not None:
+                    list_kwargs["data_view_name"] = resolved_resource_name
+                success = func(resource_id, **list_kwargs)
             if run_state is not None:
                 run_state["output_format"] = list_format
                 run_state["details"] = {"operation_success": success, "discovery_command": attr}

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -991,7 +991,12 @@ def _infer_run_mode_enum(args: argparse.Namespace) -> RunMode:
             bool(
                 getattr(args, "list_dataviews", False)
                 or getattr(args, "list_connections", False)
-                or getattr(args, "list_datasets", False),
+                or getattr(args, "list_datasets", False)
+                or getattr(args, "describe_dataview", None)
+                or getattr(args, "list_metrics", None)
+                or getattr(args, "list_dimensions", None)
+                or getattr(args, "list_segments", None)
+                or getattr(args, "list_calculated_metrics", None)
             ),
         ),
         (RunMode.CONFIG_STATUS, bool(getattr(args, "config_status", False) or getattr(args, "config_json", False))),
@@ -7915,6 +7920,46 @@ def list_dataviews(
 # ==================== DESCRIBE DATA VIEW ====================
 
 
+def _normalize_single_dataview_payload(raw_dv: Any) -> dict[str, Any] | None:
+    """Normalize getDataView payloads to one dict row when possible."""
+    if raw_dv is None:
+        return None
+    if isinstance(raw_dv, pd.DataFrame):
+        if raw_dv.empty:
+            return None
+        records = raw_dv.to_dict("records")
+        if not records:
+            return None
+        first_record = records[0]
+        return first_record if isinstance(first_record, dict) else None
+    return raw_dv if isinstance(raw_dv, dict) else None
+
+
+def _looks_like_dataview_error_payload(payload: dict[str, Any]) -> bool:
+    """Return True when a getDataView payload matches API error object shape."""
+    normalized_keys = {str(key).strip().casefold() for key in payload}
+    if not normalized_keys:
+        return True
+
+    explicit_error_keys = {"error", "errorcode", "errordescription", "error_description"}
+    if normalized_keys & explicit_error_keys:
+        return True
+
+    has_identity = bool(payload.get("id")) or bool(payload.get("name"))
+    generic_error_keys = {"statuscode", "status_code", "status", "message", "detail", "title", "type"}
+    return not has_identity and bool(normalized_keys & generic_error_keys)
+
+
+def _require_accessible_dataview(cja: Any, data_view_id: str) -> dict[str, Any]:
+    """Fetch a data view and raise DiscoveryNotFoundError when inaccessible/invalid."""
+    payload = _normalize_single_dataview_payload(cja.getDataView(data_view_id))
+    if payload is None or _looks_like_dataview_error_payload(payload):
+        raise DiscoveryNotFoundError(f"Data view '{data_view_id}' not found")
+    if not payload.get("id") and not payload.get("name"):
+        raise DiscoveryNotFoundError(f"Data view '{data_view_id}' not found")
+    return payload
+
+
 def _fetch_describe_dataview(
     data_view_id: str,
     output_format: str,
@@ -7922,11 +7967,7 @@ def _fetch_describe_dataview(
     """Return a fetch_and_format callback for describe_dataview."""
 
     def _inner(cja: Any, _is_machine_readable: bool) -> str | None:
-        raw_dv = cja.getDataView(data_view_id)
-        if raw_dv is None:
-            raise DiscoveryNotFoundError(f"Data view '{data_view_id}' not found")
-        if isinstance(raw_dv, pd.DataFrame):
-            raw_dv = raw_dv.to_dict("records")[0] if len(raw_dv) > 0 else {}
+        raw_dv = _require_accessible_dataview(cja, data_view_id)
 
         dv_id = raw_dv.get("id", data_view_id)
         dv_name = raw_dv.get("name", "N/A")
@@ -8076,15 +8117,14 @@ def _resolve_dataview_name(cja: Any, data_view_id: str) -> str:
     Uses ``getDataView(id)`` to fetch a single resource instead of
     listing all data views, avoiding an expensive API round-trip.
 
-    Returns the name if found, or ``"Unknown"`` on failure.
+    Raises DiscoveryNotFoundError if the data view is missing or inaccessible.
     """
-    with contextlib.suppress(Exception):
-        raw_dv = cja.getDataView(data_view_id)
-        if isinstance(raw_dv, pd.DataFrame):
-            raw_dv = raw_dv.to_dict("records")[0] if len(raw_dv) > 0 else {}
-        if isinstance(raw_dv, dict):
-            return raw_dv.get("name", "Unknown")
-    return "Unknown"
+    raw_dv = _require_accessible_dataview(cja, data_view_id)
+    raw_name = raw_dv.get("name")
+    if raw_name is None:
+        return "Unknown"
+    normalized_name = str(raw_name).strip()
+    return normalized_name or "Unknown"
 
 
 def _fetch_metrics_list(

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -8198,6 +8198,30 @@ def _count_component_items_or_na(raw_payload: Any) -> int | str:
     return _count_component_items_or_na_from_assessment(raw_payload)
 
 
+def _normalize_describe_dataview_metadata(raw_dv: dict[str, Any], *, default_id: str) -> dict[str, str]:
+    """Normalize describe_dataview metadata fields for safe display/serialization."""
+    connection_id = _pick_first_present_text(
+        (
+            raw_dv.get("parentDataGroupId"),
+            raw_dv.get("connectionId"),
+            raw_dv.get("connection_id"),
+        ),
+        default="N/A",
+        treat_null_like_strings=True,
+    )
+    created = _extract_timestamp_from_record(raw_dv, "created") or "N/A"
+    modified = _extract_timestamp_from_record(raw_dv, "modified") or "N/A"
+    return {
+        "id": _normalize_optional_text(raw_dv.get("id"), default=default_id),
+        "name": _normalize_optional_text(raw_dv.get("name"), default="N/A"),
+        "owner": _extract_owner_name_from_record(raw_dv),
+        "description": _normalize_optional_text(raw_dv.get("description"), default=""),
+        "connection_id": connection_id,
+        "created": created,
+        "modified": modified,
+    }
+
+
 def _fetch_describe_dataview(
     data_view_id: str,
     output_format: str,
@@ -8207,13 +8231,14 @@ def _fetch_describe_dataview(
     def _inner(cja: Any, _is_machine_readable: bool) -> str | None:
         raw_dv = _require_accessible_dataview(cja, data_view_id)
 
-        dv_id = _normalize_optional_text(raw_dv.get("id"), default=data_view_id)
-        dv_name = _normalize_optional_text(raw_dv.get("name"), default="N/A")
-        owner_name = _extract_owner_name(raw_dv.get("owner"))
-        description = raw_dv.get("description", "")
-        connection_id = _normalize_optional_text(raw_dv.get("parentDataGroupId"), default="N/A")
-        created = _normalize_optional_text(raw_dv.get("created"), default="N/A")
-        modified = _normalize_optional_text(raw_dv.get("modified"), default="N/A")
+        dv_metadata = _normalize_describe_dataview_metadata(raw_dv, default_id=data_view_id)
+        dv_id = dv_metadata["id"]
+        dv_name = dv_metadata["name"]
+        owner_name = dv_metadata["owner"]
+        description = dv_metadata["description"]
+        connection_id = dv_metadata["connection_id"]
+        created = dv_metadata["created"]
+        modified = dv_metadata["modified"]
 
         def _safe_count(api_call: Callable, *args: Any, **kwargs: Any) -> int | str:
             """Call an API method and return the item count, or 'N/A' on failure."""
@@ -8293,7 +8318,7 @@ def _fetch_describe_dataview(
         lines.append("=" * rule_width)
         lines.append(f"  ID:            {dv_id}")
         lines.append(f"  Owner:         {owner_name}")
-        desc_text = description or "(none)"
+        desc_text = description if description else "(none)"
         desc_prefix = "  Description:   "
         desc_avail = term_width - len(desc_prefix)
         if desc_avail > 20 and len(desc_text) > desc_avail:

--- a/tests/README.md
+++ b/tests/README.md
@@ -89,7 +89,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 4,862 comprehensive tests**
+**Total: 4,870 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -99,7 +99,7 @@ tests/
 | `test_ux_features.py` | 123 | UX features: --open, --stats, --output, --list-dataviews formats, inventory validation, inventory summary, include-all-inventory |
 | `test_org_report.py` | 172 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
 | `test_org_report_integration.py` | 17 | Org-wide analysis integration tests: end-to-end flows, caching, filtering, governance |
-| `test_cli.py` | 353 | Command-line interface and argument parsing |
+| `test_cli.py` | 357 | Command-line interface and argument parsing |
 | `test_profiles.py` | 48 | Multi-organization profile support |
 | `test_derived_inventory.py` | 62 | Derived fields inventory feature |
 | `test_inventory_utils.py` | 47 | Inventory utilities and helpers |
@@ -120,7 +120,7 @@ tests/
 | `test_validation_cache.py` | 19 | Validation result caching |
 | `test_process_single_dataview.py` | 22 | End-to-end single data view processing |
 | `test_optimized_validation.py` | 16 | Optimized data quality validation |
-| `test_name_resolution.py` | 22 | Data view name to ID resolution |
+| `test_name_resolution.py` | 24 | Data view name to ID resolution |
 | `test_shared_cache.py` | 17 | Shared validation cache |
 | `test_logging_optimization.py` | 17 | Logging performance optimizations |
 | `test_env_credentials.py` | 15 | Environment variable credentials |
@@ -156,7 +156,7 @@ tests/
 | `test_segments_coverage.py` | 78 | Segment comparison operators, container types, sequence variants |
 | `test_small_module_coverage.py` | 113 | Logging, utils, calculated metrics, constants, lazy, tuning, locks, org cache |
 | `test_diff_inventory_output.py` | 88 | Inventory diff output across all formats (console, JSON, HTML, Excel, MD, CSV) |
-| `test_cli_command_handlers.py` | 129 | CLI dispatch for --stats, --org-report, --list-snapshots, discovery inspection, diff config unpacking |
+| `test_cli_command_handlers.py` | 131 | CLI dispatch for --stats, --org-report, --list-snapshots, discovery inspection, diff config unpacking |
 | `test_profile_management.py` | 45 | Interactive profile creation, import, test, show |
 | `test_snapshot_commands.py` | 58 | Snapshot creation, comparison, name resolution |
 | `test_config_and_resolution.py` | 82 | Config status, validation, stats, name resolution |
@@ -176,7 +176,7 @@ tests/
 | `test_exception_contracts.py` | 13 | Exception boundary contract tests |
 | `test_parallel_validation.py` | 9 | Parallel validation operations |
 | `test_update_test_counts.py` | 2 | Test count validation tests |
-| **Total** | **4,862** | **Collected via pytest --collect-only** |
+| **Total** | **4,870** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -580,7 +580,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (4,862 tests total)
+- [x] Comprehensive test coverage (4,870 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 48 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -89,7 +89,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 4,870 comprehensive tests**
+**Total: 4,881 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -99,7 +99,7 @@ tests/
 | `test_ux_features.py` | 123 | UX features: --open, --stats, --output, --list-dataviews formats, inventory validation, inventory summary, include-all-inventory |
 | `test_org_report.py` | 172 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
 | `test_org_report_integration.py` | 17 | Org-wide analysis integration tests: end-to-end flows, caching, filtering, governance |
-| `test_cli.py` | 357 | Command-line interface and argument parsing |
+| `test_cli.py` | 368 | Command-line interface and argument parsing |
 | `test_profiles.py` | 48 | Multi-organization profile support |
 | `test_derived_inventory.py` | 62 | Derived fields inventory feature |
 | `test_inventory_utils.py` | 47 | Inventory utilities and helpers |
@@ -176,7 +176,7 @@ tests/
 | `test_exception_contracts.py` | 13 | Exception boundary contract tests |
 | `test_parallel_validation.py` | 9 | Parallel validation operations |
 | `test_update_test_counts.py` | 2 | Test count validation tests |
-| **Total** | **4,870** | **Collected via pytest --collect-only** |
+| **Total** | **4,881** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -580,7 +580,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (4,870 tests total)
+- [x] Comprehensive test coverage (4,881 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 48 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -89,7 +89,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 4,850 comprehensive tests**
+**Total: 4,859 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -99,7 +99,7 @@ tests/
 | `test_ux_features.py` | 123 | UX features: --open, --stats, --output, --list-dataviews formats, inventory validation, inventory summary, include-all-inventory |
 | `test_org_report.py` | 172 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
 | `test_org_report_integration.py` | 17 | Org-wide analysis integration tests: end-to-end flows, caching, filtering, governance |
-| `test_cli.py` | 352 | Command-line interface and argument parsing |
+| `test_cli.py` | 353 | Command-line interface and argument parsing |
 | `test_profiles.py` | 48 | Multi-organization profile support |
 | `test_derived_inventory.py` | 62 | Derived fields inventory feature |
 | `test_inventory_utils.py` | 47 | Inventory utilities and helpers |
@@ -159,7 +159,7 @@ tests/
 | `test_cli_command_handlers.py` | 127 | CLI dispatch for --stats, --org-report, --list-snapshots, discovery inspection, diff config unpacking |
 | `test_profile_management.py` | 45 | Interactive profile creation, import, test, show |
 | `test_snapshot_commands.py` | 58 | Snapshot creation, comparison, name resolution |
-| `test_config_and_resolution.py` | 81 | Config status, validation, stats, name resolution |
+| `test_config_and_resolution.py` | 82 | Config status, validation, stats, name resolution |
 | `test_derived_fields_edge_cases.py` | 34 | Derived fields edge cases and coverage |
 | `test_diff_command_coverage.py` | 45 | Diff command edge cases and coverage |
 | `test_generator_interactive_and_console.py` | 24 | Generator interactive and console tests |
@@ -176,7 +176,7 @@ tests/
 | `test_exception_contracts.py` | 13 | Exception boundary contract tests |
 | `test_parallel_validation.py` | 9 | Parallel validation operations |
 | `test_update_test_counts.py` | 2 | Test count validation tests |
-| **Total** | **4,850** | **Collected via pytest --collect-only** |
+| **Total** | **4,859** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -580,7 +580,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (4,850 tests total)
+- [x] Comprehensive test coverage (4,859 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 48 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -87,7 +87,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 4,756 comprehensive tests**
+**Total: 4,769 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -152,7 +152,7 @@ tests/
 | `test_segments_coverage.py` | 78 | Segment comparison operators, container types, sequence variants |
 | `test_small_module_coverage.py` | 113 | Logging, utils, calculated metrics, constants, lazy, tuning, locks, org cache |
 | `test_diff_inventory_output.py` | 88 | Inventory diff output across all formats (console, JSON, HTML, Excel, MD, CSV) |
-| `test_cli_command_handlers.py` | 98 | CLI dispatch for --stats, --org-report, --list-snapshots, diff config unpacking |
+| `test_cli_command_handlers.py` | 111 | CLI dispatch for --stats, --org-report, --list-snapshots, diff config unpacking |
 | `test_profile_management.py` | 45 | Interactive profile creation, import, test, show |
 | `test_snapshot_commands.py` | 58 | Snapshot creation, comparison, name resolution |
 | `test_config_and_resolution.py` | 81 | Config status, validation, stats, name resolution |
@@ -172,7 +172,7 @@ tests/
 | `test_exception_contracts.py` | 13 | Exception boundary contract tests |
 | `test_parallel_validation.py` | 9 | Parallel validation operations |
 | `test_update_test_counts.py` | 2 | Test count validation tests |
-| **Total** | **4,756** | **Collected via pytest --collect-only** |
+| **Total** | **4,769** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -576,7 +576,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (4,756 tests total)
+- [x] Comprehensive test coverage (4,769 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 48 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -87,7 +87,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 4,819 comprehensive tests**
+**Total: 4,834 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -97,7 +97,7 @@ tests/
 | `test_ux_features.py` | 123 | UX features: --open, --stats, --output, --list-dataviews formats, inventory validation, inventory summary, include-all-inventory |
 | `test_org_report.py` | 172 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
 | `test_org_report_integration.py` | 17 | Org-wide analysis integration tests: end-to-end flows, caching, filtering, governance |
-| `test_cli.py` | 332 | Command-line interface and argument parsing |
+| `test_cli.py` | 339 | Command-line interface and argument parsing |
 | `test_profiles.py` | 48 | Multi-organization profile support |
 | `test_derived_inventory.py` | 62 | Derived fields inventory feature |
 | `test_inventory_utils.py` | 47 | Inventory utilities and helpers |
@@ -172,7 +172,7 @@ tests/
 | `test_exception_contracts.py` | 13 | Exception boundary contract tests |
 | `test_parallel_validation.py` | 9 | Parallel validation operations |
 | `test_update_test_counts.py` | 2 | Test count validation tests |
-| **Total** | **4,819** | **Collected via pytest --collect-only** |
+| **Total** | **4,834** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -576,7 +576,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (4,819 tests total)
+- [x] Comprehensive test coverage (4,834 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 48 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -87,7 +87,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 4,834 comprehensive tests**
+**Total: 4,837 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -172,7 +172,7 @@ tests/
 | `test_exception_contracts.py` | 13 | Exception boundary contract tests |
 | `test_parallel_validation.py` | 9 | Parallel validation operations |
 | `test_update_test_counts.py` | 2 | Test count validation tests |
-| **Total** | **4,834** | **Collected via pytest --collect-only** |
+| **Total** | **4,837** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -89,7 +89,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 4,859 comprehensive tests**
+**Total: 4,862 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -128,7 +128,7 @@ tests/
 | `test_early_exit.py` | 11 | Early exit optimizations |
 | `test_data_quality.py` | 10 | Data quality validation logic |
 | `test_parallel_validation.py` | 9 | Parallel validation operations |
-| `test_discovery_formatters.py` | 31 | Shared discovery formatters, WorkerArgs dataclass, _exit_error, BANNER_WIDTH |
+| `test_discovery_formatters.py` | 32 | Shared discovery formatters, WorkerArgs dataclass, _exit_error, BANNER_WIDTH |
 | `test_discovery_normalization.py` | 8 | Discovery normalization helpers (missing values, owner extraction, tags) |
 | `test_discovery_payloads.py` | 11 | Discovery payload classification (error detection, component extraction) |
 | `test_output_content_validation.py` | 26 | Output format content validation (CSV, JSON, HTML, Excel, Markdown roundtrip) |
@@ -156,7 +156,7 @@ tests/
 | `test_segments_coverage.py` | 78 | Segment comparison operators, container types, sequence variants |
 | `test_small_module_coverage.py` | 113 | Logging, utils, calculated metrics, constants, lazy, tuning, locks, org cache |
 | `test_diff_inventory_output.py` | 88 | Inventory diff output across all formats (console, JSON, HTML, Excel, MD, CSV) |
-| `test_cli_command_handlers.py` | 127 | CLI dispatch for --stats, --org-report, --list-snapshots, discovery inspection, diff config unpacking |
+| `test_cli_command_handlers.py` | 129 | CLI dispatch for --stats, --org-report, --list-snapshots, discovery inspection, diff config unpacking |
 | `test_profile_management.py` | 45 | Interactive profile creation, import, test, show |
 | `test_snapshot_commands.py` | 58 | Snapshot creation, comparison, name resolution |
 | `test_config_and_resolution.py` | 82 | Config status, validation, stats, name resolution |
@@ -176,7 +176,7 @@ tests/
 | `test_exception_contracts.py` | 13 | Exception boundary contract tests |
 | `test_parallel_validation.py` | 9 | Parallel validation operations |
 | `test_update_test_counts.py` | 2 | Test count validation tests |
-| **Total** | **4,859** | **Collected via pytest --collect-only** |
+| **Total** | **4,862** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -580,7 +580,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (4,859 tests total)
+- [x] Comprehensive test coverage (4,862 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 48 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -87,7 +87,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 4,708 comprehensive tests**
+**Total: 4,745 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -172,7 +172,7 @@ tests/
 | `test_exception_contracts.py` | 13 | Exception boundary contract tests |
 | `test_parallel_validation.py` | 9 | Parallel validation operations |
 | `test_update_test_counts.py` | 2 | Test count validation tests |
-| **Total** | **4,708** | **Collected via pytest --collect-only** |
+| **Total** | **4,745** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -576,7 +576,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (4,708 tests total)
+- [x] Comprehensive test coverage (4,745 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 48 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -87,7 +87,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 4,769 comprehensive tests**
+**Total: 4,774 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -97,7 +97,7 @@ tests/
 | `test_ux_features.py` | 123 | UX features: --open, --stats, --output, --list-dataviews formats, inventory validation, inventory summary, include-all-inventory |
 | `test_org_report.py` | 172 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
 | `test_org_report_integration.py` | 17 | Org-wide analysis integration tests: end-to-end flows, caching, filtering, governance |
-| `test_cli.py` | 310 | Command-line interface and argument parsing |
+| `test_cli.py` | 311 | Command-line interface and argument parsing |
 | `test_profiles.py` | 48 | Multi-organization profile support |
 | `test_derived_inventory.py` | 62 | Derived fields inventory feature |
 | `test_inventory_utils.py` | 47 | Inventory utilities and helpers |
@@ -126,7 +126,7 @@ tests/
 | `test_early_exit.py` | 11 | Early exit optimizations |
 | `test_data_quality.py` | 10 | Data quality validation logic |
 | `test_parallel_validation.py` | 9 | Parallel validation operations |
-| `test_discovery_formatters.py` | 27 | Shared discovery formatters, WorkerArgs dataclass, _exit_error, BANNER_WIDTH |
+| `test_discovery_formatters.py` | 31 | Shared discovery formatters, WorkerArgs dataclass, _exit_error, BANNER_WIDTH |
 | `test_output_content_validation.py` | 26 | Output format content validation (CSV, JSON, HTML, Excel, Markdown roundtrip) |
 | `test_malformed_api_responses.py` | 19 | Negative tests for malformed/unexpected API responses |
 | `test_main_entry_points.py` | 19 | main() and _main_impl() entry points, dispatch, run_state, run summary |
@@ -172,7 +172,7 @@ tests/
 | `test_exception_contracts.py` | 13 | Exception boundary contract tests |
 | `test_parallel_validation.py` | 9 | Parallel validation operations |
 | `test_update_test_counts.py` | 2 | Test count validation tests |
-| **Total** | **4,769** | **Collected via pytest --collect-only** |
+| **Total** | **4,774** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -87,7 +87,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 4,837 comprehensive tests**
+**Total: 4,838 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -152,7 +152,7 @@ tests/
 | `test_segments_coverage.py` | 78 | Segment comparison operators, container types, sequence variants |
 | `test_small_module_coverage.py` | 113 | Logging, utils, calculated metrics, constants, lazy, tuning, locks, org cache |
 | `test_diff_inventory_output.py` | 88 | Inventory diff output across all formats (console, JSON, HTML, Excel, MD, CSV) |
-| `test_cli_command_handlers.py` | 126 | CLI dispatch for --stats, --org-report, --list-snapshots, diff config unpacking |
+| `test_cli_command_handlers.py` | 127 | CLI dispatch for --stats, --org-report, --list-snapshots, diff config unpacking |
 | `test_profile_management.py` | 45 | Interactive profile creation, import, test, show |
 | `test_snapshot_commands.py` | 58 | Snapshot creation, comparison, name resolution |
 | `test_config_and_resolution.py` | 81 | Config status, validation, stats, name resolution |
@@ -172,7 +172,7 @@ tests/
 | `test_exception_contracts.py` | 13 | Exception boundary contract tests |
 | `test_parallel_validation.py` | 9 | Parallel validation operations |
 | `test_update_test_counts.py` | 2 | Test count validation tests |
-| **Total** | **4,837** | **Collected via pytest --collect-only** |
+| **Total** | **4,838** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -576,7 +576,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (4,837 tests total)
+- [x] Comprehensive test coverage (4,838 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 48 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -87,7 +87,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 4,774 comprehensive tests**
+**Total: 4,819 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -97,7 +97,7 @@ tests/
 | `test_ux_features.py` | 123 | UX features: --open, --stats, --output, --list-dataviews formats, inventory validation, inventory summary, include-all-inventory |
 | `test_org_report.py` | 172 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
 | `test_org_report_integration.py` | 17 | Org-wide analysis integration tests: end-to-end flows, caching, filtering, governance |
-| `test_cli.py` | 311 | Command-line interface and argument parsing |
+| `test_cli.py` | 332 | Command-line interface and argument parsing |
 | `test_profiles.py` | 48 | Multi-organization profile support |
 | `test_derived_inventory.py` | 62 | Derived fields inventory feature |
 | `test_inventory_utils.py` | 47 | Inventory utilities and helpers |
@@ -152,7 +152,7 @@ tests/
 | `test_segments_coverage.py` | 78 | Segment comparison operators, container types, sequence variants |
 | `test_small_module_coverage.py` | 113 | Logging, utils, calculated metrics, constants, lazy, tuning, locks, org cache |
 | `test_diff_inventory_output.py` | 88 | Inventory diff output across all formats (console, JSON, HTML, Excel, MD, CSV) |
-| `test_cli_command_handlers.py` | 111 | CLI dispatch for --stats, --org-report, --list-snapshots, diff config unpacking |
+| `test_cli_command_handlers.py` | 126 | CLI dispatch for --stats, --org-report, --list-snapshots, diff config unpacking |
 | `test_profile_management.py` | 45 | Interactive profile creation, import, test, show |
 | `test_snapshot_commands.py` | 58 | Snapshot creation, comparison, name resolution |
 | `test_config_and_resolution.py` | 81 | Config status, validation, stats, name resolution |
@@ -172,7 +172,7 @@ tests/
 | `test_exception_contracts.py` | 13 | Exception boundary contract tests |
 | `test_parallel_validation.py` | 9 | Parallel validation operations |
 | `test_update_test_counts.py` | 2 | Test count validation tests |
-| **Total** | **4,774** | **Collected via pytest --collect-only** |
+| **Total** | **4,819** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -576,7 +576,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (4,774 tests total)
+- [x] Comprehensive test coverage (4,819 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 48 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -97,7 +97,7 @@ tests/
 | `test_ux_features.py` | 123 | UX features: --open, --stats, --output, --list-dataviews formats, inventory validation, inventory summary, include-all-inventory |
 | `test_org_report.py` | 172 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
 | `test_org_report_integration.py` | 17 | Org-wide analysis integration tests: end-to-end flows, caching, filtering, governance |
-| `test_cli.py` | 282 | Command-line interface and argument parsing |
+| `test_cli.py` | 310 | Command-line interface and argument parsing |
 | `test_profiles.py` | 48 | Multi-organization profile support |
 | `test_derived_inventory.py` | 62 | Derived fields inventory feature |
 | `test_inventory_utils.py` | 47 | Inventory utilities and helpers |
@@ -152,7 +152,7 @@ tests/
 | `test_segments_coverage.py` | 78 | Segment comparison operators, container types, sequence variants |
 | `test_small_module_coverage.py` | 113 | Logging, utils, calculated metrics, constants, lazy, tuning, locks, org cache |
 | `test_diff_inventory_output.py` | 88 | Inventory diff output across all formats (console, JSON, HTML, Excel, MD, CSV) |
-| `test_cli_command_handlers.py` | 78 | CLI dispatch for --stats, --org-report, --list-snapshots, diff config unpacking |
+| `test_cli_command_handlers.py` | 87 | CLI dispatch for --stats, --org-report, --list-snapshots, diff config unpacking |
 | `test_profile_management.py` | 45 | Interactive profile creation, import, test, show |
 | `test_snapshot_commands.py` | 58 | Snapshot creation, comparison, name resolution |
 | `test_config_and_resolution.py` | 81 | Config status, validation, stats, name resolution |

--- a/tests/README.md
+++ b/tests/README.md
@@ -19,6 +19,8 @@ tests/
 ├── test_derived_inventory.py        # Derived fields inventory tests
 ├── test_diff_comparison.py          # Data view diff comparison tests
 ├── test_discovery_formatters.py     # Discovery formatters and WorkerArgs tests
+├── test_discovery_normalization.py  # Discovery normalization helpers tests
+├── test_discovery_payloads.py       # Discovery payload classification tests
 ├── test_dry_run.py                  # Dry-run mode tests
 ├── test_early_exit.py               # Early exit optimization tests
 ├── test_edge_cases.py               # Edge cases and configuration tests
@@ -66,7 +68,7 @@ tests/
 ├── test_segments_coverage.py        # Segments module coverage (operators, containers)
 ├── test_small_module_coverage.py    # Small module coverage (logging, utils, calc metrics)
 ├── test_diff_inventory_output.py   # Inventory diff output across all formats
-├── test_cli_command_handlers.py    # CLI dispatch (--stats, --org-report, --list-snapshots)
+├── test_cli_command_handlers.py    # CLI dispatch (--stats, --org-report, --list-snapshots, discovery inspection)
 ├── test_profile_management.py      # Interactive profile creation, import, test, show
 ├── test_snapshot_commands.py        # Snapshot creation, comparison, name resolution
 ├── test_config_and_resolution.py    # Config status, validation, stats, name resolution
@@ -127,6 +129,8 @@ tests/
 | `test_data_quality.py` | 10 | Data quality validation logic |
 | `test_parallel_validation.py` | 9 | Parallel validation operations |
 | `test_discovery_formatters.py` | 31 | Shared discovery formatters, WorkerArgs dataclass, _exit_error, BANNER_WIDTH |
+| `test_discovery_normalization.py` | 8 | Discovery normalization helpers (missing values, owner extraction, tags) |
+| `test_discovery_payloads.py` | 9 | Discovery payload classification (error detection, component extraction) |
 | `test_output_content_validation.py` | 26 | Output format content validation (CSV, JSON, HTML, Excel, Markdown roundtrip) |
 | `test_malformed_api_responses.py` | 19 | Negative tests for malformed/unexpected API responses |
 | `test_main_entry_points.py` | 19 | main() and _main_impl() entry points, dispatch, run_state, run summary |
@@ -152,7 +156,7 @@ tests/
 | `test_segments_coverage.py` | 78 | Segment comparison operators, container types, sequence variants |
 | `test_small_module_coverage.py` | 113 | Logging, utils, calculated metrics, constants, lazy, tuning, locks, org cache |
 | `test_diff_inventory_output.py` | 88 | Inventory diff output across all formats (console, JSON, HTML, Excel, MD, CSV) |
-| `test_cli_command_handlers.py` | 127 | CLI dispatch for --stats, --org-report, --list-snapshots, diff config unpacking |
+| `test_cli_command_handlers.py` | 127 | CLI dispatch for --stats, --org-report, --list-snapshots, discovery inspection, diff config unpacking |
 | `test_profile_management.py` | 45 | Interactive profile creation, import, test, show |
 | `test_snapshot_commands.py` | 58 | Snapshot creation, comparison, name resolution |
 | `test_config_and_resolution.py` | 81 | Config status, validation, stats, name resolution |

--- a/tests/README.md
+++ b/tests/README.md
@@ -89,7 +89,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 4,838 comprehensive tests**
+**Total: 4,850 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -99,7 +99,7 @@ tests/
 | `test_ux_features.py` | 123 | UX features: --open, --stats, --output, --list-dataviews formats, inventory validation, inventory summary, include-all-inventory |
 | `test_org_report.py` | 172 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
 | `test_org_report_integration.py` | 17 | Org-wide analysis integration tests: end-to-end flows, caching, filtering, governance |
-| `test_cli.py` | 342 | Command-line interface and argument parsing |
+| `test_cli.py` | 352 | Command-line interface and argument parsing |
 | `test_profiles.py` | 48 | Multi-organization profile support |
 | `test_derived_inventory.py` | 62 | Derived fields inventory feature |
 | `test_inventory_utils.py` | 47 | Inventory utilities and helpers |
@@ -130,7 +130,7 @@ tests/
 | `test_parallel_validation.py` | 9 | Parallel validation operations |
 | `test_discovery_formatters.py` | 31 | Shared discovery formatters, WorkerArgs dataclass, _exit_error, BANNER_WIDTH |
 | `test_discovery_normalization.py` | 8 | Discovery normalization helpers (missing values, owner extraction, tags) |
-| `test_discovery_payloads.py` | 9 | Discovery payload classification (error detection, component extraction) |
+| `test_discovery_payloads.py` | 11 | Discovery payload classification (error detection, component extraction) |
 | `test_output_content_validation.py` | 26 | Output format content validation (CSV, JSON, HTML, Excel, Markdown roundtrip) |
 | `test_malformed_api_responses.py` | 19 | Negative tests for malformed/unexpected API responses |
 | `test_main_entry_points.py` | 19 | main() and _main_impl() entry points, dispatch, run_state, run summary |
@@ -176,7 +176,7 @@ tests/
 | `test_exception_contracts.py` | 13 | Exception boundary contract tests |
 | `test_parallel_validation.py` | 9 | Parallel validation operations |
 | `test_update_test_counts.py` | 2 | Test count validation tests |
-| **Total** | **4,838** | **Collected via pytest --collect-only** |
+| **Total** | **4,850** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -580,7 +580,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (4,838 tests total)
+- [x] Comprehensive test coverage (4,850 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 48 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -87,7 +87,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 4,745 comprehensive tests**
+**Total: 4,756 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -152,7 +152,7 @@ tests/
 | `test_segments_coverage.py` | 78 | Segment comparison operators, container types, sequence variants |
 | `test_small_module_coverage.py` | 113 | Logging, utils, calculated metrics, constants, lazy, tuning, locks, org cache |
 | `test_diff_inventory_output.py` | 88 | Inventory diff output across all formats (console, JSON, HTML, Excel, MD, CSV) |
-| `test_cli_command_handlers.py` | 87 | CLI dispatch for --stats, --org-report, --list-snapshots, diff config unpacking |
+| `test_cli_command_handlers.py` | 98 | CLI dispatch for --stats, --org-report, --list-snapshots, diff config unpacking |
 | `test_profile_management.py` | 45 | Interactive profile creation, import, test, show |
 | `test_snapshot_commands.py` | 58 | Snapshot creation, comparison, name resolution |
 | `test_config_and_resolution.py` | 81 | Config status, validation, stats, name resolution |
@@ -172,7 +172,7 @@ tests/
 | `test_exception_contracts.py` | 13 | Exception boundary contract tests |
 | `test_parallel_validation.py` | 9 | Parallel validation operations |
 | `test_update_test_counts.py` | 2 | Test count validation tests |
-| **Total** | **4,745** | **Collected via pytest --collect-only** |
+| **Total** | **4,756** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -576,7 +576,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (4,745 tests total)
+- [x] Comprehensive test coverage (4,756 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 48 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -576,7 +576,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (4,769 tests total)
+- [x] Comprehensive test coverage (4,774 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 48 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -97,7 +97,7 @@ tests/
 | `test_ux_features.py` | 123 | UX features: --open, --stats, --output, --list-dataviews formats, inventory validation, inventory summary, include-all-inventory |
 | `test_org_report.py` | 172 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
 | `test_org_report_integration.py` | 17 | Org-wide analysis integration tests: end-to-end flows, caching, filtering, governance |
-| `test_cli.py` | 339 | Command-line interface and argument parsing |
+| `test_cli.py` | 342 | Command-line interface and argument parsing |
 | `test_profiles.py` | 48 | Multi-organization profile support |
 | `test_derived_inventory.py` | 62 | Derived fields inventory feature |
 | `test_inventory_utils.py` | 47 | Inventory utilities and helpers |
@@ -576,7 +576,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (4,834 tests total)
+- [x] Comprehensive test coverage (4,837 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 48 tests

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,6 +22,7 @@ from cja_auto_sdr.generator import (
     list_dataviews,
     list_dimensions,
     list_metrics,
+    list_segments,
     parse_arguments,
 )
 
@@ -4430,3 +4431,120 @@ class TestListDimensions:
         output = json.loads(f.getvalue())
         assert output["count"] == 1
         assert output["dimensions"][0]["name"] == "Browser"
+
+
+class TestListSegments:
+    """Tests for --list-segments command."""
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_list_segments_json(self, mock_profile, mock_configure, mock_cjapy):
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
+        import pandas as pd
+
+        cja.getFilters.return_value = pd.DataFrame([
+            {
+                "id": "s1", "name": "Mobile", "owner": {"name": "Jane"},
+                "description": "Mobile visitors", "approved": True,
+                "tags": [{"name": "prod"}], "created": "2025-01-01", "modified": "2025-06-01",
+            },
+        ])
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = list_segments("dv_1", output_format="json")
+
+        assert result is True
+        output = json.loads(f.getvalue())
+        assert output["dataViewId"] == "dv_1"
+        assert output["count"] == 1
+        seg = output["segments"][0]
+        assert seg["name"] == "Mobile"
+        assert seg["owner"] == "Jane"
+        assert seg["approved"] is True
+        assert seg["tags"] == ["prod"]
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_list_segments_csv(self, mock_profile, mock_configure, mock_cjapy):
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
+        import pandas as pd
+
+        cja.getFilters.return_value = pd.DataFrame([
+            {
+                "id": "s1", "name": "Mobile", "owner": {"name": "Jane"},
+                "description": "", "approved": False, "tags": [],
+                "created": "2025-01-01", "modified": "2025-06-01",
+            },
+        ])
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = list_segments("dv_1", output_format="csv")
+
+        assert result is True
+        lines = f.getvalue().strip().split("\n")
+        assert "id" in lines[0] and "approved" in lines[0]
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_list_segments_table_approved_rendering(self, mock_profile, mock_configure, mock_cjapy):
+        """approved renders as Yes/No in table mode."""
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
+        import pandas as pd
+
+        cja.getFilters.return_value = pd.DataFrame([
+            {"id": "s1", "name": "Approved Seg", "owner": {"name": "Jane"},
+             "description": "", "approved": True, "tags": [], "created": "", "modified": ""},
+            {"id": "s2", "name": "Unapproved Seg", "owner": {"name": "Bob"},
+             "description": "", "approved": False, "tags": [], "created": "", "modified": ""},
+        ])
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = list_segments("dv_1", output_format="table")
+
+        assert result is True
+        output = f.getvalue()
+        assert "Yes" in output
+        assert "No" in output
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_list_segments_empty(self, mock_profile, mock_configure, mock_cjapy):
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
+        import pandas as pd
+
+        cja.getFilters.return_value = pd.DataFrame()
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = list_segments("dv_1", output_format="json")
+
+        assert result is True
+        output = json.loads(f.getvalue())
+        assert output["count"] == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,7 @@ import pytest
 
 # Import the function we're testing
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from cja_auto_sdr.core.exceptions import APIError
 from cja_auto_sdr.generator import (
     _emit_output,
     _extract_dataset_info,
@@ -4600,6 +4601,71 @@ class TestDescribeDataview:
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")
     @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_describe_dataview_apierror_status_not_found(self, mock_profile, mock_configure, mock_cjapy):
+        """Raised getDataView APIError(403/404) should preserve not_found contract."""
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataView.side_effect = APIError("Forbidden", status_code=403, operation="getDataView")
+
+        import io
+        from contextlib import redirect_stderr, redirect_stdout
+
+        out = io.StringIO()
+        err = io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            result = describe_dataview("dv_hidden", output_format="json")
+
+        assert result is False
+        payload = json.loads(err.getvalue())
+        assert payload["error_type"] == "not_found"
+        assert payload["error"] == "Data view 'dv_hidden' not found"
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_describe_dataview_apierror_message_not_found(self, mock_profile, mock_configure, mock_cjapy):
+        """Message-only APIError markers from getDataView should map to not_found."""
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataView.side_effect = APIError("resource_not_found for data view lookup")
+
+        import io
+        from contextlib import redirect_stderr, redirect_stdout
+
+        out = io.StringIO()
+        err = io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            result = describe_dataview("dv_missing", output_format="json")
+
+        assert result is False
+        payload = json.loads(err.getvalue())
+        assert payload["error_type"] == "not_found"
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_describe_dataview_apierror_5xx_remains_connectivity_error(self, mock_profile, mock_configure, mock_cjapy):
+        """Non-not-found API errors should remain connectivity failures."""
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataView.side_effect = APIError("Backend unavailable", status_code=503, operation="getDataView")
+
+        import io
+        from contextlib import redirect_stderr, redirect_stdout
+
+        out = io.StringIO()
+        err = io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            result = describe_dataview("dv_flaky", output_format="json")
+
+        assert result is False
+        payload = json.loads(err.getvalue())
+        assert "error_type" not in payload
+        assert "Failed to connect to CJA API" in payload["error"]
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
     def test_describe_dataview_na_identity_fields_treated_as_not_found(self, mock_profile, mock_configure, mock_cjapy):
         """NA-like id/name payloads should fail as not_found, not generic command failures."""
         mock_configure.return_value = (True, "config", None)
@@ -4731,6 +4797,84 @@ def test_list_inspection_commands_na_identity_fields_treated_as_not_found(
     import pandas as pd
 
     cja.getDataView.return_value = {"id": pd.NA, "name": pd.NA}
+    getattr(cja, component_method).return_value = []
+
+    import io
+    from contextlib import redirect_stderr, redirect_stdout
+
+    out = io.StringIO()
+    err = io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        result = command("dv_missing", output_format="json")
+
+    assert result is False
+    payload = json.loads(err.getvalue())
+    assert payload["error_type"] == "not_found"
+    assert getattr(cja, component_method).call_count == 0
+
+
+@pytest.mark.parametrize(
+    ("command", "component_method"),
+    [
+        (list_metrics, "getMetrics"),
+        (list_dimensions, "getDimensions"),
+        (list_segments, "getFilters"),
+        (list_calculated_metrics, "getCalculatedMetrics"),
+    ],
+)
+@patch("cja_auto_sdr.generator.cjapy")
+@patch("cja_auto_sdr.generator.configure_cjapy")
+@patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+def test_list_inspection_commands_get_dataview_apierror_status_treated_as_not_found(
+    mock_profile,
+    mock_configure,
+    mock_cjapy,
+    command,
+    component_method,
+):
+    """Raised getDataView APIError(403/404) should fail with not_found for all list inspection commands."""
+    mock_configure.return_value = (True, "config", None)
+    cja = mock_cjapy.CJA.return_value
+    cja.getDataView.side_effect = APIError("Forbidden", status_code=403, operation="getDataView")
+    getattr(cja, component_method).return_value = []
+
+    import io
+    from contextlib import redirect_stderr, redirect_stdout
+
+    out = io.StringIO()
+    err = io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        result = command("dv_hidden", output_format="json")
+
+    assert result is False
+    payload = json.loads(err.getvalue())
+    assert payload["error_type"] == "not_found"
+    assert getattr(cja, component_method).call_count == 0
+
+
+@pytest.mark.parametrize(
+    ("command", "component_method"),
+    [
+        (list_metrics, "getMetrics"),
+        (list_dimensions, "getDimensions"),
+        (list_segments, "getFilters"),
+        (list_calculated_metrics, "getCalculatedMetrics"),
+    ],
+)
+@patch("cja_auto_sdr.generator.cjapy")
+@patch("cja_auto_sdr.generator.configure_cjapy")
+@patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+def test_list_inspection_commands_get_dataview_apierror_message_treated_as_not_found(
+    mock_profile,
+    mock_configure,
+    mock_cjapy,
+    command,
+    component_method,
+):
+    """Message-only not_found APIError from getDataView should preserve not_found typing."""
+    mock_configure.return_value = (True, "config", None)
+    cja = mock_cjapy.CJA.return_value
+    cja.getDataView.side_effect = APIError("resource_not_found while resolving data view")
     getattr(cja, component_method).return_value = []
 
     import io

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,6 +20,7 @@ from cja_auto_sdr.generator import (
     list_connections,
     list_datasets,
     list_dataviews,
+    list_metrics,
     parse_arguments,
 )
 
@@ -4222,3 +4223,106 @@ class TestDescribeDataview:
         assert result is True
         output = json.loads(f.getvalue())
         assert "error" in output
+
+
+class TestListMetrics:
+    """Tests for --list-metrics command."""
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_list_metrics_json(self, mock_profile, mock_configure, mock_cjapy):
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
+        import pandas as pd
+
+        cja.getMetrics.return_value = pd.DataFrame([
+            {"id": "metrics/pageviews", "name": "Page Views", "type": "decimal", "description": "Total views"},
+            {"id": "metrics/visits", "name": "Visits", "type": "decimal", "description": "Unique visits"},
+        ])
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = list_metrics("dv_1", output_format="json")
+
+        assert result is True
+        output = json.loads(f.getvalue())
+        assert output["dataViewId"] == "dv_1"
+        assert output["count"] == 2
+        assert output["metrics"][0]["id"] in ("metrics/pageviews", "metrics/visits")
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_list_metrics_csv(self, mock_profile, mock_configure, mock_cjapy):
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
+        import pandas as pd
+
+        cja.getMetrics.return_value = pd.DataFrame([
+            {"id": "metrics/pageviews", "name": "Page Views", "type": "decimal", "description": ""},
+        ])
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = list_metrics("dv_1", output_format="csv")
+
+        assert result is True
+        lines = f.getvalue().strip().split("\n")
+        assert lines[0] == "id,name,type,description"
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_list_metrics_empty(self, mock_profile, mock_configure, mock_cjapy):
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
+        import pandas as pd
+
+        cja.getMetrics.return_value = pd.DataFrame()
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = list_metrics("dv_1", output_format="json")
+
+        assert result is True
+        output = json.loads(f.getvalue())
+        assert output["count"] == 0
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_list_metrics_with_filter(self, mock_profile, mock_configure, mock_cjapy):
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
+        import pandas as pd
+
+        cja.getMetrics.return_value = pd.DataFrame([
+            {"id": "metrics/pageviews", "name": "Page Views", "type": "decimal", "description": ""},
+            {"id": "metrics/revenue", "name": "Revenue", "type": "currency", "description": ""},
+        ])
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = list_metrics("dv_1", output_format="json", filter_pattern="revenue")
+
+        assert result is True
+        output = json.loads(f.getvalue())
+        assert output["count"] == 1
+        assert output["metrics"][0]["name"] == "Revenue"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,6 +15,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from cja_auto_sdr.generator import (
     _emit_output,
     _extract_dataset_info,
+    describe_dataview,
     generate_sample_config,
     list_connections,
     list_datasets,
@@ -4072,3 +4073,152 @@ class TestDiscoveryInspectionParsing:
         """New flags are mutually exclusive with each other."""
         with pytest.raises(SystemExit):
             parse_arguments(["--describe-dataview", "dv_1", "--list-metrics", "dv_1"])
+
+
+class TestDescribeDataview:
+    """Tests for --describe-dataview command."""
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_describe_dataview_json(self, mock_profile, mock_configure, mock_cjapy):
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataView.return_value = {
+            "id": "dv_1",
+            "name": "Test View",
+            "owner": {"name": "Jane"},
+            "description": "A test view",
+            "parentDataGroupId": "conn_1",
+            "created": "2025-01-01",
+            "modified": "2025-06-01",
+        }
+        cja.getMetrics.return_value = [{"id": f"m{i}"} for i in range(5)]
+        cja.getDimensions.return_value = [{"id": f"d{i}"} for i in range(3)]
+        cja.getFilters.return_value = [{"id": f"s{i}"} for i in range(2)]
+        cja.getCalculatedMetrics.return_value = [{"id": f"cm{i}"} for i in range(1)]
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = describe_dataview("dv_1", output_format="json")
+
+        assert result is True
+        output = json.loads(f.getvalue())
+        dv = output["dataView"]
+        assert dv["id"] == "dv_1"
+        assert dv["name"] == "Test View"
+        assert dv["owner"] == "Jane"
+        assert dv["components"]["metrics"] == 5
+        assert dv["components"]["dimensions"] == 3
+        assert dv["components"]["segments"] == 2
+        assert dv["components"]["calculatedMetrics"] == 1
+        assert dv["components"]["total"] == 11
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_describe_dataview_csv(self, mock_profile, mock_configure, mock_cjapy):
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataView.return_value = {
+            "id": "dv_1", "name": "Test", "owner": {"name": "Jane"},
+            "description": "", "parentDataGroupId": "conn_1",
+            "created": "2025-01-01", "modified": "2025-06-01",
+        }
+        cja.getMetrics.return_value = [{"id": "m1"}]
+        cja.getDimensions.return_value = [{"id": "d1"}]
+        cja.getFilters.return_value = []
+        cja.getCalculatedMetrics.return_value = []
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = describe_dataview("dv_1", output_format="csv")
+
+        assert result is True
+        lines = f.getvalue().strip().split("\n")
+        assert "id" in lines[0]
+        assert "dv_1" in lines[1]
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_describe_dataview_table(self, mock_profile, mock_configure, mock_cjapy):
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataView.return_value = {
+            "id": "dv_1", "name": "Test View", "owner": {"name": "Jane"},
+            "description": "Desc", "parentDataGroupId": "conn_1",
+            "created": "2025-01-01", "modified": "2025-06-01",
+        }
+        cja.getMetrics.return_value = [{"id": "m1"}, {"id": "m2"}]
+        cja.getDimensions.return_value = [{"id": "d1"}]
+        cja.getFilters.return_value = [{"id": "s1"}]
+        cja.getCalculatedMetrics.return_value = []
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = describe_dataview("dv_1", output_format="table")
+
+        assert result is True
+        output = f.getvalue()
+        assert "Test View" in output
+        assert "Jane" in output
+        assert "Dimensions" in output
+        assert "Metrics" in output
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_describe_dataview_graceful_segment_failure(self, mock_profile, mock_configure, mock_cjapy):
+        """If getFilters fails, segments count shows as N/A."""
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataView.return_value = {
+            "id": "dv_1", "name": "Test", "owner": {"name": "Jane"},
+            "description": "", "parentDataGroupId": "conn_1",
+            "created": "2025-01-01", "modified": "2025-06-01",
+        }
+        cja.getMetrics.return_value = [{"id": "m1"}]
+        cja.getDimensions.return_value = [{"id": "d1"}]
+        cja.getFilters.side_effect = Exception("API error")
+        cja.getCalculatedMetrics.return_value = []
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = describe_dataview("dv_1", output_format="json")
+
+        assert result is True
+        output = json.loads(f.getvalue())
+        assert output["dataView"]["components"]["segments"] == "N/A"
+        assert output["dataView"]["components"]["total"] == "N/A"
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_describe_dataview_not_found(self, mock_profile, mock_configure, mock_cjapy):
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataView.return_value = None
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = describe_dataview("dv_nonexistent", output_format="json")
+
+        assert result is True
+        output = json.loads(f.getvalue())
+        assert "error" in output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,6 +17,7 @@ from cja_auto_sdr.generator import (
     _extract_dataset_info,
     describe_dataview,
     generate_sample_config,
+    list_calculated_metrics,
     list_connections,
     list_datasets,
     list_dataviews,
@@ -4544,6 +4545,125 @@ class TestListSegments:
         f = io.StringIO()
         with redirect_stdout(f):
             result = list_segments("dv_1", output_format="json")
+
+        assert result is True
+        output = json.loads(f.getvalue())
+        assert output["count"] == 0
+
+
+class TestListCalculatedMetrics:
+    """Tests for --list-calculated-metrics command."""
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_list_calc_metrics_json(self, mock_profile, mock_configure, mock_cjapy):
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
+        import pandas as pd
+
+        cja.getCalculatedMetrics.return_value = pd.DataFrame([
+            {
+                "id": "cm1", "name": "Bounce Rate", "owner": {"name": "Jane"},
+                "description": "Bounce rate calc", "type": "percent",
+                "polarity": "negative", "precision": 2,
+                "approved": True, "tags": [],
+                "created": "2025-01-01", "modified": "2025-06-01",
+            },
+        ])
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = list_calculated_metrics("dv_1", output_format="json")
+
+        assert result is True
+        output = json.loads(f.getvalue())
+        assert output["dataViewId"] == "dv_1"
+        assert output["count"] == 1
+        cm = output["calculatedMetrics"][0]
+        assert cm["name"] == "Bounce Rate"
+        assert cm["polarity"] == "negative"
+        assert cm["type"] == "percent"
+        assert cm["precision"] == 2
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_list_calc_metrics_csv(self, mock_profile, mock_configure, mock_cjapy):
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
+        import pandas as pd
+
+        cja.getCalculatedMetrics.return_value = pd.DataFrame([
+            {"id": "cm1", "name": "Bounce Rate", "owner": {"name": "Jane"},
+             "description": "", "type": "percent", "polarity": "negative",
+             "precision": 2, "approved": True, "tags": [],
+             "created": "2025-01-01", "modified": "2025-06-01"},
+        ])
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = list_calculated_metrics("dv_1", output_format="csv")
+
+        assert result is True
+        lines = f.getvalue().strip().split("\n")
+        assert "polarity" in lines[0] and "precision" in lines[0]
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_list_calc_metrics_table_omits_precision(self, mock_profile, mock_configure, mock_cjapy):
+        """Table output omits precision column to save width."""
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
+        import pandas as pd
+
+        cja.getCalculatedMetrics.return_value = pd.DataFrame([
+            {"id": "cm1", "name": "Bounce Rate", "owner": {"name": "Jane"},
+             "description": "", "type": "percent", "polarity": "negative",
+             "precision": 2, "approved": True, "tags": [],
+             "created": "", "modified": ""},
+        ])
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = list_calculated_metrics("dv_1", output_format="table")
+
+        assert result is True
+        output = f.getvalue()
+        assert "Bounce Rate" in output
+        # Table should show polarity and approved but NOT precision
+        assert "Precision" not in output
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_list_calc_metrics_empty(self, mock_profile, mock_configure, mock_cjapy):
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
+        import pandas as pd
+
+        cja.getCalculatedMetrics.return_value = pd.DataFrame()
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = list_calculated_metrics("dv_1", output_format="json")
 
         assert result is True
         output = json.loads(f.getvalue())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,6 +20,7 @@ from cja_auto_sdr.generator import (
     list_connections,
     list_datasets,
     list_dataviews,
+    list_dimensions,
     list_metrics,
     parse_arguments,
 )
@@ -4326,3 +4327,106 @@ class TestListMetrics:
         output = json.loads(f.getvalue())
         assert output["count"] == 1
         assert output["metrics"][0]["name"] == "Revenue"
+
+
+class TestListDimensions:
+    """Tests for --list-dimensions command."""
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_list_dimensions_json(self, mock_profile, mock_configure, mock_cjapy):
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
+        import pandas as pd
+
+        cja.getDimensions.return_value = pd.DataFrame([
+            {"id": "variables/page", "name": "Page", "type": "string", "description": "Page URL"},
+            {"id": "variables/browser", "name": "Browser", "type": "string", "description": ""},
+        ])
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = list_dimensions("dv_1", output_format="json")
+
+        assert result is True
+        output = json.loads(f.getvalue())
+        assert output["dataViewId"] == "dv_1"
+        assert output["count"] == 2
+        assert "dimensions" in output
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_list_dimensions_csv(self, mock_profile, mock_configure, mock_cjapy):
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
+        import pandas as pd
+
+        cja.getDimensions.return_value = pd.DataFrame([
+            {"id": "variables/page", "name": "Page", "type": "string", "description": ""},
+        ])
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = list_dimensions("dv_1", output_format="csv")
+
+        assert result is True
+        lines = f.getvalue().strip().split("\n")
+        assert lines[0] == "id,name,type,description"
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_list_dimensions_empty(self, mock_profile, mock_configure, mock_cjapy):
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
+        import pandas as pd
+
+        cja.getDimensions.return_value = pd.DataFrame()
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = list_dimensions("dv_1", output_format="json")
+
+        assert result is True
+        output = json.loads(f.getvalue())
+        assert output["count"] == 0
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_list_dimensions_with_filter(self, mock_profile, mock_configure, mock_cjapy):
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
+        import pandas as pd
+
+        cja.getDimensions.return_value = pd.DataFrame([
+            {"id": "variables/page", "name": "Page", "type": "string", "description": ""},
+            {"id": "variables/browser", "name": "Browser", "type": "string", "description": ""},
+        ])
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = list_dimensions("dv_1", output_format="json", filter_pattern="browser")
+
+        assert result is True
+        output = json.loads(f.getvalue())
+        assert output["count"] == 1
+        assert output["dimensions"][0]["name"] == "Browser"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3966,6 +3966,8 @@ class TestRunModeInference:
         ("argv", "expected_mode"),
         [
             (["cja_auto_sdr", "--list-dataviews", "--org-report"], "discovery"),
+            (["cja_auto_sdr", "--describe-dataview", "dv_1"], "discovery"),
+            (["cja_auto_sdr", "--list-metrics", "dv_1"], "discovery"),
             (["cja_auto_sdr", "--config-status", "--validate-config"], "config_status"),
             (["cja_auto_sdr", "--diff", "dv_a", "dv_b", "--dry-run"], "diff"),
             (["cja_auto_sdr", "dv_test", "--snapshot", "baseline.json", "--compare-with-prev"], "snapshot"),
@@ -4285,6 +4287,32 @@ class TestDescribeDataview:
         assert "error" in output
         assert output["error_type"] == "not_found"
 
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_describe_dataview_error_payload_treated_as_not_found(self, mock_profile, mock_configure, mock_cjapy):
+        """API error-shaped payloads from getDataView should fail as not_found."""
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataView.return_value = {
+            "statusCode": 404,
+            "errorCode": "resource_not_found",
+            "errorDescription": "Data view was not found",
+        }
+
+        import io
+        from contextlib import redirect_stderr, redirect_stdout
+
+        out = io.StringIO()
+        err = io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            result = describe_dataview("dv_missing", output_format="json")
+
+        assert result is False
+        payload = json.loads(err.getvalue())
+        assert payload["error_type"] == "not_found"
+        assert "dv_missing" in payload["error"]
+
 
 class TestListMetrics:
     """Tests for --list-metrics command."""
@@ -4365,6 +4393,31 @@ class TestListMetrics:
         assert result is True
         output = json.loads(f.getvalue())
         assert output["count"] == 0
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_list_metrics_invalid_dataview_fails_not_found(self, mock_profile, mock_configure, mock_cjapy):
+        """Invalid/inaccessible data views should fail instead of returning empty metrics."""
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataView.return_value = {"statusCode": 404, "errorCode": "not_found"}
+        import pandas as pd
+
+        cja.getMetrics.return_value = pd.DataFrame()
+
+        import io
+        from contextlib import redirect_stderr, redirect_stdout
+
+        out = io.StringIO()
+        err = io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            result = list_metrics("dv_bad", output_format="json")
+
+        assert result is False
+        payload = json.loads(err.getvalue())
+        assert payload["error_type"] == "not_found"
+        cja.getMetrics.assert_not_called()
 
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")
@@ -4474,6 +4527,31 @@ class TestListDimensions:
         assert result is True
         output = json.loads(f.getvalue())
         assert output["count"] == 0
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_list_dimensions_invalid_dataview_fails_not_found(self, mock_profile, mock_configure, mock_cjapy):
+        """Invalid/inaccessible data views should fail instead of returning empty dimensions."""
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataView.return_value = {"statusCode": 403, "message": "forbidden"}
+        import pandas as pd
+
+        cja.getDimensions.return_value = pd.DataFrame()
+
+        import io
+        from contextlib import redirect_stderr, redirect_stdout
+
+        out = io.StringIO()
+        err = io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            result = list_dimensions("dv_bad", output_format="json")
+
+        assert result is False
+        payload = json.loads(err.getvalue())
+        assert payload["error_type"] == "not_found"
+        cja.getDimensions.assert_not_called()
 
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")
@@ -4652,6 +4730,31 @@ class TestListSegments:
         output = json.loads(f.getvalue())
         assert output["count"] == 0
 
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_list_segments_invalid_dataview_fails_not_found(self, mock_profile, mock_configure, mock_cjapy):
+        """Invalid/inaccessible data views should fail instead of returning empty segments."""
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataView.return_value = {"errorCode": "not_found", "errorDescription": "missing"}
+        import pandas as pd
+
+        cja.getFilters.return_value = pd.DataFrame()
+
+        import io
+        from contextlib import redirect_stderr, redirect_stdout
+
+        out = io.StringIO()
+        err = io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            result = list_segments("dv_bad", output_format="json")
+
+        assert result is False
+        payload = json.loads(err.getvalue())
+        assert payload["error_type"] == "not_found"
+        cja.getFilters.assert_not_called()
+
 
 class TestListCalculatedMetrics:
     """Tests for --list-calculated-metrics command."""
@@ -4800,3 +4903,28 @@ class TestListCalculatedMetrics:
         assert result is True
         output = json.loads(f.getvalue())
         assert output["count"] == 0
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_list_calc_metrics_invalid_dataview_fails_not_found(self, mock_profile, mock_configure, mock_cjapy):
+        """Invalid/inaccessible data views should fail instead of returning empty calculated metrics."""
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataView.return_value = {"statusCode": 403, "message": "forbidden"}
+        import pandas as pd
+
+        cja.getCalculatedMetrics.return_value = pd.DataFrame()
+
+        import io
+        from contextlib import redirect_stderr, redirect_stdout
+
+        out = io.StringIO()
+        err = io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            result = list_calculated_metrics("dv_bad", output_format="json")
+
+        assert result is False
+        payload = json.loads(err.getvalue())
+        assert payload["error_type"] == "not_found"
+        cja.getCalculatedMetrics.assert_not_called()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4348,6 +4348,50 @@ class TestDescribeDataview:
         assert components["dimensions"] == 1
         assert components["total"] == "N/A"
 
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_describe_dataview_empty_typed_component_tables_count_as_zero(
+        self,
+        mock_profile,
+        mock_configure,
+        mock_cjapy,
+    ):
+        """Empty typed DataFrames are valid no-result responses and should count as zero."""
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataView.return_value = {
+            "id": "dv_1",
+            "name": "Test View",
+            "owner": {"name": "Jane"},
+            "description": "Desc",
+            "parentDataGroupId": "conn_1",
+            "created": "2025-01-01",
+            "modified": "2025-06-01",
+        }
+        import pandas as pd
+
+        cja.getMetrics.return_value = pd.DataFrame(columns=["id", "name", "type"])
+        cja.getDimensions.return_value = pd.DataFrame(columns=["id", "name", "type"])
+        cja.getFilters.return_value = pd.DataFrame(columns=["id", "name", "type"])
+        cja.getCalculatedMetrics.return_value = pd.DataFrame(columns=["id", "name", "type"])
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = describe_dataview("dv_1", output_format="json")
+
+        assert result is True
+        output = json.loads(f.getvalue())
+        components = output["dataView"]["components"]
+        assert components["metrics"] == 0
+        assert components["dimensions"] == 0
+        assert components["segments"] == 0
+        assert components["calculatedMetrics"] == 0
+        assert components["total"] == 0
+
 
 class TestListMetrics:
     """Tests for --list-metrics command."""
@@ -4428,6 +4472,30 @@ class TestListMetrics:
         assert result is True
         output = json.loads(f.getvalue())
         assert output["count"] == 0
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_list_metrics_empty_typed_dataframe_is_not_error(self, mock_profile, mock_configure, mock_cjapy):
+        """A zero-row metrics table with standard columns is a valid empty result."""
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataView.return_value = {"id": "dv_1", "name": "Test View"}
+        import pandas as pd
+
+        cja.getMetrics.return_value = pd.DataFrame(columns=["id", "name", "type", "description"])
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = list_metrics("dv_1", output_format="json")
+
+        assert result is True
+        output = json.loads(f.getvalue())
+        assert output["count"] == 0
+        assert output["metrics"] == []
 
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")
@@ -4584,6 +4652,30 @@ class TestListDimensions:
         assert result is True
         output = json.loads(f.getvalue())
         assert output["count"] == 0
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_list_dimensions_empty_typed_dataframe_is_not_error(self, mock_profile, mock_configure, mock_cjapy):
+        """A zero-row dimensions table with standard columns is a valid empty result."""
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataView.return_value = {"id": "dv_1", "name": "Test View"}
+        import pandas as pd
+
+        cja.getDimensions.return_value = pd.DataFrame(columns=["id", "name", "type", "description"])
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = list_dimensions("dv_1", output_format="json")
+
+        assert result is True
+        output = json.loads(f.getvalue())
+        assert output["count"] == 0
+        assert output["dimensions"] == []
 
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")
@@ -4887,6 +4979,30 @@ class TestListSegments:
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")
     @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_list_segments_empty_typed_dataframe_is_not_error(self, mock_profile, mock_configure, mock_cjapy):
+        """A zero-row segments table with typed columns is a valid empty result."""
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataView.return_value = {"id": "dv_1", "name": "Test View"}
+        import pandas as pd
+
+        cja.getFilters.return_value = pd.DataFrame(columns=["id", "name", "type"])
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = list_segments("dv_1", output_format="json")
+
+        assert result is True
+        output = json.loads(f.getvalue())
+        assert output["count"] == 0
+        assert output["segments"] == []
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
     def test_list_segments_invalid_dataview_fails_not_found(self, mock_profile, mock_configure, mock_cjapy):
         """Invalid/inaccessible data views should fail instead of returning empty segments."""
         mock_configure.return_value = (True, "config", None)
@@ -5162,6 +5278,30 @@ class TestListCalculatedMetrics:
         assert result is True
         output = json.loads(f.getvalue())
         assert output["count"] == 0
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_list_calc_metrics_empty_typed_dataframe_is_not_error(self, mock_profile, mock_configure, mock_cjapy):
+        """A zero-row calculated metrics table with standard columns is valid empty data."""
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataView.return_value = {"id": "dv_1", "name": "Test View"}
+        import pandas as pd
+
+        cja.getCalculatedMetrics.return_value = pd.DataFrame(columns=["id", "name", "type", "description"])
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = list_calculated_metrics("dv_1", output_format="json")
+
+        assert result is True
+        output = json.loads(f.getvalue())
+        assert output["count"] == 0
+        assert output["calculatedMetrics"] == []
 
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1996,6 +1996,20 @@ class TestExtractDatasetInfo:
         result = _extract_dataset_info({"dataset_id": "ds_333", "dataset_name": "Legacy Events"})
         assert result == {"id": "ds_333", "name": "Legacy Events"}
 
+    def test_pd_na_fields_fallback_to_na(self):
+        """Pandas missing scalars in id/name fields should not raise and should normalize to N/A."""
+        import pandas as pd
+
+        result = _extract_dataset_info({"id": pd.NA, "name": pd.NA})
+        assert result == {"id": "N/A", "name": "N/A"}
+
+    def test_pd_na_prefers_alternate_fields(self):
+        """Missing primary dataset fields should fall back to alternate aliases."""
+        import pandas as pd
+
+        result = _extract_dataset_info({"id": pd.NA, "datasetId": "ds_999", "name": pd.NA, "datasetName": "Alt Name"})
+        assert result == {"id": "ds_999", "name": "Alt Name"}
+
 
 class TestListDataviewsFunction:
     """Test list_dataviews() function with mocks"""
@@ -2081,6 +2095,50 @@ class TestListDataviewsFunction:
         output = f.getvalue()
         assert "N/A" in output
         assert "None" not in output
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_list_dataviews_owner_scalar_nan_shows_na(self, mock_profile, mock_configure, mock_cjapy):
+        """NaN scalar owner values should normalize to N/A."""
+        mock_configure.return_value = (True, "config", None)
+        mock_cja_instance = mock_cjapy.CJA.return_value
+        mock_cja_instance.getDataViews.return_value = [{"id": "dv_1", "name": "Test View", "owner": float("nan")}]
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = list_dataviews(output_format="json")
+
+        assert result is True
+        output = json.loads(f.getvalue())
+        assert output["dataViews"][0]["owner"] == "N/A"
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_list_dataviews_owner_dict_pd_na_name_falls_back(self, mock_profile, mock_configure, mock_cjapy):
+        """Owner dict fields should skip pd.NA values and fall back to populated aliases."""
+        import pandas as pd
+
+        mock_configure.return_value = (True, "config", None)
+        mock_cja_instance = mock_cjapy.CJA.return_value
+        mock_cja_instance.getDataViews.return_value = [
+            {"id": "dv_1", "name": "Test View", "owner": {"name": pd.NA, "email": "owner@example.com"}},
+        ]
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = list_dataviews(output_format="json")
+
+        assert result is True
+        output = json.loads(f.getvalue())
+        assert output["dataViews"][0]["owner"] == "owner@example.com"
 
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")
@@ -2310,6 +2368,43 @@ class TestListConnectionsFunction:
         assert result is True
         output = json.loads(f.getvalue())
         assert output["connections"][0]["owner"] == "N/A"
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_list_connections_pd_na_owner_full_name_falls_back_to_owner(
+        self,
+        mock_profile,
+        mock_configure,
+        mock_cjapy,
+    ):
+        """pd.NA ownerFullName should not error and should fall back to owner object aliases."""
+        import pandas as pd
+
+        mock_configure.return_value = (True, "config", None)
+        mock_cja_instance = mock_cjapy.CJA.return_value
+        mock_cja_instance.getConnections.return_value = {
+            "content": [
+                {
+                    "id": "conn_1",
+                    "name": "Test Conn",
+                    "ownerFullName": pd.NA,
+                    "owner": {"name": "Fallback Owner"},
+                    "dataSets": [],
+                },
+            ],
+        }
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = list_connections(output_format="json")
+
+        assert result is True
+        output = json.loads(f.getvalue())
+        assert output["connections"][0]["owner"] == "Fallback Owner"
 
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")
@@ -4839,6 +4934,66 @@ class TestListSegments:
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")
     @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_list_segments_mixed_tags_and_missing_owner_values(self, mock_profile, mock_configure, mock_cjapy):
+        """Mixed tagged/untagged rows with NaN/pd.NA values should normalize without errors."""
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataView.return_value = {"id": "dv_1", "name": "Test View"}
+        import pandas as pd
+
+        cja.getFilters.return_value = pd.DataFrame(
+            [
+                {
+                    "id": "s1",
+                    "name": "Tagged Segment",
+                    "owner": {"name": "Owner One"},
+                    "approved": True,
+                    "tags": [{"name": "prod"}],
+                    "created": "2025-01-01",
+                    "modified": "2025-01-02",
+                },
+                {
+                    "id": "s2",
+                    "name": "Untagged Segment",
+                    "owner": float("nan"),
+                    "ownerFullName": "Alias Owner",
+                    "approved": False,
+                    "tags": float("nan"),
+                    "createdDate": "2025-01-03",
+                    "modifiedDate": "2025-01-04",
+                },
+                {
+                    "id": "s3",
+                    "name": "NA Owner Segment",
+                    "owner": pd.NA,
+                    "ownerFullName": "Alias Owner NA",
+                    "approved": False,
+                    "tags": pd.NA,
+                    "createdDate": "2025-01-05",
+                    "modifiedDate": "2025-01-06",
+                },
+            ]
+        )
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = list_segments("dv_1", output_format="json")
+
+        assert result is True
+        output = json.loads(f.getvalue())
+        segments_by_id = {segment["id"]: segment for segment in output["segments"]}
+        assert segments_by_id["s1"]["tags"] == ["prod"]
+        assert segments_by_id["s2"]["tags"] == []
+        assert segments_by_id["s3"]["tags"] == []
+        assert segments_by_id["s2"]["owner"] == "Alias Owner"
+        assert segments_by_id["s3"]["owner"] == "Alias Owner NA"
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
     def test_list_segments_owner_and_date_aliases_table(self, mock_profile, mock_configure, mock_cjapy):
         """Alias-based governance metadata should also appear in table output."""
         mock_configure.return_value = (True, "config", None)
@@ -5136,6 +5291,78 @@ class TestListCalculatedMetrics:
         assert cm["owner"] == "Alias Owner"
         assert cm["created"] == "2025-01-01"
         assert cm["modified"] == "2025-06-01"
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_list_calc_metrics_mixed_tags_and_missing_owner_values(self, mock_profile, mock_configure, mock_cjapy):
+        """Mixed tags and missing owner scalars should normalize without raising TypeError."""
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataView.return_value = {"id": "dv_1", "name": "Test View"}
+        import pandas as pd
+
+        cja.getCalculatedMetrics.return_value = pd.DataFrame(
+            [
+                {
+                    "id": "cm1",
+                    "name": "Tagged Metric",
+                    "owner": {"name": "Owner One"},
+                    "description": "Tagged metric",
+                    "type": "percent",
+                    "polarity": "negative",
+                    "precision": 2,
+                    "approved": True,
+                    "tags": [{"name": "prod"}],
+                    "created": "2025-01-01",
+                    "modified": "2025-01-02",
+                },
+                {
+                    "id": "cm2",
+                    "name": "Untagged Metric",
+                    "owner": float("nan"),
+                    "ownerFullName": "Alias Metric Owner",
+                    "description": "Untagged metric",
+                    "type": "number",
+                    "polarity": "positive",
+                    "precision": 0,
+                    "approved": False,
+                    "tags": float("nan"),
+                    "createdDate": "2025-01-03",
+                    "modifiedDate": "2025-01-04",
+                },
+                {
+                    "id": "cm3",
+                    "name": "NA Owner Metric",
+                    "owner": pd.NA,
+                    "ownerFullName": "Alias Metric Owner NA",
+                    "description": "pd.NA owner",
+                    "type": "number",
+                    "polarity": "positive",
+                    "precision": 0,
+                    "approved": False,
+                    "tags": pd.NA,
+                    "createdDate": "2025-01-05",
+                    "modifiedDate": "2025-01-06",
+                },
+            ]
+        )
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = list_calculated_metrics("dv_1", output_format="json")
+
+        assert result is True
+        output = json.loads(f.getvalue())
+        metrics_by_id = {metric["id"]: metric for metric in output["calculatedMetrics"]}
+        assert metrics_by_id["cm1"]["tags"] == ["prod"]
+        assert metrics_by_id["cm2"]["tags"] == []
+        assert metrics_by_id["cm3"]["tags"] == []
+        assert metrics_by_id["cm2"]["owner"] == "Alias Metric Owner"
+        assert metrics_by_id["cm3"]["owner"] == "Alias Metric Owner NA"
 
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4747,6 +4747,68 @@ def test_list_inspection_commands_na_identity_fields_treated_as_not_found(
     assert getattr(cja, component_method).call_count == 0
 
 
+@pytest.mark.parametrize(
+    ("command", "component_method", "component_key", "component_payload"),
+    [
+        (
+            list_metrics,
+            "getMetrics",
+            "metrics",
+            [{"id": "m1", "name": "Metric One", "type": "decimal", "description": ""}],
+        ),
+        (
+            list_dimensions,
+            "getDimensions",
+            "dimensions",
+            [{"id": "d1", "name": "Dimension One", "type": "string", "description": ""}],
+        ),
+        (
+            list_segments,
+            "getFilters",
+            "segments",
+            [{"id": "s1", "name": "Segment One"}],
+        ),
+        (
+            list_calculated_metrics,
+            "getCalculatedMetrics",
+            "calculatedMetrics",
+            [{"id": "cm1", "name": "Calc One"}],
+        ),
+    ],
+)
+@patch("cja_auto_sdr.generator.cjapy")
+@patch("cja_auto_sdr.generator.configure_cjapy")
+@patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+def test_list_inspection_commands_use_canonical_dataview_name_over_preferred_query(
+    mock_profile,
+    mock_configure,
+    mock_cjapy,
+    command,
+    component_method,
+    component_key,
+    component_payload,
+):
+    """Inspection list output should use the canonical API name, not raw query text."""
+    mock_configure.return_value = (True, "config", None)
+    cja = mock_cjapy.CJA.return_value
+    cja.getDataView.return_value = {"id": "dv_1", "name": "Production Web"}
+    getattr(cja, component_method).return_value = component_payload
+
+    import io
+    from contextlib import redirect_stdout
+
+    out = io.StringIO()
+    with redirect_stdout(out):
+        result = command("dv_1", output_format="json", data_view_name="Prod Web")
+
+    assert result is True
+    payload = json.loads(out.getvalue())
+    assert payload["dataViewId"] == "dv_1"
+    assert payload["dataViewName"] == "Production Web"
+    assert payload["count"] == 1
+    assert len(payload[component_key]) == 1
+
+
 class TestListMetrics:
     """Tests for --list-metrics command."""
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4220,7 +4220,11 @@ class TestDescribeDataview:
         assert result is True
         output = f.getvalue()
         # Description should be split across multiple lines
-        desc_lines = [line for line in output.split("\n") if "Description" in line or (line.startswith("                 ") and "long" in line)]
+        desc_lines = [
+            line
+            for line in output.split("\n")
+            if "Description" in line or (line.startswith("                 ") and "long" in line)
+        ]
         assert len(desc_lines) > 1, "Long description should wrap to multiple lines"
         # No single line should exceed terminal width by much
         for line in output.split("\n"):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4217,6 +4217,62 @@ class TestDescribeDataview:
         assert dv["components"]["segments"] == 2
         assert dv["components"]["calculatedMetrics"] == 1
         assert dv["components"]["total"] == 11
+        cja.getMetrics.assert_called_once_with("dv_1", inclType="hidden", full=True)
+        cja.getDimensions.assert_called_once_with("dv_1", inclType="hidden", full=True)
+        cja.getFilters.assert_called_once_with(dataIds="dv_1", full=True)
+        cja.getCalculatedMetrics.assert_called_once_with(dataIds="dv_1", full=True)
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_describe_dataview_json_counts_hidden_metrics_and_dimensions(
+        self,
+        mock_profile,
+        mock_configure,
+        mock_cjapy,
+    ):
+        """describe_dataview component counts should include hidden metrics and dimensions."""
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataView.return_value = {
+            "id": "dv_1",
+            "name": "Test View",
+            "owner": {"name": "Jane"},
+            "description": "A test view",
+            "parentDataGroupId": "conn_1",
+            "created": "2025-01-01",
+            "modified": "2025-06-01",
+        }
+
+        def _get_metrics(_data_view_id, **kwargs):
+            if kwargs.get("inclType") == "hidden" and kwargs.get("full") is True:
+                return [{"id": "m_visible"}, {"id": "m_hidden"}]
+            return [{"id": "m_visible"}]
+
+        def _get_dimensions(_data_view_id, **kwargs):
+            if kwargs.get("inclType") == "hidden" and kwargs.get("full") is True:
+                return [{"id": "d_visible"}, {"id": "d_hidden"}]
+            return [{"id": "d_visible"}]
+
+        cja.getMetrics.side_effect = _get_metrics
+        cja.getDimensions.side_effect = _get_dimensions
+        cja.getFilters.return_value = []
+        cja.getCalculatedMetrics.return_value = []
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = describe_dataview("dv_1", output_format="json")
+
+        assert result is True
+        components = json.loads(f.getvalue())["dataView"]["components"]
+        assert components["metrics"] == 2
+        assert components["dimensions"] == 2
+        assert components["total"] == 4
+        cja.getMetrics.assert_called_once_with("dv_1", inclType="hidden", full=True)
+        cja.getDimensions.assert_called_once_with("dv_1", inclType="hidden", full=True)
 
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")
@@ -5204,6 +5260,7 @@ class TestListSegments:
         assert seg["owner"] == "Jane"
         assert seg["approved"] is True
         assert seg["tags"] == ["prod"]
+        cja.getFilters.assert_called_once_with(dataIds="dv_1", full=True)
 
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")
@@ -5597,6 +5654,7 @@ class TestListCalculatedMetrics:
         assert cm["polarity"] == "negative"
         assert cm["type"] == "percent"
         assert cm["precision"] == 2
+        cja.getCalculatedMetrics.assert_called_once_with(dataIds="dv_1", full=True)
 
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4128,9 +4128,13 @@ class TestDescribeDataview:
         mock_configure.return_value = (True, "config", None)
         cja = mock_cjapy.CJA.return_value
         cja.getDataView.return_value = {
-            "id": "dv_1", "name": "Test", "owner": {"name": "Jane"},
-            "description": "", "parentDataGroupId": "conn_1",
-            "created": "2025-01-01", "modified": "2025-06-01",
+            "id": "dv_1",
+            "name": "Test",
+            "owner": {"name": "Jane"},
+            "description": "",
+            "parentDataGroupId": "conn_1",
+            "created": "2025-01-01",
+            "modified": "2025-06-01",
         }
         cja.getMetrics.return_value = [{"id": "m1"}]
         cja.getDimensions.return_value = [{"id": "d1"}]
@@ -4156,9 +4160,13 @@ class TestDescribeDataview:
         mock_configure.return_value = (True, "config", None)
         cja = mock_cjapy.CJA.return_value
         cja.getDataView.return_value = {
-            "id": "dv_1", "name": "Test View", "owner": {"name": "Jane"},
-            "description": "Desc", "parentDataGroupId": "conn_1",
-            "created": "2025-01-01", "modified": "2025-06-01",
+            "id": "dv_1",
+            "name": "Test View",
+            "owner": {"name": "Jane"},
+            "description": "Desc",
+            "parentDataGroupId": "conn_1",
+            "created": "2025-01-01",
+            "modified": "2025-06-01",
         }
         cja.getMetrics.return_value = [{"id": "m1"}, {"id": "m2"}]
         cja.getDimensions.return_value = [{"id": "d1"}]
@@ -4187,9 +4195,13 @@ class TestDescribeDataview:
         mock_configure.return_value = (True, "config", None)
         cja = mock_cjapy.CJA.return_value
         cja.getDataView.return_value = {
-            "id": "dv_1", "name": "Test", "owner": {"name": "Jane"},
-            "description": "", "parentDataGroupId": "conn_1",
-            "created": "2025-01-01", "modified": "2025-06-01",
+            "id": "dv_1",
+            "name": "Test",
+            "owner": {"name": "Jane"},
+            "description": "",
+            "parentDataGroupId": "conn_1",
+            "created": "2025-01-01",
+            "modified": "2025-06-01",
         }
         cja.getMetrics.return_value = [{"id": "m1"}]
         cja.getDimensions.return_value = [{"id": "d1"}]
@@ -4240,10 +4252,12 @@ class TestListMetrics:
         cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
         import pandas as pd
 
-        cja.getMetrics.return_value = pd.DataFrame([
-            {"id": "metrics/pageviews", "name": "Page Views", "type": "decimal", "description": "Total views"},
-            {"id": "metrics/visits", "name": "Visits", "type": "decimal", "description": "Unique visits"},
-        ])
+        cja.getMetrics.return_value = pd.DataFrame(
+            [
+                {"id": "metrics/pageviews", "name": "Page Views", "type": "decimal", "description": "Total views"},
+                {"id": "metrics/visits", "name": "Visits", "type": "decimal", "description": "Unique visits"},
+            ]
+        )
 
         import io
         from contextlib import redirect_stdout
@@ -4267,9 +4281,11 @@ class TestListMetrics:
         cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
         import pandas as pd
 
-        cja.getMetrics.return_value = pd.DataFrame([
-            {"id": "metrics/pageviews", "name": "Page Views", "type": "decimal", "description": ""},
-        ])
+        cja.getMetrics.return_value = pd.DataFrame(
+            [
+                {"id": "metrics/pageviews", "name": "Page Views", "type": "decimal", "description": ""},
+            ]
+        )
 
         import io
         from contextlib import redirect_stdout
@@ -4313,10 +4329,12 @@ class TestListMetrics:
         cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
         import pandas as pd
 
-        cja.getMetrics.return_value = pd.DataFrame([
-            {"id": "metrics/pageviews", "name": "Page Views", "type": "decimal", "description": ""},
-            {"id": "metrics/revenue", "name": "Revenue", "type": "currency", "description": ""},
-        ])
+        cja.getMetrics.return_value = pd.DataFrame(
+            [
+                {"id": "metrics/pageviews", "name": "Page Views", "type": "decimal", "description": ""},
+                {"id": "metrics/revenue", "name": "Revenue", "type": "currency", "description": ""},
+            ]
+        )
 
         import io
         from contextlib import redirect_stdout
@@ -4343,10 +4361,12 @@ class TestListDimensions:
         cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
         import pandas as pd
 
-        cja.getDimensions.return_value = pd.DataFrame([
-            {"id": "variables/page", "name": "Page", "type": "string", "description": "Page URL"},
-            {"id": "variables/browser", "name": "Browser", "type": "string", "description": ""},
-        ])
+        cja.getDimensions.return_value = pd.DataFrame(
+            [
+                {"id": "variables/page", "name": "Page", "type": "string", "description": "Page URL"},
+                {"id": "variables/browser", "name": "Browser", "type": "string", "description": ""},
+            ]
+        )
 
         import io
         from contextlib import redirect_stdout
@@ -4370,9 +4390,11 @@ class TestListDimensions:
         cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
         import pandas as pd
 
-        cja.getDimensions.return_value = pd.DataFrame([
-            {"id": "variables/page", "name": "Page", "type": "string", "description": ""},
-        ])
+        cja.getDimensions.return_value = pd.DataFrame(
+            [
+                {"id": "variables/page", "name": "Page", "type": "string", "description": ""},
+            ]
+        )
 
         import io
         from contextlib import redirect_stdout
@@ -4416,10 +4438,12 @@ class TestListDimensions:
         cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
         import pandas as pd
 
-        cja.getDimensions.return_value = pd.DataFrame([
-            {"id": "variables/page", "name": "Page", "type": "string", "description": ""},
-            {"id": "variables/browser", "name": "Browser", "type": "string", "description": ""},
-        ])
+        cja.getDimensions.return_value = pd.DataFrame(
+            [
+                {"id": "variables/page", "name": "Page", "type": "string", "description": ""},
+                {"id": "variables/browser", "name": "Browser", "type": "string", "description": ""},
+            ]
+        )
 
         import io
         from contextlib import redirect_stdout
@@ -4446,13 +4470,20 @@ class TestListSegments:
         cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
         import pandas as pd
 
-        cja.getFilters.return_value = pd.DataFrame([
-            {
-                "id": "s1", "name": "Mobile", "owner": {"name": "Jane"},
-                "description": "Mobile visitors", "approved": True,
-                "tags": [{"name": "prod"}], "created": "2025-01-01", "modified": "2025-06-01",
-            },
-        ])
+        cja.getFilters.return_value = pd.DataFrame(
+            [
+                {
+                    "id": "s1",
+                    "name": "Mobile",
+                    "owner": {"name": "Jane"},
+                    "description": "Mobile visitors",
+                    "approved": True,
+                    "tags": [{"name": "prod"}],
+                    "created": "2025-01-01",
+                    "modified": "2025-06-01",
+                },
+            ]
+        )
 
         import io
         from contextlib import redirect_stdout
@@ -4480,13 +4511,20 @@ class TestListSegments:
         cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
         import pandas as pd
 
-        cja.getFilters.return_value = pd.DataFrame([
-            {
-                "id": "s1", "name": "Mobile", "owner": {"name": "Jane"},
-                "description": "", "approved": False, "tags": [],
-                "created": "2025-01-01", "modified": "2025-06-01",
-            },
-        ])
+        cja.getFilters.return_value = pd.DataFrame(
+            [
+                {
+                    "id": "s1",
+                    "name": "Mobile",
+                    "owner": {"name": "Jane"},
+                    "description": "",
+                    "approved": False,
+                    "tags": [],
+                    "created": "2025-01-01",
+                    "modified": "2025-06-01",
+                },
+            ]
+        )
 
         import io
         from contextlib import redirect_stdout
@@ -4509,12 +4547,30 @@ class TestListSegments:
         cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
         import pandas as pd
 
-        cja.getFilters.return_value = pd.DataFrame([
-            {"id": "s1", "name": "Approved Seg", "owner": {"name": "Jane"},
-             "description": "", "approved": True, "tags": [], "created": "", "modified": ""},
-            {"id": "s2", "name": "Unapproved Seg", "owner": {"name": "Bob"},
-             "description": "", "approved": False, "tags": [], "created": "", "modified": ""},
-        ])
+        cja.getFilters.return_value = pd.DataFrame(
+            [
+                {
+                    "id": "s1",
+                    "name": "Approved Seg",
+                    "owner": {"name": "Jane"},
+                    "description": "",
+                    "approved": True,
+                    "tags": [],
+                    "created": "",
+                    "modified": "",
+                },
+                {
+                    "id": "s2",
+                    "name": "Unapproved Seg",
+                    "owner": {"name": "Bob"},
+                    "description": "",
+                    "approved": False,
+                    "tags": [],
+                    "created": "",
+                    "modified": "",
+                },
+            ]
+        )
 
         import io
         from contextlib import redirect_stdout
@@ -4563,15 +4619,23 @@ class TestListCalculatedMetrics:
         cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
         import pandas as pd
 
-        cja.getCalculatedMetrics.return_value = pd.DataFrame([
-            {
-                "id": "cm1", "name": "Bounce Rate", "owner": {"name": "Jane"},
-                "description": "Bounce rate calc", "type": "percent",
-                "polarity": "negative", "precision": 2,
-                "approved": True, "tags": [],
-                "created": "2025-01-01", "modified": "2025-06-01",
-            },
-        ])
+        cja.getCalculatedMetrics.return_value = pd.DataFrame(
+            [
+                {
+                    "id": "cm1",
+                    "name": "Bounce Rate",
+                    "owner": {"name": "Jane"},
+                    "description": "Bounce rate calc",
+                    "type": "percent",
+                    "polarity": "negative",
+                    "precision": 2,
+                    "approved": True,
+                    "tags": [],
+                    "created": "2025-01-01",
+                    "modified": "2025-06-01",
+                },
+            ]
+        )
 
         import io
         from contextlib import redirect_stdout
@@ -4599,12 +4663,23 @@ class TestListCalculatedMetrics:
         cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
         import pandas as pd
 
-        cja.getCalculatedMetrics.return_value = pd.DataFrame([
-            {"id": "cm1", "name": "Bounce Rate", "owner": {"name": "Jane"},
-             "description": "", "type": "percent", "polarity": "negative",
-             "precision": 2, "approved": True, "tags": [],
-             "created": "2025-01-01", "modified": "2025-06-01"},
-        ])
+        cja.getCalculatedMetrics.return_value = pd.DataFrame(
+            [
+                {
+                    "id": "cm1",
+                    "name": "Bounce Rate",
+                    "owner": {"name": "Jane"},
+                    "description": "",
+                    "type": "percent",
+                    "polarity": "negative",
+                    "precision": 2,
+                    "approved": True,
+                    "tags": [],
+                    "created": "2025-01-01",
+                    "modified": "2025-06-01",
+                },
+            ]
+        )
 
         import io
         from contextlib import redirect_stdout
@@ -4627,12 +4702,23 @@ class TestListCalculatedMetrics:
         cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
         import pandas as pd
 
-        cja.getCalculatedMetrics.return_value = pd.DataFrame([
-            {"id": "cm1", "name": "Bounce Rate", "owner": {"name": "Jane"},
-             "description": "", "type": "percent", "polarity": "negative",
-             "precision": 2, "approved": True, "tags": [],
-             "created": "", "modified": ""},
-        ])
+        cja.getCalculatedMetrics.return_value = pd.DataFrame(
+            [
+                {
+                    "id": "cm1",
+                    "name": "Bounce Rate",
+                    "owner": {"name": "Jane"},
+                    "description": "",
+                    "type": "percent",
+                    "polarity": "negative",
+                    "precision": 2,
+                    "approved": True,
+                    "tags": [],
+                    "created": "",
+                    "modified": "",
+                },
+            ]
+        )
 
         import io
         from contextlib import redirect_stdout

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4273,15 +4273,17 @@ class TestDescribeDataview:
         cja.getDataView.return_value = None
 
         import io
-        from contextlib import redirect_stdout
+        from contextlib import redirect_stderr, redirect_stdout
 
-        f = io.StringIO()
-        with redirect_stdout(f):
+        out = io.StringIO()
+        err = io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
             result = describe_dataview("dv_nonexistent", output_format="json")
 
-        assert result is True
-        output = json.loads(f.getvalue())
+        assert result is False
+        output = json.loads(err.getvalue())
         assert "error" in output
+        assert output["error_type"] == "not_found"
 
 
 class TestListMetrics:
@@ -4293,7 +4295,7 @@ class TestListMetrics:
     def test_list_metrics_json(self, mock_profile, mock_configure, mock_cjapy):
         mock_configure.return_value = (True, "config", None)
         cja = mock_cjapy.CJA.return_value
-        cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
+        cja.getDataView.return_value = {"id": "dv_1", "name": "Test View"}
         import pandas as pd
 
         cja.getMetrics.return_value = pd.DataFrame(
@@ -4322,7 +4324,7 @@ class TestListMetrics:
     def test_list_metrics_csv(self, mock_profile, mock_configure, mock_cjapy):
         mock_configure.return_value = (True, "config", None)
         cja = mock_cjapy.CJA.return_value
-        cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
+        cja.getDataView.return_value = {"id": "dv_1", "name": "Test View"}
         import pandas as pd
 
         cja.getMetrics.return_value = pd.DataFrame(
@@ -4348,7 +4350,7 @@ class TestListMetrics:
     def test_list_metrics_empty(self, mock_profile, mock_configure, mock_cjapy):
         mock_configure.return_value = (True, "config", None)
         cja = mock_cjapy.CJA.return_value
-        cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
+        cja.getDataView.return_value = {"id": "dv_1", "name": "Test View"}
         import pandas as pd
 
         cja.getMetrics.return_value = pd.DataFrame()
@@ -4370,7 +4372,7 @@ class TestListMetrics:
     def test_list_metrics_with_filter(self, mock_profile, mock_configure, mock_cjapy):
         mock_configure.return_value = (True, "config", None)
         cja = mock_cjapy.CJA.return_value
-        cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
+        cja.getDataView.return_value = {"id": "dv_1", "name": "Test View"}
         import pandas as pd
 
         cja.getMetrics.return_value = pd.DataFrame(
@@ -4402,7 +4404,7 @@ class TestListDimensions:
     def test_list_dimensions_json(self, mock_profile, mock_configure, mock_cjapy):
         mock_configure.return_value = (True, "config", None)
         cja = mock_cjapy.CJA.return_value
-        cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
+        cja.getDataView.return_value = {"id": "dv_1", "name": "Test View"}
         import pandas as pd
 
         cja.getDimensions.return_value = pd.DataFrame(
@@ -4431,7 +4433,7 @@ class TestListDimensions:
     def test_list_dimensions_csv(self, mock_profile, mock_configure, mock_cjapy):
         mock_configure.return_value = (True, "config", None)
         cja = mock_cjapy.CJA.return_value
-        cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
+        cja.getDataView.return_value = {"id": "dv_1", "name": "Test View"}
         import pandas as pd
 
         cja.getDimensions.return_value = pd.DataFrame(
@@ -4457,7 +4459,7 @@ class TestListDimensions:
     def test_list_dimensions_empty(self, mock_profile, mock_configure, mock_cjapy):
         mock_configure.return_value = (True, "config", None)
         cja = mock_cjapy.CJA.return_value
-        cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
+        cja.getDataView.return_value = {"id": "dv_1", "name": "Test View"}
         import pandas as pd
 
         cja.getDimensions.return_value = pd.DataFrame()
@@ -4479,7 +4481,7 @@ class TestListDimensions:
     def test_list_dimensions_with_filter(self, mock_profile, mock_configure, mock_cjapy):
         mock_configure.return_value = (True, "config", None)
         cja = mock_cjapy.CJA.return_value
-        cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
+        cja.getDataView.return_value = {"id": "dv_1", "name": "Test View"}
         import pandas as pd
 
         cja.getDimensions.return_value = pd.DataFrame(
@@ -4511,7 +4513,7 @@ class TestListSegments:
     def test_list_segments_json(self, mock_profile, mock_configure, mock_cjapy):
         mock_configure.return_value = (True, "config", None)
         cja = mock_cjapy.CJA.return_value
-        cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
+        cja.getDataView.return_value = {"id": "dv_1", "name": "Test View"}
         import pandas as pd
 
         cja.getFilters.return_value = pd.DataFrame(
@@ -4552,7 +4554,7 @@ class TestListSegments:
     def test_list_segments_csv(self, mock_profile, mock_configure, mock_cjapy):
         mock_configure.return_value = (True, "config", None)
         cja = mock_cjapy.CJA.return_value
-        cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
+        cja.getDataView.return_value = {"id": "dv_1", "name": "Test View"}
         import pandas as pd
 
         cja.getFilters.return_value = pd.DataFrame(
@@ -4588,7 +4590,7 @@ class TestListSegments:
         """approved renders as Yes/No in table mode."""
         mock_configure.return_value = (True, "config", None)
         cja = mock_cjapy.CJA.return_value
-        cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
+        cja.getDataView.return_value = {"id": "dv_1", "name": "Test View"}
         import pandas as pd
 
         cja.getFilters.return_value = pd.DataFrame(
@@ -4634,7 +4636,7 @@ class TestListSegments:
     def test_list_segments_empty(self, mock_profile, mock_configure, mock_cjapy):
         mock_configure.return_value = (True, "config", None)
         cja = mock_cjapy.CJA.return_value
-        cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
+        cja.getDataView.return_value = {"id": "dv_1", "name": "Test View"}
         import pandas as pd
 
         cja.getFilters.return_value = pd.DataFrame()
@@ -4660,7 +4662,7 @@ class TestListCalculatedMetrics:
     def test_list_calc_metrics_json(self, mock_profile, mock_configure, mock_cjapy):
         mock_configure.return_value = (True, "config", None)
         cja = mock_cjapy.CJA.return_value
-        cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
+        cja.getDataView.return_value = {"id": "dv_1", "name": "Test View"}
         import pandas as pd
 
         cja.getCalculatedMetrics.return_value = pd.DataFrame(
@@ -4704,7 +4706,7 @@ class TestListCalculatedMetrics:
     def test_list_calc_metrics_csv(self, mock_profile, mock_configure, mock_cjapy):
         mock_configure.return_value = (True, "config", None)
         cja = mock_cjapy.CJA.return_value
-        cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
+        cja.getDataView.return_value = {"id": "dv_1", "name": "Test View"}
         import pandas as pd
 
         cja.getCalculatedMetrics.return_value = pd.DataFrame(
@@ -4743,7 +4745,7 @@ class TestListCalculatedMetrics:
         """Table output omits precision column to save width."""
         mock_configure.return_value = (True, "config", None)
         cja = mock_cjapy.CJA.return_value
-        cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
+        cja.getDataView.return_value = {"id": "dv_1", "name": "Test View"}
         import pandas as pd
 
         cja.getCalculatedMetrics.return_value = pd.DataFrame(
@@ -4783,7 +4785,7 @@ class TestListCalculatedMetrics:
     def test_list_calc_metrics_empty(self, mock_profile, mock_configure, mock_cjapy):
         mock_configure.return_value = (True, "config", None)
         cja = mock_cjapy.CJA.return_value
-        cja.getDataViews.return_value = [{"id": "dv_1", "name": "Test View"}]
+        cja.getDataView.return_value = {"id": "dv_1", "name": "Test View"}
         import pandas as pd
 
         cja.getCalculatedMetrics.return_value = pd.DataFrame()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4430,8 +4430,9 @@ class TestDescribeDataview:
 
         import csv
         import io
-        import pandas as pd
         from contextlib import redirect_stdout
+
+        import pandas as pd
 
         cja.getDataView.return_value = pd.DataFrame(
             [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4331,6 +4331,138 @@ class TestDescribeDataview:
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")
     @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_describe_dataview_table_dataframe_nan_description(self, mock_profile, mock_configure, mock_cjapy):
+        """DataFrame-shaped getDataView payload with NaN description should render safely."""
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+
+        import pandas as pd
+
+        cja.getDataView.return_value = pd.DataFrame(
+            [
+                {
+                    "id": "dv_1",
+                    "name": "Test View",
+                    "owner": {"name": "Jane"},
+                    "description": float("nan"),
+                    "parentDataGroupId": "conn_1",
+                    "created": "2025-01-01",
+                    "modified": "2025-06-01",
+                }
+            ]
+        )
+        cja.getMetrics.return_value = [{"id": "m1"}]
+        cja.getDimensions.return_value = [{"id": "d1"}]
+        cja.getFilters.return_value = []
+        cja.getCalculatedMetrics.return_value = []
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = describe_dataview("dv_1", output_format="table")
+
+        assert result is True
+        output = f.getvalue()
+        assert "Description:   (none)" in output
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_describe_dataview_json_dataframe_nan_description_normalized(
+        self,
+        mock_profile,
+        mock_configure,
+        mock_cjapy,
+    ):
+        """DataFrame payload null-like description should serialize as empty string."""
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+
+        import pandas as pd
+
+        cja.getDataView.return_value = pd.DataFrame(
+            [
+                {
+                    "id": "dv_1",
+                    "name": "Test View",
+                    "ownerName": "Jane",
+                    "description": pd.NA,
+                    "connectionId": "conn_alias",
+                    "createdDate": "2025-01-01",
+                    "modifiedDate": "2025-06-01",
+                }
+            ]
+        )
+        cja.getMetrics.return_value = [{"id": "m1"}]
+        cja.getDimensions.return_value = [{"id": "d1"}]
+        cja.getFilters.return_value = []
+        cja.getCalculatedMetrics.return_value = []
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = describe_dataview("dv_1", output_format="json")
+
+        assert result is True
+        output = json.loads(f.getvalue())
+        assert output["dataView"]["description"] == ""
+        assert output["dataView"]["owner"] == "Jane"
+        assert output["dataView"]["connectionId"] == "conn_alias"
+        assert output["dataView"]["created"] == "2025-01-01"
+        assert output["dataView"]["modified"] == "2025-06-01"
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_describe_dataview_csv_dataframe_nan_description_normalized(
+        self,
+        mock_profile,
+        mock_configure,
+        mock_cjapy,
+    ):
+        """CSV output should not emit literal nan for null-like descriptions."""
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+
+        import csv
+        import io
+        import pandas as pd
+        from contextlib import redirect_stdout
+
+        cja.getDataView.return_value = pd.DataFrame(
+            [
+                {
+                    "id": "dv_1",
+                    "name": "Test View",
+                    "owner": {"name": "Jane"},
+                    "description": float("nan"),
+                    "parentDataGroupId": "conn_1",
+                    "created": "2025-01-01",
+                    "modified": "2025-06-01",
+                }
+            ]
+        )
+        cja.getMetrics.return_value = [{"id": "m1"}]
+        cja.getDimensions.return_value = [{"id": "d1"}]
+        cja.getFilters.return_value = []
+        cja.getCalculatedMetrics.return_value = []
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = describe_dataview("dv_1", output_format="csv")
+
+        assert result is True
+        rows = list(csv.DictReader(io.StringIO(f.getvalue())))
+        assert len(rows) == 1
+        assert rows[0]["description"] == ""
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
     def test_describe_dataview_graceful_segment_failure(self, mock_profile, mock_configure, mock_cjapy):
         """If getFilters fails, segments count shows as N/A."""
         mock_configure.return_value = (True, "config", None)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4038,3 +4038,37 @@ class TestProfileImportCLI:
                 main()
 
         assert exc_info.value.code == 1
+
+
+class TestDiscoveryInspectionParsing:
+    """Tests for new discovery inspection CLI arguments."""
+
+    def test_describe_dataview_stores_id(self):
+        args = parse_arguments(["--describe-dataview", "dv_abc123"])
+        assert args.describe_dataview == "dv_abc123"
+
+    def test_list_metrics_stores_id(self):
+        args = parse_arguments(["--list-metrics", "dv_abc123"])
+        assert args.list_metrics == "dv_abc123"
+
+    def test_list_dimensions_stores_id(self):
+        args = parse_arguments(["--list-dimensions", "dv_abc123"])
+        assert args.list_dimensions == "dv_abc123"
+
+    def test_list_segments_stores_id(self):
+        args = parse_arguments(["--list-segments", "dv_abc123"])
+        assert args.list_segments == "dv_abc123"
+
+    def test_list_calculated_metrics_stores_id(self):
+        args = parse_arguments(["--list-calculated-metrics", "dv_abc123"])
+        assert args.list_calculated_metrics == "dv_abc123"
+
+    def test_new_flags_mutual_exclusivity_with_existing(self):
+        """New flags are mutually exclusive with existing discovery commands."""
+        with pytest.raises(SystemExit):
+            parse_arguments(["--list-dataviews", "--describe-dataview", "dv_1"])
+
+    def test_new_flags_mutual_exclusivity_with_each_other(self):
+        """New flags are mutually exclusive with each other."""
+        with pytest.raises(SystemExit):
+            parse_arguments(["--describe-dataview", "dv_1", "--list-metrics", "dv_1"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4313,6 +4313,41 @@ class TestDescribeDataview:
         assert payload["error_type"] == "not_found"
         assert "dv_missing" in payload["error"]
 
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_describe_dataview_component_error_payload_reports_na(self, mock_profile, mock_configure, mock_cjapy):
+        """Error-shaped component payloads should degrade to N/A counts, not numeric zero."""
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataView.return_value = {
+            "id": "dv_1",
+            "name": "Test View",
+            "owner": {"name": "Jane"},
+            "description": "Desc",
+            "parentDataGroupId": "conn_1",
+            "created": "2025-01-01",
+            "modified": "2025-06-01",
+        }
+        cja.getMetrics.return_value = {"statusCode": 500, "message": "backend timeout"}
+        cja.getDimensions.return_value = [{"id": "d1"}]
+        cja.getFilters.return_value = []
+        cja.getCalculatedMetrics.return_value = []
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = describe_dataview("dv_1", output_format="json")
+
+        assert result is True
+        output = json.loads(f.getvalue())
+        components = output["dataView"]["components"]
+        assert components["metrics"] == "N/A"
+        assert components["dimensions"] == 1
+        assert components["total"] == "N/A"
+
 
 class TestListMetrics:
     """Tests for --list-metrics command."""
@@ -4418,6 +4453,28 @@ class TestListMetrics:
         payload = json.loads(err.getvalue())
         assert payload["error_type"] == "not_found"
         cja.getMetrics.assert_not_called()
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_list_metrics_component_error_payload_fails_not_found(self, mock_profile, mock_configure, mock_cjapy):
+        """Error-shaped metrics payloads should fail, not produce count=0 success."""
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataView.return_value = {"id": "dv_1", "name": "Test View"}
+        cja.getMetrics.return_value = {"statusCode": 403, "errorCode": "forbidden"}
+
+        import io
+        from contextlib import redirect_stderr, redirect_stdout
+
+        out = io.StringIO()
+        err = io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            result = list_metrics("dv_1", output_format="json")
+
+        assert result is False
+        payload = json.loads(err.getvalue())
+        assert payload["error_type"] == "not_found"
 
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")
@@ -4552,6 +4609,28 @@ class TestListDimensions:
         payload = json.loads(err.getvalue())
         assert payload["error_type"] == "not_found"
         cja.getDimensions.assert_not_called()
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_list_dimensions_component_error_payload_fails_not_found(self, mock_profile, mock_configure, mock_cjapy):
+        """Error-shaped dimensions payloads should fail, not produce count=0 success."""
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataView.return_value = {"id": "dv_1", "name": "Test View"}
+        cja.getDimensions.return_value = {"statusCode": 403, "message": "forbidden"}
+
+        import io
+        from contextlib import redirect_stderr, redirect_stdout
+
+        out = io.StringIO()
+        err = io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            result = list_dimensions("dv_1", output_format="json")
+
+        assert result is False
+        payload = json.loads(err.getvalue())
+        assert payload["error_type"] == "not_found"
 
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")
@@ -4755,6 +4834,28 @@ class TestListSegments:
         assert payload["error_type"] == "not_found"
         cja.getFilters.assert_not_called()
 
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_list_segments_component_error_payload_fails_not_found(self, mock_profile, mock_configure, mock_cjapy):
+        """Error-shaped segments payloads should fail, not produce count=0 success."""
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataView.return_value = {"id": "dv_1", "name": "Test View"}
+        cja.getFilters.return_value = {"statusCode": 403, "errorCode": "forbidden"}
+
+        import io
+        from contextlib import redirect_stderr, redirect_stdout
+
+        out = io.StringIO()
+        err = io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            result = list_segments("dv_1", output_format="json")
+
+        assert result is False
+        payload = json.loads(err.getvalue())
+        assert payload["error_type"] == "not_found"
+
 
 class TestListCalculatedMetrics:
     """Tests for --list-calculated-metrics command."""
@@ -4928,3 +5029,30 @@ class TestListCalculatedMetrics:
         payload = json.loads(err.getvalue())
         assert payload["error_type"] == "not_found"
         cja.getCalculatedMetrics.assert_not_called()
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_list_calc_metrics_component_error_payload_fails_not_found(
+        self,
+        mock_profile,
+        mock_configure,
+        mock_cjapy,
+    ):
+        """Error-shaped calculated metrics payloads should fail, not produce count=0 success."""
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataView.return_value = {"id": "dv_1", "name": "Test View"}
+        cja.getCalculatedMetrics.return_value = {"statusCode": 403, "message": "forbidden"}
+
+        import io
+        from contextlib import redirect_stderr, redirect_stdout
+
+        out = io.StringIO()
+        err = io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            result = list_calculated_metrics("dv_1", output_format="json")
+
+        assert result is False
+        payload = json.loads(err.getvalue())
+        assert payload["error_type"] == "not_found"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4187,6 +4187,46 @@ class TestDescribeDataview:
         assert "Dimensions" in output
         assert "Metrics" in output
 
+    @patch("cja_auto_sdr.generator.shutil.get_terminal_size", return_value=os.terminal_size((80, 24)))
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_describe_dataview_long_description_wraps(self, mock_profile, mock_configure, mock_cjapy, _mock_term):
+        """Long description text wraps within terminal width."""
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        long_desc = "This is a very long description. " * 10
+        cja.getDataView.return_value = {
+            "id": "dv_1",
+            "name": "Test View",
+            "owner": {"name": "Jane"},
+            "description": long_desc,
+            "parentDataGroupId": "conn_1",
+            "created": "2025-01-01",
+            "modified": "2025-06-01",
+        }
+        cja.getMetrics.return_value = [{"id": "m1"}]
+        cja.getDimensions.return_value = [{"id": "d1"}]
+        cja.getFilters.return_value = []
+        cja.getCalculatedMetrics.return_value = []
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = describe_dataview("dv_1", output_format="table")
+
+        assert result is True
+        output = f.getvalue()
+        # Description should be split across multiple lines
+        desc_lines = [line for line in output.split("\n") if "Description" in line or (line.startswith("                 ") and "long" in line)]
+        assert len(desc_lines) > 1, "Long description should wrap to multiple lines"
+        # No single line should exceed terminal width by much
+        for line in output.split("\n"):
+            if line.strip() and not line.startswith("="):
+                assert len(line) <= 85, f"Line too long ({len(line)}): {line[:50]}..."
+
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")
     @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4722,6 +4722,79 @@ class TestListMetrics:
         assert output["dataViewId"] == "dv_1"
         assert output["count"] == 2
         assert output["metrics"][0]["id"] in ("metrics/pageviews", "metrics/visits")
+        cja.getMetrics.assert_called_once_with("dv_1", inclType="hidden", full=True)
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_list_metrics_json_normalizes_nullable_fields(self, mock_profile, mock_configure, mock_cjapy):
+        """Null-like metric type/description values should normalize for strict JSON output."""
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataView.return_value = {"id": "dv_1", "name": "Test View"}
+        import pandas as pd
+
+        cja.getMetrics.return_value = pd.DataFrame(
+            [
+                {
+                    "id": "metrics/revenue",
+                    "name": "Revenue",
+                    "type": float("nan"),
+                    "description": pd.NA,
+                },
+            ]
+        )
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = list_metrics("dv_1", output_format="json")
+
+        assert result is True
+        output_text = f.getvalue()
+        assert '"type": NaN' not in output_text
+        assert '"description": NaN' not in output_text
+        output = json.loads(output_text)
+        assert output["metrics"][0]["type"] == "N/A"
+        assert output["metrics"][0]["description"] == ""
+
+    @patch("cja_auto_sdr.generator._build_metric_display_row")
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_list_metrics_json_output_contract_failure_emits_structured_error(
+        self,
+        mock_profile,
+        mock_configure,
+        mock_cjapy,
+        mock_row_builder,
+    ):
+        """Unexpected non-JSON values should fail with output_contract errors."""
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataView.return_value = {"id": "dv_1", "name": "Test View"}
+        cja.getMetrics.return_value = [{"id": "metrics/raw", "name": "Raw Metric"}]
+        mock_row_builder.return_value = {
+            "id": "metrics/raw",
+            "name": "Raw Metric",
+            "type": float("nan"),
+            "description": "",
+        }
+
+        import io
+        from contextlib import redirect_stderr, redirect_stdout
+
+        out = io.StringIO()
+        err = io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            result = list_metrics("dv_1", output_format="json")
+
+        assert result is False
+        payload = json.loads(err.getvalue())
+        assert payload["error_type"] == "output_contract"
+        assert "non-JSON-compliant" in payload["error"]
 
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")
@@ -4902,6 +4975,43 @@ class TestListDimensions:
         assert output["dataViewId"] == "dv_1"
         assert output["count"] == 2
         assert "dimensions" in output
+        cja.getDimensions.assert_called_once_with("dv_1", inclType="hidden", full=True)
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_list_dimensions_json_normalizes_nullable_fields(self, mock_profile, mock_configure, mock_cjapy):
+        """Null-like dimension type/description values should normalize for strict JSON output."""
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataView.return_value = {"id": "dv_1", "name": "Test View"}
+        import pandas as pd
+
+        cja.getDimensions.return_value = pd.DataFrame(
+            [
+                {
+                    "id": "variables/browser",
+                    "name": "Browser",
+                    "type": pd.NA,
+                    "description": float("nan"),
+                },
+            ]
+        )
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = list_dimensions("dv_1", output_format="json")
+
+        assert result is True
+        output_text = f.getvalue()
+        assert '"type": NaN' not in output_text
+        assert '"description": NaN' not in output_text
+        output = json.loads(output_text)
+        assert output["dimensions"][0]["type"] == "N/A"
+        assert output["dimensions"][0]["description"] == ""
 
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")
@@ -5133,6 +5243,41 @@ class TestListSegments:
         assert seg["owner"] == "Alias Owner"
         assert seg["created"] == "2025-02-01"
         assert seg["modified"] == "2025-07-15"
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_list_segments_json_normalizes_nullable_description(self, mock_profile, mock_configure, mock_cjapy):
+        """Null-like segment descriptions should be normalized before JSON serialization."""
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataView.return_value = {"id": "dv_1", "name": "Test View"}
+        import pandas as pd
+
+        cja.getFilters.return_value = pd.DataFrame(
+            [
+                {
+                    "id": "s1",
+                    "name": "Nullable Description Segment",
+                    "description": float("nan"),
+                    "approved": True,
+                    "tags": [],
+                },
+            ]
+        )
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = list_segments("dv_1", output_format="json")
+
+        assert result is True
+        output_text = f.getvalue()
+        assert '"description": NaN' not in output_text
+        output = json.loads(output_text)
+        assert output["segments"][0]["description"] == ""
 
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")
@@ -5494,6 +5639,51 @@ class TestListCalculatedMetrics:
         assert cm["owner"] == "Alias Owner"
         assert cm["created"] == "2025-01-01"
         assert cm["modified"] == "2025-06-01"
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_list_calc_metrics_json_normalizes_nullable_fields(self, mock_profile, mock_configure, mock_cjapy):
+        """Null-like calculated metric fields should be normalized before JSON emission."""
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataView.return_value = {"id": "dv_1", "name": "Test View"}
+        import pandas as pd
+
+        cja.getCalculatedMetrics.return_value = pd.DataFrame(
+            [
+                {
+                    "id": "cm_nullable",
+                    "name": "Nullable Metric",
+                    "description": float("nan"),
+                    "type": pd.NA,
+                    "polarity": float("nan"),
+                    "precision": float("nan"),
+                    "approved": True,
+                    "tags": [],
+                },
+            ]
+        )
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = list_calculated_metrics("dv_1", output_format="json")
+
+        assert result is True
+        output_text = f.getvalue()
+        assert '"description": NaN' not in output_text
+        assert '"type": NaN' not in output_text
+        assert '"polarity": NaN' not in output_text
+        assert '"precision": NaN' not in output_text
+        output = json.loads(output_text)
+        row = output["calculatedMetrics"][0]
+        assert row["description"] == ""
+        assert row["type"] == ""
+        assert row["polarity"] == ""
+        assert row["precision"] == 0
 
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4708,6 +4708,81 @@ class TestListSegments:
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")
     @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_list_segments_owner_and_date_aliases_json(self, mock_profile, mock_configure, mock_cjapy):
+        """ownerFullName/createdDate/modifiedDate aliases should populate governance fields."""
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataView.return_value = {"id": "dv_1", "name": "Test View"}
+        import pandas as pd
+
+        cja.getFilters.return_value = pd.DataFrame(
+            [
+                {
+                    "id": "s1",
+                    "name": "Mobile",
+                    "ownerFullName": "Alias Owner",
+                    "description": "Alias metadata segment",
+                    "approved": True,
+                    "tags": [],
+                    "createdDate": "2025-02-01",
+                    "modifiedDate": "2025-07-15",
+                },
+            ]
+        )
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = list_segments("dv_1", output_format="json")
+
+        assert result is True
+        output = json.loads(f.getvalue())
+        seg = output["segments"][0]
+        assert seg["owner"] == "Alias Owner"
+        assert seg["created"] == "2025-02-01"
+        assert seg["modified"] == "2025-07-15"
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_list_segments_owner_and_date_aliases_table(self, mock_profile, mock_configure, mock_cjapy):
+        """Alias-based governance metadata should also appear in table output."""
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataView.return_value = {"id": "dv_1", "name": "Test View"}
+        import pandas as pd
+
+        cja.getFilters.return_value = pd.DataFrame(
+            [
+                {
+                    "id": "s1",
+                    "name": "Mobile",
+                    "ownerFullName": "Alias Owner",
+                    "description": "Alias metadata segment",
+                    "approved": True,
+                    "tags": [],
+                    "createdDate": "2025-02-01",
+                    "modifiedDate": "2025-07-15",
+                },
+            ]
+        )
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = list_segments("dv_1", output_format="table")
+
+        assert result is True
+        output = f.getvalue()
+        assert "Alias Owner" in output
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
     def test_list_segments_csv(self, mock_profile, mock_configure, mock_cjapy):
         mock_configure.return_value = (True, "config", None)
         cja = mock_cjapy.CJA.return_value
@@ -4903,6 +4978,89 @@ class TestListCalculatedMetrics:
         assert cm["polarity"] == "negative"
         assert cm["type"] == "percent"
         assert cm["precision"] == 2
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_list_calc_metrics_owner_and_date_aliases_json(self, mock_profile, mock_configure, mock_cjapy):
+        """Alias owner/date fields should be normalized in calculated metrics JSON output."""
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataView.return_value = {"id": "dv_1", "name": "Test View"}
+        import pandas as pd
+
+        cja.getCalculatedMetrics.return_value = pd.DataFrame(
+            [
+                {
+                    "id": "cm1",
+                    "name": "Bounce Rate",
+                    "ownerFullName": "Alias Owner",
+                    "description": "Bounce rate calc",
+                    "type": "percent",
+                    "polarity": "negative",
+                    "precision": 2,
+                    "approved": True,
+                    "tags": [],
+                    "createdDate": "2025-01-01",
+                    "modifiedDate": "2025-06-01",
+                },
+            ]
+        )
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = list_calculated_metrics("dv_1", output_format="json")
+
+        assert result is True
+        output = json.loads(f.getvalue())
+        cm = output["calculatedMetrics"][0]
+        assert cm["owner"] == "Alias Owner"
+        assert cm["created"] == "2025-01-01"
+        assert cm["modified"] == "2025-06-01"
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_list_calc_metrics_owner_and_date_aliases_csv(self, mock_profile, mock_configure, mock_cjapy):
+        """Alias owner/date fields should propagate into calculated metrics CSV output."""
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataView.return_value = {"id": "dv_1", "name": "Test View"}
+        import pandas as pd
+
+        cja.getCalculatedMetrics.return_value = pd.DataFrame(
+            [
+                {
+                    "id": "cm1",
+                    "name": "Bounce Rate",
+                    "ownerFullName": "Alias Owner",
+                    "description": "Bounce rate calc",
+                    "type": "percent",
+                    "polarity": "negative",
+                    "precision": 2,
+                    "approved": True,
+                    "tags": [],
+                    "createdDate": "2025-01-01",
+                    "modifiedDate": "2025-06-01",
+                },
+            ]
+        )
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = list_calculated_metrics("dv_1", output_format="csv")
+
+        assert result is True
+        lines = f.getvalue().strip().split("\n")
+        assert "Alias Owner" in lines[1]
+        assert "2025-01-01" in lines[1]
+        assert "2025-06-01" in lines[1]
 
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4544,6 +4544,34 @@ class TestDescribeDataview:
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")
     @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_describe_dataview_na_identity_fields_treated_as_not_found(self, mock_profile, mock_configure, mock_cjapy):
+        """NA-like id/name payloads should fail as not_found, not generic command failures."""
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+
+        import pandas as pd
+
+        cja.getDataView.return_value = {"id": pd.NA, "name": pd.NA, "description": "missing identity"}
+
+        import io
+        from contextlib import redirect_stderr, redirect_stdout
+
+        out = io.StringIO()
+        err = io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            result = describe_dataview("dv_missing", output_format="json")
+
+        assert result is False
+        payload = json.loads(err.getvalue())
+        assert payload["error_type"] == "not_found"
+        cja.getMetrics.assert_not_called()
+        cja.getDimensions.assert_not_called()
+        cja.getFilters.assert_not_called()
+        cja.getCalculatedMetrics.assert_not_called()
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
     def test_describe_dataview_component_error_payload_reports_na(self, mock_profile, mock_configure, mock_cjapy):
         """Error-shaped component payloads should degrade to N/A counts, not numeric zero."""
         mock_configure.return_value = (True, "config", None)
@@ -4619,6 +4647,48 @@ class TestDescribeDataview:
         assert components["segments"] == 0
         assert components["calculatedMetrics"] == 0
         assert components["total"] == 0
+
+
+@pytest.mark.parametrize(
+    ("command", "component_method"),
+    [
+        (list_metrics, "getMetrics"),
+        (list_dimensions, "getDimensions"),
+        (list_segments, "getFilters"),
+        (list_calculated_metrics, "getCalculatedMetrics"),
+    ],
+)
+@patch("cja_auto_sdr.generator.cjapy")
+@patch("cja_auto_sdr.generator.configure_cjapy")
+@patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+def test_list_inspection_commands_na_identity_fields_treated_as_not_found(
+    mock_profile,
+    mock_configure,
+    mock_cjapy,
+    command,
+    component_method,
+):
+    """All list inspection commands should reject NA-like dataview identity payloads as not_found."""
+    mock_configure.return_value = (True, "config", None)
+    cja = mock_cjapy.CJA.return_value
+
+    import pandas as pd
+
+    cja.getDataView.return_value = {"id": pd.NA, "name": pd.NA}
+    getattr(cja, component_method).return_value = []
+
+    import io
+    from contextlib import redirect_stderr, redirect_stdout
+
+    out = io.StringIO()
+    err = io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        result = command("dv_missing", output_format="json")
+
+    assert result is False
+    payload = json.loads(err.getvalue())
+    assert payload["error_type"] == "not_found"
+    assert getattr(cja, component_method).call_count == 0
 
 
 class TestListMetrics:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4226,10 +4226,10 @@ class TestDescribeDataview:
             if "Description" in line or (line.startswith("                 ") and "long" in line)
         ]
         assert len(desc_lines) > 1, "Long description should wrap to multiple lines"
-        # No single line should exceed terminal width by much
+        # No line should exceed terminal width (80 columns)
         for line in output.split("\n"):
-            if line.strip() and not line.startswith("="):
-                assert len(line) <= 85, f"Line too long ({len(line)}): {line[:50]}..."
+            if line.strip():
+                assert len(line) <= 80, f"Line too long ({len(line)}): {line[:50]}..."
 
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")

--- a/tests/test_cli_command_handlers.py
+++ b/tests/test_cli_command_handlers.py
@@ -2181,3 +2181,207 @@ class TestDiscoveryInspectionNameResolution:
         assert exc_info.value.code == 0
         mock_resolve.assert_not_called()
         assert mock_fn.call_args[0][0] == "dv_456"
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    @patch("cja_auto_sdr.generator.describe_dataview")
+    def test_name_no_match_error_suggests_list_dataviews(self, mock_fn, mock_resolve, capsys):
+        """Unresolved name error should suggest running --list-dataviews."""
+        mock_resolve.return_value = ([], {})
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--describe-dataview", "No Such View"])
+                mock_pa.return_value = args
+                _main_impl(run_state={})
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "--list-dataviews" in captured.err
+
+
+class TestDiscoveryInspectionOutputFile:
+    """Tests for --output FILE with inspection commands."""
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.list_metrics")
+    def test_output_file_forwarded_to_command(self, mock_fn, tmp_path):
+        """--output FILE should be forwarded to the command function."""
+        mock_fn.return_value = True
+        out_file = str(tmp_path / "metrics.json")
+        with pytest.raises(SystemExit):
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--list-metrics", "dv_1", "--format", "json", "--output", out_file])
+                mock_pa.return_value = args
+                _main_impl(run_state={})
+        assert mock_fn.call_args[1]["output_file"] == out_file
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.list_dimensions")
+    def test_output_file_forwarded_to_list_dimensions(self, mock_fn, tmp_path):
+        """--output FILE should be forwarded to list_dimensions."""
+        mock_fn.return_value = True
+        out_file = str(tmp_path / "dims.csv")
+        with pytest.raises(SystemExit):
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--list-dimensions", "dv_1", "--format", "csv", "--output", out_file])
+                mock_pa.return_value = args
+                _main_impl(run_state={})
+        assert mock_fn.call_args[1]["output_file"] == out_file
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.describe_dataview")
+    def test_output_file_forwarded_to_describe_dataview(self, mock_fn, tmp_path):
+        """--output FILE should be forwarded to describe_dataview."""
+        mock_fn.return_value = True
+        out_file = str(tmp_path / "desc.json")
+        with pytest.raises(SystemExit):
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--describe-dataview", "dv_1", "--format", "json", "--output", out_file])
+                mock_pa.return_value = args
+                _main_impl(run_state={})
+        assert mock_fn.call_args[1]["output_file"] == out_file
+
+
+class TestDiscoveryInspectionExcludePattern:
+    """Tests for --exclude pattern forwarding in inspection commands."""
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.list_metrics")
+    def test_exclude_pattern_forwarded_to_list_metrics(self, mock_fn):
+        """--exclude pattern should be forwarded as exclude_pattern kwarg."""
+        mock_fn.return_value = True
+        with pytest.raises(SystemExit):
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--list-metrics", "dv_1", "--exclude", "internal.*"])
+                mock_pa.return_value = args
+                _main_impl()
+        assert mock_fn.call_args[1]["exclude_pattern"] == "internal.*"
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.list_dimensions")
+    def test_exclude_pattern_forwarded_to_list_dimensions(self, mock_fn):
+        """--exclude pattern should be forwarded to list_dimensions."""
+        mock_fn.return_value = True
+        with pytest.raises(SystemExit):
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--list-dimensions", "dv_1", "--exclude", "test.*"])
+                mock_pa.return_value = args
+                _main_impl()
+        assert mock_fn.call_args[1]["exclude_pattern"] == "test.*"
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.list_calculated_metrics")
+    def test_filter_and_exclude_combined(self, mock_fn):
+        """--filter and --exclude should both be forwarded together."""
+        mock_fn.return_value = True
+        with pytest.raises(SystemExit):
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(
+                    ["--list-calculated-metrics", "dv_1", "--filter", "revenue.*", "--exclude", "test.*"]
+                )
+                mock_pa.return_value = args
+                _main_impl()
+        assert mock_fn.call_args[1]["filter_pattern"] == "revenue.*"
+        assert mock_fn.call_args[1]["exclude_pattern"] == "test.*"
+
+
+class TestDiscoveryInspectionSortDescending:
+    """Tests for --sort with descending prefix in inspection commands."""
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.list_metrics")
+    def test_sort_descending_forwarded(self, mock_fn):
+        """--sort=-name should be forwarded as-is to the command function."""
+        mock_fn.return_value = True
+        with pytest.raises(SystemExit):
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--list-metrics", "dv_1", "--sort=-name"])
+                mock_pa.return_value = args
+                _main_impl()
+        assert mock_fn.call_args[1]["sort_expression"] == "-name"
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.list_segments")
+    def test_sort_ascending_forwarded(self, mock_fn):
+        """--sort name (ascending) should be forwarded to the command function."""
+        mock_fn.return_value = True
+        with pytest.raises(SystemExit):
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--list-segments", "dv_1", "--sort", "id"])
+                mock_pa.return_value = args
+                _main_impl()
+        assert mock_fn.call_args[1]["sort_expression"] == "id"
+
+
+class TestDiscoveryInspectionLimitDispatch:
+    """Tests for --limit forwarding through inspection dispatch."""
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.list_dimensions")
+    def test_limit_forwarded_to_list_dimensions(self, mock_fn):
+        """--limit should be forwarded as integer to the command function."""
+        mock_fn.return_value = True
+        with pytest.raises(SystemExit):
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--list-dimensions", "dv_1", "--limit", "5"])
+                mock_pa.return_value = args
+                _main_impl()
+        assert mock_fn.call_args[1]["limit"] == 5
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.list_calculated_metrics")
+    def test_limit_forwarded_to_list_calculated_metrics(self, mock_fn):
+        """--limit should be forwarded to list_calculated_metrics."""
+        mock_fn.return_value = True
+        with pytest.raises(SystemExit):
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--list-calculated-metrics", "dv_1", "--limit", "20"])
+                mock_pa.return_value = args
+                _main_impl()
+        assert mock_fn.call_args[1]["limit"] == 20
+
+
+class TestDescribeDataviewIgnoresFilterSortLimit:
+    """Tests that describe_dataview silently ignores filter/sort/limit kwargs."""
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.describe_dataview")
+    def test_filter_sort_limit_do_not_cause_error(self, mock_fn):
+        """--filter, --sort, --limit with --describe-dataview should not error."""
+        mock_fn.return_value = True
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(
+                    ["--describe-dataview", "dv_1", "--filter", "something", "--sort", "name", "--limit", "10"]
+                )
+                mock_pa.return_value = args
+                _main_impl(run_state={})
+        assert exc_info.value.code == 0
+        mock_fn.assert_called_once()
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_describe_dataview_kwargs_absorbed(self, mock_profile, mock_configure, mock_cjapy):
+        """describe_dataview() should accept and ignore unexpected kwargs via **_kwargs."""
+        from cja_auto_sdr.generator import describe_dataview
+
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataView.return_value = {"id": "dv_1", "name": "Test", "owner": {"name": "Admin"}}
+        import pandas as pd
+
+        cja.getMetrics.return_value = pd.DataFrame([{"id": "m1"}])
+        cja.getDimensions.return_value = pd.DataFrame([{"id": "d1"}])
+        cja.getFilters.return_value = pd.DataFrame()
+        cja.getCalculatedMetrics.return_value = pd.DataFrame()
+
+        # These should be silently absorbed by **_kwargs
+        result = describe_dataview(
+            "dv_1",
+            output_format="json",
+            filter_pattern="anything",
+            exclude_pattern="something",
+            limit=10,
+            sort_expression="-name",
+        )
+        assert result is True

--- a/tests/test_cli_command_handlers.py
+++ b/tests/test_cli_command_handlers.py
@@ -2003,3 +2003,181 @@ class TestDiscoveryInspectionDispatch:
         assert call_kwargs[1]["filter_pattern"] == "active.*"
         assert call_kwargs[1]["sort_expression"] == "name"
         assert call_kwargs[1]["limit"] == 10
+
+
+class TestDiscoveryInspectionNameResolution:
+    """Tests for data view name resolution in ID-bearing discovery commands."""
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    @patch("cja_auto_sdr.generator.describe_dataview")
+    def test_id_passthrough_skips_resolution(self, mock_fn, mock_resolve):
+        """Data view IDs (dv_...) should pass through without calling resolve_data_view_names."""
+        mock_fn.return_value = True
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--describe-dataview", "dv_123"])
+                mock_pa.return_value = args
+                _main_impl(run_state={})
+        assert exc_info.value.code == 0
+        mock_resolve.assert_not_called()
+        assert mock_fn.call_args[0][0] == "dv_123"
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    @patch("cja_auto_sdr.generator.describe_dataview")
+    def test_name_resolves_to_single_id(self, mock_fn, mock_resolve):
+        """A name that resolves to a single data view ID should be passed to the command."""
+        mock_resolve.return_value = (["dv_resolved"], {"My View": ["dv_resolved"]})
+        mock_fn.return_value = True
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--describe-dataview", "My View"])
+                mock_pa.return_value = args
+                _main_impl(run_state={})
+        assert exc_info.value.code == 0
+        mock_resolve.assert_called_once()
+        assert mock_fn.call_args[0][0] == "dv_resolved"
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    @patch("cja_auto_sdr.generator.describe_dataview")
+    def test_name_no_match_exits_one(self, mock_fn, mock_resolve, capsys):
+        """A name with no matches should exit 1 with an error."""
+        mock_resolve.return_value = ([], {})
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--describe-dataview", "Nonexistent View"])
+                mock_pa.return_value = args
+                _main_impl(run_state={})
+        assert exc_info.value.code == 1
+        mock_fn.assert_not_called()
+        captured = capsys.readouterr()
+        assert "Could not resolve data view" in captured.err
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.prompt_for_selection")
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    @patch("cja_auto_sdr.generator.describe_dataview")
+    def test_ambiguous_name_interactive_select(self, mock_fn, mock_resolve, mock_prompt):
+        """An ambiguous name in interactive mode should call prompt_for_selection."""
+        mock_resolve.return_value = (["dv_a", "dv_b"], {"Shared": ["dv_a", "dv_b"]})
+        mock_prompt.return_value = "dv_b"
+        mock_fn.return_value = True
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--describe-dataview", "Shared"])
+                mock_pa.return_value = args
+                _main_impl(run_state={})
+        assert exc_info.value.code == 0
+        mock_prompt.assert_called_once()
+        assert mock_fn.call_args[0][0] == "dv_b"
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.prompt_for_selection")
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    @patch("cja_auto_sdr.generator.describe_dataview")
+    def test_ambiguous_name_non_interactive_exits_one(self, mock_fn, mock_resolve, mock_prompt, capsys):
+        """An ambiguous name in non-interactive mode should exit 1 with disambiguation list."""
+        mock_resolve.return_value = (["dv_a", "dv_b"], {"Shared": ["dv_a", "dv_b"]})
+        mock_prompt.return_value = None  # non-interactive
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--describe-dataview", "Shared"])
+                mock_pa.return_value = args
+                _main_impl(run_state={})
+        assert exc_info.value.code == 1
+        mock_fn.assert_not_called()
+        captured = capsys.readouterr()
+        assert "ambiguous" in captured.err.lower()
+        assert "dv_a" in captured.err
+        assert "dv_b" in captured.err
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    @patch("cja_auto_sdr.generator.describe_dataview")
+    def test_name_match_option_forwarded(self, mock_fn, mock_resolve):
+        """--name-match should be forwarded to resolve_data_view_names as match_mode."""
+        mock_resolve.return_value = (["dv_found"], {"View": ["dv_found"]})
+        mock_fn.return_value = True
+        with pytest.raises(SystemExit):
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--describe-dataview", "View", "--name-match", "fuzzy"])
+                mock_pa.return_value = args
+                _main_impl(run_state={})
+        assert mock_resolve.call_args[1]["match_mode"] == "fuzzy"
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    @patch("cja_auto_sdr.generator.list_metrics")
+    def test_list_metrics_name_resolution(self, mock_fn, mock_resolve):
+        """--list-metrics should resolve names to IDs."""
+        mock_resolve.return_value = (["dv_m1"], {"Metrics View": ["dv_m1"]})
+        mock_fn.return_value = True
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--list-metrics", "Metrics View"])
+                mock_pa.return_value = args
+                _main_impl(run_state={})
+        assert exc_info.value.code == 0
+        assert mock_fn.call_args[0][0] == "dv_m1"
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    @patch("cja_auto_sdr.generator.list_dimensions")
+    def test_list_dimensions_name_resolution(self, mock_fn, mock_resolve):
+        """--list-dimensions should resolve names to IDs."""
+        mock_resolve.return_value = (["dv_d1"], {"Dims View": ["dv_d1"]})
+        mock_fn.return_value = True
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--list-dimensions", "Dims View"])
+                mock_pa.return_value = args
+                _main_impl(run_state={})
+        assert exc_info.value.code == 0
+        assert mock_fn.call_args[0][0] == "dv_d1"
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    @patch("cja_auto_sdr.generator.list_segments")
+    def test_list_segments_name_resolution(self, mock_fn, mock_resolve):
+        """--list-segments should resolve names to IDs."""
+        mock_resolve.return_value = (["dv_s1"], {"Segs View": ["dv_s1"]})
+        mock_fn.return_value = True
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--list-segments", "Segs View"])
+                mock_pa.return_value = args
+                _main_impl(run_state={})
+        assert exc_info.value.code == 0
+        assert mock_fn.call_args[0][0] == "dv_s1"
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    @patch("cja_auto_sdr.generator.list_calculated_metrics")
+    def test_list_calculated_metrics_name_resolution(self, mock_fn, mock_resolve):
+        """--list-calculated-metrics should resolve names to IDs."""
+        mock_resolve.return_value = (["dv_cm1"], {"Calc View": ["dv_cm1"]})
+        mock_fn.return_value = True
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--list-calculated-metrics", "Calc View"])
+                mock_pa.return_value = args
+                _main_impl(run_state={})
+        assert exc_info.value.code == 0
+        assert mock_fn.call_args[0][0] == "dv_cm1"
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    @patch("cja_auto_sdr.generator.list_metrics")
+    def test_id_passthrough_list_metrics(self, mock_fn, mock_resolve):
+        """--list-metrics with a dv_ ID should skip resolution."""
+        mock_fn.return_value = True
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--list-metrics", "dv_456"])
+                mock_pa.return_value = args
+                _main_impl(run_state={})
+        assert exc_info.value.code == 0
+        mock_resolve.assert_not_called()
+        assert mock_fn.call_args[0][0] == "dv_456"

--- a/tests/test_cli_command_handlers.py
+++ b/tests/test_cli_command_handlers.py
@@ -2366,8 +2366,12 @@ class TestDiscoveryInspectionNameResolution:
     @patch("cja_auto_sdr.generator.resolve_data_view_names")
     @patch("cja_auto_sdr.generator.list_metrics")
     def test_list_metrics_name_resolution(self, mock_fn, mock_resolve):
-        """--list-metrics should resolve names to IDs."""
-        mock_resolve.return_value = (["dv_m1"], {"Metrics View": ["dv_m1"]})
+        """--list-metrics should forward the canonical resolved data view name."""
+        mock_resolve.return_value = (
+            ["dv_m1"],
+            {"Metrics View": ["dv_m1"]},
+            NameResolutionDiagnostics(resolved_name_by_id={"dv_m1": "Metrics Canonical"}),
+        )
         mock_fn.return_value = True
         with pytest.raises(SystemExit) as exc_info:
             with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
@@ -2376,14 +2380,18 @@ class TestDiscoveryInspectionNameResolution:
                 _main_impl(run_state={})
         assert exc_info.value.code == 0
         assert mock_fn.call_args[0][0] == "dv_m1"
-        assert mock_fn.call_args[1]["data_view_name"] == "Metrics View"
+        assert mock_fn.call_args[1]["data_view_name"] == "Metrics Canonical"
 
     @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
     @patch("cja_auto_sdr.generator.resolve_data_view_names")
     @patch("cja_auto_sdr.generator.list_dimensions")
     def test_list_dimensions_name_resolution(self, mock_fn, mock_resolve):
-        """--list-dimensions should resolve names to IDs."""
-        mock_resolve.return_value = (["dv_d1"], {"Dims View": ["dv_d1"]})
+        """--list-dimensions should forward the canonical resolved data view name."""
+        mock_resolve.return_value = (
+            ["dv_d1"],
+            {"Dims View": ["dv_d1"]},
+            NameResolutionDiagnostics(resolved_name_by_id={"dv_d1": "Dimensions Canonical"}),
+        )
         mock_fn.return_value = True
         with pytest.raises(SystemExit) as exc_info:
             with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
@@ -2392,14 +2400,18 @@ class TestDiscoveryInspectionNameResolution:
                 _main_impl(run_state={})
         assert exc_info.value.code == 0
         assert mock_fn.call_args[0][0] == "dv_d1"
-        assert mock_fn.call_args[1]["data_view_name"] == "Dims View"
+        assert mock_fn.call_args[1]["data_view_name"] == "Dimensions Canonical"
 
     @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
     @patch("cja_auto_sdr.generator.resolve_data_view_names")
     @patch("cja_auto_sdr.generator.list_segments")
     def test_list_segments_name_resolution(self, mock_fn, mock_resolve):
-        """--list-segments should resolve names to IDs."""
-        mock_resolve.return_value = (["dv_s1"], {"Segs View": ["dv_s1"]})
+        """--list-segments should forward the canonical resolved data view name."""
+        mock_resolve.return_value = (
+            ["dv_s1"],
+            {"Segs View": ["dv_s1"]},
+            NameResolutionDiagnostics(resolved_name_by_id={"dv_s1": "Segments Canonical"}),
+        )
         mock_fn.return_value = True
         with pytest.raises(SystemExit) as exc_info:
             with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
@@ -2408,14 +2420,18 @@ class TestDiscoveryInspectionNameResolution:
                 _main_impl(run_state={})
         assert exc_info.value.code == 0
         assert mock_fn.call_args[0][0] == "dv_s1"
-        assert mock_fn.call_args[1]["data_view_name"] == "Segs View"
+        assert mock_fn.call_args[1]["data_view_name"] == "Segments Canonical"
 
     @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
     @patch("cja_auto_sdr.generator.resolve_data_view_names")
     @patch("cja_auto_sdr.generator.list_calculated_metrics")
     def test_list_calculated_metrics_name_resolution(self, mock_fn, mock_resolve):
-        """--list-calculated-metrics should resolve names to IDs."""
-        mock_resolve.return_value = (["dv_cm1"], {"Calc View": ["dv_cm1"]})
+        """--list-calculated-metrics should forward the canonical resolved data view name."""
+        mock_resolve.return_value = (
+            ["dv_cm1"],
+            {"Calc View": ["dv_cm1"]},
+            NameResolutionDiagnostics(resolved_name_by_id={"dv_cm1": "Calculated Canonical"}),
+        )
         mock_fn.return_value = True
         with pytest.raises(SystemExit) as exc_info:
             with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
@@ -2424,7 +2440,43 @@ class TestDiscoveryInspectionNameResolution:
                 _main_impl(run_state={})
         assert exc_info.value.code == 0
         assert mock_fn.call_args[0][0] == "dv_cm1"
-        assert mock_fn.call_args[1]["data_view_name"] == "Calc View"
+        assert mock_fn.call_args[1]["data_view_name"] == "Calculated Canonical"
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    @patch("cja_auto_sdr.generator.list_metrics")
+    def test_list_metrics_name_resolution_legacy_tuple_omits_preferred_name(self, mock_fn, mock_resolve):
+        """Legacy resolver tuples should not inject raw query text as data_view_name."""
+        mock_resolve.return_value = (["dv_m1"], {"Prod Web": ["dv_m1"]})
+        mock_fn.return_value = True
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--list-metrics", "Prod Web", "--name-match", "fuzzy"])
+                mock_pa.return_value = args
+                _main_impl(run_state={})
+        assert exc_info.value.code == 0
+        assert mock_fn.call_args[0][0] == "dv_m1"
+        assert "data_view_name" not in mock_fn.call_args[1]
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    @patch("cja_auto_sdr.generator.list_metrics")
+    def test_list_metrics_name_resolution_fuzzy_uses_canonical_name(self, mock_fn, mock_resolve):
+        """Fuzzy inspection name matches should use canonical names in downstream output."""
+        mock_resolve.return_value = (
+            ["dv_prod_web"],
+            {"Prod Web": ["dv_prod_web"]},
+            NameResolutionDiagnostics(resolved_name_by_id={"dv_prod_web": "Production Web"}),
+        )
+        mock_fn.return_value = True
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--list-metrics", "Prod Web", "--name-match", "fuzzy"])
+                mock_pa.return_value = args
+                _main_impl(run_state={})
+        assert exc_info.value.code == 0
+        assert mock_fn.call_args[0][0] == "dv_prod_web"
+        assert mock_fn.call_args[1]["data_view_name"] == "Production Web"
 
     @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
     @patch("cja_auto_sdr.generator.resolve_data_view_names")

--- a/tests/test_cli_command_handlers.py
+++ b/tests/test_cli_command_handlers.py
@@ -1869,3 +1869,131 @@ class TestMainImplDiffLabels:
         # Labels should have been parsed as a tuple and passed through
         mock_diff.assert_called_once()
         assert mock_diff.call_args[1]["labels"] == ("Before", "After")
+
+
+# ==================== _main_impl: ID-bearing discovery inspection dispatch ====================
+
+
+class TestDiscoveryInspectionDispatch:
+    """Tests for dispatch of new ID-bearing discovery commands."""
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.describe_dataview")
+    def test_describe_dataview_dispatch(self, mock_fn):
+        mock_fn.return_value = True
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--describe-dataview", "dv_1"])
+                mock_pa.return_value = args
+                _main_impl(run_state={})
+        assert exc_info.value.code == 0
+        mock_fn.assert_called_once()
+        assert mock_fn.call_args[0][0] == "dv_1"
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.list_metrics")
+    def test_list_metrics_dispatch(self, mock_fn):
+        mock_fn.return_value = True
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--list-metrics", "dv_1"])
+                mock_pa.return_value = args
+                _main_impl(run_state={})
+        assert exc_info.value.code == 0
+        mock_fn.assert_called_once()
+        assert mock_fn.call_args[0][0] == "dv_1"
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.list_dimensions")
+    def test_list_dimensions_dispatch(self, mock_fn):
+        mock_fn.return_value = True
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--list-dimensions", "dv_1"])
+                mock_pa.return_value = args
+                _main_impl(run_state={})
+        assert exc_info.value.code == 0
+        mock_fn.assert_called_once()
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.list_segments")
+    def test_list_segments_dispatch(self, mock_fn):
+        mock_fn.return_value = True
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--list-segments", "dv_1"])
+                mock_pa.return_value = args
+                _main_impl(run_state={})
+        assert exc_info.value.code == 0
+        mock_fn.assert_called_once()
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.list_calculated_metrics")
+    def test_list_calculated_metrics_dispatch(self, mock_fn):
+        mock_fn.return_value = True
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--list-calculated-metrics", "dv_1"])
+                mock_pa.return_value = args
+                _main_impl(run_state={})
+        assert exc_info.value.code == 0
+        mock_fn.assert_called_once()
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.describe_dataview")
+    def test_describe_dataview_stdout_forces_json(self, mock_fn):
+        """When output is stdout, format should default to json."""
+        mock_fn.return_value = True
+        run_state = {}
+        with pytest.raises(SystemExit):
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--describe-dataview", "dv_1", "--output", "-"])
+                mock_pa.return_value = args
+                _main_impl(run_state=run_state)
+        assert run_state["output_format"] == "json"
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.list_metrics")
+    def test_list_metrics_csv_format_preserved(self, mock_fn):
+        """Explicit csv format should be preserved for ID-bearing discovery commands."""
+        mock_fn.return_value = True
+        run_state = {}
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--list-metrics", "dv_1", "--format", "csv"])
+                mock_pa.return_value = args
+                _main_impl(run_state=run_state)
+        assert exc_info.value.code == 0
+        assert run_state["output_format"] == "csv"
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.list_dimensions")
+    def test_list_dimensions_failure_exits_one(self, mock_fn):
+        """When the command function returns False, should exit 1."""
+        mock_fn.return_value = False
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--list-dimensions", "dv_1"])
+                mock_pa.return_value = args
+                _main_impl()
+        assert exc_info.value.code == 1
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.list_segments")
+    def test_list_segments_passes_filter_and_sort(self, mock_fn):
+        """Filter and sort options should be forwarded to the command function."""
+        mock_fn.return_value = True
+        with pytest.raises(SystemExit):
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments([
+                    "--list-segments", "dv_1",
+                    "--filter", "active.*",
+                    "--sort", "name",
+                    "--limit", "10",
+                ])
+                mock_pa.return_value = args
+                _main_impl()
+        call_kwargs = mock_fn.call_args
+        assert call_kwargs[1]["filter_pattern"] == "active.*"
+        assert call_kwargs[1]["sort_expression"] == "name"
+        assert call_kwargs[1]["limit"] == 10

--- a/tests/test_cli_command_handlers.py
+++ b/tests/test_cli_command_handlers.py
@@ -23,6 +23,7 @@ from cja_auto_sdr.core.exceptions import APIError, CJASDRError
 from cja_auto_sdr.generator import (
     DiffConfig,
     DiffSnapshotConfig,
+    NameResolutionDiagnostics,
     _main_impl,
     handle_diff_command,
     handle_diff_snapshot_command,
@@ -2084,6 +2085,156 @@ class TestDiscoveryInspectionNameResolution:
         captured = capsys.readouterr()
         assert "Could not resolve data view" in captured.err
 
+    @pytest.mark.parametrize(
+        "argv",
+        [
+            ["--describe-dataview", "Nonexistent View", "--format", "json"],
+            ["--describe-dataview", "Nonexistent View", "--format", "csv"],
+            ["--describe-dataview", "Nonexistent View", "--output", "-"],
+        ],
+    )
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    @patch("cja_auto_sdr.generator.describe_dataview")
+    def test_name_no_match_machine_readable_emits_structured_error(self, mock_fn, mock_resolve, capsys, argv):
+        """Machine-readable inspection modes should emit a structured JSON error for unresolved names."""
+        mock_resolve.return_value = ([], {})
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                mock_pa.return_value = parse_arguments(argv)
+                _main_impl(run_state={})
+        assert exc_info.value.code == 1
+        mock_fn.assert_not_called()
+        payload = json.loads(capsys.readouterr().err)
+        assert payload["error_type"] == "not_found"
+        assert "Could not resolve data view" in payload["error"]
+        assert "--list-dataviews" in payload["error"]
+
+    @pytest.mark.parametrize(
+        "argv",
+        [
+            ["--describe-dataview", "Broken View", "--format", "json"],
+            ["--describe-dataview", "Broken View", "--format", "csv"],
+            ["--describe-dataview", "Broken View", "--output", "-"],
+        ],
+    )
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    @patch("cja_auto_sdr.generator.describe_dataview")
+    def test_machine_readable_resolution_setup_failure_reports_configuration_error(
+        self,
+        mock_fn,
+        mock_resolve,
+        capsys,
+        argv,
+    ):
+        """Setup/configuration failures should not be mislabeled as not_found."""
+
+        def _mock_resolver(_identifiers, _config_file, logger, **_kwargs):
+            setattr(
+                logger,
+                "_name_resolution_diagnostics",
+                NameResolutionDiagnostics(
+                    error_type="configuration_error",
+                    error_message="Failed to configure credentials: Missing credentials",
+                ),
+            )
+            return [], {}
+
+        mock_resolve.side_effect = _mock_resolver
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                mock_pa.return_value = parse_arguments(argv)
+                _main_impl(run_state={})
+
+        assert exc_info.value.code == 1
+        mock_fn.assert_not_called()
+        payload = json.loads(capsys.readouterr().err)
+        assert payload["error_type"] == "configuration_error"
+        assert "Failed to configure credentials" in payload["error"]
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    @patch("cja_auto_sdr.generator.describe_dataview")
+    def test_machine_readable_resolution_connectivity_failure_reports_connectivity_error(
+        self,
+        mock_fn,
+        mock_resolve,
+        capsys,
+    ):
+        """Connectivity/API failures should surface as connectivity_error."""
+
+        def _mock_resolver(_identifiers, _config_file, logger, **_kwargs):
+            setattr(
+                logger,
+                "_name_resolution_diagnostics",
+                NameResolutionDiagnostics(
+                    error_type="connectivity_error",
+                    error_message="Failed to resolve data view names: network timeout",
+                ),
+            )
+            return [], {}
+
+        mock_resolve.side_effect = _mock_resolver
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                mock_pa.return_value = parse_arguments(["--describe-dataview", "Timeout View", "--format", "json"])
+                _main_impl(run_state={})
+
+        assert exc_info.value.code == 1
+        mock_fn.assert_not_called()
+        payload = json.loads(capsys.readouterr().err)
+        assert payload["error_type"] == "connectivity_error"
+        assert "network timeout" in payload["error"]
+
+    @pytest.mark.parametrize(
+        "argv",
+        [
+            ["--describe-dataview", "Noisy View", "--format", "json"],
+            ["--describe-dataview", "Noisy View", "--format", "csv"],
+            ["--describe-dataview", "Noisy View", "--output", "-"],
+        ],
+    )
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    @patch("cja_auto_sdr.generator.describe_dataview")
+    def test_machine_readable_resolution_logs_do_not_pollute_json_error(
+        self,
+        mock_fn,
+        mock_resolve,
+        capsys,
+        argv,
+    ):
+        """Resolver logger output must not precede machine-readable JSON errors."""
+
+        def _mock_resolver(_identifiers, _config_file, logger, **_kwargs):
+            logger.error("resolver plain log line")
+            setattr(
+                logger,
+                "_name_resolution_diagnostics",
+                NameResolutionDiagnostics(
+                    error_type="configuration_error",
+                    error_message="Failed to configure credentials: bad profile",
+                ),
+            )
+            return [], {}
+
+        mock_resolve.side_effect = _mock_resolver
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                mock_pa.return_value = parse_arguments(argv)
+                _main_impl(run_state={})
+
+        assert exc_info.value.code == 1
+        mock_fn.assert_not_called()
+        stderr_output = capsys.readouterr().err
+        payload = json.loads(stderr_output)
+        assert payload["error_type"] == "configuration_error"
+        assert "resolver plain log line" not in stderr_output
+
     @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
     @patch("cja_auto_sdr.generator.prompt_for_selection")
     @patch("cja_auto_sdr.generator.resolve_data_view_names")
@@ -2121,6 +2272,41 @@ class TestDiscoveryInspectionNameResolution:
         assert "ambiguous" in captured.err.lower()
         assert "dv_a" in captured.err
         assert "dv_b" in captured.err
+
+    @pytest.mark.parametrize(
+        "argv",
+        [
+            ["--describe-dataview", "Shared", "--format", "json"],
+            ["--describe-dataview", "Shared", "--format", "csv"],
+            ["--describe-dataview", "Shared", "--output", "-"],
+        ],
+    )
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.prompt_for_selection")
+    @patch("cja_auto_sdr.generator.resolve_data_view_names")
+    @patch("cja_auto_sdr.generator.describe_dataview")
+    def test_ambiguous_name_machine_readable_emits_structured_error(
+        self,
+        mock_fn,
+        mock_resolve,
+        mock_prompt,
+        capsys,
+        argv,
+    ):
+        """Machine-readable inspection modes should fail with structured ambiguity details."""
+        mock_resolve.return_value = (["dv_a", "dv_b"], {"Shared": ["dv_a", "dv_b"]})
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                mock_pa.return_value = parse_arguments(argv)
+                _main_impl(run_state={})
+        assert exc_info.value.code == 1
+        mock_fn.assert_not_called()
+        mock_prompt.assert_not_called()
+        payload = json.loads(capsys.readouterr().err)
+        assert payload["error_type"] == "ambiguous_name"
+        assert payload["data_view_name"] == "Shared"
+        assert payload["matches"] == ["dv_a", "dv_b"]
+        assert "Specify an exact data view ID" in payload["error"]
 
     @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
     @patch("cja_auto_sdr.generator.resolve_data_view_names")

--- a/tests/test_cli_command_handlers.py
+++ b/tests/test_cli_command_handlers.py
@@ -1653,6 +1653,25 @@ class TestMainImplListSnapshots:
         emitted = mock_emit.call_args[0][0]
         assert "No snapshots found" in emitted
 
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.SnapshotManager")
+    def test_list_snapshots_json_output_contract_error_is_controlled(self, mock_sm_cls, capsys):
+        """Non-finite JSON values should fail with a structured output_contract error."""
+        mock_sm = MagicMock()
+        mock_sm.list_snapshots.return_value = [{"data_view_id": "dv_nan", "metrics_count": float("nan")}]
+        mock_sm_cls.return_value = mock_sm
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                mock_pa.return_value = parse_arguments(["--list-snapshots", "--format", "json"])
+                _main_impl()
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        payload = json.loads(captured.err)
+        assert payload["error_type"] == "output_contract"
+        assert "Snapshot listing output contains non-JSON-compliant values" in payload["error"]
+
 
 # ==================== _main_impl: --show-only / --include-all-inventory ====================
 
@@ -1845,6 +1864,30 @@ class TestMainImplPruneSnapshots:
         assert exc_info.value.code == 0
         # Should have pruned for dv_prune only
         mock_sm.apply_retention_policy.assert_called_once()
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.resolve_auto_prune_retention")
+    @patch("cja_auto_sdr.generator.SnapshotManager")
+    def test_prune_json_output_contract_error_is_controlled(self, mock_sm_cls, mock_retention, capsys):
+        """Non-finite JSON values should fail with a structured output_contract error."""
+        mock_retention.return_value = (1, None)
+
+        mock_sm = MagicMock()
+        mock_sm.list_snapshots.return_value = [{"data_view_id": "dv_test", "filepath": "/snap1.json"}]
+        mock_sm.apply_retention_policy.return_value = [float("nan")]
+        mock_sm_cls.return_value = mock_sm
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--prune-snapshots", "--keep-last", "1", "--format", "json"])
+                mock_pa.return_value = args
+                _main_impl()
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        payload = json.loads(captured.err)
+        assert payload["error_type"] == "output_contract"
+        assert "Snapshot prune output contains non-JSON-compliant values" in payload["error"]
 
 
 # ==================== _main_impl: --diff-labels ====================

--- a/tests/test_cli_command_handlers.py
+++ b/tests/test_cli_command_handlers.py
@@ -2130,16 +2130,15 @@ class TestDiscoveryInspectionNameResolution:
     ):
         """Setup/configuration failures should not be mislabeled as not_found."""
 
-        def _mock_resolver(_identifiers, _config_file, logger, **_kwargs):
-            setattr(
-                logger,
-                "_name_resolution_diagnostics",
+        def _mock_resolver(_identifiers, _config_file, _logger, **_kwargs):
+            return (
+                [],
+                {},
                 NameResolutionDiagnostics(
                     error_type="configuration_error",
                     error_message="Failed to configure credentials: Missing credentials",
                 ),
             )
-            return [], {}
 
         mock_resolve.side_effect = _mock_resolver
 
@@ -2165,16 +2164,15 @@ class TestDiscoveryInspectionNameResolution:
     ):
         """Connectivity/API failures should surface as connectivity_error."""
 
-        def _mock_resolver(_identifiers, _config_file, logger, **_kwargs):
-            setattr(
-                logger,
-                "_name_resolution_diagnostics",
+        def _mock_resolver(_identifiers, _config_file, _logger, **_kwargs):
+            return (
+                [],
+                {},
                 NameResolutionDiagnostics(
                     error_type="connectivity_error",
                     error_message="Failed to resolve data view names: network timeout",
                 ),
             )
-            return [], {}
 
         mock_resolve.side_effect = _mock_resolver
 
@@ -2211,15 +2209,14 @@ class TestDiscoveryInspectionNameResolution:
 
         def _mock_resolver(_identifiers, _config_file, logger, **_kwargs):
             logger.error("resolver plain log line")
-            setattr(
-                logger,
-                "_name_resolution_diagnostics",
+            return (
+                [],
+                {},
                 NameResolutionDiagnostics(
                     error_type="configuration_error",
                     error_message="Failed to configure credentials: bad profile",
                 ),
             )
-            return [], {}
 
         mock_resolve.side_effect = _mock_resolver
 
@@ -2556,11 +2553,11 @@ class TestDiscoveryInspectionLimitDispatch:
 
 
 class TestDescribeDataviewIgnoresFilterSortLimit:
-    """Tests that describe_dataview silently ignores filter/sort/limit kwargs."""
+    """Tests that describe_dataview ignores filter/sort/limit kwargs with a warning."""
 
     @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
     @patch("cja_auto_sdr.generator.describe_dataview")
-    def test_filter_sort_limit_do_not_cause_error(self, mock_fn):
+    def test_filter_sort_limit_do_not_cause_error(self, mock_fn, capsys):
         """--filter, --sort, --limit with --describe-dataview should not error."""
         mock_fn.return_value = True
         with pytest.raises(SystemExit) as exc_info:
@@ -2572,6 +2569,34 @@ class TestDescribeDataviewIgnoresFilterSortLimit:
                 _main_impl(run_state={})
         assert exc_info.value.code == 0
         mock_fn.assert_called_once()
+        assert "--filter, --sort, --limit options are ignored with --describe-dataview" in capsys.readouterr().err
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.describe_dataview")
+    def test_filter_sort_limit_warning_suppressed_for_machine_readable_mode(self, mock_fn, capsys):
+        """Machine-readable describe mode should avoid warning text on stderr."""
+        mock_fn.return_value = True
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(
+                    [
+                        "--describe-dataview",
+                        "dv_1",
+                        "--format",
+                        "json",
+                        "--filter",
+                        "something",
+                        "--sort",
+                        "name",
+                        "--limit",
+                        "10",
+                    ]
+                )
+                mock_pa.return_value = args
+                _main_impl(run_state={})
+        assert exc_info.value.code == 0
+        mock_fn.assert_called_once()
+        assert "ignored with --describe-dataview" not in capsys.readouterr().err
 
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")

--- a/tests/test_cli_command_handlers.py
+++ b/tests/test_cli_command_handlers.py
@@ -1985,12 +1985,18 @@ class TestDiscoveryInspectionDispatch:
         mock_fn.return_value = True
         with pytest.raises(SystemExit):
             with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
-                args = parse_arguments([
-                    "--list-segments", "dv_1",
-                    "--filter", "active.*",
-                    "--sort", "name",
-                    "--limit", "10",
-                ])
+                args = parse_arguments(
+                    [
+                        "--list-segments",
+                        "dv_1",
+                        "--filter",
+                        "active.*",
+                        "--sort",
+                        "name",
+                        "--limit",
+                        "10",
+                    ]
+                )
                 mock_pa.return_value = args
                 _main_impl()
         call_kwargs = mock_fn.call_args

--- a/tests/test_cli_command_handlers.py
+++ b/tests/test_cli_command_handlers.py
@@ -2333,6 +2333,7 @@ class TestDiscoveryInspectionNameResolution:
                 _main_impl(run_state={})
         assert exc_info.value.code == 0
         assert mock_fn.call_args[0][0] == "dv_m1"
+        assert mock_fn.call_args[1]["data_view_name"] == "Metrics View"
 
     @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
     @patch("cja_auto_sdr.generator.resolve_data_view_names")
@@ -2348,6 +2349,7 @@ class TestDiscoveryInspectionNameResolution:
                 _main_impl(run_state={})
         assert exc_info.value.code == 0
         assert mock_fn.call_args[0][0] == "dv_d1"
+        assert mock_fn.call_args[1]["data_view_name"] == "Dims View"
 
     @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
     @patch("cja_auto_sdr.generator.resolve_data_view_names")
@@ -2363,6 +2365,7 @@ class TestDiscoveryInspectionNameResolution:
                 _main_impl(run_state={})
         assert exc_info.value.code == 0
         assert mock_fn.call_args[0][0] == "dv_s1"
+        assert mock_fn.call_args[1]["data_view_name"] == "Segs View"
 
     @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
     @patch("cja_auto_sdr.generator.resolve_data_view_names")
@@ -2378,6 +2381,7 @@ class TestDiscoveryInspectionNameResolution:
                 _main_impl(run_state={})
         assert exc_info.value.code == 0
         assert mock_fn.call_args[0][0] == "dv_cm1"
+        assert mock_fn.call_args[1]["data_view_name"] == "Calc View"
 
     @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
     @patch("cja_auto_sdr.generator.resolve_data_view_names")
@@ -2393,6 +2397,7 @@ class TestDiscoveryInspectionNameResolution:
         assert exc_info.value.code == 0
         mock_resolve.assert_not_called()
         assert mock_fn.call_args[0][0] == "dv_456"
+        assert "data_view_name" not in mock_fn.call_args[1]
 
     @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
     @patch("cja_auto_sdr.generator.resolve_data_view_names")
@@ -2598,30 +2603,16 @@ class TestDescribeDataviewIgnoresFilterSortLimit:
         mock_fn.assert_called_once()
         assert "ignored with --describe-dataview" not in capsys.readouterr().err
 
-    @patch("cja_auto_sdr.generator.cjapy")
-    @patch("cja_auto_sdr.generator.configure_cjapy")
-    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
-    def test_describe_dataview_kwargs_absorbed(self, mock_profile, mock_configure, mock_cjapy):
-        """describe_dataview() should accept and ignore unexpected kwargs via **_kwargs."""
+    def test_describe_dataview_rejects_unexpected_kwargs(self):
+        """describe_dataview() should fail fast on unsupported kwargs."""
         from cja_auto_sdr.generator import describe_dataview
 
-        mock_configure.return_value = (True, "config", None)
-        cja = mock_cjapy.CJA.return_value
-        cja.getDataView.return_value = {"id": "dv_1", "name": "Test", "owner": {"name": "Admin"}}
-        import pandas as pd
-
-        cja.getMetrics.return_value = pd.DataFrame([{"id": "m1"}])
-        cja.getDimensions.return_value = pd.DataFrame([{"id": "d1"}])
-        cja.getFilters.return_value = pd.DataFrame()
-        cja.getCalculatedMetrics.return_value = pd.DataFrame()
-
-        # These should be silently absorbed by **_kwargs
-        result = describe_dataview(
-            "dv_1",
-            output_format="json",
-            filter_pattern="anything",
-            exclude_pattern="something",
-            limit=10,
-            sort_expression="-name",
-        )
-        assert result is True
+        with pytest.raises(TypeError):
+            describe_dataview(
+                "dv_1",
+                output_format="json",
+                filter_pattern="anything",
+                exclude_pattern="something",
+                limit=10,
+                sort_expression="-name",
+            )

--- a/tests/test_cli_command_handlers.py
+++ b/tests/test_cli_command_handlers.py
@@ -1891,6 +1891,35 @@ class TestDiscoveryInspectionDispatch:
         assert mock_fn.call_args[0][0] == "dv_1"
 
     @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.describe_dataview")
+    def test_describe_dataview_sets_discovery_mode_in_run_state(self, mock_fn):
+        """ID-bearing discovery inspection commands should infer discovery mode."""
+        mock_fn.return_value = True
+        run_state = {}
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--describe-dataview", "dv_1"])
+                mock_pa.return_value = args
+                _main_impl(run_state=run_state)
+
+        assert exc_info.value.code == 0
+        assert run_state["mode"] == "discovery"
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.describe_dataview")
+    def test_describe_dataview_rejects_fail_on_quality(self, mock_fn, capsys):
+        """Discovery inspection commands should reject SDR-only --fail-on-quality."""
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                args = parse_arguments(["--describe-dataview", "dv_1", "--fail-on-quality", "HIGH"])
+                mock_pa.return_value = args
+                _main_impl(run_state={})
+
+        assert exc_info.value.code == 1
+        assert "--fail-on-quality is only supported in SDR generation mode" in capsys.readouterr().err
+        mock_fn.assert_not_called()
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
     @patch("cja_auto_sdr.generator.list_metrics")
     def test_list_metrics_dispatch(self, mock_fn):
         mock_fn.return_value = True

--- a/tests/test_config_and_resolution.py
+++ b/tests/test_config_and_resolution.py
@@ -390,6 +390,42 @@ class TestShowStats:
         assert result is True
         data = json.loads(capsys.readouterr().out)
         assert data["count"] == 1
+        mock_cja.getMetrics.assert_called_once_with("dv_test", inclType="hidden", full=True)
+        mock_cja.getDimensions.assert_called_once_with("dv_test", inclType="hidden", full=True)
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_json_format_counts_hidden_components(self, mock_config, mock_cjapy, capsys: pytest.CaptureFixture) -> None:
+        """show_stats should include hidden metrics/dimensions for parity with discovery commands."""
+        from cja_auto_sdr.generator import show_stats
+
+        mock_config.return_value = (True, "file", None)
+        mock_cja = MagicMock()
+        mock_cja.getDataView.return_value = {"name": "Test DV", "owner": {"name": "Alice"}, "description": ""}
+
+        def _get_metrics(_dv_id: str, **kwargs):
+            if kwargs.get("inclType") == "hidden" and kwargs.get("full") is True:
+                return pd.DataFrame({"id": ["m_visible", "m_hidden"]})
+            return pd.DataFrame({"id": ["m_visible"]})
+
+        def _get_dimensions(_dv_id: str, **kwargs):
+            if kwargs.get("inclType") == "hidden" and kwargs.get("full") is True:
+                return pd.DataFrame({"id": ["d_visible", "d_hidden"]})
+            return pd.DataFrame({"id": ["d_visible"]})
+
+        mock_cja.getMetrics.side_effect = _get_metrics
+        mock_cja.getDimensions.side_effect = _get_dimensions
+        mock_cjapy.CJA.return_value = mock_cja
+
+        result = show_stats(["dv_test"], output_format="json")
+        assert result is True
+        data = json.loads(capsys.readouterr().out)
+        assert data["stats"][0]["metrics"] == 2
+        assert data["stats"][0]["dimensions"] == 2
+        assert data["stats"][0]["total_components"] == 4
+        assert data["totals"]["metrics"] == 2
+        assert data["totals"]["dimensions"] == 2
+        assert data["totals"]["components"] == 4
 
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")
@@ -511,12 +547,12 @@ class TestShowStats:
                 raise RuntimeError("unexpected dv lookup failure")
             return {"name": "Healthy DV", "owner": {"name": "Alice"}, "description": "ok"}
 
-        def _get_metrics(dv_id: str):
+        def _get_metrics(dv_id: str, **_kwargs):
             if failure_stage == "getMetrics" and dv_id == "dv_bad":
                 raise RuntimeError("unexpected metrics failure")
             return pd.DataFrame({"id": ["m1"]})
 
-        def _get_dimensions(dv_id: str):
+        def _get_dimensions(dv_id: str, **_kwargs):
             if failure_stage == "getDimensions" and dv_id == "dv_bad":
                 raise RuntimeError("unexpected dimensions failure")
             return pd.DataFrame({"id": ["d1"]})

--- a/tests/test_discovery_component_consistency.py
+++ b/tests/test_discovery_component_consistency.py
@@ -1,0 +1,190 @@
+"""Consistency and contract tests for discovery component fetching/counting."""
+
+import io
+import json
+import logging
+from contextlib import redirect_stdout
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import cja_auto_sdr.generator as generator
+from cja_auto_sdr.generator import (
+    describe_dataview,
+    list_dimensions,
+    list_metrics,
+    run_dry_run,
+    show_stats,
+)
+
+
+@pytest.mark.parametrize(
+    ("fetch_spec", "method_name", "expected_args", "expected_kwargs"),
+    [
+        (
+            generator._METRICS_COMPONENT_FETCH_SPEC,
+            "getMetrics",
+            ("dv_test",),
+            {"inclType": "hidden", "full": True},
+        ),
+        (
+            generator._DIMENSIONS_COMPONENT_FETCH_SPEC,
+            "getDimensions",
+            ("dv_test",),
+            {"inclType": "hidden", "full": True},
+        ),
+        (
+            generator._SEGMENTS_COMPONENT_FETCH_SPEC,
+            "getFilters",
+            (),
+            {"dataIds": "dv_test", "full": True},
+        ),
+        (
+            generator._CALCULATED_METRICS_COMPONENT_FETCH_SPEC,
+            "getCalculatedMetrics",
+            (),
+            {"dataIds": "dv_test", "full": True},
+        ),
+    ],
+)
+def test_fetch_component_payload_honors_component_fetch_specs(
+    fetch_spec,
+    method_name,
+    expected_args,
+    expected_kwargs,
+):
+    """All component families should follow their declarative fetch-spec contract."""
+    cja = MagicMock()
+    expected_payload = [{"id": "row_1"}]
+    getattr(cja, method_name).return_value = expected_payload
+
+    payload = generator._fetch_component_payload(cja, "dv_test", fetch_spec)
+
+    assert payload == expected_payload
+    getattr(cja, method_name).assert_called_once_with(*expected_args, **expected_kwargs)
+
+
+@patch("cja_auto_sdr.generator.cjapy")
+@patch("cja_auto_sdr.generator.configure_cjapy")
+@patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+def test_hidden_component_counts_are_consistent_across_describe_list_and_stats(
+    _mock_profile,
+    mock_configure,
+    mock_cjapy,
+):
+    """describe/list/stats should all count hidden metrics/dimensions consistently."""
+    mock_configure.return_value = (True, "config", None)
+    cja = mock_cjapy.CJA.return_value
+    cja.getDataView.return_value = {
+        "id": "dv_1",
+        "name": "Parity View",
+        "owner": {"name": "Alice"},
+        "description": "Parity check",
+        "parentDataGroupId": "conn_1",
+        "created": "2025-01-01",
+        "modified": "2025-01-02",
+    }
+
+    def _get_metrics(_dv_id: str, **kwargs):
+        assert kwargs == {"inclType": "hidden", "full": True}
+        return [{"id": "m_visible"}, {"id": "m_hidden"}]
+
+    def _get_dimensions(_dv_id: str, **kwargs):
+        assert kwargs == {"inclType": "hidden", "full": True}
+        return [{"id": "d_visible"}, {"id": "d_hidden"}]
+
+    cja.getMetrics.side_effect = _get_metrics
+    cja.getDimensions.side_effect = _get_dimensions
+    cja.getFilters.return_value = []
+    cja.getCalculatedMetrics.return_value = []
+
+    describe_out = io.StringIO()
+    with redirect_stdout(describe_out):
+        assert describe_dataview("dv_1", output_format="json") is True
+    describe_payload = json.loads(describe_out.getvalue())
+
+    metrics_out = io.StringIO()
+    with redirect_stdout(metrics_out):
+        assert list_metrics("dv_1", output_format="json") is True
+    metrics_payload = json.loads(metrics_out.getvalue())
+
+    dimensions_out = io.StringIO()
+    with redirect_stdout(dimensions_out):
+        assert list_dimensions("dv_1", output_format="json") is True
+    dimensions_payload = json.loads(dimensions_out.getvalue())
+
+    stats_out = io.StringIO()
+    with redirect_stdout(stats_out):
+        assert show_stats(["dv_1"], output_format="json", output_file="-", quiet=True) is True
+    stats_payload = json.loads(stats_out.getvalue())
+
+    assert describe_payload["dataView"]["components"]["metrics"] == 2
+    assert describe_payload["dataView"]["components"]["dimensions"] == 2
+    assert metrics_payload["count"] == 2
+    assert dimensions_payload["count"] == 2
+    assert stats_payload["stats"][0]["metrics"] == 2
+    assert stats_payload["stats"][0]["dimensions"] == 2
+    assert stats_payload["stats"][0]["total_components"] == 4
+
+
+@patch("cja_auto_sdr.generator.cjapy")
+@patch("cja_auto_sdr.generator.configure_cjapy")
+def test_show_stats_error_shaped_component_payload_falls_back_to_error_row(
+    mock_configure,
+    mock_cjapy,
+):
+    """Error-shaped component payloads should not be treated as numeric counts."""
+    mock_configure.return_value = (True, "config", None)
+    cja = mock_cjapy.CJA.return_value
+    cja.getDataView.return_value = {"name": "Parity View", "owner": {"name": "Alice"}, "description": ""}
+    cja.getMetrics.return_value = {"statusCode": 500, "message": "timeout"}
+    cja.getDimensions.return_value = [{"id": "d_visible"}]
+
+    stats_out = io.StringIO()
+    with redirect_stdout(stats_out):
+        assert show_stats(["dv_1"], output_format="json", output_file="-", quiet=True) is True
+    payload = json.loads(stats_out.getvalue())
+
+    assert payload["count"] == 1
+    assert payload["stats"][0]["name"] == "ERROR"
+    assert payload["stats"][0]["metrics"] == 0
+    assert payload["stats"][0]["dimensions"] == 0
+    assert payload["totals"]["components"] == 0
+
+
+@patch("cja_auto_sdr.generator.validate_config_file", return_value=True)
+@patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "config", {}))
+@patch("cja_auto_sdr.generator.cjapy")
+@patch("cja_auto_sdr.generator.make_api_call_with_retry")
+def test_run_dry_run_uses_hidden_inclusive_component_fetch_contract(
+    mock_retry,
+    mock_cjapy,
+    _mock_configure,
+    _mock_validate_config,
+    capsys: pytest.CaptureFixture,
+):
+    """dry-run should fetch metrics/dimensions with hidden-inclusive args via shared contract."""
+    mock_cja = MagicMock()
+    mock_cjapy.CJA.return_value = mock_cja
+    mock_cja.getDataViews.return_value = []
+    mock_cja.getDataView.return_value = {"name": "DryRun View"}
+    mock_cja.getMetrics.return_value = [{"id": "m_visible"}, {"id": "m_hidden"}]
+    mock_cja.getDimensions.return_value = [{"id": "d_visible"}, {"id": "d_hidden"}]
+
+    observed_operations: list[str] = []
+
+    def _retry_passthrough(api_call, *args, **kwargs):
+        observed_operations.append(kwargs.get("operation_name", ""))
+        return api_call(*args)
+
+    mock_retry.side_effect = _retry_passthrough
+
+    logger = logging.getLogger("test_discovery_component_consistency_dry_run")
+    result = run_dry_run(["dv_1"], "config.json", logger)
+
+    assert result is True
+    assert "getMetrics(dv_1)" in observed_operations
+    assert "getDimensions(dv_1)" in observed_operations
+    mock_cja.getMetrics.assert_called_once_with("dv_1", inclType="hidden", full=True)
+    mock_cja.getDimensions.assert_called_once_with("dv_1", inclType="hidden", full=True)
+    assert "Components: 2 metrics, 2 dimensions" in capsys.readouterr().out

--- a/tests/test_discovery_formatters.py
+++ b/tests/test_discovery_formatters.py
@@ -1,6 +1,8 @@
 """Tests for shared discovery command formatting helpers."""
 
 import json
+import os
+from unittest.mock import patch
 
 import pytest
 
@@ -145,6 +147,47 @@ class TestFormatAsTable:
         items = [{"a": "1"}]
         result = _format_as_table("H:", items, ["a"])
         assert result.startswith("\n")
+
+    def test_long_last_column_wraps_to_terminal_width(self):
+        """Last column text wraps when table would exceed terminal width."""
+        long_desc = "word " * 60  # 300 chars
+        items = [{"id": "x", "desc": long_desc.strip()}]
+        with patch("cja_auto_sdr.generator.shutil.get_terminal_size", return_value=os.terminal_size((80, 24))):
+            result = _format_as_table("H:", items, ["id", "desc"], col_labels=["ID", "Description"])
+        data_lines = [line for line in result.split("\n") if line.strip()]
+        # Description should be split across multiple lines
+        assert len(data_lines) > 4  # header + labels + separator + multiple wrapped lines
+
+    def test_wrapping_preserves_continuation_indent(self):
+        """Continuation lines indent to align with the last column."""
+        long_desc = "word " * 40
+        items = [{"id": "abc", "desc": long_desc.strip()}]
+        with patch("cja_auto_sdr.generator.shutil.get_terminal_size", return_value=os.terminal_size((60, 24))):
+            result = _format_as_table("H:", items, ["id", "desc"], col_labels=["ID", "Desc"])
+        lines = result.split("\n")
+        # Find continuation lines (lines that start with spaces and contain "word")
+        data_start = next(i for i, line in enumerate(lines) if line.startswith("---")) + 1
+        data_lines = [line for line in lines[data_start:] if line.strip()]
+        if len(data_lines) > 1:
+            # Continuation lines should be indented to the last column position
+            first_word_pos = data_lines[0].index("word")
+            for cont_line in data_lines[1:]:
+                assert cont_line.startswith(" " * first_word_pos)
+
+    def test_no_wrapping_when_table_fits_terminal(self):
+        """Short values are not wrapped even with terminal constraint."""
+        items = [{"id": "x", "desc": "Short"}]
+        with patch("cja_auto_sdr.generator.shutil.get_terminal_size", return_value=os.terminal_size((200, 24))):
+            result = _format_as_table("H:", items, ["id", "desc"], col_labels=["ID", "Desc"])
+        data_lines = [line for line in result.split("\n") if "Short" in line]
+        assert len(data_lines) == 1  # no wrapping needed
+
+    def test_single_column_table_not_wrapped(self):
+        """Tables with a single column skip wrapping logic."""
+        items = [{"id": "a_long_value_that_exceeds_terminal"}]
+        with patch("cja_auto_sdr.generator.shutil.get_terminal_size", return_value=os.terminal_size((20, 24))):
+            result = _format_as_table("H:", items, ["id"])
+        assert "a_long_value_that_exceeds_terminal" in result
 
 
 # ==================== WorkerArgs ====================

--- a/tests/test_discovery_formatters.py
+++ b/tests/test_discovery_formatters.py
@@ -8,6 +8,7 @@ import pytest
 
 from cja_auto_sdr.core.constants import BANNER_WIDTH
 from cja_auto_sdr.generator import (
+    OutputContractError,
     WorkerArgs,
     _apply_discovery_filters_and_sort,
     _exit_error,
@@ -48,6 +49,11 @@ class TestFormatAsJson:
         payload = {"a": {"b": {"c": 1}}}
         result = _format_as_json(payload)
         assert json.loads(result)["a"]["b"]["c"] == 1
+
+    def test_non_finite_values_raise_output_contract_error(self):
+        """NaN/Infinity should fail strict JSON serialization."""
+        with pytest.raises(OutputContractError, match="non-JSON-compliant"):
+            _format_as_json({"count": float("nan")}, contract_label="Snapshot output")
 
 
 # ==================== _format_as_csv ====================

--- a/tests/test_discovery_normalization.py
+++ b/tests/test_discovery_normalization.py
@@ -1,0 +1,70 @@
+"""Tests for discovery normalization helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+from cja_auto_sdr.core.discovery_normalization import (
+    extract_owner_name,
+    extract_owner_name_from_record,
+    extract_tags,
+    is_missing_value,
+    normalize_display_text,
+    pick_first_present_text,
+)
+
+
+def test_is_missing_value_handles_pandas_scalars() -> None:
+    assert is_missing_value(None) is True
+    assert is_missing_value(float("nan")) is True
+    assert is_missing_value(pd.NA) is True
+
+
+def test_is_missing_value_handles_blank_and_null_like_strings() -> None:
+    assert is_missing_value("", treat_blank_string=True) is True
+    assert is_missing_value("   ", treat_blank_string=True) is True
+    assert is_missing_value(" NaN ", treat_null_like_strings=True) is True
+    assert is_missing_value("value", treat_blank_string=True, treat_null_like_strings=True) is False
+
+
+def test_normalize_display_text_treats_null_like_strings_as_missing() -> None:
+    assert normalize_display_text(pd.NA, default="N/A", treat_null_like_strings=True) == "N/A"
+    assert normalize_display_text(" nan ", default="N/A", treat_null_like_strings=True) == "N/A"
+    assert normalize_display_text("  Alice  ", default="N/A", treat_null_like_strings=True) == "Alice"
+
+
+def test_pick_first_present_text_skips_missing_candidates() -> None:
+    candidates: list[Any] = [pd.NA, float("nan"), "", "none", "Owner A"]
+    assert pick_first_present_text(candidates, default="N/A", treat_null_like_strings=True) == "Owner A"
+
+
+def test_extract_owner_name_falls_back_through_owner_fields() -> None:
+    owner = {"name": pd.NA, "fullName": " ", "email": "alias@example.com"}
+    assert extract_owner_name(owner) == "alias@example.com"
+
+
+def test_extract_owner_name_from_record_uses_alias_when_owner_missing_like() -> None:
+    record = {"owner": float("nan"), "ownerFullName": "Alias Owner"}
+    assert extract_owner_name_from_record(record) == "Alias Owner"
+
+
+def test_extract_tags_handles_mixed_and_missing_values() -> None:
+    raw_tags: list[Any] = [
+        {"name": "kpi"},
+        pd.NA,
+        float("nan"),
+        {"name": " nan "},
+        "finance",
+        "   ",
+    ]
+    assert extract_tags(raw_tags) == ["kpi", "finance"]
+
+
+def test_extract_tags_handles_scalar_missing_values() -> None:
+    assert extract_tags(float("nan")) == []
+    assert extract_tags(pd.NA) == []
+    assert extract_tags("nan") == []
+    assert extract_tags("prod") == ["prod"]
+

--- a/tests/test_discovery_normalization.py
+++ b/tests/test_discovery_normalization.py
@@ -67,4 +67,3 @@ def test_extract_tags_handles_scalar_missing_values() -> None:
     assert extract_tags(pd.NA) == []
     assert extract_tags("nan") == []
     assert extract_tags("prod") == ["prod"]
-

--- a/tests/test_discovery_payloads.py
+++ b/tests/test_discovery_payloads.py
@@ -63,3 +63,13 @@ def test_dataview_payload_error_shape_detected() -> None:
 def test_dataview_payload_with_identity_not_error() -> None:
     payload = {"id": "dv_1", "name": "Test View", "status": "active"}
     assert is_dataview_error_payload(payload) is False
+
+
+def test_dataview_payload_with_na_identity_values_is_treated_as_error() -> None:
+    payload = {"statusCode": 404, "message": "missing", "id": pd.NA, "name": pd.NA}
+    assert is_dataview_error_payload(payload) is True
+
+
+def test_dataview_payload_with_na_id_and_present_name_is_not_error() -> None:
+    payload = {"statusCode": 200, "message": "ok", "id": pd.NA, "name": "Test View"}
+    assert is_dataview_error_payload(payload) is False

--- a/tests/test_discovery_payloads.py
+++ b/tests/test_discovery_payloads.py
@@ -1,0 +1,65 @@
+"""Tests for discovery payload classification contracts."""
+
+import pandas as pd
+
+from cja_auto_sdr.core.discovery_payloads import (
+    PayloadKind,
+    assess_component_payload,
+    count_component_items_or_na,
+    is_dataview_error_payload,
+)
+
+
+def test_assess_component_empty_typed_dataframe_is_empty() -> None:
+    frame = pd.DataFrame(columns=["id", "name", "type"])
+    assessment = assess_component_payload(frame)
+    assert assessment.kind is PayloadKind.EMPTY
+    assert assessment.rows == []
+
+
+def test_assess_component_empty_error_dataframe_is_error() -> None:
+    frame = pd.DataFrame(columns=["statusCode", "message"])
+    assessment = assess_component_payload(frame)
+    assert assessment.kind is PayloadKind.ERROR
+
+
+def test_assess_component_sequence_payload_prefers_embedded_rows() -> None:
+    payload = {"statusCode": 200, "message": "ok", "data": []}
+    assessment = assess_component_payload(payload)
+    assert assessment.kind is PayloadKind.EMPTY
+    assert assessment.rows == []
+
+
+def test_assess_component_explicit_error_wins_over_envelope_rows() -> None:
+    payload = {"errorCode": "forbidden", "data": []}
+    assessment = assess_component_payload(payload)
+    assert assessment.kind is PayloadKind.ERROR
+
+
+def test_assess_component_regular_rows_are_data() -> None:
+    payload = [
+        {"id": "metrics/revenue", "name": "Revenue", "type": "currency"},
+        {"id": "metrics/pageviews", "name": "Page Views", "type": "decimal"},
+    ]
+    assessment = assess_component_payload(payload)
+    assert assessment.kind is PayloadKind.DATA
+    assert len(assessment.rows) == 2
+
+
+def test_count_component_items_or_na_for_empty_typed_dataframe() -> None:
+    frame = pd.DataFrame(columns=["id", "name", "type"])
+    assert count_component_items_or_na(frame) == 0
+
+
+def test_count_component_items_or_na_for_error_payload() -> None:
+    payload = {"statusCode": 500, "message": "backend timeout"}
+    assert count_component_items_or_na(payload) == "N/A"
+
+
+def test_dataview_payload_error_shape_detected() -> None:
+    assert is_dataview_error_payload({"statusCode": 404, "errorCode": "not_found"}) is True
+
+
+def test_dataview_payload_with_identity_not_error() -> None:
+    payload = {"id": "dv_1", "name": "Test View", "status": "active"}
+    assert is_dataview_error_payload(payload) is False

--- a/tests/test_name_resolution.py
+++ b/tests/test_name_resolution.py
@@ -10,7 +10,7 @@ import pytest
 
 # Import the functions we're testing
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from cja_auto_sdr.generator import _data_view_cache, is_data_view_id, resolve_data_view_names
+from cja_auto_sdr.generator import NameResolutionDiagnostics, _data_view_cache, is_data_view_id, resolve_data_view_names
 
 
 class TestDataViewIDDetection:
@@ -344,6 +344,49 @@ class TestDataViewNameResolution:
 
         assert ids == ["dv_prod123"]
         assert name_map == {"Production Analytic": ["dv_prod123"]}
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    def test_resolve_include_diagnostics_exposes_canonical_name_map(self, mock_cjapy):
+        """Diagnostics should expose canonical names keyed by resolved data view ID."""
+        mock_cja_instance = MagicMock()
+        mock_cja_instance.getDataViews.return_value = self.mock_dataviews
+        mock_cjapy.CJA.return_value = mock_cja_instance
+        mock_cjapy.importConfigFile.return_value = None
+
+        ids, name_map, diagnostics = resolve_data_view_names(
+            ["production analytics"],
+            "config.json",
+            self.logger,
+            match_mode="insensitive",
+            include_diagnostics=True,
+        )
+
+        assert ids == ["dv_prod123"]
+        assert name_map == {"production analytics": ["dv_prod123"]}
+        assert isinstance(diagnostics, NameResolutionDiagnostics)
+        assert diagnostics.error_type is None
+        assert diagnostics.error_message is None
+        assert diagnostics.resolved_name_by_id == {"dv_prod123": "Production Analytics"}
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    def test_resolve_include_diagnostics_returns_empty_name_map_for_unknown_id(self, mock_cjapy):
+        """IDs not present in accessible views should not produce canonical-name mappings."""
+        mock_cja_instance = MagicMock()
+        mock_cja_instance.getDataViews.return_value = self.mock_dataviews
+        mock_cjapy.CJA.return_value = mock_cja_instance
+        mock_cjapy.importConfigFile.return_value = None
+
+        ids, name_map, diagnostics = resolve_data_view_names(
+            ["dv_unknown"],
+            "config.json",
+            self.logger,
+            include_diagnostics=True,
+        )
+
+        assert ids == ["dv_unknown"]
+        assert name_map == {}
+        assert isinstance(diagnostics, NameResolutionDiagnostics)
+        assert diagnostics.resolved_name_by_id == {}
 
     def test_resolve_invalid_match_mode(self):
         """Invalid match mode should raise ValueError."""

--- a/tests/test_output_content_validation.py
+++ b/tests/test_output_content_validation.py
@@ -38,7 +38,7 @@ def rich_data_dict():
         "Metadata": pd.DataFrame(
             {
                 "Property": ["Generated At", "Data View ID", "Tool Version", "Total Metrics"],
-                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.3.1", 3],
+                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.3.2", 3],
             },
         ),
         "Data Quality": pd.DataFrame(
@@ -104,7 +104,7 @@ def rich_metadata_dict():
         "Generated At": "2025-01-15 10:30:00 PST",
         "Data View ID": "dv_content_test",
         "Data View Name": "Test DataView",
-        "Tool Version": "3.3.1",
+        "Tool Version": "3.3.2",
         "Metrics Count": "3",
         "Dimensions Count": "4",
     }
@@ -224,7 +224,7 @@ class TestJSONContentValidation:
             data = json.load(f)
 
         assert data["metadata"]["Data View ID"] == "dv_content_test"
-        assert data["metadata"]["Tool Version"] == "3.3.1"
+        assert data["metadata"]["Tool Version"] == "3.3.2"
 
 
 # ===================================================================

--- a/tests/test_ux_features.py
+++ b/tests/test_ux_features.py
@@ -185,8 +185,8 @@ class TestShowStatsFunction:
         mock_cja = MagicMock()
         mock_cjapy.CJA.return_value = mock_cja
         mock_cja.getDataView.return_value = {"name": "Test View", "owner": {"name": "Owner"}}
-        mock_cja.getMetrics.return_value = MagicMock(empty=False, __len__=lambda x: 10)
-        mock_cja.getDimensions.return_value = MagicMock(empty=False, __len__=lambda x: 5)
+        mock_cja.getMetrics.return_value = [{"id": f"m{i}"} for i in range(10)]
+        mock_cja.getDimensions.return_value = [{"id": f"d{i}"} for i in range(5)]
 
         # Capture stdout
         captured_output = StringIO()
@@ -208,8 +208,8 @@ class TestShowStatsFunction:
         mock_cja = MagicMock()
         mock_cjapy.CJA.return_value = mock_cja
         mock_cja.getDataView.return_value = {"name": "Test View", "owner": {"name": "Owner"}}
-        mock_cja.getMetrics.return_value = MagicMock(empty=False, __len__=lambda x: 10)
-        mock_cja.getDimensions.return_value = MagicMock(empty=False, __len__=lambda x: 5)
+        mock_cja.getMetrics.return_value = [{"id": f"m{i}"} for i in range(10)]
+        mock_cja.getDimensions.return_value = [{"id": f"d{i}"} for i in range(5)]
 
         # Capture stdout
         captured_output = StringIO()
@@ -230,8 +230,8 @@ class TestShowStatsFunction:
         mock_cja = MagicMock()
         mock_cjapy.CJA.return_value = mock_cja
         mock_cja.getDataView.return_value = {"name": "Test View", "owner": {"name": "Owner"}}
-        mock_cja.getMetrics.return_value = MagicMock(empty=False, __len__=lambda x: 10)
-        mock_cja.getDimensions.return_value = MagicMock(empty=False, __len__=lambda x: 5)
+        mock_cja.getMetrics.return_value = [{"id": f"m{i}"} for i in range(10)]
+        mock_cja.getDimensions.return_value = [{"id": f"d{i}"} for i in range(5)]
 
         # Capture stdout
         captured_output = StringIO()

--- a/tests/test_ux_features.py
+++ b/tests/test_ux_features.py
@@ -344,11 +344,11 @@ class TestCombinedFeatures:
 class TestVersionUpdated:
     """Test that version is correct"""
 
-    def test_version_is_3_3_1(self):
-        """Test that version is 3.3.1"""
+    def test_version_is_3_3_2(self):
+        """Test that version is 3.3.2"""
         from cja_auto_sdr.generator import __version__
 
-        assert __version__ == "3.3.1"
+        assert __version__ == "3.3.2"
 
 
 class TestFormatAutoDetection:


### PR DESCRIPTION
## Summary

Five new discovery inspection commands for drilling into individual data view resources without generating a full SDR:

- **`--describe-dataview <ID>`** — Show detailed metadata and component counts (metrics, dimensions, segments, calculated metrics)
- **`--list-metrics <ID>`** — List all metrics in a data view with `--filter`/`--sort`/`--limit` support
- **`--list-dimensions <ID>`** — List all dimensions in a data view with `--filter`/`--sort`/`--limit` support
- **`--list-segments <ID>`** — List all segments/filters scoped to a data view with owner and governance fields
- **`--list-calculated-metrics <ID>`** — List all calculated metrics with type, polarity, and governance fields

### Highlights

- All five commands support `--format table/json/csv`, `--output`, and `--profile` for multi-org workflows
- Reuses existing discovery infrastructure (`_run_list_command()`, `_emit_output()`, `_apply_discovery_filters_and_sort()`)
- Graceful degradation: `--describe-dataview` shows "N/A" for component counts when API permissions are limited
- 160 new tests across `test_cli.py` and `test_cli_command_handlers.py`

### Files Changed

| Area | Files |
|------|-------|
| CLI parser | `src/cja_auto_sdr/cli/parser.py` |
| Implementation | `src/cja_auto_sdr/generator.py` (+697 lines) |
| Tests | `tests/test_cli.py` (+716 lines), `tests/test_cli_command_handlers.py` (+134 lines) |
| Docs | `CLI_REFERENCE.md`, `QUICK_REFERENCE.md`, `QUICKSTART_GUIDE.md`, `OUTPUT_FORMATS.md`, `CONFIGURATION.md`, `README.md`, `CHANGELOG.md` |
| Version | Bumped to v3.3.2 across all 8 tracked locations |

## Test plan

- [x] All 4,737 tests pass (8 skipped)
- [x] 98.70% coverage (above 95% gate)
- [x] Ruff lint + format clean
- [x] Version sync check passes (`scripts/check_version_sync.py`)
- [x] CI green on push