### PR TITLE
Release v3.3.4: DX & Observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to the CJA SDR Generator project will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.4] - 2026-02-25
+
+### Added
+- **Shell completion setup**: New `--completion bash/zsh/fish` flag prints activation scripts for shell tab-completion. Fast-path — no heavyweight imports needed. Prints install instructions if argcomplete is not installed.
+- **Run summary environment metadata**: `--run-summary-json` output now includes an `environment` block with Python version, platform, and dependency versions (cjapy, pandas, numpy, xlsxwriter, tqdm) for CI/CD diagnostics
+- **Startup dependency versions**: Startup diagnostics now log core dependency versions at INFO level (e.g. `Dependencies: cjapy=0.2.4, pandas=2.3.3, ...`) alongside the existing Python/platform line
+- **Profile list org_id display**: `--profile-list` now reads and displays the `org_id` from each profile's configuration, making it easy to distinguish profiles for multi-org users. Follows `.env` overrides `config.json` precedence.
+- **Enhanced config validation**: `--validate-config` expanded from 3-step to 5-step process — now checks Python version compatibility, core/optional dependency versions, output directory write permissions in addition to credentials and API connectivity
+
+### Changed
+- **Narrowed exception handling (batch 2)**: 13 broad `except Exception` catches in generator.py replaced with specific exception types (`OSError`, `KeyError`, `TypeError`, `ValueError`). 15 remaining intentional boundaries annotated with `# Intentional:` comments documenting why they remain broad.
+
 ## [3.3.3] - 2026-02-23
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ CJA SDR Generator - A tool for generating Solution Design Reference (SDR) docume
 
 - Package manager: uv
 - Entry point: `cja_auto_sdr` command (via pyproject.toml scripts)
-- Current version: v3.3.3
+- Current version: v3.3.4
 - Main script: `generator.py` (~10k lines) — subpackages use lazy forwarding via `make_getattr()` in `core/lazy.py`
 
 ## CI & Quality

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (5,061+ tests)
+├── tests/                     # Test suite (5,068+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (4,962+ tests)
+├── tests/                     # Test suite (5,031+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (5,068+ tests)
+├── tests/                     # Test suite (5,077+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (5,077+ tests)
+├── tests/                     # Test suite (5,080+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (5,080+ tests)
+├── tests/                     # Test suite (5,083+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (4,947+ tests)
+├── tests/                     # Test suite (4,962+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (5,038+ tests)
+├── tests/                     # Test suite (5,061+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (5,031+ tests)
+├── tests/                     # Test suite (5,032+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (5,032+ tests)
+├── tests/                     # Test suite (5,038+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -96,6 +96,7 @@ cja-auto-sdr [OPTIONS] DATA_VIEW_ID_OR_NAME [...]
 | `--show-timings` | Display performance timing breakdown after processing | False |
 | `--config-json` | Output `--config-status` as machine-readable JSON (for scripting and CI/CD) | False |
 | `--yes, -y` | Skip confirmation prompts (e.g., for large batch operations) | False |
+| `--completion {bash,zsh,fish}` | Generate shell completion activation script for the specified shell and exit. Prints install instructions if argcomplete is not installed | - |
 
 ### Processing
 
@@ -162,7 +163,7 @@ Manage credentials for multiple Adobe Organizations. Profiles are stored in `~/.
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--profile NAME`, `-p NAME` | Use named profile from `~/.cja/orgs/<NAME>/` | `$CJA_PROFILE` |
-| `--profile-list` | List all available profiles | - |
+| `--profile-list` | List all available profiles with their org_id | - |
 | `--profile-add NAME` | Create a new profile interactively | - |
 | `--profile-show NAME` | Show profile configuration (secrets masked) | - |
 | `--profile-test NAME` | Test profile credentials and API connectivity | - |
@@ -209,7 +210,7 @@ cja_auto_sdr --list-dataviews
 |--------|-------------|---------|
 | `--dry-run` | Validate config without generating reports | False |
 | `--validate-only` | Alias for --dry-run | False |
-| `--validate-config` | Validate config and API connectivity (no data view required) | False |
+| `--validate-config` | Validate config and API connectivity (no data view required). Runs 5 steps: environment check, dependency check, credentials check, API connectivity test, and output permissions check | False |
 | `--list-dataviews` | List accessible data views and exit. Supports `--format json/csv` and `--output -` for machine-readable output | False |
 | `--list-connections` | List all accessible connections with their datasets. Falls back to connection IDs derived from data views if the service account lacks product-admin privileges. Supports `--format json/csv` and `--output` | False |
 | `--list-datasets` | List all data views with their backing connections and dataset details. Shows connection names when available, IDs when not. Supports `--format json/csv` and `--output` | False |
@@ -1163,6 +1164,14 @@ Throughput: 9.7 data views per minute
 ## Shell Tab-Completion
 
 Enable tab-completion for all CLI options using the `argcomplete` package.
+
+**Quick setup (v3.3.4+):**
+
+```bash
+cja_auto_sdr --completion bash >> ~/.bashrc
+cja_auto_sdr --completion zsh >> ~/.zshrc
+cja_auto_sdr --completion fish > ~/.config/fish/completions/cja_auto_sdr.fish
+```
 
 ### Installation
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -343,7 +343,7 @@ There are two commands for checking your configuration:
 | Command | API Call | Best For |
 |---------|----------|----------|
 | `--config-status` | No | Quick troubleshooting—shows configuration source, fields, and masked credentials |
-| `--validate-config` | Yes | Full validation—tests API connectivity and authentication |
+| `--validate-config` | Yes | Full validation—runs 5 checks: environment, dependencies, credentials, API connectivity, and output permissions |
 
 ```bash
 # Quick check: Show configuration status without API call (fast)
@@ -359,9 +359,20 @@ cja_auto_sdr --config-file /path/to/config.json --validate-config
 cja_auto_sdr --dry-run
 ```
 
+**`--validate-config` runs 5 steps:**
+
+```text
+[1/5] Checking environment... Python 3.14.2, darwin
+[2/5] Checking dependencies... core: cjapy, pandas, numpy, xlsxwriter, tqdm; optional: scipy, argcomplete, python-dotenv
+[3/5] Checking credentials... profile "default" loaded
+[4/5] Testing API connectivity... authenticated as user@example.com
+[5/5] Checking output permissions... output directory writable
+✔ All checks passed
+```
+
 **When to use each:**
 - Use `--config-status` first for quick troubleshooting (no network required)
-- Use `--validate-config` to verify API connectivity and authentication
+- Use `--validate-config` for full validation—checks environment, dependencies, credentials, API connectivity, and output permissions
 
 ---
 
@@ -910,10 +921,11 @@ cja_auto_sdr --list-dataviews --log-level DEBUG
 
 ### Startup Diagnostics
 
-At launch, the tool logs a diagnostic line containing the tool version, Python version, platform, active log level, and inferred run mode (batch, single, or discovery). This appears automatically at `INFO` level and is useful for troubleshooting environment issues in CI/CD logs or support requests:
+At launch, the tool logs diagnostic lines containing the tool version, Python version, platform, active log level, inferred run mode (batch, single, or discovery), and dependency versions. These appear automatically at `INFO` level and are useful for troubleshooting environment issues in CI/CD logs or support requests:
 
 ```text
 CJA SDR Generator v3.3.4 | Python 3.14.2 | darwin | log_level=INFO | mode=single
+Dependencies: cjapy=0.2.4.post3, pandas=2.3.3, numpy=2.2.1, xlsxwriter=3.2.9, tqdm=4.67.0
 ```
 
 ### Structured JSON Logging

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -913,7 +913,7 @@ cja_auto_sdr --list-dataviews --log-level DEBUG
 At launch, the tool logs a diagnostic line containing the tool version, Python version, platform, active log level, and inferred run mode (batch, single, or discovery). This appears automatically at `INFO` level and is useful for troubleshooting environment issues in CI/CD logs or support requests:
 
 ```text
-CJA SDR Generator v3.3.3 | Python 3.14.2 | darwin | log_level=INFO | mode=single
+CJA SDR Generator v3.3.4 | Python 3.14.2 | darwin | log_level=INFO | mode=single
 ```
 
 ### Structured JSON Logging

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -203,7 +203,7 @@ This command:
 
 ```bash
 $ uv run cja_auto_sdr -V
-cja_auto_sdr 3.3.3
+cja_auto_sdr 3.3.4
 ```
 
 > **Important:** All commands in this guide assume you're in the `cja_auto_sdr` directory. If you see "command not found", make sure you're in the right directory and have run `uv sync`.

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Quick Reference Card
 
-Single-page command cheat sheet for CJA SDR Generator v3.3.3.
+Single-page command cheat sheet for CJA SDR Generator v3.3.4.
 
 ## Four Main Modes
 

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -284,7 +284,7 @@ cja_auto_sdr --org-report --include-metadata
 cja_auto_sdr --profile-add client-a
 cja_auto_sdr --profile-add client-b
 
-# List all profiles
+# List all profiles (shows org_id from each profile config)
 cja_auto_sdr --profile-list
 
 # Use a specific profile
@@ -500,11 +500,16 @@ export GITHUB_STEP_SUMMARY=/path/to/summary.md
 # Generate sample config file
 cja_auto_sdr --sample-config
 
-# Validate configuration and API connection
+# Validate configuration and API connection (5-step: environment,
+# dependencies, credentials, API connectivity, output permissions)
 cja_auto_sdr --validate-config
 
 # Test specific data views without generating
 cja_auto_sdr dv_12345 --dry-run
+
+# Enable shell tab-completion
+cja_auto_sdr --completion bash >> ~/.bashrc
+cja_auto_sdr --completion zsh >> ~/.zshrc
 ```
 
 See [CONFIGURATION.md](CONFIGURATION.md) for detailed setup of `config.json` and environment variables.

--- a/docs/SHELL_COMPLETION.md
+++ b/docs/SHELL_COMPLETION.md
@@ -9,7 +9,33 @@ Shell completion allows you to:
 - See available choices for options (e.g., `--format ` + `TAB` shows all formats)
 - Reduce typos and speed up your workflow
 
-## Quick Setup
+## Quick Setup (Recommended)
+
+The easiest way to enable completions is with the built-in `--completion` flag:
+
+### Bash
+
+```bash
+cja_auto_sdr --completion bash >> ~/.bashrc
+source ~/.bashrc
+```
+
+### Zsh
+
+```bash
+cja_auto_sdr --completion zsh >> ~/.zshrc
+source ~/.zshrc
+```
+
+### Fish
+
+```bash
+cja_auto_sdr --completion fish > ~/.config/fish/completions/cja_auto_sdr.fish
+```
+
+> **Note:** If `argcomplete` is not installed, this command will print install instructions.
+
+## Manual Setup (Alternative)
 
 ### Bash
 

--- a/src/cja_auto_sdr/__main__.py
+++ b/src/cja_auto_sdr/__main__.py
@@ -1,8 +1,9 @@
 """Fast-path entry point for CJA Auto SDR.
 
-Lightweight flags (``--version``, ``--help``, ``--exit-codes``) are handled
-here *before* any heavyweight imports (pandas, cjapy, tqdm) so that simple
-informational queries return in under 100 ms.
+Lightweight flags (``--version``, ``--help``, ``--exit-codes``,
+``--completion``) are handled here *before* any heavyweight imports
+(pandas, cjapy, tqdm) so that simple informational queries return in
+under 100 ms.
 
 All other invocations fall through to the full ``generator.main()`` path.
 
@@ -23,9 +24,18 @@ from cja_auto_sdr.cli.option_resolution import resolve_long_option_token as _res
 _VERSION_OPTION = "--version"
 _VERSION_SHORT_OPTION = "-V"
 
+_COMPLETION_OPTION = "--completion"
 _RUN_SUMMARY_OPTION = "--run-summary-json"
 _ARGCOMPLETE_ENV_VAR = "_ARGCOMPLETE"
 _FALSEY_ENV_VALUES = frozenset({"", "0", "false", "no", "off"})
+
+_SUPPORTED_SHELLS = frozenset({"bash", "zsh", "fish"})
+
+_COMPLETION_SCRIPTS: dict[str, str] = {
+    "bash": 'eval "$(register-python-argcomplete cja_auto_sdr)"',
+    "zsh": ('autoload -U bashcompinit && bashcompinit\neval "$(register-python-argcomplete cja_auto_sdr)"'),
+    "fish": "register-python-argcomplete --shell fish cja_auto_sdr | source",
+}
 
 
 class _OptionSpec(NamedTuple):
@@ -325,6 +335,55 @@ def _print_exit_codes() -> None:
     print_exit_codes(banner_width=BANNER_WIDTH)
 
 
+def _extract_completion_shell(argv: list[str]) -> str | None:
+    """Extract the shell name following ``--completion`` in *argv*.
+
+    Returns the shell name (e.g. ``"bash"``) or ``None`` if ``--completion``
+    is not present.  Raises ``SystemExit(1)`` when ``--completion`` appears
+    with no following argument or with an unsupported shell name.
+    """
+    args = argv[1:]  # skip argv[0]
+    try:
+        idx = args.index(_COMPLETION_OPTION)
+    except ValueError:
+        return None
+
+    if idx + 1 >= len(args):
+        print(
+            f"error: --completion requires a shell argument ({', '.join(sorted(_SUPPORTED_SHELLS))})",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+    shell = args[idx + 1].lower()
+    if shell not in _SUPPORTED_SHELLS:
+        print(
+            f"error: unsupported shell '{shell}'. Supported shells: {', '.join(sorted(_SUPPORTED_SHELLS))}",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+    return shell
+
+
+def _handle_completion(shell: str) -> None:
+    """Print the shell completion activation script and exit.
+
+    Exits 0 on success, 1 if argcomplete is not installed.
+    """
+    try:
+        import argcomplete as _argcomplete  # noqa: F401
+    except ImportError:
+        print(
+            "error: argcomplete is not installed. Install it with:\n  pip install argcomplete",
+            file=sys.stderr,
+        )
+        raise SystemExit(1) from None
+
+    print(_COMPLETION_SCRIPTS[shell])
+    raise SystemExit(0)
+
+
 def main() -> None:
     """Entry point with fast-path for lightweight flags."""
     # Argcomplete shell completion relies on parser-side hooks in
@@ -334,6 +393,13 @@ def main() -> None:
 
         _generator_main()
         return
+
+    # --completion fast-path: detect before heavyweight imports.
+    completion_shell = _extract_completion_shell(sys.argv)
+    if completion_shell is not None:
+        _handle_completion(completion_shell)
+        # _handle_completion always raises SystemExit; this is a safety net.
+        return  # pragma: no cover
 
     flag = _is_fast_path_flag(sys.argv)
 

--- a/src/cja_auto_sdr/__main__.py
+++ b/src/cja_auto_sdr/__main__.py
@@ -384,6 +384,16 @@ def _handle_completion(shell: str) -> None:
     raise SystemExit(0)
 
 
+def _completion_fast_path_allowed(argv: list[str]) -> bool:
+    """Return True when completion can be handled directly in __main__.
+
+    When run-summary is requested, completion must flow through
+    ``generator.main()`` so summary emission remains contract-consistent.
+    """
+    args = argv[1:] if len(argv) > 1 else []
+    return not _has_run_summary_contract_flag(args)
+
+
 def main() -> None:
     """Entry point with fast-path for lightweight flags."""
     # Argcomplete shell completion relies on parser-side hooks in
@@ -394,12 +404,14 @@ def main() -> None:
         _generator_main()
         return
 
-    # --completion fast-path: detect before heavyweight imports.
-    completion_shell = _extract_completion_shell(sys.argv)
-    if completion_shell is not None:
-        _handle_completion(completion_shell)
-        # _handle_completion always raises SystemExit; this is a safety net.
-        return  # pragma: no cover
+    # --completion fast-path: detect before heavyweight imports, except when
+    # run-summary is requested (must route through generator.main()).
+    if _completion_fast_path_allowed(sys.argv):
+        completion_shell = _extract_completion_shell(sys.argv)
+        if completion_shell is not None:
+            _handle_completion(completion_shell)
+            # _handle_completion always raises SystemExit; this is a safety net.
+            return  # pragma: no cover
 
     flag = _is_fast_path_flag(sys.argv)
 

--- a/src/cja_auto_sdr/__main__.py
+++ b/src/cja_auto_sdr/__main__.py
@@ -13,6 +13,7 @@ Used by both ``python -m cja_auto_sdr`` and the console-script entry points.
 from __future__ import annotations
 
 import os
+import shlex
 import sys
 import types
 from collections.abc import Mapping
@@ -28,13 +29,14 @@ _COMPLETION_OPTION = "--completion"
 _RUN_SUMMARY_OPTION = "--run-summary-json"
 _ARGCOMPLETE_ENV_VAR = "_ARGCOMPLETE"
 _FALSEY_ENV_VALUES = frozenset({"", "0", "false", "no", "off"})
+_DEFAULT_COMPLETION_COMMAND = "cja_auto_sdr"
 
 _SUPPORTED_SHELLS = frozenset({"bash", "zsh", "fish"})
 
-_COMPLETION_SCRIPTS: dict[str, str] = {
-    "bash": 'eval "$(register-python-argcomplete cja_auto_sdr)"',
-    "zsh": ('autoload -U bashcompinit && bashcompinit\neval "$(register-python-argcomplete cja_auto_sdr)"'),
-    "fish": "register-python-argcomplete --shell fish cja_auto_sdr | source",
+_COMPLETION_SCRIPT_TEMPLATES: dict[str, str] = {
+    "bash": 'eval "$(register-python-argcomplete {command})"',
+    "zsh": ('autoload -U bashcompinit && bashcompinit\neval "$(register-python-argcomplete {command})"'),
+    "fish": "register-python-argcomplete --shell fish {command} | source",
 }
 
 
@@ -66,6 +68,13 @@ class _ArgparseProbeResult(NamedTuple):
 
     status: int
     output: str | None
+
+
+class _ArgparseProbeParseResult(NamedTuple):
+    """Result of probing argparse parse success/termination."""
+
+    namespace: object | None
+    termination: _ArgparseProbeResult | None
 
 
 def _is_argcomplete_completion_active(environ: Mapping[str, str] | None = None) -> bool:
@@ -229,6 +238,11 @@ def _probe_argparse_termination(args: list[str], argv0: str | None = None) -> _A
     This uses the real parser as the source of truth for precedence and
     validation (help/version actions, missing values, and mutex conflicts).
     """
+    return _probe_argparse_parse(args, argv0).termination
+
+
+def _probe_argparse_parse(args: list[str], argv0: str | None = None) -> _ArgparseProbeParseResult:
+    """Probe argparse parse result for *args* without emitting output."""
     from cja_auto_sdr.cli.parser import parse_arguments
 
     parser = parse_arguments(return_parser=True, enable_autocomplete=False)
@@ -248,11 +262,14 @@ def _probe_argparse_termination(args: list[str], argv0: str | None = None) -> _A
     parser._print_message = types.MethodType(_capture_output, parser)
 
     try:
-        parser.parse_args(args)
+        namespace = parser.parse_args(args)
     except _ArgparseProbeExit as probe_exit:
         rendered_output = probe_exit.message or "".join(captured_output) or None
-        return _ArgparseProbeResult(status=probe_exit.status, output=rendered_output)
-    return None
+        return _ArgparseProbeParseResult(
+            namespace=None,
+            termination=_ArgparseProbeResult(status=probe_exit.status, output=rendered_output),
+        )
+    return _ArgparseProbeParseResult(namespace=namespace, termination=None)
 
 
 def _is_fast_path_flag(argv: list[str]) -> str | None:
@@ -322,6 +339,34 @@ def _resolve_program_name(
     return program_name or "cja_auto_sdr"
 
 
+def _resolve_completion_command_name(argv0: str | None) -> str:
+    """Return the command name used in shell completion registration."""
+    if not argv0:
+        return _DEFAULT_COMPLETION_COMMAND
+
+    command_name = os.path.basename(argv0).strip()
+    if not command_name or command_name == "__main__.py":
+        return _DEFAULT_COMPLETION_COMMAND
+
+    return command_name
+
+
+def _render_completion_script(shell: str, command_name: str) -> str:
+    """Render shell completion script for *shell* and *command_name*."""
+    template = _COMPLETION_SCRIPT_TEMPLATES.get(shell)
+    if template is None:
+        raise ValueError(f"Unsupported shell: {shell}")
+
+    quoted_command = shlex.quote(_resolve_completion_command_name(command_name))
+    return template.format(command=quoted_command)
+
+
+# Backward-compatible default snippets for tests and static validation.
+_COMPLETION_SCRIPTS: dict[str, str] = {
+    shell: _render_completion_script(shell, _DEFAULT_COMPLETION_COMMAND) for shell in _SUPPORTED_SHELLS
+}
+
+
 def _print_version(program_name: str = "cja_auto_sdr") -> None:
     from cja_auto_sdr.core.version import __version__
 
@@ -366,11 +411,18 @@ def _extract_completion_shell(argv: list[str]) -> str | None:
     return shell
 
 
-def _handle_completion(shell: str) -> None:
+def _handle_completion(shell: str, argv0: str | None = None) -> None:
     """Print the shell completion activation script and exit.
 
     Exits 0 on success, 1 if argcomplete is not installed.
     """
+    if shell not in _SUPPORTED_SHELLS:
+        print(
+            f"error: unsupported shell '{shell}'. Supported shells: {', '.join(sorted(_SUPPORTED_SHELLS))}",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
     try:
         import argcomplete as _argcomplete  # noqa: F401
     except ImportError:
@@ -380,18 +432,50 @@ def _handle_completion(shell: str) -> None:
         )
         raise SystemExit(1) from None
 
-    print(_COMPLETION_SCRIPTS[shell])
+    command_name = _resolve_completion_command_name(argv0)
+    print(_render_completion_script(shell, command_name))
     raise SystemExit(0)
 
 
-def _completion_fast_path_allowed(argv: list[str]) -> bool:
-    """Return True when completion can be handled directly in __main__.
+def _completion_fast_path_shell(argv: list[str]) -> str | None:
+    """Return completion shell for standalone, parse-valid fast-path requests.
 
-    When run-summary is requested, completion must flow through
-    ``generator.main()`` so summary emission remains contract-consistent.
+    Any mixed flags, parse errors, or argparse action precedence cases fall
+    through to ``generator.main()`` to preserve parser behavior.
     """
     args = argv[1:] if len(argv) > 1 else []
-    return not _has_run_summary_contract_flag(args)
+    if not args:
+        return None
+
+    # Preserve run-summary contract: summary emission must route through
+    # generator.main() regardless of option ordering.
+    if _has_run_summary_contract_flag(args):
+        return None
+
+    scan = _scan_option_tokens(args)
+    if scan.has_parse_error:
+        return None
+
+    if _COMPLETION_OPTION not in scan.options:
+        return None
+
+    # Completion fast-path is intentionally strict: only standalone completion
+    # requests are intercepted; mixed option combinations defer to argparse.
+    if any(option != _COMPLETION_OPTION for option in scan.options):
+        return None
+
+    probe = _probe_argparse_parse(args, argv[0] if argv else None)
+    if probe.termination is not None or probe.namespace is None:
+        return None
+
+    completion_shell = getattr(probe.namespace, "completion", None)
+    if completion_shell is None:
+        return None
+
+    if getattr(probe.namespace, "data_views", []):
+        return None
+
+    return str(completion_shell).lower()
 
 
 def main() -> None:
@@ -404,14 +488,13 @@ def main() -> None:
         _generator_main()
         return
 
-    # --completion fast-path: detect before heavyweight imports, except when
-    # run-summary is requested (must route through generator.main()).
-    if _completion_fast_path_allowed(sys.argv):
-        completion_shell = _extract_completion_shell(sys.argv)
-        if completion_shell is not None:
-            _handle_completion(completion_shell)
-            # _handle_completion always raises SystemExit; this is a safety net.
-            return  # pragma: no cover
+    # --completion fast-path: only standalone, parser-valid completion requests
+    # are handled here. Mixed/invalid argv must defer to full argparse flow.
+    completion_shell = _completion_fast_path_shell(sys.argv)
+    if completion_shell is not None:
+        _handle_completion(completion_shell, sys.argv[0] if sys.argv else None)
+        # _handle_completion always raises SystemExit; this is a safety net.
+        return  # pragma: no cover
 
     flag = _is_fast_path_flag(sys.argv)
 

--- a/src/cja_auto_sdr/cli/parser.py
+++ b/src/cja_auto_sdr/cli/parser.py
@@ -256,6 +256,13 @@ Requirements:
     parser.add_argument("--exit-codes", action="store_true", help="Display exit code reference and exit")
 
     parser.add_argument(
+        "--completion",
+        choices=["bash", "zsh", "fish"],
+        metavar="SHELL",
+        help="Print shell completion activation script for SHELL (bash, zsh, fish) and exit",
+    )
+
+    parser.add_argument(
         "data_views",
         nargs="*",
         metavar="DATA_VIEW_ID_OR_NAME",

--- a/src/cja_auto_sdr/core/logging.py
+++ b/src/cja_auto_sdr/core/logging.py
@@ -2,6 +2,7 @@
 
 import atexit
 import contextlib
+import importlib.metadata
 import json
 import logging
 import os
@@ -411,6 +412,23 @@ def flush_logging_handlers(logger: logging.Logger | logging.LoggerAdapter | None
             handler.flush()
 
 
+_CORE_DEPENDENCIES = ("cjapy", "pandas", "numpy", "xlsxwriter", "tqdm")
+
+
+def _collect_dependency_versions() -> dict[str, str]:
+    """Return a mapping of core dependency names to their installed versions.
+
+    Falls back to ``"?"`` for any package that cannot be found.
+    """
+    versions: dict[str, str] = {}
+    for pkg in _CORE_DEPENDENCIES:
+        try:
+            versions[pkg] = importlib.metadata.version(pkg)
+        except importlib.metadata.PackageNotFoundError:
+            versions[pkg] = "?"
+    return versions
+
+
 def _infer_run_mode(data_view_id: str | None, batch_mode: bool) -> str:
     """Infer the run mode from setup_logging parameters."""
     if batch_mode:
@@ -527,6 +545,9 @@ def setup_logging(
         f"Python {sys.version.split()[0]} on {sys.platform}",
         extra={"python_version": sys.version.split()[0], "platform": sys.platform},
     )
+    dep_versions = _collect_dependency_versions()
+    dep_summary = ", ".join(f"{pkg}={ver}" for pkg, ver in dep_versions.items())
+    logger.info(f"Dependencies: {dep_summary}", extra={"dependency_versions": dep_versions})
     logger.info(f"Log level: {log_level.upper()}", extra={"log_level": log_level.upper()})
     logger.info(f"Run mode: {_infer_run_mode(data_view_id, batch_mode)}")
 

--- a/src/cja_auto_sdr/core/logging.py
+++ b/src/cja_auto_sdr/core/logging.py
@@ -425,7 +425,7 @@ def _collect_dependency_versions() -> dict[str, str]:
     for pkg in _CORE_DEPENDENCIES:
         try:
             versions[pkg] = importlib.metadata.version(pkg)
-        except importlib.metadata.PackageNotFoundError:
+        except Exception:  # PackageNotFoundError, corrupt metadata, OSError, etc.
             versions[pkg] = "?"
     return versions
 

--- a/src/cja_auto_sdr/core/logging.py
+++ b/src/cja_auto_sdr/core/logging.py
@@ -9,6 +9,7 @@ import os
 import re
 import sys
 from datetime import UTC, datetime
+from functools import lru_cache
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
@@ -429,6 +430,17 @@ def _collect_dependency_versions() -> dict[str, str]:
     return versions
 
 
+@lru_cache(maxsize=1)
+def _cached_startup_dependency_versions() -> tuple[tuple[str, str], ...]:
+    """Cache dependency versions used by startup logging across setup calls."""
+    return tuple(_collect_dependency_versions().items())
+
+
+def _startup_dependency_versions_for_logging() -> dict[str, str]:
+    """Return startup dependency versions as a fresh dict copy."""
+    return dict(_cached_startup_dependency_versions())
+
+
 def _infer_run_mode(data_view_id: str | None, batch_mode: bool) -> str:
     """Infer the run mode from setup_logging parameters."""
     if batch_mode:
@@ -536,20 +548,25 @@ def setup_logging(
     _logging_initialized = True
     _current_log_file = log_file
 
-    if log_file is not None:
-        logger.info(f"Logging initialized. Log file: {log_file}")
-    else:
-        logger.info("Logging initialized. Console output only.")
-    logger.info(f"CJA SDR Generator version: {__version__}", extra={"sdr_version": __version__})
-    logger.info(
-        f"Python {sys.version.split()[0]} on {sys.platform}",
-        extra={"python_version": sys.version.split()[0], "platform": sys.platform},
-    )
-    dep_versions = _collect_dependency_versions()
-    dep_summary = ", ".join(f"{pkg}={ver}" for pkg, ver in dep_versions.items())
-    logger.info(f"Dependencies: {dep_summary}", extra={"dependency_versions": dep_versions})
-    logger.info(f"Log level: {log_level.upper()}", extra={"log_level": log_level.upper()})
-    logger.info(f"Run mode: {_infer_run_mode(data_view_id, batch_mode)}")
+    if logger.isEnabledFor(logging.INFO):
+        if log_file is not None:
+            logger.info(f"Logging initialized. Log file: {log_file}")
+        else:
+            logger.info("Logging initialized. Console output only.")
+        logger.info(f"CJA SDR Generator version: {__version__}", extra={"sdr_version": __version__})
+        logger.info(
+            f"Python {sys.version.split()[0]} on {sys.platform}",
+            extra={"python_version": sys.version.split()[0], "platform": sys.platform},
+        )
+        try:
+            dep_versions = _startup_dependency_versions_for_logging()
+        except Exception:
+            dep_versions = dict.fromkeys(_CORE_DEPENDENCIES, "?")
+            logger.debug("Failed to resolve dependency versions for startup logging", exc_info=True)
+        dep_summary = ", ".join(f"{pkg}={ver}" for pkg, ver in dep_versions.items())
+        logger.info(f"Dependencies: {dep_summary}", extra={"dependency_versions": dep_versions})
+        logger.info(f"Log level: {log_level.upper()}", extra={"log_level": log_level.upper()})
+        logger.info(f"Run mode: {_infer_run_mode(data_view_id, batch_mode)}")
 
     # Flush handlers to ensure log file is not empty even on early exit
     for handler in logging.root.handlers:

--- a/src/cja_auto_sdr/core/version.py
+++ b/src/cja_auto_sdr/core/version.py
@@ -1,3 +1,3 @@
 """Version information for CJA Auto SDR."""
 
-__version__ = "3.3.3"
+__version__ = "3.3.4"

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -1085,20 +1085,17 @@ def _processing_result_to_summary(result: ProcessingResult) -> dict[str, Any]:
     }
 
 
-_ENVIRONMENT_DEPENDENCIES = ("cjapy", "pandas", "numpy", "xlsxwriter", "tqdm")
-
-
 def _collect_environment_info() -> dict[str, Any]:
-    """Collect runtime environment info for the run summary payload."""
+    """Collect runtime environment info for the run summary payload.
+
+    Reuses :func:`core.logging._collect_dependency_versions` as the single
+    source of truth for dependency names and version lookup, remapping the
+    ``"?"`` fallback to ``"unknown"`` for the JSON contract.
+    """
     vi = sys.version_info
     python_version = f"{vi.major}.{vi.minor}.{vi.micro}"
 
-    deps: dict[str, str] = {}
-    for pkg in _ENVIRONMENT_DEPENDENCIES:
-        try:
-            deps[pkg] = importlib.metadata.version(pkg)
-        except importlib.metadata.PackageNotFoundError:
-            deps[pkg] = "unknown"
+    deps = {pkg: (v if v != "?" else "unknown") for pkg, v in _collect_dependency_versions().items()}
 
     return {
         "python_version": python_version,
@@ -1248,7 +1245,14 @@ from cja_auto_sdr.api.tuning import APIWorkerTuner
 
 # ==================== LOGGING SETUP ====================
 # ==================== LOGGING (moved to core/logging.py) ====================
-from cja_auto_sdr.core.logging import JSONFormatter, flush_logging_handlers, setup_logging, with_log_context
+from cja_auto_sdr.core.logging import (
+    _CORE_DEPENDENCIES,
+    JSONFormatter,
+    _collect_dependency_versions,
+    flush_logging_handlers,
+    setup_logging,
+    with_log_context,
+)
 
 # ==================== PERFORMANCE TRACKING (moved to core/perf.py) ====================
 from cja_auto_sdr.core.perf import PerformanceTracker
@@ -10376,7 +10380,11 @@ def show_config_status(config_file: str = "config.json", profile: str | None = N
 # ==================== VALIDATE CONFIG ====================
 
 
-def validate_config_only(config_file: str = "config.json", profile: str | None = None) -> bool:
+def validate_config_only(
+    config_file: str = "config.json",
+    profile: str | None = None,
+    output_dir: str = ".",
+) -> bool:
     """
     Validate configuration and API connectivity without processing data views.
 
@@ -10390,6 +10398,7 @@ def validate_config_only(config_file: str = "config.json", profile: str | None =
     Args:
         config_file: Path to CJA configuration file
         profile: Optional profile name to use for credentials
+        output_dir: Directory to check for write permissions
 
     Returns:
         True if configuration is valid and API is reachable
@@ -10619,11 +10628,11 @@ def validate_config_only(config_file: str = "config.json", profile: str | None =
     if all_passed:
         print()
         print("[5/5] Checking output permissions...")
-        output_dir = "."
-        if os.access(output_dir, os.W_OK):
-            print(f"  \u2713 Output directory writable: {output_dir}")
+        resolved_dir = os.path.abspath(output_dir)
+        if os.access(resolved_dir, os.W_OK):
+            print(f"  \u2713 Output directory writable: {resolved_dir}")
         else:
-            print(f"  \u2717 Output directory not writable: {output_dir}")
+            print(f"  \u2717 Output directory not writable: {resolved_dir}")
             all_passed = False
 
     # Summary
@@ -14477,7 +14486,11 @@ def _main_impl(run_state: dict[str, Any] | None = None):
 
     # Handle --validate-config mode (no data view required)
     if args.validate_config:
-        success = validate_config_only(args.config_file, profile=getattr(args, "profile", None))
+        success = validate_config_only(
+            args.config_file,
+            profile=getattr(args, "profile", None),
+            output_dir=getattr(args, "output_dir", "."),
+        )
         if run_state is not None:
             run_state["details"] = {"operation_success": success}
         sys.exit(0 if success else 1)

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -1097,7 +1097,7 @@ def _collect_environment_info() -> dict[str, Any]:
     for pkg in _ENVIRONMENT_DEPENDENCIES:
         try:
             deps[pkg] = importlib.metadata.version(pkg)
-        except importlib.metadata.PackageNotFoundError, ValueError:
+        except importlib.metadata.PackageNotFoundError:
             deps[pkg] = "unknown"
 
     return {

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -1097,7 +1097,7 @@ def _collect_environment_info() -> dict[str, Any]:
     for pkg in _ENVIRONMENT_DEPENDENCIES:
         try:
             deps[pkg] = importlib.metadata.version(pkg)
-        except Exception:
+        except importlib.metadata.PackageNotFoundError, ValueError:
             deps[pkg] = "unknown"
 
     return {
@@ -2021,7 +2021,7 @@ def test_profile(profile_name: str) -> bool:
         finally:
             os.unlink(temp_config.name)
 
-    except Exception as e:
+    except Exception as e:  # Intentional: wraps cjapy API calls that may raise anything
         print("   API connection: FAILED")
         print(f"   Error: {e}")
         print()
@@ -2179,7 +2179,7 @@ def validate_data_view(cja: cjapy.CJA, data_view_id: str, logger: logging.Logger
 
     except KeyboardInterrupt, SystemExit:
         raise
-    except Exception as e:
+    except Exception as e:  # Intentional: wraps cjapy API validation calls
         logger.error("=" * BANNER_WIDTH)
         logger.error("DATA VIEW VALIDATION ERROR")
         logger.error("=" * BANNER_WIDTH)
@@ -2601,7 +2601,7 @@ def write_excel_output(
         logger.error(f"OS error creating Excel file: {e}")
         logger.error("Check disk space and path validity")
         raise
-    except Exception as e:
+    except (KeyError, TypeError, ValueError) as e:
         logger.error(_format_error_msg("creating Excel file", error=e))
         raise
 
@@ -2648,7 +2648,7 @@ def write_csv_output(
         logger.error(f"OS error creating CSV files: {e}")
         logger.error("Check disk space and path validity")
         raise
-    except Exception as e:
+    except (KeyError, TypeError, ValueError) as e:
         logger.error(_format_error_msg("creating CSV files", error=e))
         raise
 
@@ -2747,7 +2747,7 @@ def write_json_output(
         logger.error(f"JSON serialization error: {e}")
         logger.error("Data contains non-serializable values")
         raise
-    except Exception as e:
+    except (KeyError, AttributeError) as e:
         logger.error(_format_error_msg("creating JSON file", error=e))
         raise
 
@@ -3013,7 +3013,7 @@ def write_html_output(
         logger.error(f"OS error creating HTML file: {e}")
         logger.error("Check disk space and path validity")
         raise
-    except Exception as e:
+    except (KeyError, TypeError, ValueError) as e:
         logger.error(_format_error_msg("creating HTML file", error=e))
         raise
 
@@ -3165,7 +3165,7 @@ def write_markdown_output(
         logger.error(f"OS error creating Markdown file: {e}")
         logger.error("Check disk space and path validity")
         raise
-    except Exception as e:
+    except (KeyError, TypeError, ValueError) as e:
         logger.error(_format_error_msg("creating Markdown file", error=e))
         raise
 
@@ -4046,7 +4046,7 @@ def write_diff_json_output(
         logger.info(f"Diff JSON file created: {json_file}")
         return json_file
 
-    except Exception as e:
+    except (OSError, TypeError, ValueError) as e:
         logger.error(_format_error_msg("creating diff JSON file", error=e))
         raise
 
@@ -4223,7 +4223,7 @@ def write_diff_markdown_output(
         logger.info(f"Diff Markdown file created: {markdown_file}")
         return markdown_file
 
-    except Exception as e:
+    except (OSError, KeyError, TypeError, ValueError) as e:
         logger.error(_format_error_msg("creating diff Markdown file", error=e))
         raise
 
@@ -4620,7 +4620,7 @@ def write_diff_html_output(
         logger.info(f"Diff HTML file created: {html_file}")
         return html_file
 
-    except Exception as e:
+    except (OSError, KeyError, TypeError, ValueError) as e:
         logger.error(_format_error_msg("creating diff HTML file", error=e))
         raise
 
@@ -4831,7 +4831,7 @@ def write_diff_excel_output(
         logger.info(f"Diff Excel file created: {excel_file}")
         return excel_file
 
-    except Exception as e:
+    except (OSError, KeyError, TypeError, ValueError) as e:
         logger.error(_format_error_msg("creating diff Excel file", error=e))
         raise
 
@@ -4996,7 +4996,7 @@ def write_diff_csv_output(
         logger.info(f"Diff CSV files created in: {csv_dir}")
         return csv_dir
 
-    except Exception as e:
+    except (OSError, KeyError, TypeError, ValueError) as e:
         logger.error(_format_error_msg("creating diff CSV files", error=e))
         raise
 
@@ -5327,7 +5327,7 @@ def process_inventory_summary(
     except RECOVERABLE_API_EXCEPTIONS as e:
         print(ConsoleColors.error(f"ERROR: Failed to fetch data view: {e}"), file=sys.stderr)
         return {"error": str(e)}
-    except Exception as e:
+    except Exception as e:  # Intentional: fallback after RECOVERABLE_API for cjapy calls
         print(ConsoleColors.error(f"ERROR: Failed to fetch data view (unexpected): {e}"), file=sys.stderr)
         logger.debug("Unexpected error fetching data view", exc_info=True)
         return {"error": str(e)}
@@ -6315,8 +6315,8 @@ def process_single_dataview(
                 duration=time.time() - start_time,
                 error_message=f"Permission denied: {e!s}",
             )
-        except Exception as e:
-            logger.critical(f"Failed to generate Excel file: {e!s}")
+        except (OSError, KeyError, TypeError, ValueError) as e:
+            logger.critical(f"Failed to generate output file: {e!s}")
             logger.exception("Full exception details:")
             logger.info("=" * BANNER_WIDTH)
             logger.info("EXECUTION FAILED")
@@ -6334,7 +6334,7 @@ def process_single_dataview(
                 error_message=str(e),
             )
 
-    except Exception as e:
+    except Exception as e:  # Intentional: top-level processing boundary for API + runtime errors
         logger.critical(f"Unexpected error processing data view {data_view_id}: {e!s}")
         logger.exception("Full exception details:")
         logger.info("=" * BANNER_WIDTH)
@@ -6659,7 +6659,7 @@ class BatchProcessor:
                             for f in future_to_dv:
                                 f.cancel()
                             raise
-                        except Exception as e:
+                        except Exception as e:  # Intentional: batch worker resilience boundary
                             is_expected = isinstance(e, RECOVERABLE_BATCH_WORKER_EXCEPTIONS)
                             prefix = "EXCEPTION" if is_expected else "UNEXPECTED EXCEPTION"
                             self.logger.error(f"[{self.batch_id}] ✗ {dv_id}: {prefix} - {e!s}")
@@ -6969,7 +6969,7 @@ def run_dry_run(data_views: list[str], config_file: str, logger: logging.Logger,
             print(f"  ✗ {dv_id}: Error - {e!s}")
             invalid_count += 1
             all_passed = False
-        except Exception as e:
+        except Exception as e:  # Intentional: fallback after RECOVERABLE_API for cjapy calls
             logger.debug(f"Unexpected dry-run validation error for {dv_id}: {e!s}", exc_info=True)
             print(f"  ✗ {dv_id}: Error - {_dry_run_error_text(e)}")
             invalid_count += 1
@@ -7577,7 +7577,7 @@ def resolve_data_view_names(
             resolution_diagnostics,
             include_diagnostics=include_diagnostics,
         )
-    except Exception as e:
+    except Exception as e:  # Intentional: fallback after RECOVERABLE_API for cjapy calls
         error_message = f"Failed to resolve data view names (unexpected): {e!s}"
         logger.error(error_message)
         logger.debug("Unexpected error during name resolution", exc_info=True)
@@ -8424,7 +8424,7 @@ def _require_accessible_dataview(cja: Any, data_view_id: str) -> dict[str, Any]:
     """Fetch a data view and raise DiscoveryNotFoundError when inaccessible/invalid."""
     try:
         raw_payload = cja.getDataView(data_view_id)
-    except Exception as e:
+    except Exception as e:  # Intentional: wraps cjapy.getDataView() which may raise anything
         if _is_inaccessible_dataview_lookup_error(e):
             raise DiscoveryNotFoundError(f"Data view '{data_view_id}' not found") from e
         raise
@@ -8707,7 +8707,7 @@ def _count_component_items_for_fetch_spec(cja: Any, data_view_id: str, fetch_spe
     try:
         payload = _fetch_component_payload(cja, data_view_id, fetch_spec)
         return _count_component_items_or_na_from_assessment(payload)
-    except Exception:
+    except Exception:  # Intentional: wraps cjapy API; best-effort count
         return "N/A"
 
 
@@ -8735,7 +8735,7 @@ def _count_component_items_for_fetch_spec_with_retry(
         logger.debug("Could not fetch %s count for %s: non-countable payload", component_label, data_view_id)
     except RECOVERABLE_API_EXCEPTIONS as e:
         logger.debug("Could not fetch %s count for %s: %s", component_label, data_view_id, e)
-    except Exception as e:
+    except Exception as e:  # Intentional: fallback after RECOVERABLE_API for cjapy calls
         logger.debug("Unexpected %s count error for %s: %s", component_label, data_view_id, e, exc_info=True)
     return 0
 
@@ -10209,7 +10209,7 @@ def _read_config_status_file(config_file: str, logger: logging.Logger) -> tuple[
         return None, f"{config_file} is not valid JSON"
     except (UnicodeDecodeError, ConfigurationError, OSError) as e:
         return None, f"Cannot read {config_file}: {e}"
-    except Exception as e:
+    except (ValueError, TypeError) as e:
         logger.debug("Unexpected error reading config file in --config-status", exc_info=True)
         return None, f"Cannot read {config_file}: {e}"
 
@@ -10610,7 +10610,7 @@ def validate_config_only(config_file: str = "config.json", profile: str | None =
     except RECOVERABLE_API_EXCEPTIONS as e:
         print(f"  \u2717 API connection failed: {e!s}")
         all_passed = False
-    except Exception as e:
+    except Exception as e:  # Intentional: fallback after RECOVERABLE_API for cjapy calls
         print(f"  \u2717 API connection failed (unexpected): {e!s}")
         logging.getLogger(__name__).debug("Unexpected validate-config error", exc_info=True)
         all_passed = False
@@ -14065,7 +14065,7 @@ def handle_compare_snapshots_command(
         print(ConsoleColors.error(f"ERROR: Failed to compare snapshots: {e!s}"), file=sys.stderr)
         logger.debug("Snapshot comparison failed", exc_info=True)
         return False, False, None
-    except Exception as e:
+    except Exception as e:  # Intentional: tiered command boundary (see RECOVERABLE_COMMAND_HANDLER_EXCEPTIONS)
         print(ConsoleColors.error(f"ERROR: Failed to compare snapshots (unexpected): {e!s}"), file=sys.stderr)
         logger.debug("Unexpected snapshot comparison error", exc_info=True)
         return False, False, None
@@ -16126,7 +16126,7 @@ def main():
     except SystemExit as exc:
         exit_code = _normalize_exit_code(exc.code)
         raise
-    except Exception:
+    except Exception:  # Intentional: last-resort handler in main()
         exit_code = 1
         raise
     finally:
@@ -16167,7 +16167,7 @@ def main():
             output_dir = run_state.get("output_dir") or "."
             try:
                 write_run_summary_output(summary_payload, run_summary_output, output_dir=output_dir)
-            except Exception as e:
+            except Exception as e:  # Intentional: finally-block guard; must not mask original exception
                 print(
                     ConsoleColors.warning(f"Warning: Failed to write run summary to '{run_summary_output}': {e!s}"),
                     file=sys.stderr,

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -10381,9 +10381,11 @@ def validate_config_only(config_file: str = "config.json", profile: str | None =
     Validate configuration and API connectivity without processing data views.
 
     Tests:
-        1. Profile, environment variables, or config file exists
-        2. Required credentials are present
-        3. CJA API connection works
+        1. Check environment (Python version, platform)
+        2. Check dependencies (core + optional, with versions)
+        3. Check credentials (profile > env > config file)
+        4. Test API connectivity
+        5. Check output permissions (writable output dir)
 
     Args:
         config_file: Path to CJA configuration file
@@ -10418,27 +10420,84 @@ def validate_config_only(config_file: str = "config.json", profile: str | None =
                     masked = value[:4] + "****" + value[-4:] if len(value) > 8 else "****"
                 else:
                     masked = value
-                print(f"    ✓ {field_name}: {masked}")
+                print(f"    \u2713 {field_name}: {masked}")
             else:
-                print(f"    ✗ {field_name}: not set (required)")
+                print(f"    \u2717 {field_name}: not set (required)")
                 missing.append(field_name)
 
         for field_name in optional_fields:
             if creds.get(field_name):
-                print(f"    ✓ {field_name}: {creds[field_name]}")
+                print(f"    \u2713 {field_name}: {creds[field_name]}")
             else:
                 print(f"    - {field_name}: not set (optional)")
 
         print()
         if missing:
-            print(f"  ✗ Missing required fields: {', '.join(missing)}")
+            print(f"  \u2717 Missing required fields: {', '.join(missing)}")
             return False
-        print("  ✓ All required fields present")
-        print(f"  → Using: {source_name}")
+        print("  \u2713 All required fields present")
+        print(f"  \u2192 Using: {source_name}")
         return True
 
-    # Step 1: Check credentials (priority: profile > env > config file)
-    print("[1/3] Checking credentials...")
+    # Step 1: Check environment
+    print("[1/5] Checking environment...")
+    vi = sys.version_info
+    python_version = f"{vi.major}.{vi.minor}.{vi.micro}"
+    if vi >= (3, 14):
+        print(f"  \u2713 Python {python_version} (minimum: 3.14)")
+    else:
+        print(f"  \u2717 Python {python_version} (minimum: 3.14)")
+        all_passed = False
+    platform_system = platform.system()
+    platform_release = platform.release()
+    platform_label = sys.platform
+    if platform_system == "Darwin":
+        mac_ver = platform.mac_ver()[0]
+        if mac_ver:
+            platform_label += f" (macOS {mac_ver})"
+        else:
+            platform_label += f" ({platform_system} {platform_release})"
+    elif platform_system:
+        platform_label += f" ({platform_system} {platform_release})"
+    print(f"  \u2713 Platform: {platform_label}")
+
+    # Step 2: Check dependencies
+    print()
+    print("[2/5] Checking dependencies...")
+
+    # Core dependencies (must exist)
+    _core_deps = ("cjapy", "pandas", "numpy", "xlsxwriter", "tqdm")
+    for pkg in _core_deps:
+        try:
+            ver = importlib.metadata.version(pkg)
+            print(f"  \u2713 {pkg} {ver}")
+        except importlib.metadata.PackageNotFoundError:
+            print(f"  \u2717 {pkg} (not installed)")
+            all_passed = False
+
+    # Optional dependencies (info-only, never fail validation)
+    _optional_deps = (
+        ("scipy", "for --org-report clustering"),
+        ("argcomplete", "for shell tab-completion"),
+        ("python-dotenv", "for .env file loading"),
+    )
+    for pkg, purpose in _optional_deps:
+        try:
+            ver = importlib.metadata.version(pkg)
+            print(f"  - {pkg} {ver} (optional, {purpose})")
+        except importlib.metadata.PackageNotFoundError:
+            print(f"  - {pkg} not installed (optional, {purpose})")
+
+    if not all_passed:
+        print()
+        print("=" * BANNER_WIDTH)
+        print(ConsoleColors.error("VALIDATION FAILED - Fix issues above"))
+        print("=" * BANNER_WIDTH)
+        return False
+
+    # Step 3: Check credentials (priority: profile > env > config file)
+    print()
+    print("[3/5] Checking credentials...")
 
     # Priority 1: Profile
     if profile:
@@ -10446,33 +10505,33 @@ def validate_config_only(config_file: str = "config.json", profile: str | None =
         try:
             profile_creds = load_profile_credentials(profile, logger)
             if profile_creds:
-                print(f"  ✓ Profile '{profile}' found")
+                print(f"  \u2713 Profile '{profile}' found")
                 if display_credentials(profile_creds, f"Profile: {profile}"):
                     active_credentials = profile_creds
                     credential_source = "profile"
                 else:
                     all_passed = False
         except ProfileNotFoundError:
-            print(f"  ✗ Profile '{profile}' not found")
+            print(f"  \u2717 Profile '{profile}' not found")
             print()
             print("  Create the profile with:")
             print(f"    cja_auto_sdr --profile-add {profile}")
             all_passed = False
         except ProfileConfigError as e:
-            print(f"  ✗ Profile '{profile}' has invalid configuration: {e}")
+            print(f"  \u2717 Profile '{profile}' has invalid configuration: {e}")
             all_passed = False
 
     # Priority 2: Environment variables (if no profile or profile failed)
     if not active_credentials and all_passed:
         env_credentials = load_credentials_from_env()
         if env_credentials:
-            print("  ✓ Environment variables detected")
+            print("  \u2713 Environment variables detected")
             if validate_env_credentials(env_credentials, logger):
                 if display_credentials(env_credentials, "Environment variables"):
                     active_credentials = env_credentials
                     credential_source = "env"
             else:
-                print("  ⚠ Environment credentials incomplete, checking config file...")
+                print("  \u26a0 Environment credentials incomplete, checking config file...")
         else:
             if not profile:
                 print("  - No environment variables set")
@@ -10480,25 +10539,25 @@ def validate_config_only(config_file: str = "config.json", profile: str | None =
     # Priority 3: Config file (if no profile and no env)
     if not active_credentials and all_passed:
         print()
-        print("[2/3] Checking configuration file...")
+        print("[3/5] Checking configuration file...")
         config_path = Path(config_file)
         if config_path.exists():
             abs_path = config_path.resolve()
-            print(f"  ✓ Config file found: {abs_path}")
+            print(f"  \u2713 Config file found: {abs_path}")
             try:
                 with open(config_file) as f:
                     config = json.load(f)
-                print("  ✓ Config file is valid JSON")
+                print("  \u2713 Config file is valid JSON")
                 if display_credentials(config, f"Config file ({config_file})"):
                     active_credentials = config
                     credential_source = "file"
                 else:
                     all_passed = False
             except json.JSONDecodeError as e:
-                print(f"  ✗ Invalid JSON: {e!s}")
+                print(f"  \u2717 Invalid JSON: {e!s}")
                 all_passed = False
         else:
-            print(f"  ✗ Config file not found: {config_file}")
+            print(f"  \u2717 Config file not found: {config_file}")
             print()
             print("  To create a sample config file:")
             print("    cja_auto_sdr --sample-config")
@@ -10513,7 +10572,7 @@ def validate_config_only(config_file: str = "config.json", profile: str | None =
             all_passed = False
     elif active_credentials and credential_source in ("profile", "env"):
         print()
-        print(f"[2/3] Skipping config file check (using {credential_source} credentials)")
+        print(f"[3/5] Skipping config file check (using {credential_source} credentials)")
 
     if not all_passed:
         print()
@@ -10522,9 +10581,9 @@ def validate_config_only(config_file: str = "config.json", profile: str | None =
         print("=" * BANNER_WIDTH)
         return False
 
-    # Step 3: Test API connection
+    # Step 4: Test API connection
     print()
-    print("[3/3] Testing API connection...")
+    print("[4/5] Testing API connection...")
     try:
         # Configure cjapy with the active credentials
         if credential_source in ("profile", "env"):
@@ -10533,28 +10592,39 @@ def validate_config_only(config_file: str = "config.json", profile: str | None =
             cjapy.importConfigFile(config_file)
 
         cja = cjapy.CJA()
-        print("  ✓ CJA client initialized")
+        print("  \u2713 CJA client initialized")
 
         # Test connection with API call
         available_dvs = cja.getDataViews()
         if available_dvs is not None:
             dv_count = len(available_dvs) if hasattr(available_dvs, "__len__") else 0
-            print("  ✓ API connection successful")
-            print(f"  ✓ Found {dv_count} accessible data view(s)")
+            print("  \u2713 API connection successful")
+            print(f"  \u2713 Found {dv_count} accessible data view(s)")
         else:
-            print("  ⚠ API returned empty response - connection may be unstable")
+            print("  \u26a0 API returned empty response - connection may be unstable")
 
     except KeyboardInterrupt, SystemExit:
         print()
         print(ConsoleColors.warning("Validation cancelled."))
         raise
     except RECOVERABLE_API_EXCEPTIONS as e:
-        print(f"  ✗ API connection failed: {e!s}")
+        print(f"  \u2717 API connection failed: {e!s}")
         all_passed = False
     except Exception as e:
-        print(f"  ✗ API connection failed (unexpected): {e!s}")
+        print(f"  \u2717 API connection failed (unexpected): {e!s}")
         logging.getLogger(__name__).debug("Unexpected validate-config error", exc_info=True)
         all_passed = False
+
+    # Step 5: Check output permissions
+    if all_passed:
+        print()
+        print("[5/5] Checking output permissions...")
+        output_dir = "."
+        if os.access(output_dir, os.W_OK):
+            print(f"  \u2713 Output directory writable: {output_dir}")
+        else:
+            print(f"  \u2717 Output directory not writable: {output_dir}")
+            all_passed = False
 
     # Summary
     print()

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -1504,18 +1504,13 @@ def _read_profile_org_id(profile_path: Path) -> str | None:
             pass
 
     # Override: .env (takes precedence, matching load_profile_credentials)
-    env_file = profile_path / ".env"
-    if env_file.exists():
-        try:
-            with open(env_file) as f:
-                for line in f:
-                    line = line.strip()
-                    if line.startswith("ORG_ID="):
-                        value = line.partition("=")[2].strip().strip('"').strip("'")
-                        if value:
-                            org_id = value
-        except OSError:
-            pass
+    env_credentials = load_profile_dotenv(profile_path)
+    if env_credentials:
+        env_org_id = env_credentials.get("org_id")
+        if isinstance(env_org_id, str):
+            normalized_org_id = env_org_id.strip()
+            if normalized_org_id:
+                org_id = normalized_org_id
 
     return org_id
 
@@ -10380,6 +10375,43 @@ def show_config_status(config_file: str = "config.json", profile: str | None = N
 # ==================== VALIDATE CONFIG ====================
 
 
+def _resolve_output_dir_path(output_dir: str | Path) -> Path:
+    """Resolve output directory for permission checks without requiring it to exist."""
+    output_path = Path(output_dir).expanduser()
+    try:
+        return output_path.resolve(strict=False)
+    # PEP 758 (Python 3.14+): `except A, B:` is equivalent to `except (A, B):`.
+    except OSError, RuntimeError, ValueError:
+        return Path(os.path.abspath(str(output_path)))
+
+
+def _check_output_dir_access(output_dir: str | Path) -> tuple[bool, Path, str, Path | None]:
+    """Check whether an output directory is writable now or creatable later.
+
+    Returns:
+        Tuple: (is_accessible, resolved_output_dir, reason, parent_dir)
+    """
+    resolved_dir = _resolve_output_dir_path(output_dir)
+
+    if resolved_dir.exists():
+        if not resolved_dir.is_dir():
+            return False, resolved_dir, "not_directory", None
+        if os.access(resolved_dir, os.W_OK | os.X_OK):
+            return True, resolved_dir, "writable", None
+        return False, resolved_dir, "not_writable", None
+
+    for candidate in resolved_dir.parents:
+        if not candidate.exists():
+            continue
+        if not candidate.is_dir():
+            return False, resolved_dir, "parent_not_directory", candidate
+        if os.access(candidate, os.W_OK | os.X_OK):
+            return True, resolved_dir, "creatable", candidate
+        return False, resolved_dir, "parent_not_writable", candidate
+
+    return False, resolved_dir, "no_existing_parent", None
+
+
 def validate_config_only(
     config_file: str = "config.json",
     profile: str | None = None,
@@ -10628,11 +10660,25 @@ def validate_config_only(
     if all_passed:
         print()
         print("[5/5] Checking output permissions...")
-        resolved_dir = os.path.abspath(output_dir)
-        if os.access(resolved_dir, os.W_OK):
+        output_access_ok, resolved_dir, access_reason, parent_dir = _check_output_dir_access(output_dir)
+        if output_access_ok and access_reason == "creatable" and parent_dir is not None:
+            print(f"  \u2713 Output directory creatable: {resolved_dir} (parent writable: {parent_dir})")
+        elif output_access_ok:
             print(f"  \u2713 Output directory writable: {resolved_dir}")
         else:
-            print(f"  \u2717 Output directory not writable: {resolved_dir}")
+            if access_reason == "not_directory":
+                print(f"  \u2717 Output path is not a directory: {resolved_dir}")
+            elif access_reason == "parent_not_directory" and parent_dir is not None:
+                print(
+                    "  \u2717 Cannot create output directory: "
+                    f"{resolved_dir} (path component is not a directory: {parent_dir})",
+                )
+            elif access_reason == "parent_not_writable" and parent_dir is not None:
+                print(f"  \u2717 Cannot create output directory: {resolved_dir} (parent not writable: {parent_dir})")
+            elif access_reason == "no_existing_parent":
+                print(f"  \u2717 Cannot determine writable parent for output directory: {resolved_dir}")
+            else:
+                print(f"  \u2717 Output directory not writable: {resolved_dir}")
             all_passed = False
 
     # Summary
@@ -15559,20 +15605,22 @@ def _main_impl(run_state: dict[str, Any] | None = None):
         sys.exit(1)
 
     # Proactive output directory write check - fail fast before API calls
-    output_dir = Path(args.output_dir)
-    if output_dir.exists():
-        # Directory exists - check write permissions
-        if not os.access(output_dir, os.W_OK):
-            print(ConsoleColors.error(f"ERROR: Cannot write to output directory: {output_dir}"), file=sys.stderr)
-            print("Check permissions and try again.", file=sys.stderr)
-            sys.exit(1)
-    else:
-        # Directory doesn't exist - check we can create it by checking parent
-        parent_dir = output_dir.parent
-        if parent_dir.exists() and not os.access(parent_dir, os.W_OK):
-            print(ConsoleColors.error(f"ERROR: Cannot create output directory: {output_dir}"), file=sys.stderr)
+    output_access_ok, resolved_output_dir, access_reason, parent_dir = _check_output_dir_access(args.output_dir)
+    if not output_access_ok:
+        if access_reason == "not_directory":
+            print(ConsoleColors.error(f"ERROR: Output path is not a directory: {resolved_output_dir}"), file=sys.stderr)
+        elif access_reason == "parent_not_directory" and parent_dir is not None:
+            print(ConsoleColors.error(f"ERROR: Cannot create output directory: {resolved_output_dir}"), file=sys.stderr)
+            print(f"Path component is not a directory: {parent_dir}", file=sys.stderr)
+        elif access_reason == "parent_not_writable" and parent_dir is not None:
+            print(ConsoleColors.error(f"ERROR: Cannot create output directory: {resolved_output_dir}"), file=sys.stderr)
             print(f"Parent directory {parent_dir} is not writable.", file=sys.stderr)
-            sys.exit(1)
+        else:
+            print(
+                ConsoleColors.error(f"ERROR: Cannot write to output directory: {resolved_output_dir}"), file=sys.stderr
+            )
+            print("Check permissions and try again.", file=sys.stderr)
+        sys.exit(1)
 
     # Process data views - start timing here for accurate processing-only runtime
     processing_start_time = time.time()

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -10517,6 +10517,9 @@ def validate_config_only(
         except importlib.metadata.PackageNotFoundError:
             print(f"  \u2717 {pkg} (not installed)")
             all_passed = False
+        except Exception as exc:
+            print(f"  \u2717 {pkg} (metadata error: {exc})")
+            all_passed = False
 
     # Optional dependencies (info-only, never fail validation)
     _optional_deps = (
@@ -10530,6 +10533,8 @@ def validate_config_only(
             print(f"  - {pkg} {ver} (optional, {purpose})")
         except importlib.metadata.PackageNotFoundError:
             print(f"  - {pkg} not installed (optional, {purpose})")
+        except Exception as exc:
+            print(f"  - {pkg} metadata error: {exc} (optional, {purpose})")
 
     if not all_passed:
         print()

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -481,6 +481,7 @@ class RunMode(Enum):
     """CLI run modes used by dispatch and run summary classification."""
 
     EXIT_CODES = "exit_codes"
+    COMPLETION = "completion"
     SAMPLE_CONFIG = "sample_config"
     PROFILE_MANAGEMENT = "profile_management"
     GIT_INIT = "git_init"
@@ -1009,6 +1010,7 @@ def _infer_run_mode_enum(args: argparse.Namespace) -> RunMode:
     """Infer run mode using the same precedence as command dispatch in _main_impl."""
     mode_checks: tuple[tuple[RunMode, bool], ...] = (
         (RunMode.EXIT_CODES, getattr(args, "exit_codes", False)),
+        (RunMode.COMPLETION, bool(getattr(args, "completion", None))),
         (RunMode.SAMPLE_CONFIG, getattr(args, "sample_config", False)),
         (
             RunMode.PROFILE_MANAGEMENT,

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -14237,6 +14237,13 @@ def _main_impl(run_state: dict[str, Any] | None = None):
         print_exit_codes(banner_width=BANNER_WIDTH)
         sys.exit(0)
 
+    # Handle --completion mode (safety net — normally caught by __main__ fast-path)
+    completion_shell = getattr(args, "completion", None)
+    if completion_shell is not None:
+        from cja_auto_sdr.__main__ import _handle_completion
+
+        _handle_completion(completion_shell)
+
     # Handle --sample-config mode (no data view required)
     if args.sample_config:
         success = generate_sample_config()

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -1474,7 +1474,9 @@ def resolve_active_profile(cli_profile: str | None = None) -> str | None:
 def _read_profile_org_id(profile_path: Path) -> str | None:
     """Read org_id from a profile directory (best-effort, no validation).
 
-    Checks config.json first, then falls back to .env.
+    Matches ``load_profile_credentials`` precedence: .env values override
+    config.json values.  We read config.json first as a base, then let .env
+    override if present.
 
     Args:
         profile_path: Path to the profile directory
@@ -1482,21 +1484,22 @@ def _read_profile_org_id(profile_path: Path) -> str | None:
     Returns:
         The org_id string, or None if not found or unreadable
     """
-    # Try config.json first
+    org_id: str | None = None
+
     config_file = profile_path / "config.json"
     if config_file.exists():
         try:
             with open(config_file) as f:
                 data = json.load(f)
             if isinstance(data, dict):
-                org_id = data.get("org_id")
-                if org_id and isinstance(org_id, str):
-                    return org_id.strip()
+                val = data.get("org_id")
+                if val and isinstance(val, str) and val.strip():
+                    org_id = val.strip()
         # PEP 758 (Python 3.14+): `except A, B:` is equivalent to `except (A, B):`.
         except OSError, json.JSONDecodeError, ValueError:
             pass
 
-    # Fall back to .env
+    # Override: .env (takes precedence, matching load_profile_credentials)
     env_file = profile_path / ".env"
     if env_file.exists():
         try:
@@ -1506,11 +1509,11 @@ def _read_profile_org_id(profile_path: Path) -> str | None:
                     if line.startswith("ORG_ID="):
                         value = line.partition("=")[2].strip().strip('"').strip("'")
                         if value:
-                            return value
+                            org_id = value
         except OSError:
             pass
 
-    return None
+    return org_id
 
 
 def list_profiles(output_format: str = "table") -> bool:

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -1008,9 +1008,10 @@ def _infer_run_status(exit_code: int, run_state: dict[str, Any]) -> str:
 
 def _infer_run_mode_enum(args: argparse.Namespace) -> RunMode:
     """Infer run mode using the same precedence as command dispatch in _main_impl."""
+    completion_shell = _completion_shell_from_args(args)
     mode_checks: tuple[tuple[RunMode, bool], ...] = (
         (RunMode.EXIT_CODES, getattr(args, "exit_codes", False)),
-        (RunMode.COMPLETION, bool(getattr(args, "completion", None))),
+        (RunMode.COMPLETION, completion_shell is not None),
         (RunMode.SAMPLE_CONFIG, getattr(args, "sample_config", False)),
         (
             RunMode.PROFILE_MANAGEMENT,
@@ -1057,6 +1058,30 @@ def _infer_run_mode_enum(args: argparse.Namespace) -> RunMode:
         if is_active:
             return mode
     return RunMode.SDR
+
+
+def _completion_shell_from_args(args: argparse.Namespace) -> str | None:
+    """Return normalized completion shell from parsed args, if present."""
+    raw_completion = getattr(args, "completion", None)
+    if not isinstance(raw_completion, str):
+        return None
+    normalized = raw_completion.strip().lower()
+    return normalized or None
+
+
+def _handle_completion_prevalidation(
+    completion_shell: str,
+    run_state: dict[str, Any] | None = None,
+) -> NoReturn:
+    """Handle completion mode before unrelated global validation paths."""
+    from cja_auto_sdr.__main__ import _handle_completion
+
+    try:
+        _handle_completion(completion_shell, sys.argv[0] if sys.argv else None)
+    except SystemExit as exc:
+        if run_state is not None:
+            run_state["details"] = {"operation_success": _normalize_exit_code(exc.code) == 0}
+        raise
 
 
 def _infer_run_mode(args: argparse.Namespace) -> str:
@@ -14189,6 +14214,12 @@ def _main_impl(run_state: dict[str, Any] | None = None):
         run_state["data_view_inputs"] = list(getattr(args, "data_views", []))
         run_state["run_summary_output"] = getattr(args, "run_summary_json", run_state.get("run_summary_output"))
 
+    # Completion must short-circuit before unrelated option parsing/validation
+    # so mixed argv (for run-summary and fast-path fallbacks) remains robust.
+    completion_shell = _completion_shell_from_args(args)
+    if completion_shell is not None:
+        _handle_completion_prevalidation(completion_shell, run_state=run_state)
+
     run_summary_to_stdout = getattr(args, "run_summary_json", None) in ("-", "stdout")
     quality_policy_path = getattr(args, "quality_policy", None)
     applied_quality_policy: dict[str, Any] = {}
@@ -14307,13 +14338,6 @@ def _main_impl(run_state: dict[str, Any] | None = None):
 
         print_exit_codes(banner_width=BANNER_WIDTH)
         sys.exit(0)
-
-    # Handle --completion mode (safety net — normally caught by __main__ fast-path)
-    completion_shell = getattr(args, "completion", None)
-    if completion_shell is not None:
-        from cja_auto_sdr.__main__ import _handle_completion
-
-        _handle_completion(completion_shell, sys.argv[0] if sys.argv else None)
 
     # Handle --sample-config mode (no data view required)
     if args.sample_config:

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -14297,7 +14297,7 @@ def _main_impl(run_state: dict[str, Any] | None = None):
     if completion_shell is not None:
         from cja_auto_sdr.__main__ import _handle_completion
 
-        _handle_completion(completion_shell)
+        _handle_completion(completion_shell, sys.argv[0] if sys.argv else None)
 
     # Handle --sample-config mode (no data view required)
     if args.sample_config:

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -1471,6 +1471,48 @@ def resolve_active_profile(cli_profile: str | None = None) -> str | None:
     return os.environ.get("CJA_PROFILE")
 
 
+def _read_profile_org_id(profile_path: Path) -> str | None:
+    """Read org_id from a profile directory (best-effort, no validation).
+
+    Checks config.json first, then falls back to .env.
+
+    Args:
+        profile_path: Path to the profile directory
+
+    Returns:
+        The org_id string, or None if not found or unreadable
+    """
+    # Try config.json first
+    config_file = profile_path / "config.json"
+    if config_file.exists():
+        try:
+            with open(config_file) as f:
+                data = json.load(f)
+            if isinstance(data, dict):
+                org_id = data.get("org_id")
+                if org_id and isinstance(org_id, str):
+                    return org_id.strip()
+        # PEP 758 (Python 3.14+): `except A, B:` is equivalent to `except (A, B):`.
+        except OSError, json.JSONDecodeError, ValueError:
+            pass
+
+    # Fall back to .env
+    env_file = profile_path / ".env"
+    if env_file.exists():
+        try:
+            with open(env_file) as f:
+                for line in f:
+                    line = line.strip()
+                    if line.startswith("ORG_ID="):
+                        value = line.partition("=")[2].strip().strip('"').strip("'")
+                        if value:
+                            return value
+        except OSError:
+            pass
+
+    return None
+
+
 def list_profiles(output_format: str = "table") -> bool:
     """List all profiles with status indicators.
 
@@ -1514,7 +1556,17 @@ def list_profiles(output_format: str = "table") -> bool:
             if has_env:
                 config_source.append(".env")
 
-            profiles.append({"name": profile_name, "active": is_active, "sources": config_source, "path": str(item)})
+            org_id = _read_profile_org_id(item)
+
+            profiles.append(
+                {
+                    "name": profile_name,
+                    "active": is_active,
+                    "sources": config_source,
+                    "path": str(item),
+                    "org_id": org_id,
+                }
+            )
 
     if output_format == "json":
         print(json.dumps({"profiles": profiles, "count": len(profiles), "active": active_profile}, indent=2))
@@ -1531,13 +1583,18 @@ def list_profiles(output_format: str = "table") -> bool:
             print("To create a profile, run:")
             print("  cja_auto_sdr --profile-add <profile-name>")
         else:
-            print(f"{'Profile':<25} {'Sources':<20} {'Status'}")
-            print("-" * 60)
+            # Column widths: marker(2) + name(23) + org_id(32) + sources(20) + status
+            max_org_width = 30
+            print(f"  {'Profile':<23} {'Org ID':<{max_org_width}}  {'Sources':<20} {'Status'}")
+            print("  " + "-" * 60)
             for p in profiles:
                 status = "[active]" if p["active"] else ""
                 sources = ", ".join(p["sources"])
-                marker = "●" if p["active"] else " "
-                print(f"{marker} {p['name']:<23} {sources:<20} {status}")
+                marker = "\u25cf" if p["active"] else " "
+                org_display = p["org_id"] or "\u2014"
+                if len(org_display) > max_org_width:
+                    org_display = org_display[: max_org_width - 1] + "\u2026"
+                print(f"{marker} {p['name']:<23} {org_display:<{max_org_width}}  {sources:<20} {status}")
 
             print()
             print(f"Total: {len(profiles)} profile(s)")

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -3,10 +3,12 @@ import contextlib
 import csv
 import hashlib
 import html
+import importlib.metadata
 import io
 import json
 import logging
 import os
+import platform
 import re
 import shlex
 import shutil
@@ -1080,6 +1082,29 @@ def _processing_result_to_summary(result: ProcessingResult) -> dict[str, Any]:
         "calculated_metrics_high_complexity": result.calculated_metrics_high_complexity,
         "derived_fields_count": result.derived_fields_count,
         "derived_fields_high_complexity": result.derived_fields_high_complexity,
+    }
+
+
+_ENVIRONMENT_DEPENDENCIES = ("cjapy", "pandas", "numpy", "xlsxwriter", "tqdm")
+
+
+def _collect_environment_info() -> dict[str, Any]:
+    """Collect runtime environment info for the run summary payload."""
+    vi = sys.version_info
+    python_version = f"{vi.major}.{vi.minor}.{vi.micro}"
+
+    deps: dict[str, str] = {}
+    for pkg in _ENVIRONMENT_DEPENDENCIES:
+        try:
+            deps[pkg] = importlib.metadata.version(pkg)
+        except Exception:
+            deps[pkg] = "unknown"
+
+    return {
+        "python_version": python_version,
+        "platform": sys.platform,
+        "platform_version": platform.platform(),
+        "dependencies": deps,
     }
 
 
@@ -15976,6 +16001,7 @@ def main():
             summary_payload = {
                 "summary_version": "1.0",
                 "tool_version": __version__,
+                "environment": _collect_environment_info(),
                 "started_at": summary_start,
                 "ended_at": datetime.now(UTC).isoformat(),
                 "duration_seconds": round(time.time() - summary_start_perf, 3),

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -1369,7 +1369,8 @@ def load_profile_dotenv(profile_path: Path) -> dict[str, str] | None:
         profile_path: Path to profile directory
 
     Returns:
-        Dictionary with credentials if .env exists and is valid, None otherwise
+        Dictionary with credentials if .env exists and is valid, None otherwise.
+        Malformed/unreadable files are treated as missing.
     """
     env_file = profile_path / ".env"
     if not env_file.exists():
@@ -1377,7 +1378,9 @@ def load_profile_dotenv(profile_path: Path) -> dict[str, str] | None:
 
     credentials = {}
     try:
-        with open(env_file) as f:
+        # Profiles are written by this tool as UTF-8; decode failures are handled
+        # as unreadable input so one bad file does not break profile operations.
+        with open(env_file, encoding="utf-8") as f:
             for line in f:
                 line = line.strip()
                 if not line or line.startswith("#"):
@@ -1392,7 +1395,8 @@ def load_profile_dotenv(profile_path: Path) -> dict[str, str] | None:
                         # Use CREDENTIAL_FIELDS for allowed fields (single source of truth)
                         if config_key in CREDENTIAL_FIELDS["all"]:
                             credentials[config_key] = value
-    except OSError:
+    # PEP 758 (Python 3.14+): `except A, B:` is equivalent to `except (A, B):`.
+    except OSError, UnicodeDecodeError:
         return None
 
     return credentials or None
@@ -1560,7 +1564,12 @@ def list_profiles(output_format: str = "table") -> bool:
             if has_env:
                 config_source.append(".env")
 
-            org_id = _read_profile_org_id(item)
+            try:
+                org_id = _read_profile_org_id(item)
+            except Exception:
+                # Best-effort metadata enrichment only; listing must remain
+                # available even if an individual profile cannot be read.
+                org_id = None
 
             profiles.append(
                 {

--- a/tests/README.md
+++ b/tests/README.md
@@ -92,7 +92,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 5,080 comprehensive tests**
+**Total: 5,083 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -182,8 +182,8 @@ tests/
 | `test_update_test_counts.py` | 2 | Test count validation tests |
 | `test_cli_smoke_modes.py` | 10 | CLI smoke tests for core command modes |
 | `test_generator_mock_contract.py` | 2 | Generator mock symbol contract tests |
-| `test_completion.py` | 47 | Shell completion flag (--completion bash/zsh/fish) |
-| **Total** | **5,080** | **Collected via pytest --collect-only** |
+| `test_completion.py` | 50 | Shell completion flag (--completion bash/zsh/fish) |
+| **Total** | **5,083** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -587,7 +587,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (5,080 tests total)
+- [x] Comprehensive test coverage (5,083 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 76 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -92,7 +92,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 4,947 comprehensive tests**
+**Total: 4,962 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -138,7 +138,7 @@ tests/
 | `test_output_content_validation.py` | 26 | Output format content validation (CSV, JSON, HTML, Excel, Markdown roundtrip) |
 | `test_malformed_api_responses.py` | 19 | Negative tests for malformed/unexpected API responses |
 | `test_main_entry_points.py` | 19 | main() and _main_impl() entry points, dispatch, run_state, run summary |
-| `test_quality_policy_and_run_summary.py` | 57 | Quality policy functions and run summary/status inference |
+| `test_quality_policy_and_run_summary.py` | 65 | Quality policy functions and run summary/status inference |
 | `test_e2e_integration.py` | 16 | End-to-end integration tests with real pipeline, mocked API boundary |
 | `test_api_client.py` | 25 | API client exception paths and error handling |
 | `test_config_validation.py` | 55 | Configuration validation logic |
@@ -182,7 +182,7 @@ tests/
 | `test_update_test_counts.py` | 2 | Test count validation tests |
 | `test_cli_smoke_modes.py` | 10 | CLI smoke tests for core command modes |
 | `test_generator_mock_contract.py` | 2 | Generator mock symbol contract tests |
-| **Total** | **4,947** | **Collected via pytest --collect-only** |
+| **Total** | **4,962** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -586,7 +586,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (4,947 tests total)
+- [x] Comprehensive test coverage (4,962 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 48 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -92,7 +92,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 5,032 comprehensive tests**
+**Total: 5,038 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -103,7 +103,7 @@ tests/
 | `test_org_report.py` | 172 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
 | `test_org_report_integration.py` | 17 | Org-wide analysis integration tests: end-to-end flows, caching, filtering, governance |
 | `test_cli.py` | 384 | Command-line interface and argument parsing |
-| `test_profiles.py` | 71 | Multi-organization profile support |
+| `test_profiles.py` | 73 | Multi-organization profile support |
 | `test_derived_inventory.py` | 62 | Derived fields inventory feature |
 | `test_inventory_utils.py` | 47 | Inventory utilities and helpers |
 | `test_segments_inventory.py` | 48 | Segments inventory feature |
@@ -163,7 +163,7 @@ tests/
 | `test_cli_command_handlers.py` | 131 | CLI dispatch for --stats, --org-report, --list-snapshots, discovery inspection, diff config unpacking |
 | `test_profile_management.py` | 45 | Interactive profile creation, import, test, show |
 | `test_snapshot_commands.py` | 58 | Snapshot creation, comparison, name resolution |
-| `test_config_and_resolution.py` | 99 | Config status, validation, stats, name resolution |
+| `test_config_and_resolution.py` | 101 | Config status, validation, stats, name resolution |
 | `test_derived_fields_edge_cases.py` | 34 | Derived fields edge cases and coverage |
 | `test_diff_command_coverage.py` | 45 | Diff command edge cases and coverage |
 | `test_generator_interactive_and_console.py` | 24 | Generator interactive and console tests |
@@ -182,8 +182,8 @@ tests/
 | `test_update_test_counts.py` | 2 | Test count validation tests |
 | `test_cli_smoke_modes.py` | 10 | CLI smoke tests for core command modes |
 | `test_generator_mock_contract.py` | 2 | Generator mock symbol contract tests |
-| `test_completion.py` | 34 | Shell completion flag (--completion bash/zsh/fish) |
-| **Total** | **5,032** | **Collected via pytest --collect-only** |
+| `test_completion.py` | 36 | Shell completion flag (--completion bash/zsh/fish) |
+| **Total** | **5,038** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -587,10 +587,10 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (5,032 tests total)
+- [x] Comprehensive test coverage (5,038 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
-- [x] Profile management tests (test_profiles.py) - 71 tests
+- [x] Profile management tests (test_profiles.py) - 73 tests
 - [x] API worker auto-tuning tests (test_api_tuning.py) - 23 tests
 - [x] Circuit breaker pattern tests (test_circuit_breaker.py) - 22 tests
 - [x] Shared validation cache tests (test_shared_cache.py) - 17 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -92,7 +92,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 4,962 comprehensive tests**
+**Total: 5,031 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -182,7 +182,8 @@ tests/
 | `test_update_test_counts.py` | 2 | Test count validation tests |
 | `test_cli_smoke_modes.py` | 10 | CLI smoke tests for core command modes |
 | `test_generator_mock_contract.py` | 2 | Generator mock symbol contract tests |
-| **Total** | **4,962** | **Collected via pytest --collect-only** |
+| `test_completion.py` | 34 | Shell completion flag (--completion bash/zsh/fish) |
+| **Total** | **5,031** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -586,7 +587,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (4,962 tests total)
+- [x] Comprehensive test coverage (5,031 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 48 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -92,7 +92,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 5,038 comprehensive tests**
+**Total: 5,061 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -102,7 +102,7 @@ tests/
 | `test_ux_features.py` | 123 | UX features: --open, --stats, --output, --list-dataviews formats, inventory validation, inventory summary, include-all-inventory |
 | `test_org_report.py` | 172 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
 | `test_org_report_integration.py` | 17 | Org-wide analysis integration tests: end-to-end flows, caching, filtering, governance |
-| `test_cli.py` | 384 | Command-line interface and argument parsing |
+| `test_cli.py` | 396 | Command-line interface and argument parsing |
 | `test_profiles.py` | 73 | Multi-organization profile support |
 | `test_derived_inventory.py` | 62 | Derived fields inventory feature |
 | `test_inventory_utils.py` | 47 | Inventory utilities and helpers |
@@ -182,8 +182,8 @@ tests/
 | `test_update_test_counts.py` | 2 | Test count validation tests |
 | `test_cli_smoke_modes.py` | 10 | CLI smoke tests for core command modes |
 | `test_generator_mock_contract.py` | 2 | Generator mock symbol contract tests |
-| `test_completion.py` | 36 | Shell completion flag (--completion bash/zsh/fish) |
-| **Total** | **5,038** | **Collected via pytest --collect-only** |
+| `test_completion.py` | 47 | Shell completion flag (--completion bash/zsh/fish) |
+| **Total** | **5,061** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -587,7 +587,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (5,038 tests total)
+- [x] Comprehensive test coverage (5,061 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 73 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -92,7 +92,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 5,031 comprehensive tests**
+**Total: 5,032 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -163,7 +163,7 @@ tests/
 | `test_cli_command_handlers.py` | 131 | CLI dispatch for --stats, --org-report, --list-snapshots, discovery inspection, diff config unpacking |
 | `test_profile_management.py` | 45 | Interactive profile creation, import, test, show |
 | `test_snapshot_commands.py` | 58 | Snapshot creation, comparison, name resolution |
-| `test_config_and_resolution.py` | 98 | Config status, validation, stats, name resolution |
+| `test_config_and_resolution.py` | 99 | Config status, validation, stats, name resolution |
 | `test_derived_fields_edge_cases.py` | 34 | Derived fields edge cases and coverage |
 | `test_diff_command_coverage.py` | 45 | Diff command edge cases and coverage |
 | `test_generator_interactive_and_console.py` | 24 | Generator interactive and console tests |
@@ -183,7 +183,7 @@ tests/
 | `test_cli_smoke_modes.py` | 10 | CLI smoke tests for core command modes |
 | `test_generator_mock_contract.py` | 2 | Generator mock symbol contract tests |
 | `test_completion.py` | 34 | Shell completion flag (--completion bash/zsh/fish) |
-| **Total** | **5,031** | **Collected via pytest --collect-only** |
+| **Total** | **5,032** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -587,7 +587,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (5,031 tests total)
+- [x] Comprehensive test coverage (5,032 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 71 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -103,7 +103,7 @@ tests/
 | `test_org_report.py` | 172 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
 | `test_org_report_integration.py` | 17 | Org-wide analysis integration tests: end-to-end flows, caching, filtering, governance |
 | `test_cli.py` | 384 | Command-line interface and argument parsing |
-| `test_profiles.py` | 48 | Multi-organization profile support |
+| `test_profiles.py` | 71 | Multi-organization profile support |
 | `test_derived_inventory.py` | 62 | Derived fields inventory feature |
 | `test_inventory_utils.py` | 47 | Inventory utilities and helpers |
 | `test_segments_inventory.py` | 48 | Segments inventory feature |
@@ -147,7 +147,7 @@ tests/
 | `test_snapshot.py` | 72 | Diff snapshot creation and comparison |
 | `test_colors.py` | 121 | Console color formatting, themes, TTY detection |
 | `test_exceptions.py` | 64 | Custom exception classes construction and formatting |
-| `test_logging_redaction.py` | 136 | Logging, sensitive data redaction, JSON formatter |
+| `test_logging_redaction.py` | 143 | Logging, sensitive data redaction, JSON formatter |
 | `test_config_dataclasses.py` | 88 | Config dataclasses and constants functions |
 | `test_lock_manager.py` | 48 | Lock manager acquire/release/heartbeat lifecycle |
 | `test_lazy_forwarding.py` | 71 | Lazy-forwarding infrastructure and make_getattr() |
@@ -163,7 +163,7 @@ tests/
 | `test_cli_command_handlers.py` | 131 | CLI dispatch for --stats, --org-report, --list-snapshots, discovery inspection, diff config unpacking |
 | `test_profile_management.py` | 45 | Interactive profile creation, import, test, show |
 | `test_snapshot_commands.py` | 58 | Snapshot creation, comparison, name resolution |
-| `test_config_and_resolution.py` | 86 | Config status, validation, stats, name resolution |
+| `test_config_and_resolution.py` | 98 | Config status, validation, stats, name resolution |
 | `test_derived_fields_edge_cases.py` | 34 | Derived fields edge cases and coverage |
 | `test_diff_command_coverage.py` | 45 | Diff command edge cases and coverage |
 | `test_generator_interactive_and_console.py` | 24 | Generator interactive and console tests |
@@ -590,7 +590,7 @@ Check for drift (CI-friendly):
 - [x] Comprehensive test coverage (5,031 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
-- [x] Profile management tests (test_profiles.py) - 48 tests
+- [x] Profile management tests (test_profiles.py) - 71 tests
 - [x] API worker auto-tuning tests (test_api_tuning.py) - 23 tests
 - [x] Circuit breaker pattern tests (test_circuit_breaker.py) - 22 tests
 - [x] Shared validation cache tests (test_shared_cache.py) - 17 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -92,7 +92,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 5,061 comprehensive tests**
+**Total: 5,068 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -102,7 +102,7 @@ tests/
 | `test_ux_features.py` | 123 | UX features: --open, --stats, --output, --list-dataviews formats, inventory validation, inventory summary, include-all-inventory |
 | `test_org_report.py` | 172 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
 | `test_org_report_integration.py` | 17 | Org-wide analysis integration tests: end-to-end flows, caching, filtering, governance |
-| `test_cli.py` | 396 | Command-line interface and argument parsing |
+| `test_cli.py` | 399 | Command-line interface and argument parsing |
 | `test_profiles.py` | 73 | Multi-organization profile support |
 | `test_derived_inventory.py` | 62 | Derived fields inventory feature |
 | `test_inventory_utils.py` | 47 | Inventory utilities and helpers |
@@ -137,7 +137,7 @@ tests/
 | `test_discovery_component_consistency.py` | 7 | Discovery component retrieval consistency |
 | `test_output_content_validation.py` | 26 | Output format content validation (CSV, JSON, HTML, Excel, Markdown roundtrip) |
 | `test_malformed_api_responses.py` | 19 | Negative tests for malformed/unexpected API responses |
-| `test_main_entry_points.py` | 19 | main() and _main_impl() entry points, dispatch, run_state, run summary |
+| `test_main_entry_points.py` | 20 | main() and _main_impl() entry points, dispatch, run_state, run summary |
 | `test_quality_policy_and_run_summary.py` | 65 | Quality policy functions and run summary/status inference |
 | `test_e2e_integration.py` | 16 | End-to-end integration tests with real pipeline, mocked API boundary |
 | `test_api_client.py` | 25 | API client exception paths and error handling |
@@ -147,7 +147,7 @@ tests/
 | `test_snapshot.py` | 72 | Diff snapshot creation and comparison |
 | `test_colors.py` | 121 | Console color formatting, themes, TTY detection |
 | `test_exceptions.py` | 64 | Custom exception classes construction and formatting |
-| `test_logging_redaction.py` | 143 | Logging, sensitive data redaction, JSON formatter |
+| `test_logging_redaction.py` | 146 | Logging, sensitive data redaction, JSON formatter |
 | `test_config_dataclasses.py` | 88 | Config dataclasses and constants functions |
 | `test_lock_manager.py` | 48 | Lock manager acquire/release/heartbeat lifecycle |
 | `test_lazy_forwarding.py` | 71 | Lazy-forwarding infrastructure and make_getattr() |
@@ -183,7 +183,7 @@ tests/
 | `test_cli_smoke_modes.py` | 10 | CLI smoke tests for core command modes |
 | `test_generator_mock_contract.py` | 2 | Generator mock symbol contract tests |
 | `test_completion.py` | 47 | Shell completion flag (--completion bash/zsh/fish) |
-| **Total** | **5,061** | **Collected via pytest --collect-only** |
+| **Total** | **5,068** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -587,7 +587,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (5,061 tests total)
+- [x] Comprehensive test coverage (5,068 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 73 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -92,7 +92,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 5,077 comprehensive tests**
+**Total: 5,080 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -103,7 +103,7 @@ tests/
 | `test_org_report.py` | 172 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
 | `test_org_report_integration.py` | 17 | Org-wide analysis integration tests: end-to-end flows, caching, filtering, governance |
 | `test_cli.py` | 399 | Command-line interface and argument parsing |
-| `test_profiles.py` | 73 | Multi-organization profile support |
+| `test_profiles.py` | 76 | Multi-organization profile support |
 | `test_derived_inventory.py` | 62 | Derived fields inventory feature |
 | `test_inventory_utils.py` | 47 | Inventory utilities and helpers |
 | `test_segments_inventory.py` | 48 | Segments inventory feature |
@@ -183,7 +183,7 @@ tests/
 | `test_cli_smoke_modes.py` | 10 | CLI smoke tests for core command modes |
 | `test_generator_mock_contract.py` | 2 | Generator mock symbol contract tests |
 | `test_completion.py` | 47 | Shell completion flag (--completion bash/zsh/fish) |
-| **Total** | **5,077** | **Collected via pytest --collect-only** |
+| **Total** | **5,080** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -587,10 +587,10 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (5,077 tests total)
+- [x] Comprehensive test coverage (5,080 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
-- [x] Profile management tests (test_profiles.py) - 73 tests
+- [x] Profile management tests (test_profiles.py) - 76 tests
 - [x] API worker auto-tuning tests (test_api_tuning.py) - 23 tests
 - [x] Circuit breaker pattern tests (test_circuit_breaker.py) - 22 tests
 - [x] Shared validation cache tests (test_shared_cache.py) - 17 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -92,7 +92,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 5,068 comprehensive tests**
+**Total: 5,077 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -138,7 +138,7 @@ tests/
 | `test_output_content_validation.py` | 26 | Output format content validation (CSV, JSON, HTML, Excel, Markdown roundtrip) |
 | `test_malformed_api_responses.py` | 19 | Negative tests for malformed/unexpected API responses |
 | `test_main_entry_points.py` | 20 | main() and _main_impl() entry points, dispatch, run_state, run summary |
-| `test_quality_policy_and_run_summary.py` | 65 | Quality policy functions and run summary/status inference |
+| `test_quality_policy_and_run_summary.py` | 67 | Quality policy functions and run summary/status inference |
 | `test_e2e_integration.py` | 16 | End-to-end integration tests with real pipeline, mocked API boundary |
 | `test_api_client.py` | 25 | API client exception paths and error handling |
 | `test_config_validation.py` | 55 | Configuration validation logic |
@@ -147,7 +147,7 @@ tests/
 | `test_snapshot.py` | 72 | Diff snapshot creation and comparison |
 | `test_colors.py` | 121 | Console color formatting, themes, TTY detection |
 | `test_exceptions.py` | 64 | Custom exception classes construction and formatting |
-| `test_logging_redaction.py` | 146 | Logging, sensitive data redaction, JSON formatter |
+| `test_logging_redaction.py` | 149 | Logging, sensitive data redaction, JSON formatter |
 | `test_config_dataclasses.py` | 88 | Config dataclasses and constants functions |
 | `test_lock_manager.py` | 48 | Lock manager acquire/release/heartbeat lifecycle |
 | `test_lazy_forwarding.py` | 71 | Lazy-forwarding infrastructure and make_getattr() |
@@ -163,7 +163,7 @@ tests/
 | `test_cli_command_handlers.py` | 131 | CLI dispatch for --stats, --org-report, --list-snapshots, discovery inspection, diff config unpacking |
 | `test_profile_management.py` | 45 | Interactive profile creation, import, test, show |
 | `test_snapshot_commands.py` | 58 | Snapshot creation, comparison, name resolution |
-| `test_config_and_resolution.py` | 101 | Config status, validation, stats, name resolution |
+| `test_config_and_resolution.py` | 105 | Config status, validation, stats, name resolution |
 | `test_derived_fields_edge_cases.py` | 34 | Derived fields edge cases and coverage |
 | `test_diff_command_coverage.py` | 45 | Diff command edge cases and coverage |
 | `test_generator_interactive_and_console.py` | 24 | Generator interactive and console tests |
@@ -183,7 +183,7 @@ tests/
 | `test_cli_smoke_modes.py` | 10 | CLI smoke tests for core command modes |
 | `test_generator_mock_contract.py` | 2 | Generator mock symbol contract tests |
 | `test_completion.py` | 47 | Shell completion flag (--completion bash/zsh/fish) |
-| **Total** | **5,068** | **Collected via pytest --collect-only** |
+| **Total** | **5,077** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -587,7 +587,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (5,068 tests total)
+- [x] Comprehensive test coverage (5,077 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 73 tests

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -754,6 +754,24 @@ class TestFastPathEntryPoint:
         assert _has_run_summary_flag(["--profile-import", "client-a", "--run-summary-json"]) is False
         assert _has_run_summary_flag(["--profile-import", "client-a", "--run-summary-json", "--version"]) is False
 
+    @pytest.mark.parametrize(
+        ("argv", "expected_shell"),
+        [
+            (["prog", "--completion", "bash"], "bash"),
+            (["prog", "--completion=zsh"], "zsh"),
+            (["prog", "--completion"], None),
+            (["prog", "--completion", "ksh"], None),
+            (["prog", "--profile", "--completion", "bash"], None),
+            (["prog", "--version", "--completion", "ksh"], None),
+            (["prog", "--completion", "bash", "dv_test"], None),
+            (["prog", "--completion", "bash", "--run-summary-json", "stdout"], None),
+        ],
+    )
+    def test_completion_fast_path_shell_only_allows_parse_valid_standalone_requests(self, argv, expected_shell):
+        from cja_auto_sdr.__main__ import _completion_fast_path_shell
+
+        assert _completion_fast_path_shell(argv) == expected_shell
+
     def test_fast_path_version_output(self, capsys):
         from cja_auto_sdr.__main__ import _print_version
         from cja_auto_sdr.core.version import __version__
@@ -777,6 +795,22 @@ class TestFastPathEntryPoint:
             == "python3 -m cja_auto_sdr"
         )
         assert _resolve_program_name("") == "cja_auto_sdr"
+
+    def test_resolve_completion_command_name(self):
+        from cja_auto_sdr.__main__ import _resolve_completion_command_name
+
+        assert _resolve_completion_command_name("cja_auto_sdr") == "cja_auto_sdr"
+        assert _resolve_completion_command_name("cja-auto-sdr") == "cja-auto-sdr"
+        assert _resolve_completion_command_name("/usr/local/bin/cja-auto-sdr") == "cja-auto-sdr"
+        assert _resolve_completion_command_name("__main__.py") == "cja_auto_sdr"
+        assert _resolve_completion_command_name("") == "cja_auto_sdr"
+        assert _resolve_completion_command_name(None) == "cja_auto_sdr"
+
+    def test_render_completion_script_quotes_command_names(self):
+        from cja_auto_sdr.__main__ import _render_completion_script
+
+        script = _render_completion_script("bash", "cja auto sdr")
+        assert "register-python-argcomplete 'cja auto sdr'" in script
 
     def test_fast_path_version_output_uses_program_name(self, capsys):
         from cja_auto_sdr.__main__ import _print_version
@@ -981,6 +1015,31 @@ class TestFastPathEntryPoint:
 
         assert result.returncode == 2
         assert stderr_substring in result.stderr
+
+    def test_fast_path_malformed_completion_with_missing_option_value_preserves_argparse_error_exit(self):
+        result = subprocess.run(
+            ["uv", "run", "cja_auto_sdr", "--profile", "--completion", "bash"],
+            capture_output=True,
+            text=True,
+            cwd=os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        )
+
+        assert result.returncode == 2
+        assert "expected one argument" in result.stderr
+
+    def test_fast_path_version_with_invalid_completion_shell_preserves_version_precedence(self):
+        from cja_auto_sdr.core.version import __version__
+
+        result = subprocess.run(
+            ["uv", "run", "cja_auto_sdr", "--version", "--completion", "ksh"],
+            capture_output=True,
+            text=True,
+            cwd=os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        )
+
+        assert result.returncode == 0
+        assert result.stdout.strip() == f"cja_auto_sdr {__version__}"
+        assert "unsupported shell" not in result.stderr
 
     def test_fast_path_help_before_version_preserves_help_precedence(self):
         import subprocess

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3891,6 +3891,31 @@ class TestRunSummaryOutput:
         assert "EXIT CODE REFERENCE" not in result.stdout
         assert "EXIT CODE REFERENCE" in result.stderr
 
+    def test_run_summary_completion_mode_classification(self, tmp_path):
+        """Completion runs should emit run summary mode=completion."""
+        from cja_auto_sdr.generator import main
+
+        summary_file = tmp_path / "run_summary_completion.json"
+        fake_argcomplete = type(sys)("argcomplete")
+
+        with (
+            patch.object(
+                sys,
+                "argv",
+                ["cja_auto_sdr", "--completion", "bash", "--run-summary-json", str(summary_file)],
+            ),
+            patch.dict("sys.modules", {"argcomplete": fake_argcomplete}),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 0
+        payload = json.loads(summary_file.read_text())
+        self._assert_run_summary_schema(payload)
+        assert payload["mode"] == "completion"
+        assert payload["exit_code"] == 0
+        assert payload["status"] == "success"
+
     def test_run_summary_stdout_subprocess_version_is_order_independent(self):
         """E2E: --version should still emit run summary JSON regardless of flag order."""
         repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -4246,6 +4271,8 @@ class TestRunModeInference:
     @pytest.mark.parametrize(
         ("argv", "expected_mode"),
         [
+            (["cja_auto_sdr", "--exit-codes", "--completion", "bash"], "exit_codes"),
+            (["cja_auto_sdr", "--completion", "bash", "--sample-config"], "completion"),
             (["cja_auto_sdr", "--list-dataviews", "--org-report"], "discovery"),
             (["cja_auto_sdr", "--describe-dataview", "dv_1"], "discovery"),
             (["cja_auto_sdr", "--list-metrics", "dv_1"], "discovery"),

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -11,6 +11,7 @@ Covers:
 
 from __future__ import annotations
 
+import json
 import sys
 from unittest.mock import patch
 
@@ -241,6 +242,36 @@ class TestCompletionFastPath:
         assert int(exc_info.value.code) == 1
         stderr = capsys.readouterr().err
         assert "unsupported shell 'ksh'" in stderr
+
+    @pytest.mark.parametrize(
+        "argv_tail",
+        [
+            ["--completion", "bash", "--run-summary-json", "stdout"],
+            ["--run-summary-json", "stdout", "--completion", "bash"],
+        ],
+    )
+    def test_completion_with_run_summary_routes_through_generator_contract(self, argv_tail, capsys):
+        """Run-summary contract must bypass completion fast-path and emit JSON summary."""
+        from cja_auto_sdr import __main__ as entrypoint
+
+        argv = ["cja_auto_sdr", *argv_tail]
+        fake_argcomplete = type(sys)("argcomplete")
+        fake_argcomplete.autocomplete = lambda *_args, **_kwargs: None
+        with (
+            patch.object(sys, "argv", argv),
+            patch.dict("sys.modules", {"argcomplete": fake_argcomplete}),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                entrypoint.main()
+
+        assert int(exc_info.value.code) == 0
+        captured = capsys.readouterr()
+        payload = json.loads(captured.out)
+        assert payload["summary_version"] == "1.0"
+        assert payload["exit_code"] == 0
+        assert payload["command"]["argv"] == argv
+        assert "register-python-argcomplete" in captured.err
+        assert "register-python-argcomplete" not in captured.out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -1,0 +1,347 @@
+"""Tests for --completion bash/zsh/fish flag.
+
+Covers:
+- Fast-path detection in __main__.py for each supported shell
+- Correct activation script output on stdout for bash, zsh, fish
+- Missing argcomplete triggers stderr message and exit 1
+- Invalid shell name triggers stderr error and exit 1
+- --completion with no shell argument triggers stderr error and exit 1
+- Safety-net dispatch from generator._main_impl()
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_entrypoint_main(argv: list[str]):
+    """Call __main__.main() with the given argv and capture SystemExit."""
+    from cja_auto_sdr import __main__ as entrypoint
+
+    with patch.object(sys, "argv", argv):
+        with pytest.raises(SystemExit) as exc_info:
+            entrypoint.main()
+    return exc_info
+
+
+# ---------------------------------------------------------------------------
+# _extract_completion_shell unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractCompletionShell:
+    """Unit tests for _extract_completion_shell()."""
+
+    def test_returns_none_when_no_completion_flag(self):
+        from cja_auto_sdr.__main__ import _extract_completion_shell
+
+        assert _extract_completion_shell(["prog", "--version"]) is None
+
+    def test_returns_none_for_empty_args(self):
+        from cja_auto_sdr.__main__ import _extract_completion_shell
+
+        assert _extract_completion_shell(["prog"]) is None
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh", "fish"])
+    def test_extracts_valid_shell(self, shell):
+        from cja_auto_sdr.__main__ import _extract_completion_shell
+
+        result = _extract_completion_shell(["prog", "--completion", shell])
+        assert result == shell
+
+    def test_shell_name_is_case_insensitive(self):
+        from cja_auto_sdr.__main__ import _extract_completion_shell
+
+        assert _extract_completion_shell(["prog", "--completion", "BASH"]) == "bash"
+        assert _extract_completion_shell(["prog", "--completion", "Zsh"]) == "zsh"
+        assert _extract_completion_shell(["prog", "--completion", "FISH"]) == "fish"
+
+    def test_missing_shell_argument_exits_1(self, capsys):
+        from cja_auto_sdr.__main__ import _extract_completion_shell
+
+        with pytest.raises(SystemExit) as exc_info:
+            _extract_completion_shell(["prog", "--completion"])
+
+        assert int(exc_info.value.code) == 1
+        stderr = capsys.readouterr().err
+        assert "--completion requires a shell argument" in stderr
+
+    def test_invalid_shell_exits_1(self, capsys):
+        from cja_auto_sdr.__main__ import _extract_completion_shell
+
+        with pytest.raises(SystemExit) as exc_info:
+            _extract_completion_shell(["prog", "--completion", "powershell"])
+
+        assert int(exc_info.value.code) == 1
+        stderr = capsys.readouterr().err
+        assert "unsupported shell 'powershell'" in stderr
+        assert "bash" in stderr
+        assert "zsh" in stderr
+        assert "fish" in stderr
+
+
+# ---------------------------------------------------------------------------
+# _handle_completion unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestHandleCompletion:
+    """Unit tests for _handle_completion()."""
+
+    @pytest.mark.parametrize(
+        ("shell", "expected_fragment"),
+        [
+            ("bash", 'eval "$(register-python-argcomplete cja_auto_sdr)"'),
+            ("zsh", "autoload -U bashcompinit && bashcompinit"),
+            ("zsh", 'eval "$(register-python-argcomplete cja_auto_sdr)"'),
+            ("fish", "register-python-argcomplete --shell fish cja_auto_sdr | source"),
+        ],
+    )
+    def test_prints_activation_script_to_stdout(self, shell, expected_fragment, capsys):
+        """Each shell produces the correct activation snippet on stdout."""
+        from cja_auto_sdr.__main__ import _handle_completion
+
+        with patch.dict("sys.modules", {"argcomplete": type(sys)("argcomplete")}):
+            with pytest.raises(SystemExit) as exc_info:
+                _handle_completion(shell)
+
+        assert int(exc_info.value.code) == 0
+        stdout = capsys.readouterr().out
+        assert expected_fragment in stdout
+
+    def test_missing_argcomplete_prints_install_instructions(self, capsys):
+        """When argcomplete is missing, print install instructions to stderr and exit 1."""
+        from cja_auto_sdr.__main__ import _handle_completion
+
+        with patch.dict("sys.modules", {"argcomplete": None}):
+            with pytest.raises(SystemExit) as exc_info:
+                _handle_completion("bash")
+
+        assert int(exc_info.value.code) == 1
+        captured = capsys.readouterr()
+        assert captured.out == ""  # nothing on stdout
+        assert "argcomplete is not installed" in captured.err
+        assert "pip install argcomplete" in captured.err
+
+    def test_stdout_contains_no_stderr_content(self, capsys):
+        """Verify script goes to stdout and nothing leaks to stderr on success."""
+        from cja_auto_sdr.__main__ import _handle_completion
+
+        with patch.dict("sys.modules", {"argcomplete": type(sys)("argcomplete")}):
+            with pytest.raises(SystemExit):
+                _handle_completion("bash")
+
+        captured = capsys.readouterr()
+        assert captured.err == ""
+        assert "register-python-argcomplete" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Fast-path integration tests (via __main__.main)
+# ---------------------------------------------------------------------------
+
+
+class TestCompletionFastPath:
+    """Integration tests verifying --completion is handled in the fast path."""
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh", "fish"])
+    def test_fast_path_does_not_import_generator(self, shell, capsys):
+        """--completion should not fall through to generator.main()."""
+        from cja_auto_sdr import __main__ as entrypoint
+
+        with (
+            patch.object(sys, "argv", ["cja_auto_sdr", "--completion", shell]),
+            patch.dict("sys.modules", {"argcomplete": type(sys)("argcomplete")}),
+            patch("cja_auto_sdr.generator.main") as mock_generator_main,
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                entrypoint.main()
+
+        assert int(exc_info.value.code) == 0
+        mock_generator_main.assert_not_called()
+
+    def test_fast_path_bash_output(self, capsys):
+        """--completion bash prints the bash activation script."""
+        from cja_auto_sdr.__main__ import _COMPLETION_SCRIPTS
+
+        with (
+            patch.object(sys, "argv", ["cja_auto_sdr", "--completion", "bash"]),
+            patch.dict("sys.modules", {"argcomplete": type(sys)("argcomplete")}),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                from cja_auto_sdr import __main__ as entrypoint
+
+                entrypoint.main()
+
+        assert int(exc_info.value.code) == 0
+        stdout = capsys.readouterr().out.strip()
+        assert stdout == _COMPLETION_SCRIPTS["bash"]
+
+    def test_fast_path_zsh_output(self, capsys):
+        """--completion zsh prints the zsh activation script."""
+        from cja_auto_sdr.__main__ import _COMPLETION_SCRIPTS
+
+        with (
+            patch.object(sys, "argv", ["cja_auto_sdr", "--completion", "zsh"]),
+            patch.dict("sys.modules", {"argcomplete": type(sys)("argcomplete")}),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                from cja_auto_sdr import __main__ as entrypoint
+
+                entrypoint.main()
+
+        assert int(exc_info.value.code) == 0
+        stdout = capsys.readouterr().out.strip()
+        assert stdout == _COMPLETION_SCRIPTS["zsh"]
+
+    def test_fast_path_fish_output(self, capsys):
+        """--completion fish prints the fish activation script."""
+        from cja_auto_sdr.__main__ import _COMPLETION_SCRIPTS
+
+        with (
+            patch.object(sys, "argv", ["cja_auto_sdr", "--completion", "fish"]),
+            patch.dict("sys.modules", {"argcomplete": type(sys)("argcomplete")}),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                from cja_auto_sdr import __main__ as entrypoint
+
+                entrypoint.main()
+
+        assert int(exc_info.value.code) == 0
+        stdout = capsys.readouterr().out.strip()
+        assert stdout == _COMPLETION_SCRIPTS["fish"]
+
+    def test_fast_path_missing_shell_exits_1(self, capsys):
+        """--completion with no shell arg should exit 1 with error on stderr."""
+        from cja_auto_sdr import __main__ as entrypoint
+
+        with patch.object(sys, "argv", ["cja_auto_sdr", "--completion"]):
+            with pytest.raises(SystemExit) as exc_info:
+                entrypoint.main()
+
+        assert int(exc_info.value.code) == 1
+        stderr = capsys.readouterr().err
+        assert "--completion requires a shell argument" in stderr
+
+    def test_fast_path_invalid_shell_exits_1(self, capsys):
+        """--completion with invalid shell name should exit 1 with error on stderr."""
+        from cja_auto_sdr import __main__ as entrypoint
+
+        with patch.object(sys, "argv", ["cja_auto_sdr", "--completion", "ksh"]):
+            with pytest.raises(SystemExit) as exc_info:
+                entrypoint.main()
+
+        assert int(exc_info.value.code) == 1
+        stderr = capsys.readouterr().err
+        assert "unsupported shell 'ksh'" in stderr
+
+
+# ---------------------------------------------------------------------------
+# Argparse integration (parser recognizes --completion)
+# ---------------------------------------------------------------------------
+
+
+class TestCompletionArgparse:
+    """Tests that the argparse parser recognizes --completion."""
+
+    def test_parser_accepts_completion_bash(self):
+        from cja_auto_sdr.cli.parser import parse_arguments
+
+        args = parse_arguments(["--completion", "bash", "dv_test"])
+        assert args.completion == "bash"
+
+    def test_parser_accepts_completion_zsh(self):
+        from cja_auto_sdr.cli.parser import parse_arguments
+
+        args = parse_arguments(["--completion", "zsh", "dv_test"])
+        assert args.completion == "zsh"
+
+    def test_parser_accepts_completion_fish(self):
+        from cja_auto_sdr.cli.parser import parse_arguments
+
+        args = parse_arguments(["--completion", "fish", "dv_test"])
+        assert args.completion == "fish"
+
+    def test_parser_rejects_invalid_shell(self):
+        from cja_auto_sdr.cli.parser import parse_arguments
+
+        with pytest.raises(SystemExit):
+            parse_arguments(["--completion", "powershell", "dv_test"])
+
+    def test_parser_completion_default_is_none(self):
+        from cja_auto_sdr.cli.parser import parse_arguments
+
+        args = parse_arguments(["dv_test"])
+        assert args.completion is None
+
+
+# ---------------------------------------------------------------------------
+# Completion script content validation
+# ---------------------------------------------------------------------------
+
+
+class TestCompletionScriptContent:
+    """Validate the static content of each shell's activation script."""
+
+    def test_bash_script_content(self):
+        from cja_auto_sdr.__main__ import _COMPLETION_SCRIPTS
+
+        script = _COMPLETION_SCRIPTS["bash"]
+        assert "register-python-argcomplete" in script
+        assert "cja_auto_sdr" in script
+        assert "eval" in script
+
+    def test_zsh_script_content(self):
+        from cja_auto_sdr.__main__ import _COMPLETION_SCRIPTS
+
+        script = _COMPLETION_SCRIPTS["zsh"]
+        assert "bashcompinit" in script
+        assert "autoload" in script
+        assert "register-python-argcomplete" in script
+        assert "cja_auto_sdr" in script
+
+    def test_fish_script_content(self):
+        from cja_auto_sdr.__main__ import _COMPLETION_SCRIPTS
+
+        script = _COMPLETION_SCRIPTS["fish"]
+        assert "--shell fish" in script
+        assert "register-python-argcomplete" in script
+        assert "cja_auto_sdr" in script
+        assert "| source" in script
+
+    def test_all_supported_shells_have_scripts(self):
+        from cja_auto_sdr.__main__ import _COMPLETION_SCRIPTS, _SUPPORTED_SHELLS
+
+        assert set(_COMPLETION_SCRIPTS.keys()) == _SUPPORTED_SHELLS
+
+
+# ---------------------------------------------------------------------------
+# Safety-net: generator._main_impl handles --completion
+# ---------------------------------------------------------------------------
+
+
+class TestCompletionSafetyNet:
+    """Verify the generator._main_impl safety net for --completion."""
+
+    @pytest.mark.parametrize("shell", ["bash", "zsh", "fish"])
+    def test_generator_safety_net_handles_completion(self, shell, capsys):
+        """If --completion reaches _main_impl, it should still be handled."""
+        from cja_auto_sdr.generator import _main_impl
+
+        with (
+            patch.object(sys, "argv", ["cja_auto_sdr", "--completion", shell, "dv_test"]),
+            patch.dict("sys.modules", {"argcomplete": type(sys)("argcomplete")}),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                _main_impl()
+
+        assert int(exc_info.value.code) == 0
+        stdout = capsys.readouterr().out
+        assert "register-python-argcomplete" in stdout

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -325,6 +325,28 @@ class TestCompletionFastPath:
         assert "register-python-argcomplete" in captured.err
         assert "register-python-argcomplete" not in captured.out
 
+    def test_completion_with_run_summary_ignores_unrelated_workers_validation(self, capsys):
+        """Completion should still succeed when mixed with invalid non-completion options."""
+        from cja_auto_sdr import __main__ as entrypoint
+
+        argv = ["cja_auto_sdr", "--completion", "bash", "--workers", "0", "--run-summary-json", "stdout"]
+        fake_argcomplete = type(sys)("argcomplete")
+        fake_argcomplete.autocomplete = lambda *_args, **_kwargs: None
+        with (
+            patch.object(sys, "argv", argv),
+            patch.dict("sys.modules", {"argcomplete": fake_argcomplete}),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                entrypoint.main()
+
+        assert int(exc_info.value.code) == 0
+        captured = capsys.readouterr()
+        payload = json.loads(captured.out)
+        assert payload["mode"] == "completion"
+        assert payload["exit_code"] == 0
+        assert "--workers must be at least 1" not in captured.err
+        assert "register-python-argcomplete" in captured.err
+
 
 # ---------------------------------------------------------------------------
 # Argparse integration (parser recognizes --completion)
@@ -458,3 +480,39 @@ class TestCompletionSafetyNet:
         assert int(exc_info.value.code) == 0
         stdout = capsys.readouterr().out
         assert "register-python-argcomplete cja-auto-sdr" in stdout
+
+    def test_generator_safety_net_bypasses_workers_validation(self, capsys):
+        """Completion should run before unrelated global validation in _main_impl."""
+        from cja_auto_sdr.generator import _main_impl
+
+        with (
+            patch.object(sys, "argv", ["cja_auto_sdr", "--completion", "bash", "--workers", "0"]),
+            patch.dict("sys.modules", {"argcomplete": type(sys)("argcomplete")}),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                _main_impl()
+
+        assert int(exc_info.value.code) == 0
+        captured = capsys.readouterr()
+        assert "--workers must be at least 1" not in captured.err
+        assert "register-python-argcomplete" in captured.out
+
+    def test_generator_safety_net_bypasses_quality_policy_loading(self, capsys):
+        """Completion should not attempt to load quality-policy files."""
+        from cja_auto_sdr.generator import _main_impl
+
+        with (
+            patch.object(
+                sys,
+                "argv",
+                ["cja_auto_sdr", "--completion", "bash", "--quality-policy", "/tmp/does-not-exist-policy.json"],
+            ),
+            patch.dict("sys.modules", {"argcomplete": type(sys)("argcomplete")}),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                _main_impl()
+
+        assert int(exc_info.value.code) == 0
+        captured = capsys.readouterr()
+        assert "Failed to load --quality-policy" not in captured.err
+        assert "register-python-argcomplete" in captured.out

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -4,8 +4,8 @@ Covers:
 - Fast-path detection in __main__.py for each supported shell
 - Correct activation script output on stdout for bash, zsh, fish
 - Missing argcomplete triggers stderr message and exit 1
-- Invalid shell name triggers stderr error and exit 1
-- --completion with no shell argument triggers stderr error and exit 1
+- _extract_completion_shell helper errors for invalid/missing shell tokens
+- Fast-path defers malformed or mixed completion argv to generator/argparse flow
 - Safety-net dispatch from generator._main_impl()
 """
 
@@ -97,25 +97,26 @@ class TestHandleCompletion:
     """Unit tests for _handle_completion()."""
 
     @pytest.mark.parametrize(
-        ("shell", "expected_fragment"),
+        ("shell", "argv0", "expected_command", "expected_fragment"),
         [
-            ("bash", 'eval "$(register-python-argcomplete cja_auto_sdr)"'),
-            ("zsh", "autoload -U bashcompinit && bashcompinit"),
-            ("zsh", 'eval "$(register-python-argcomplete cja_auto_sdr)"'),
-            ("fish", "register-python-argcomplete --shell fish cja_auto_sdr | source"),
+            ("bash", "cja_auto_sdr", "cja_auto_sdr", 'eval "$(register-python-argcomplete cja_auto_sdr)"'),
+            ("bash", "cja-auto-sdr", "cja-auto-sdr", "register-python-argcomplete cja-auto-sdr"),
+            ("zsh", "/usr/local/bin/cja-auto-sdr", "cja-auto-sdr", "autoload -U bashcompinit && bashcompinit"),
+            ("fish", "__main__.py", "cja_auto_sdr", "register-python-argcomplete --shell fish cja_auto_sdr | source"),
         ],
     )
-    def test_prints_activation_script_to_stdout(self, shell, expected_fragment, capsys):
+    def test_prints_activation_script_to_stdout(self, shell, argv0, expected_command, expected_fragment, capsys):
         """Each shell produces the correct activation snippet on stdout."""
         from cja_auto_sdr.__main__ import _handle_completion
 
         with patch.dict("sys.modules", {"argcomplete": type(sys)("argcomplete")}):
             with pytest.raises(SystemExit) as exc_info:
-                _handle_completion(shell)
+                _handle_completion(shell, argv0=argv0)
 
         assert int(exc_info.value.code) == 0
         stdout = capsys.readouterr().out
         assert expected_fragment in stdout
+        assert expected_command in stdout
 
     def test_missing_argcomplete_prints_install_instructions(self, capsys):
         """When argcomplete is missing, print install instructions to stderr and exit 1."""
@@ -131,17 +132,28 @@ class TestHandleCompletion:
         assert "argcomplete is not installed" in captured.err
         assert "pip install argcomplete" in captured.err
 
+    def test_invalid_shell_prints_error_and_exits_1(self, capsys):
+        from cja_auto_sdr.__main__ import _handle_completion
+
+        with pytest.raises(SystemExit) as exc_info:
+            _handle_completion("powershell", argv0="cja_auto_sdr")
+
+        assert int(exc_info.value.code) == 1
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert "unsupported shell 'powershell'" in captured.err
+
     def test_stdout_contains_no_stderr_content(self, capsys):
         """Verify script goes to stdout and nothing leaks to stderr on success."""
         from cja_auto_sdr.__main__ import _handle_completion
 
         with patch.dict("sys.modules", {"argcomplete": type(sys)("argcomplete")}):
             with pytest.raises(SystemExit):
-                _handle_completion("bash")
+                _handle_completion("bash", argv0="cja-auto-sdr")
 
         captured = capsys.readouterr()
         assert captured.err == ""
-        assert "register-python-argcomplete" in captured.out
+        assert "register-python-argcomplete cja-auto-sdr" in captured.out
 
 
 # ---------------------------------------------------------------------------
@@ -168,12 +180,22 @@ class TestCompletionFastPath:
         assert int(exc_info.value.code) == 0
         mock_generator_main.assert_not_called()
 
-    def test_fast_path_bash_output(self, capsys):
-        """--completion bash prints the bash activation script."""
-        from cja_auto_sdr.__main__ import _COMPLETION_SCRIPTS
+    @pytest.mark.parametrize(
+        ("argv0", "expected_command"),
+        [
+            ("cja_auto_sdr", "cja_auto_sdr"),
+            ("cja-auto-sdr", "cja-auto-sdr"),
+            ("/usr/local/bin/cja-auto-sdr", "cja-auto-sdr"),
+            ("__main__.py", "cja_auto_sdr"),
+            ("", "cja_auto_sdr"),
+        ],
+    )
+    def test_fast_path_bash_output_uses_invoked_command(self, argv0, expected_command, capsys):
+        """Completion script should target the invoked command entrypoint."""
+        from cja_auto_sdr.__main__ import _render_completion_script
 
         with (
-            patch.object(sys, "argv", ["cja_auto_sdr", "--completion", "bash"]),
+            patch.object(sys, "argv", [argv0, "--completion", "bash"]),
             patch.dict("sys.modules", {"argcomplete": type(sys)("argcomplete")}),
         ):
             with pytest.raises(SystemExit) as exc_info:
@@ -183,7 +205,7 @@ class TestCompletionFastPath:
 
         assert int(exc_info.value.code) == 0
         stdout = capsys.readouterr().out.strip()
-        assert stdout == _COMPLETION_SCRIPTS["bash"]
+        assert stdout == _render_completion_script("bash", expected_command)
 
     def test_fast_path_zsh_output(self, capsys):
         """--completion zsh prints the zsh activation script."""
@@ -219,29 +241,59 @@ class TestCompletionFastPath:
         stdout = capsys.readouterr().out.strip()
         assert stdout == _COMPLETION_SCRIPTS["fish"]
 
-    def test_fast_path_missing_shell_exits_1(self, capsys):
-        """--completion with no shell arg should exit 1 with error on stderr."""
+    def test_fast_path_missing_shell_falls_through_to_generator(self):
+        """Invalid standalone completion requests must defer to argparse path."""
         from cja_auto_sdr import __main__ as entrypoint
 
-        with patch.object(sys, "argv", ["cja_auto_sdr", "--completion"]):
+        with (
+            patch.object(sys, "argv", ["cja_auto_sdr", "--completion"]),
+            patch("cja_auto_sdr.generator.main") as mock_generator_main,
+        ):
+            entrypoint.main()
+
+        mock_generator_main.assert_called_once()
+
+    def test_fast_path_invalid_shell_falls_through_to_generator(self):
+        """Unsupported completion shells must defer to argparse path."""
+        from cja_auto_sdr import __main__ as entrypoint
+
+        with (
+            patch.object(sys, "argv", ["cja_auto_sdr", "--completion", "ksh"]),
+            patch("cja_auto_sdr.generator.main") as mock_generator_main,
+        ):
+            entrypoint.main()
+
+        mock_generator_main.assert_called_once()
+
+    def test_fast_path_mixed_completion_with_missing_option_value_falls_through_to_generator(self):
+        """Mixed malformed argv must not bypass argparse validation."""
+        from cja_auto_sdr import __main__ as entrypoint
+
+        with (
+            patch.object(sys, "argv", ["cja_auto_sdr", "--profile", "--completion", "bash"]),
+            patch("cja_auto_sdr.generator.main") as mock_generator_main,
+        ):
+            entrypoint.main()
+
+        mock_generator_main.assert_called_once()
+
+    def test_fast_path_version_precedence_over_invalid_completion_shell(self, capsys):
+        """Version action precedence must win over malformed completion tokens."""
+        from cja_auto_sdr import __main__ as entrypoint
+        from cja_auto_sdr.core.version import __version__
+
+        with (
+            patch.object(sys, "argv", ["cja_auto_sdr", "--version", "--completion", "ksh"]),
+            patch("cja_auto_sdr.generator.main") as mock_generator_main,
+        ):
             with pytest.raises(SystemExit) as exc_info:
                 entrypoint.main()
 
-        assert int(exc_info.value.code) == 1
-        stderr = capsys.readouterr().err
-        assert "--completion requires a shell argument" in stderr
-
-    def test_fast_path_invalid_shell_exits_1(self, capsys):
-        """--completion with invalid shell name should exit 1 with error on stderr."""
-        from cja_auto_sdr import __main__ as entrypoint
-
-        with patch.object(sys, "argv", ["cja_auto_sdr", "--completion", "ksh"]):
-            with pytest.raises(SystemExit) as exc_info:
-                entrypoint.main()
-
-        assert int(exc_info.value.code) == 1
-        stderr = capsys.readouterr().err
-        assert "unsupported shell 'ksh'" in stderr
+        assert int(exc_info.value.code) == 0
+        mock_generator_main.assert_not_called()
+        captured = capsys.readouterr()
+        assert captured.out.strip() == f"cja_auto_sdr {__version__}"
+        assert "unsupported shell" not in captured.err
 
     @pytest.mark.parametrize(
         "argv_tail",
@@ -352,6 +404,21 @@ class TestCompletionScriptContent:
 
         assert set(_COMPLETION_SCRIPTS.keys()) == _SUPPORTED_SHELLS
 
+    @pytest.mark.parametrize(
+        ("shell", "argv0", "expected_command"),
+        [
+            ("bash", "cja-auto-sdr", "cja-auto-sdr"),
+            ("zsh", "/tmp/cja-auto-sdr", "cja-auto-sdr"),
+            ("fish", "__main__.py", "cja_auto_sdr"),
+        ],
+    )
+    def test_render_completion_script_uses_resolved_command_name(self, shell, argv0, expected_command):
+        from cja_auto_sdr.__main__ import _render_completion_script
+
+        script = _render_completion_script(shell, argv0)
+        assert expected_command in script
+        assert "register-python-argcomplete" in script
+
 
 # ---------------------------------------------------------------------------
 # Safety-net: generator._main_impl handles --completion
@@ -376,3 +443,18 @@ class TestCompletionSafetyNet:
         assert int(exc_info.value.code) == 0
         stdout = capsys.readouterr().out
         assert "register-python-argcomplete" in stdout
+
+    def test_generator_safety_net_uses_invoked_command_name(self, capsys):
+        """Safety-net path should still register completion for the invoked entrypoint."""
+        from cja_auto_sdr.generator import _main_impl
+
+        with (
+            patch.object(sys, "argv", ["cja-auto-sdr", "--completion", "bash", "dv_test"]),
+            patch.dict("sys.modules", {"argcomplete": type(sys)("argcomplete")}),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                _main_impl()
+
+        assert int(exc_info.value.code) == 0
+        stdout = capsys.readouterr().out
+        assert "register-python-argcomplete cja-auto-sdr" in stdout

--- a/tests/test_config_and_resolution.py
+++ b/tests/test_config_and_resolution.py
@@ -564,6 +564,47 @@ class TestValidateConfigOnlyOutputPermissionsStep:
         assert str(tmp_path) in output
         assert "Output directory writable" in output
 
+    @patch("cja_auto_sdr.generator._config_from_env")
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.load_profile_credentials")
+    def test_output_permissions_missing_dir_uses_parent_writability(
+        self, mock_load, mock_cjapy, _mock_config_env, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Step 5 should pass when output_dir does not exist but parent is writable."""
+        from cja_auto_sdr.generator import validate_config_only
+
+        mock_load.return_value = {"org_id": "org@Adobe", "client_id": "abcd1234efgh", "secret": "secret12345678"}
+        mock_cja = MagicMock()
+        mock_cja.getDataViews.return_value = [{"id": "dv1"}]
+        mock_cjapy.CJA.return_value = mock_cja
+        new_output_dir = tmp_path / "nested" / "new-output"
+        result = validate_config_only(profile="myprofile", output_dir=str(new_output_dir))
+        assert result is True
+        output = capsys.readouterr().out
+        assert "Output directory creatable" in output
+        assert str(new_output_dir.resolve()) in output
+
+    @patch("cja_auto_sdr.generator._config_from_env")
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.load_profile_credentials")
+    def test_output_permissions_existing_file_fails(
+        self, mock_load, mock_cjapy, _mock_config_env, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Step 5 should fail when output_dir points to a file path."""
+        from cja_auto_sdr.generator import validate_config_only
+
+        mock_load.return_value = {"org_id": "org@Adobe", "client_id": "abcd1234efgh", "secret": "secret12345678"}
+        mock_cja = MagicMock()
+        mock_cja.getDataViews.return_value = [{"id": "dv1"}]
+        mock_cjapy.CJA.return_value = mock_cja
+        output_file = tmp_path / "not-a-directory.txt"
+        output_file.write_text("x", encoding="utf-8")
+        result = validate_config_only(profile="myprofile", output_dir=str(output_file))
+        assert result is False
+        output = capsys.readouterr().out
+        assert "Output path is not a directory" in output
+        assert "VALIDATION FAILED" in output
+
     @patch("cja_auto_sdr.generator.cjapy")
     def test_output_permissions_skipped_when_api_fails(
         self, mock_cjapy, tmp_path: Path, capsys: pytest.CaptureFixture

--- a/tests/test_config_and_resolution.py
+++ b/tests/test_config_and_resolution.py
@@ -546,6 +546,24 @@ class TestValidateConfigOnlyOutputPermissionsStep:
         assert "Output directory not writable" in output
         assert "VALIDATION FAILED" in output
 
+    @patch("cja_auto_sdr.generator._config_from_env")
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.load_profile_credentials")
+    def test_output_permissions_uses_output_dir_param(
+        self, mock_load, mock_cjapy, _mock_config_env, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Step 5 should check the output_dir passed as argument, not hard-coded '.'."""
+        from cja_auto_sdr.generator import validate_config_only
+
+        mock_load.return_value = {"org_id": "org@Adobe", "client_id": "abcd1234efgh", "secret": "secret12345678"}
+        mock_cja = MagicMock()
+        mock_cja.getDataViews.return_value = [{"id": "dv1"}]
+        mock_cjapy.CJA.return_value = mock_cja
+        validate_config_only(profile="myprofile", output_dir=str(tmp_path))
+        output = capsys.readouterr().out
+        assert str(tmp_path) in output
+        assert "Output directory writable" in output
+
     @patch("cja_auto_sdr.generator.cjapy")
     def test_output_permissions_skipped_when_api_fails(
         self, mock_cjapy, tmp_path: Path, capsys: pytest.CaptureFixture

--- a/tests/test_config_and_resolution.py
+++ b/tests/test_config_and_resolution.py
@@ -506,6 +506,85 @@ class TestValidateConfigOnlyDependenciesStep:
         # Should NOT fail at step 2 — it should proceed to step 3
         assert "[3/5]" in output
 
+    def test_malformed_metadata_on_core_dep_fails_validation(self, capsys: pytest.CaptureFixture) -> None:
+        """Non-PackageNotFoundError on core dep should fail validation with diagnostic."""
+        import importlib.metadata
+
+        from cja_auto_sdr.generator import validate_config_only
+
+        original_version = importlib.metadata.version
+
+        def mock_version(pkg):
+            if pkg == "pandas":
+                raise ValueError("malformed metadata")
+            return original_version(pkg)
+
+        with patch("cja_auto_sdr.generator.importlib.metadata.version", side_effect=mock_version):
+            result = validate_config_only()
+        assert result is False
+        output = capsys.readouterr().out
+        assert "pandas" in output
+        assert "metadata error" in output
+        assert "VALIDATION FAILED" in output
+
+    def test_oserror_on_core_dep_fails_validation(self, capsys: pytest.CaptureFixture) -> None:
+        """OSError on core dep metadata should fail validation with diagnostic."""
+        import importlib.metadata
+
+        from cja_auto_sdr.generator import validate_config_only
+
+        original_version = importlib.metadata.version
+
+        def mock_version(pkg):
+            if pkg == "numpy":
+                raise OSError("corrupt dist-info")
+            return original_version(pkg)
+
+        with patch("cja_auto_sdr.generator.importlib.metadata.version", side_effect=mock_version):
+            result = validate_config_only()
+        assert result is False
+        output = capsys.readouterr().out
+        assert "numpy" in output
+        assert "metadata error" in output
+
+    def test_malformed_metadata_on_optional_dep_does_not_fail(self, capsys: pytest.CaptureFixture) -> None:
+        """Non-PackageNotFoundError on optional dep should show diagnostic but not fail."""
+        import importlib.metadata
+
+        from cja_auto_sdr.generator import validate_config_only
+
+        original_version = importlib.metadata.version
+
+        def mock_version(pkg):
+            if pkg == "scipy":
+                raise ValueError("corrupt metadata")
+            return original_version(pkg)
+
+        with patch("cja_auto_sdr.generator.importlib.metadata.version", side_effect=mock_version):
+            with patch("cja_auto_sdr.generator.load_credentials_from_env", return_value=None):
+                validate_config_only()
+        output = capsys.readouterr().out
+        assert "scipy" in output
+        assert "metadata error" in output
+        # Should proceed past step 2 — optional deps never fail validation
+        assert "[3/5]" in output
+
+    def test_all_core_deps_metadata_errors_fails_validation(self, capsys: pytest.CaptureFixture) -> None:
+        """If all core deps raise non-PackageNotFoundError, validation fails with diagnostics."""
+        from cja_auto_sdr.generator import validate_config_only
+
+        def all_broken(pkg):
+            raise RuntimeError(f"metadata backend unavailable for {pkg}")
+
+        with patch("cja_auto_sdr.generator.importlib.metadata.version", side_effect=all_broken):
+            result = validate_config_only()
+        assert result is False
+        output = capsys.readouterr().out
+        for pkg in ("cjapy", "pandas", "numpy", "xlsxwriter", "tqdm"):
+            assert pkg in output
+            assert "metadata error" in output
+        assert "VALIDATION FAILED" in output
+
 
 class TestValidateConfigOnlyOutputPermissionsStep:
     """Step [5/5]: output permissions check."""

--- a/tests/test_config_and_resolution.py
+++ b/tests/test_config_and_resolution.py
@@ -353,6 +353,261 @@ class TestValidateConfigOnly:
 
 
 # ---------------------------------------------------------------------------
+# 2b. validate_config_only — new steps (environment, dependencies, output)
+# ---------------------------------------------------------------------------
+
+
+class TestValidateConfigOnlyEnvironmentStep:
+    """Step [1/5]: environment check (Python version, platform)."""
+
+    @patch("cja_auto_sdr.generator._config_from_env")
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.load_profile_credentials")
+    def test_environment_step_shows_python_version(
+        self, mock_load, mock_cjapy, _mock_config_env, capsys: pytest.CaptureFixture
+    ) -> None:
+        from cja_auto_sdr.generator import validate_config_only
+
+        mock_load.return_value = {"org_id": "org@Adobe", "client_id": "abcd1234efgh", "secret": "secret12345678"}
+        mock_cja = MagicMock()
+        mock_cja.getDataViews.return_value = [{"id": "dv1"}]
+        mock_cjapy.CJA.return_value = mock_cja
+        validate_config_only(profile="myprofile")
+        output = capsys.readouterr().out
+        assert "[1/5] Checking environment..." in output
+        assert "Python" in output
+        assert "(minimum: 3.14)" in output
+
+    @patch("cja_auto_sdr.generator._config_from_env")
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.load_profile_credentials")
+    def test_environment_step_shows_platform(
+        self, mock_load, mock_cjapy, _mock_config_env, capsys: pytest.CaptureFixture
+    ) -> None:
+        from cja_auto_sdr.generator import validate_config_only
+
+        mock_load.return_value = {"org_id": "org@Adobe", "client_id": "abcd1234efgh", "secret": "secret12345678"}
+        mock_cja = MagicMock()
+        mock_cja.getDataViews.return_value = [{"id": "dv1"}]
+        mock_cjapy.CJA.return_value = mock_cja
+        validate_config_only(profile="myprofile")
+        output = capsys.readouterr().out
+        assert "Platform:" in output
+
+    def test_python_version_too_low_fails(self, capsys: pytest.CaptureFixture) -> None:
+        """Python version below 3.14 should fail validation."""
+        import sys as _sys
+
+        from cja_auto_sdr.generator import validate_config_only
+
+        # sys.version_info is a named tuple that supports >= comparison with
+        # a plain tuple. We create a subclass of tuple with attribute access.
+        class FakeVersionInfo(tuple):
+            __slots__ = ()
+            major = 3
+            minor = 12
+            micro = 0
+
+        fake_version_info = FakeVersionInfo((3, 12, 0))
+
+        with patch("cja_auto_sdr.generator.sys") as mock_sys:
+            mock_sys.version_info = fake_version_info
+            mock_sys.platform = _sys.platform
+            result = validate_config_only()
+        assert result is False
+        output = capsys.readouterr().out
+        assert "Python 3.12.0" in output
+        assert "VALIDATION FAILED" in output
+
+
+class TestValidateConfigOnlyDependenciesStep:
+    """Step [2/5]: dependency check (core + optional)."""
+
+    @patch("cja_auto_sdr.generator._config_from_env")
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.load_profile_credentials")
+    def test_dependencies_step_shows_core_deps(
+        self, mock_load, mock_cjapy, _mock_config_env, capsys: pytest.CaptureFixture
+    ) -> None:
+        from cja_auto_sdr.generator import validate_config_only
+
+        mock_load.return_value = {"org_id": "org@Adobe", "client_id": "abcd1234efgh", "secret": "secret12345678"}
+        mock_cja = MagicMock()
+        mock_cja.getDataViews.return_value = [{"id": "dv1"}]
+        mock_cjapy.CJA.return_value = mock_cja
+        validate_config_only(profile="myprofile")
+        output = capsys.readouterr().out
+        assert "[2/5] Checking dependencies..." in output
+        # Core deps should all show with checkmark
+        for pkg in ("cjapy", "pandas", "numpy", "xlsxwriter", "tqdm"):
+            assert pkg in output
+
+    @patch("cja_auto_sdr.generator._config_from_env")
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.load_profile_credentials")
+    def test_dependencies_step_shows_optional_deps(
+        self, mock_load, mock_cjapy, _mock_config_env, capsys: pytest.CaptureFixture
+    ) -> None:
+        from cja_auto_sdr.generator import validate_config_only
+
+        mock_load.return_value = {"org_id": "org@Adobe", "client_id": "abcd1234efgh", "secret": "secret12345678"}
+        mock_cja = MagicMock()
+        mock_cja.getDataViews.return_value = [{"id": "dv1"}]
+        mock_cjapy.CJA.return_value = mock_cja
+        validate_config_only(profile="myprofile")
+        output = capsys.readouterr().out
+        # Optional deps show with dash, regardless of installed status
+        assert "optional" in output
+        assert "--org-report clustering" in output or "org-report" in output
+        assert "shell tab-completion" in output
+        assert ".env file loading" in output
+
+    def test_missing_core_dependency_fails(self, capsys: pytest.CaptureFixture) -> None:
+        """Missing core dependency should fail validation."""
+        import importlib.metadata
+
+        from cja_auto_sdr.generator import validate_config_only
+
+        original_version = importlib.metadata.version
+
+        def mock_version(pkg):
+            if pkg == "pandas":
+                raise importlib.metadata.PackageNotFoundError(pkg)
+            return original_version(pkg)
+
+        with patch("cja_auto_sdr.generator.importlib.metadata.version", side_effect=mock_version):
+            result = validate_config_only()
+        assert result is False
+        output = capsys.readouterr().out
+        assert "pandas (not installed)" in output
+        assert "VALIDATION FAILED" in output
+
+    def test_missing_optional_dependency_does_not_fail(self, capsys: pytest.CaptureFixture) -> None:
+        """Missing optional dependency should NOT fail validation."""
+        import importlib.metadata
+
+        from cja_auto_sdr.generator import validate_config_only
+
+        original_version = importlib.metadata.version
+
+        def mock_version(pkg):
+            if pkg in ("scipy", "argcomplete", "python-dotenv"):
+                raise importlib.metadata.PackageNotFoundError(pkg)
+            return original_version(pkg)
+
+        with patch("cja_auto_sdr.generator.importlib.metadata.version", side_effect=mock_version):
+            with patch("cja_auto_sdr.generator.load_credentials_from_env", return_value=None):
+                validate_config_only()
+        # Fails for credentials, not for optional deps
+        output = capsys.readouterr().out
+        assert "scipy not installed (optional" in output
+        assert "argcomplete not installed (optional" in output
+        assert "python-dotenv not installed (optional" in output
+        # Should NOT fail at step 2 — it should proceed to step 3
+        assert "[3/5]" in output
+
+
+class TestValidateConfigOnlyOutputPermissionsStep:
+    """Step [5/5]: output permissions check."""
+
+    @patch("cja_auto_sdr.generator._config_from_env")
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.load_profile_credentials")
+    def test_output_permissions_shown_on_success(
+        self, mock_load, mock_cjapy, _mock_config_env, capsys: pytest.CaptureFixture
+    ) -> None:
+        from cja_auto_sdr.generator import validate_config_only
+
+        mock_load.return_value = {"org_id": "org@Adobe", "client_id": "abcd1234efgh", "secret": "secret12345678"}
+        mock_cja = MagicMock()
+        mock_cja.getDataViews.return_value = [{"id": "dv1"}]
+        mock_cjapy.CJA.return_value = mock_cja
+        validate_config_only(profile="myprofile")
+        output = capsys.readouterr().out
+        assert "[5/5] Checking output permissions..." in output
+        assert "Output directory writable" in output
+
+    @patch("cja_auto_sdr.generator._config_from_env")
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.load_profile_credentials")
+    def test_output_permissions_not_writable_fails(
+        self, mock_load, mock_cjapy, _mock_config_env, capsys: pytest.CaptureFixture
+    ) -> None:
+        from cja_auto_sdr.generator import validate_config_only
+
+        mock_load.return_value = {"org_id": "org@Adobe", "client_id": "abcd1234efgh", "secret": "secret12345678"}
+        mock_cja = MagicMock()
+        mock_cja.getDataViews.return_value = [{"id": "dv1"}]
+        mock_cjapy.CJA.return_value = mock_cja
+        with patch("cja_auto_sdr.generator.os.access", return_value=False):
+            result = validate_config_only(profile="myprofile")
+        assert result is False
+        output = capsys.readouterr().out
+        assert "Output directory not writable" in output
+        assert "VALIDATION FAILED" in output
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    def test_output_permissions_skipped_when_api_fails(
+        self, mock_cjapy, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Step 5 should not run when step 4 (API) fails."""
+        from cja_auto_sdr.generator import validate_config_only
+
+        config = tmp_path / "config.json"
+        config.write_text(
+            json.dumps({"org_id": "org@Adobe", "client_id": "abcd1234efgh", "secret": "secret12345678"}),
+        )
+        mock_cja = MagicMock()
+        mock_cja.getDataViews.side_effect = APIError("connection refused")
+        mock_cjapy.CJA.return_value = mock_cja
+        with patch("cja_auto_sdr.generator.load_credentials_from_env", return_value=None):
+            result = validate_config_only(config_file=str(config))
+        assert result is False
+        output = capsys.readouterr().out
+        assert "[5/5]" not in output
+
+
+class TestValidateConfigOnlyStepNumbering:
+    """Verify the 5-step numbering is correct across the full flow."""
+
+    @patch("cja_auto_sdr.generator._config_from_env")
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.load_profile_credentials")
+    def test_all_five_steps_appear(
+        self, mock_load, mock_cjapy, _mock_config_env, capsys: pytest.CaptureFixture
+    ) -> None:
+        from cja_auto_sdr.generator import validate_config_only
+
+        mock_load.return_value = {"org_id": "org@Adobe", "client_id": "abcd1234efgh", "secret": "secret12345678"}
+        mock_cja = MagicMock()
+        mock_cja.getDataViews.return_value = [{"id": "dv1"}]
+        mock_cjapy.CJA.return_value = mock_cja
+        result = validate_config_only(profile="myprofile")
+        assert result is True
+        output = capsys.readouterr().out
+        assert "[1/5]" in output
+        assert "[2/5]" in output
+        assert "[3/5]" in output
+        assert "[4/5]" in output
+        assert "[5/5]" in output
+
+    @patch("cja_auto_sdr.generator._config_from_env")
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.load_profile_credentials")
+    def test_no_old_step_numbers(self, mock_load, mock_cjapy, _mock_config_env, capsys: pytest.CaptureFixture) -> None:
+        """Old step numbering [X/3] should no longer appear."""
+        from cja_auto_sdr.generator import validate_config_only
+
+        mock_load.return_value = {"org_id": "org@Adobe", "client_id": "abcd1234efgh", "secret": "secret12345678"}
+        mock_cja = MagicMock()
+        mock_cja.getDataViews.return_value = [{"id": "dv1"}]
+        mock_cjapy.CJA.return_value = mock_cja
+        validate_config_only(profile="myprofile")
+        output = capsys.readouterr().out
+        assert "/3]" not in output
+
+
+# ---------------------------------------------------------------------------
 # 3. show_stats — lines 10226-10410
 # ---------------------------------------------------------------------------
 

--- a/tests/test_logging_redaction.py
+++ b/tests/test_logging_redaction.py
@@ -729,6 +729,49 @@ class TestCollectDependencyVersions:
         versions = _collect_dependency_versions()
         assert list(versions.keys()) == list(_CORE_DEPENDENCIES)
 
+    def test_non_package_not_found_error_returns_question_mark(self):
+        """Non-PackageNotFoundError exceptions should map to '?' (not propagate)."""
+        def metadata_bomb(name: str) -> str:
+            raise ValueError(f"malformed metadata for {name}")
+
+        with patch("cja_auto_sdr.core.logging.importlib.metadata.version", side_effect=metadata_bomb):
+            versions = _collect_dependency_versions()
+        for pkg in _CORE_DEPENDENCIES:
+            assert versions[pkg] == "?", f"{pkg} should be '?' on ValueError"
+
+    def test_oserror_during_metadata_lookup_returns_question_mark(self):
+        """OSError (e.g. corrupt dist-info) should be caught and map to '?'."""
+        def corrupt_metadata(name: str) -> str:
+            raise OSError(f"cannot read metadata for {name}")
+
+        with patch("cja_auto_sdr.core.logging.importlib.metadata.version", side_effect=corrupt_metadata):
+            versions = _collect_dependency_versions()
+        for pkg in _CORE_DEPENDENCIES:
+            assert versions[pkg] == "?"
+
+    def test_mixed_exception_types_only_affect_failing_packages(self):
+        """Different exception types per package should each be caught individually."""
+        import importlib.metadata
+
+        real_version = importlib.metadata.version
+
+        def mixed_failures(name: str) -> str:
+            if name == "cjapy":
+                raise ValueError("bad metadata")
+            if name == "tqdm":
+                raise OSError("cannot read")
+            if name == "xlsxwriter":
+                raise importlib.metadata.PackageNotFoundError(name)
+            return real_version(name)
+
+        with patch("cja_auto_sdr.core.logging.importlib.metadata.version", side_effect=mixed_failures):
+            versions = _collect_dependency_versions()
+        assert versions["cjapy"] == "?"
+        assert versions["tqdm"] == "?"
+        assert versions["xlsxwriter"] == "?"
+        assert versions["pandas"] != "?"
+        assert versions["numpy"] != "?"
+
     def test_startup_log_contains_dependency_line(self, capsys):
         """setup_logging should emit a 'Dependencies:' INFO line."""
         from cja_auto_sdr.core.logging import setup_logging

--- a/tests/test_logging_redaction.py
+++ b/tests/test_logging_redaction.py
@@ -731,6 +731,7 @@ class TestCollectDependencyVersions:
 
     def test_non_package_not_found_error_returns_question_mark(self):
         """Non-PackageNotFoundError exceptions should map to '?' (not propagate)."""
+
         def metadata_bomb(name: str) -> str:
             raise ValueError(f"malformed metadata for {name}")
 
@@ -741,6 +742,7 @@ class TestCollectDependencyVersions:
 
     def test_oserror_during_metadata_lookup_returns_question_mark(self):
         """OSError (e.g. corrupt dist-info) should be caught and map to '?'."""
+
         def corrupt_metadata(name: str) -> str:
             raise OSError(f"cannot read metadata for {name}")
 

--- a/tests/test_logging_redaction.py
+++ b/tests/test_logging_redaction.py
@@ -19,6 +19,7 @@ from cja_auto_sdr.core.logging import (
     ContextLoggerAdapter,
     JSONFormatter,
     SensitiveDataFilter,
+    _cached_startup_dependency_versions,
     _collect_dependency_versions,
     _infer_run_mode,
     _is_reserved_or_private_record_key,
@@ -764,3 +765,58 @@ class TestCollectDependencyVersions:
         dep_field = dep_entries[0].get("dependency_versions")
         assert isinstance(dep_field, dict)
         assert set(dep_field.keys()) == set(_CORE_DEPENDENCIES)
+
+    def test_startup_logging_skips_dependency_lookup_when_info_disabled(self):
+        """setup_logging should avoid dependency lookup work when INFO logs are disabled."""
+        from cja_auto_sdr.core.logging import setup_logging
+
+        _cached_startup_dependency_versions.cache_clear()
+        try:
+            with patch(
+                "cja_auto_sdr.core.logging._collect_dependency_versions",
+                side_effect=AssertionError("dependency lookup should not run"),
+            ):
+                setup_logging("test_dv", batch_mode=False, log_level="WARNING")
+        finally:
+            _cached_startup_dependency_versions.cache_clear()
+
+    def test_startup_logging_reuses_cached_dependency_lookup_across_invocations(self):
+        """Repeated setup_logging(INFO) calls should reuse cached startup dependency versions."""
+        from cja_auto_sdr.core.logging import setup_logging
+
+        _cached_startup_dependency_versions.cache_clear()
+        call_count = {"count": 0}
+
+        def _fake_collect() -> dict[str, str]:
+            call_count["count"] += 1
+            return {pkg: f"v{index}" for index, pkg in enumerate(_CORE_DEPENDENCIES)}
+
+        try:
+            with patch("cja_auto_sdr.core.logging._collect_dependency_versions", side_effect=_fake_collect):
+                setup_logging("test_dv_1", batch_mode=False, log_level="INFO")
+                setup_logging("test_dv_2", batch_mode=False, log_level="INFO")
+        finally:
+            _cached_startup_dependency_versions.cache_clear()
+
+        assert call_count["count"] == 1
+
+    def test_startup_logging_dependency_lookup_failure_falls_back_to_unknown(self, capsys):
+        """Unexpected startup dependency lookup errors should not break logging setup."""
+        from cja_auto_sdr.core.logging import setup_logging
+
+        _cached_startup_dependency_versions.cache_clear()
+        try:
+            with patch(
+                "cja_auto_sdr.core.logging._startup_dependency_versions_for_logging",
+                side_effect=RuntimeError("metadata backend unavailable"),
+            ):
+                setup_logging("test_dv", batch_mode=False, log_level="INFO")
+        finally:
+            _cached_startup_dependency_versions.cache_clear()
+
+        captured = capsys.readouterr().out
+        dep_lines = [line for line in captured.splitlines() if "Dependencies:" in line]
+        assert len(dep_lines) == 1
+        dep_line = dep_lines[0]
+        for pkg in _CORE_DEPENDENCIES:
+            assert f"{pkg}=?" in dep_line

--- a/tests/test_logging_redaction.py
+++ b/tests/test_logging_redaction.py
@@ -9,15 +9,17 @@ import json
 import logging
 import os
 import sys
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from cja_auto_sdr.core.logging import (
+    _CORE_DEPENDENCIES,
     ContextLoggerAdapter,
     JSONFormatter,
     SensitiveDataFilter,
+    _collect_dependency_versions,
     _infer_run_mode,
     _is_reserved_or_private_record_key,
     _is_sensitive_field,
@@ -672,3 +674,93 @@ class TestFlushLoggingHandlers:
         finally:
             logger.removeHandler(bad_handler)
             logger.propagate = True
+
+
+# ---------------------------------------------------------------------------
+# _collect_dependency_versions
+# ---------------------------------------------------------------------------
+class TestCollectDependencyVersions:
+    """Tests for the dependency version collection helper."""
+
+    def test_returns_all_core_dependencies(self):
+        """Result dict has an entry for every package in _CORE_DEPENDENCIES."""
+        versions = _collect_dependency_versions()
+        assert set(versions.keys()) == set(_CORE_DEPENDENCIES)
+
+    def test_installed_packages_return_version_strings(self):
+        """Packages that are installed should return non-empty version strings (not '?')."""
+        versions = _collect_dependency_versions()
+        # pandas and numpy are always installed in our test environment
+        for pkg in ("pandas", "numpy"):
+            assert versions[pkg] != "?", f"{pkg} should be installed"
+            assert versions[pkg], f"{pkg} version should not be empty"
+
+    def test_missing_package_returns_question_mark(self):
+        """A package that is not installed should map to '?'."""
+        import importlib.metadata
+
+        with patch(
+            "cja_auto_sdr.core.logging.importlib.metadata.version",
+            side_effect=importlib.metadata.PackageNotFoundError("no-such-pkg"),
+        ):
+            versions = _collect_dependency_versions()
+        for pkg in _CORE_DEPENDENCIES:
+            assert versions[pkg] == "?"
+
+    def test_partial_failure_only_affects_missing(self):
+        """If one package is missing, others should still report real versions."""
+        import importlib.metadata
+
+        real_version = importlib.metadata.version
+
+        def selective_fail(name: str) -> str:
+            if name == "xlsxwriter":
+                raise importlib.metadata.PackageNotFoundError(name)
+            return real_version(name)
+
+        with patch("cja_auto_sdr.core.logging.importlib.metadata.version", side_effect=selective_fail):
+            versions = _collect_dependency_versions()
+        assert versions["xlsxwriter"] == "?"
+        assert versions["pandas"] != "?"
+
+    def test_preserves_dependency_order(self):
+        """Keys should match the order of _CORE_DEPENDENCIES."""
+        versions = _collect_dependency_versions()
+        assert list(versions.keys()) == list(_CORE_DEPENDENCIES)
+
+    def test_startup_log_contains_dependency_line(self, capsys):
+        """setup_logging should emit a 'Dependencies:' INFO line."""
+        from cja_auto_sdr.core.logging import setup_logging
+
+        setup_logging("test_dv", batch_mode=False, log_level="INFO")
+        captured = capsys.readouterr().out
+
+        dep_lines = [line for line in captured.splitlines() if "Dependencies:" in line]
+        assert len(dep_lines) == 1
+        msg = dep_lines[0]
+        # Should mention every core dependency
+        for pkg in _CORE_DEPENDENCIES:
+            assert f"{pkg}=" in msg
+
+    def test_startup_log_json_includes_dependency_versions(self, capsys):
+        """JSON log format should include dependency_versions as a structured field."""
+        import json as _json
+
+        from cja_auto_sdr.core.logging import setup_logging
+
+        setup_logging("test_dv", batch_mode=False, log_level="INFO", log_format="json")
+        captured = capsys.readouterr().out
+
+        dep_entries = []
+        for line in captured.splitlines():
+            try:
+                entry = _json.loads(line)
+            except _json.JSONDecodeError:
+                continue
+            if "Dependencies:" in entry.get("message", ""):
+                dep_entries.append(entry)
+
+        assert len(dep_entries) == 1
+        dep_field = dep_entries[0].get("dependency_versions")
+        assert isinstance(dep_field, dict)
+        assert set(dep_field.keys()) == set(_CORE_DEPENDENCIES)

--- a/tests/test_main_entry_points.py
+++ b/tests/test_main_entry_points.py
@@ -181,6 +181,20 @@ class TestMainImplRunState:
         assert run_state["mode"] == "exit_codes"
 
     @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.__main__._handle_completion")
+    def test_run_state_mode_set_for_completion(self, mock_handle_completion):
+        run_state = {"mode": "unknown", "details": {}}
+        mock_handle_completion.side_effect = SystemExit(0)
+
+        with pytest.raises(SystemExit):
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                mock_pa.return_value = parse_arguments(["--completion", "bash"])
+                _main_impl(run_state=run_state)
+
+        assert run_state["mode"] == "completion"
+        mock_handle_completion.assert_called_once()
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
     @patch("cja_auto_sdr.generator.list_profiles")
     def test_run_state_mode_set_for_profile_management(self, mock_list):
         mock_list.return_value = True

--- a/tests/test_output_content_validation.py
+++ b/tests/test_output_content_validation.py
@@ -38,7 +38,7 @@ def rich_data_dict():
         "Metadata": pd.DataFrame(
             {
                 "Property": ["Generated At", "Data View ID", "Tool Version", "Total Metrics"],
-                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.3.3", 3],
+                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.3.4", 3],
             },
         ),
         "Data Quality": pd.DataFrame(
@@ -104,7 +104,7 @@ def rich_metadata_dict():
         "Generated At": "2025-01-15 10:30:00 PST",
         "Data View ID": "dv_content_test",
         "Data View Name": "Test DataView",
-        "Tool Version": "3.3.3",
+        "Tool Version": "3.3.4",
         "Metrics Count": "3",
         "Dimensions Count": "4",
     }
@@ -224,7 +224,7 @@ class TestJSONContentValidation:
             data = json.load(f)
 
         assert data["metadata"]["Data View ID"] == "dv_content_test"
-        assert data["metadata"]["Tool Version"] == "3.3.3"
+        assert data["metadata"]["Tool Version"] == "3.3.4"
 
 
 # ===================================================================

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -222,6 +222,12 @@ CLIENT_ID='test_client_id'
         assert result["org_id"] == "test@AdobeOrg"
         assert result["client_id"] == "test_client_id"
 
+    def test_malformed_non_utf8_env_returns_none(self, tmp_path):
+        """Malformed/non-UTF8 .env should be treated as unreadable."""
+        (tmp_path / ".env").write_bytes(b"\xff\xfe\x00invalid")
+        result = load_profile_dotenv(tmp_path)
+        assert result is None
+
 
 class TestLoadProfileCredentials:
     """Test loading and merging profile credentials"""
@@ -656,6 +662,12 @@ class TestReadProfileOrgId:
         finally:
             env_file.chmod(0o644)
 
+    def test_malformed_dotenv_falls_back_to_config_json(self, tmp_path):
+        """Malformed .env should not crash and should preserve JSON fallback."""
+        (tmp_path / "config.json").write_text('{"org_id": "SAFE@AdobeOrg"}')
+        (tmp_path / ".env").write_bytes(b"\xff\xfe\x00ORG_ID=bad")
+        assert _read_profile_org_id(tmp_path) == "SAFE@AdobeOrg"
+
     def test_strips_whitespace_from_org_id(self, tmp_path):
         """Whitespace is stripped from org_id values"""
         (tmp_path / "config.json").write_text('{"org_id": "  ABC@AdobeOrg  "}')
@@ -789,3 +801,26 @@ class TestListProfilesOrgId:
             captured = capsys.readouterr()
             data = json.loads(captured.out)
             assert data["profiles"][0]["org_id"] == "ENV_ORG@AdobeOrg"
+
+    def test_listing_continues_when_org_id_read_fails_for_one_profile(self, tmp_path, capsys):
+        """A single unreadable/malformed profile should not abort --profile-list."""
+        profiles_dir = tmp_path / "profiles"
+        profiles_dir.mkdir()
+
+        good = profiles_dir / "good"
+        good.mkdir()
+        (good / "config.json").write_text('{"org_id": "GOOD@AdobeOrg"}')
+
+        bad = profiles_dir / "bad"
+        bad.mkdir()
+        (bad / ".env").write_bytes(b"\xff\xfe\x00malformed")
+
+        with patch("cja_auto_sdr.generator.get_profiles_dir", return_value=profiles_dir):
+            result = list_profiles(output_format="json")
+            assert result is True
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        by_name = {profile["name"]: profile for profile in data["profiles"]}
+        assert by_name["good"]["org_id"] == "GOOD@AdobeOrg"
+        assert by_name["bad"]["org_id"] is None

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -14,6 +14,7 @@ from cja_auto_sdr.generator import (
     ProfileConfigError,
     ProfileError,
     ProfileNotFoundError,
+    _read_profile_org_id,
     get_cja_home,
     get_profile_path,
     get_profiles_dir,
@@ -573,3 +574,208 @@ class TestProfileExceptions:
         """Test ProfileConfigError is a ProfileError"""
         error = ProfileConfigError("Invalid config", profile_name="bad")
         assert isinstance(error, ProfileError)
+
+
+class TestReadProfileOrgId:
+    """Test _read_profile_org_id() helper — reads org_id from config.json or .env."""
+
+    def test_org_id_from_config_json(self, tmp_path):
+        """org_id is read from config.json when present"""
+        (tmp_path / "config.json").write_text('{"org_id": "ABC123@AdobeOrg"}')
+        assert _read_profile_org_id(tmp_path) == "ABC123@AdobeOrg"
+
+    def test_org_id_from_dotenv(self, tmp_path):
+        """org_id is read from .env when config.json has no org_id"""
+        (tmp_path / ".env").write_text("ORG_ID=DEF456@AdobeOrg\n")
+        assert _read_profile_org_id(tmp_path) == "DEF456@AdobeOrg"
+
+    def test_config_json_preferred_over_dotenv(self, tmp_path):
+        """config.json org_id takes precedence over .env ORG_ID"""
+        (tmp_path / "config.json").write_text('{"org_id": "FROM_JSON@AdobeOrg"}')
+        (tmp_path / ".env").write_text("ORG_ID=FROM_ENV@AdobeOrg\n")
+        assert _read_profile_org_id(tmp_path) == "FROM_JSON@AdobeOrg"
+
+    def test_falls_back_to_env_when_json_missing_org_id(self, tmp_path):
+        """Falls back to .env when config.json exists but has no org_id key"""
+        (tmp_path / "config.json").write_text('{"client_id": "x"}')
+        (tmp_path / ".env").write_text("ORG_ID=FALLBACK@AdobeOrg\n")
+        assert _read_profile_org_id(tmp_path) == "FALLBACK@AdobeOrg"
+
+    def test_returns_none_when_no_org_id_anywhere(self, tmp_path):
+        """Returns None when neither config.json nor .env has org_id"""
+        (tmp_path / "config.json").write_text('{"client_id": "x"}')
+        (tmp_path / ".env").write_text("CLIENT_ID=y\n")
+        assert _read_profile_org_id(tmp_path) is None
+
+    def test_returns_none_for_empty_directory(self, tmp_path):
+        """Returns None when profile directory has no config files"""
+        assert _read_profile_org_id(tmp_path) is None
+
+    def test_handles_corrupt_config_json(self, tmp_path):
+        """Returns None gracefully when config.json is corrupt"""
+        (tmp_path / "config.json").write_text("{not valid json!!!")
+        assert _read_profile_org_id(tmp_path) is None
+
+    def test_handles_corrupt_json_falls_back_to_env(self, tmp_path):
+        """Falls back to .env when config.json is corrupt"""
+        (tmp_path / "config.json").write_text("{bad json")
+        (tmp_path / ".env").write_text("ORG_ID=RESCUE@AdobeOrg\n")
+        assert _read_profile_org_id(tmp_path) == "RESCUE@AdobeOrg"
+
+    def test_handles_unreadable_config_json(self, tmp_path):
+        """Returns None gracefully when config.json is unreadable"""
+        config_file = tmp_path / "config.json"
+        config_file.write_text('{"org_id": "test@AdobeOrg"}')
+        config_file.chmod(0o000)
+        try:
+            # Should not raise — falls back gracefully
+            result = _read_profile_org_id(tmp_path)
+            # May be None (unreadable) — the key point is no exception
+            assert result is None or isinstance(result, str)
+        finally:
+            config_file.chmod(0o644)
+
+    def test_handles_unreadable_env_file(self, tmp_path):
+        """Returns None gracefully when .env is unreadable"""
+        env_file = tmp_path / ".env"
+        env_file.write_text("ORG_ID=test@AdobeOrg\n")
+        env_file.chmod(0o000)
+        try:
+            result = _read_profile_org_id(tmp_path)
+            assert result is None or isinstance(result, str)
+        finally:
+            env_file.chmod(0o644)
+
+    def test_strips_whitespace_from_org_id(self, tmp_path):
+        """Whitespace is stripped from org_id values"""
+        (tmp_path / "config.json").write_text('{"org_id": "  ABC@AdobeOrg  "}')
+        assert _read_profile_org_id(tmp_path) == "ABC@AdobeOrg"
+
+    def test_env_strips_quotes(self, tmp_path):
+        """Quotes are stripped from .env ORG_ID values"""
+        (tmp_path / ".env").write_text('ORG_ID="QUOTED@AdobeOrg"\n')
+        assert _read_profile_org_id(tmp_path) == "QUOTED@AdobeOrg"
+
+    def test_ignores_non_string_org_id(self, tmp_path):
+        """Returns None when org_id is not a string (e.g. integer)"""
+        (tmp_path / "config.json").write_text('{"org_id": 12345}')
+        assert _read_profile_org_id(tmp_path) is None
+
+    def test_ignores_empty_org_id(self, tmp_path):
+        """Returns None when org_id is an empty string"""
+        (tmp_path / "config.json").write_text('{"org_id": ""}')
+        assert _read_profile_org_id(tmp_path) is None
+
+    def test_ignores_empty_env_org_id(self, tmp_path):
+        """Returns None when .env ORG_ID has empty value"""
+        (tmp_path / ".env").write_text("ORG_ID=\n")
+        assert _read_profile_org_id(tmp_path) is None
+
+    def test_json_array_not_dict(self, tmp_path):
+        """Returns None when config.json is a JSON array instead of object"""
+        (tmp_path / "config.json").write_text('[{"org_id": "test@AdobeOrg"}]')
+        assert _read_profile_org_id(tmp_path) is None
+
+
+class TestListProfilesOrgId:
+    """Test that list_profiles() includes org_id in output."""
+
+    def test_table_shows_org_id_column(self, tmp_path, capsys):
+        """Table output includes Org ID column header and org_id values"""
+        profiles_dir = tmp_path / "profiles"
+        profiles_dir.mkdir()
+        profile = profiles_dir / "client-a"
+        profile.mkdir()
+        (profile / "config.json").write_text('{"org_id": "ABC123@AdobeOrg"}')
+
+        with patch("cja_auto_sdr.generator.get_profiles_dir", return_value=profiles_dir):
+            list_profiles(output_format="table")
+            captured = capsys.readouterr()
+            assert "Org ID" in captured.out
+            assert "ABC123@AdobeOrg" in captured.out
+
+    def test_table_shows_dash_for_missing_org_id(self, tmp_path, capsys):
+        """Table output shows em-dash for profiles without org_id"""
+        profiles_dir = tmp_path / "profiles"
+        profiles_dir.mkdir()
+        profile = profiles_dir / "no-org"
+        profile.mkdir()
+        (profile / "config.json").write_text('{"client_id": "x"}')
+
+        with patch("cja_auto_sdr.generator.get_profiles_dir", return_value=profiles_dir):
+            list_profiles(output_format="table")
+            captured = capsys.readouterr()
+            assert "\u2014" in captured.out  # em-dash
+
+    def test_json_includes_org_id(self, tmp_path, capsys):
+        """JSON output includes org_id field with string value"""
+        profiles_dir = tmp_path / "profiles"
+        profiles_dir.mkdir()
+        profile = profiles_dir / "client-a"
+        profile.mkdir()
+        (profile / "config.json").write_text('{"org_id": "ABC123@AdobeOrg"}')
+
+        with patch("cja_auto_sdr.generator.get_profiles_dir", return_value=profiles_dir):
+            list_profiles(output_format="json")
+            captured = capsys.readouterr()
+            data = json.loads(captured.out)
+            assert data["profiles"][0]["org_id"] == "ABC123@AdobeOrg"
+
+    def test_json_null_for_missing_org_id(self, tmp_path, capsys):
+        """JSON output uses null (None) for profiles without org_id"""
+        profiles_dir = tmp_path / "profiles"
+        profiles_dir.mkdir()
+        profile = profiles_dir / "no-org"
+        profile.mkdir()
+        (profile / "config.json").write_text('{"client_id": "x"}')
+
+        with patch("cja_auto_sdr.generator.get_profiles_dir", return_value=profiles_dir):
+            list_profiles(output_format="json")
+            captured = capsys.readouterr()
+            data = json.loads(captured.out)
+            assert data["profiles"][0]["org_id"] is None
+
+    def test_table_truncates_long_org_id(self, tmp_path, capsys):
+        """Table output truncates excessively long org_id values"""
+        profiles_dir = tmp_path / "profiles"
+        profiles_dir.mkdir()
+        profile = profiles_dir / "long-org"
+        profile.mkdir()
+        long_org = "A" * 60 + "@AdobeOrg"
+        (profile / "config.json").write_text(json.dumps({"org_id": long_org}))
+
+        with patch("cja_auto_sdr.generator.get_profiles_dir", return_value=profiles_dir):
+            list_profiles(output_format="table")
+            captured = capsys.readouterr()
+            # Should contain ellipsis, not the full org_id
+            assert "\u2026" in captured.out
+            assert long_org not in captured.out
+
+    def test_json_preserves_full_long_org_id(self, tmp_path, capsys):
+        """JSON output preserves full org_id even when long"""
+        profiles_dir = tmp_path / "profiles"
+        profiles_dir.mkdir()
+        profile = profiles_dir / "long-org"
+        profile.mkdir()
+        long_org = "A" * 60 + "@AdobeOrg"
+        (profile / "config.json").write_text(json.dumps({"org_id": long_org}))
+
+        with patch("cja_auto_sdr.generator.get_profiles_dir", return_value=profiles_dir):
+            list_profiles(output_format="json")
+            captured = capsys.readouterr()
+            data = json.loads(captured.out)
+            assert data["profiles"][0]["org_id"] == long_org
+
+    def test_org_id_from_env_in_listing(self, tmp_path, capsys):
+        """org_id sourced from .env appears in JSON listing"""
+        profiles_dir = tmp_path / "profiles"
+        profiles_dir.mkdir()
+        profile = profiles_dir / "env-only"
+        profile.mkdir()
+        (profile / ".env").write_text("ORG_ID=ENV_ORG@AdobeOrg\n")
+
+        with patch("cja_auto_sdr.generator.get_profiles_dir", return_value=profiles_dir):
+            list_profiles(output_format="json")
+            captured = capsys.readouterr()
+            data = json.loads(captured.out)
+            assert data["profiles"][0]["org_id"] == "ENV_ORG@AdobeOrg"

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -589,6 +589,16 @@ class TestReadProfileOrgId:
         (tmp_path / ".env").write_text("ORG_ID=DEF456@AdobeOrg\n")
         assert _read_profile_org_id(tmp_path) == "DEF456@AdobeOrg"
 
+    def test_org_id_from_dotenv_lowercase_key(self, tmp_path):
+        """Lowercase .env org_id key should be parsed like profile credential loading."""
+        (tmp_path / ".env").write_text("org_id=lower@AdobeOrg\n")
+        assert _read_profile_org_id(tmp_path) == "lower@AdobeOrg"
+
+    def test_org_id_from_dotenv_with_key_whitespace(self, tmp_path):
+        """Whitespace around .env keys should be normalized like profile credential loading."""
+        (tmp_path / ".env").write_text("  org_id = spaced@AdobeOrg\n")
+        assert _read_profile_org_id(tmp_path) == "spaced@AdobeOrg"
+
     def test_dotenv_overrides_config_json(self, tmp_path):
         """.env ORG_ID takes precedence over config.json, matching load_profile_credentials"""
         (tmp_path / "config.json").write_text('{"org_id": "FROM_JSON@AdobeOrg"}')

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -589,11 +589,11 @@ class TestReadProfileOrgId:
         (tmp_path / ".env").write_text("ORG_ID=DEF456@AdobeOrg\n")
         assert _read_profile_org_id(tmp_path) == "DEF456@AdobeOrg"
 
-    def test_config_json_preferred_over_dotenv(self, tmp_path):
-        """config.json org_id takes precedence over .env ORG_ID"""
+    def test_dotenv_overrides_config_json(self, tmp_path):
+        """.env ORG_ID takes precedence over config.json, matching load_profile_credentials"""
         (tmp_path / "config.json").write_text('{"org_id": "FROM_JSON@AdobeOrg"}')
         (tmp_path / ".env").write_text("ORG_ID=FROM_ENV@AdobeOrg\n")
-        assert _read_profile_org_id(tmp_path) == "FROM_JSON@AdobeOrg"
+        assert _read_profile_org_id(tmp_path) == "FROM_ENV@AdobeOrg"
 
     def test_falls_back_to_env_when_json_missing_org_id(self, tmp_path):
         """Falls back to .env when config.json exists but has no org_id key"""

--- a/tests/test_quality_policy_and_run_summary.py
+++ b/tests/test_quality_policy_and_run_summary.py
@@ -448,6 +448,7 @@ class TestCollectEnvironmentInfo:
 
     def test_non_package_not_found_error_returns_unknown(self):
         """Non-PackageNotFoundError metadata exceptions should map to 'unknown', not crash."""
+
         def metadata_bomb(pkg):
             raise ValueError(f"malformed metadata for {pkg}")
 

--- a/tests/test_quality_policy_and_run_summary.py
+++ b/tests/test_quality_policy_and_run_summary.py
@@ -422,7 +422,7 @@ class TestCollectEnvironmentInfo:
 
     def test_graceful_fallback_on_missing_package(self):
         with patch(
-            "cja_auto_sdr.generator.importlib.metadata.version",
+            "cja_auto_sdr.core.logging.importlib.metadata.version",
             side_effect=importlib.metadata.PackageNotFoundError("not found"),
         ):
             info = _collect_environment_info()
@@ -438,7 +438,7 @@ class TestCollectEnvironmentInfo:
             return real_version(pkg)
 
         with patch(
-            "cja_auto_sdr.generator.importlib.metadata.version",
+            "cja_auto_sdr.core.logging.importlib.metadata.version",
             side_effect=selective_fail,
         ):
             info = _collect_environment_info()

--- a/tests/test_quality_policy_and_run_summary.py
+++ b/tests/test_quality_policy_and_run_summary.py
@@ -445,3 +445,36 @@ class TestCollectEnvironmentInfo:
             assert info["dependencies"]["numpy"] == "unknown"
             # Other packages should still have real versions
             assert info["dependencies"]["pandas"] != "unknown"
+
+    def test_non_package_not_found_error_returns_unknown(self):
+        """Non-PackageNotFoundError metadata exceptions should map to 'unknown', not crash."""
+        def metadata_bomb(pkg):
+            raise ValueError(f"malformed metadata for {pkg}")
+
+        with patch(
+            "cja_auto_sdr.core.logging.importlib.metadata.version",
+            side_effect=metadata_bomb,
+        ):
+            info = _collect_environment_info()
+            for ver in info["dependencies"].values():
+                assert ver == "unknown"
+            # Rest of the payload should still be intact
+            assert "python_version" in info
+            assert "platform" in info
+
+    def test_oserror_during_metadata_does_not_crash_environment_info(self):
+        """OSError from corrupt dist-info should not prevent environment collection."""
+        real_version = importlib.metadata.version
+
+        def corrupt_one(pkg):
+            if pkg == "pandas":
+                raise OSError("cannot read dist-info")
+            return real_version(pkg)
+
+        with patch(
+            "cja_auto_sdr.core.logging.importlib.metadata.version",
+            side_effect=corrupt_one,
+        ):
+            info = _collect_environment_info()
+            assert info["dependencies"]["pandas"] == "unknown"
+            assert info["dependencies"]["numpy"] != "unknown"

--- a/tests/test_quality_policy_and_run_summary.py
+++ b/tests/test_quality_policy_and_run_summary.py
@@ -423,7 +423,7 @@ class TestCollectEnvironmentInfo:
     def test_graceful_fallback_on_missing_package(self):
         with patch(
             "cja_auto_sdr.generator.importlib.metadata.version",
-            side_effect=Exception("not found"),
+            side_effect=importlib.metadata.PackageNotFoundError("not found"),
         ):
             info = _collect_environment_info()
             for ver in info["dependencies"].values():
@@ -434,7 +434,7 @@ class TestCollectEnvironmentInfo:
 
         def selective_fail(pkg):
             if pkg == "numpy":
-                raise Exception("not found")
+                raise importlib.metadata.PackageNotFoundError("not found")
             return real_version(pkg)
 
         with patch(

--- a/tests/test_quality_policy_and_run_summary.py
+++ b/tests/test_quality_policy_and_run_summary.py
@@ -7,7 +7,9 @@ _coerce_run_mode.
 """
 
 import argparse
+import importlib.metadata
 import json
+from unittest.mock import patch
 
 import pytest
 
@@ -15,6 +17,7 @@ from cja_auto_sdr.generator import (
     ProcessingResult,
     RunMode,
     _coerce_run_mode,
+    _collect_environment_info,
     _infer_run_status,
     _normalize_exit_code,
     aggregate_quality_issues,
@@ -376,3 +379,69 @@ class TestCoerceRunMode:
 
     def test_int_input(self):
         assert _coerce_run_mode(42) is None
+
+
+# ==================== _collect_environment_info ====================
+
+
+class TestCollectEnvironmentInfo:
+    def test_returns_expected_keys(self):
+        info = _collect_environment_info()
+        assert "python_version" in info
+        assert "platform" in info
+        assert "platform_version" in info
+        assert "dependencies" in info
+
+    def test_python_version_format(self):
+        import sys
+
+        info = _collect_environment_info()
+        vi = sys.version_info
+        assert info["python_version"] == f"{vi.major}.{vi.minor}.{vi.micro}"
+
+    def test_platform_matches_sys(self):
+        import sys
+
+        info = _collect_environment_info()
+        assert info["platform"] == sys.platform
+
+    def test_platform_version_is_string(self):
+        info = _collect_environment_info()
+        assert isinstance(info["platform_version"], str)
+        assert len(info["platform_version"]) > 0
+
+    def test_dependencies_contains_core_packages(self):
+        info = _collect_environment_info()
+        expected = {"cjapy", "pandas", "numpy", "xlsxwriter", "tqdm"}
+        assert set(info["dependencies"].keys()) == expected
+
+    def test_dependency_versions_are_strings(self):
+        info = _collect_environment_info()
+        for pkg, ver in info["dependencies"].items():
+            assert isinstance(ver, str), f"{pkg} version is not a string"
+
+    def test_graceful_fallback_on_missing_package(self):
+        with patch(
+            "cja_auto_sdr.generator.importlib.metadata.version",
+            side_effect=Exception("not found"),
+        ):
+            info = _collect_environment_info()
+            for ver in info["dependencies"].values():
+                assert ver == "unknown"
+
+    def test_partial_failure_returns_unknown_for_failing_only(self):
+        real_version = importlib.metadata.version
+
+        def selective_fail(pkg):
+            if pkg == "numpy":
+                raise Exception("not found")
+            return real_version(pkg)
+
+        with patch(
+            "cja_auto_sdr.generator.importlib.metadata.version",
+            side_effect=selective_fail,
+        ):
+            info = _collect_environment_info()
+            assert info["dependencies"]["numpy"] == "unknown"
+            # Other packages should still have real versions
+            assert info["dependencies"]["pandas"] != "unknown"

--- a/tests/test_ux_features.py
+++ b/tests/test_ux_features.py
@@ -344,11 +344,11 @@ class TestCombinedFeatures:
 class TestVersionUpdated:
     """Test that version is correct"""
 
-    def test_version_is_3_3_3(self):
-        """Test that version is 3.3.3"""
+    def test_version_is_3_3_4(self):
+        """Test that version is 3.3.4"""
         from cja_auto_sdr.generator import __version__
 
-        assert __version__ == "3.3.3"
+        assert __version__ == "3.3.4"
 
 
 class TestFormatAutoDetection:


### PR DESCRIPTION
## Summary

Six features focused on developer experience and runtime observability, plus extensive hardening follow-ups:

- **`--completion bash/zsh/fish`** — Self-serve shell tab-completion setup. Fast-path in `__main__.py` bypasses heavyweight imports; prints install instructions if argcomplete not installed. Completion dispatch takes precedence over exit-code flags to avoid unrelated validation errors.
- **Run summary environment metadata** — `--run-summary-json` now includes Python version, platform, and dependency versions for CI/CD diagnostics.
- **Startup dependency versions** — INFO-level log line showing cjapy, pandas, numpy, xlsxwriter, tqdm versions at startup, with cached lookup to avoid repeated `importlib.metadata` calls.
- **`--profile-list` org_id display** — Shows org_id from each profile config, following `.env` overrides `config.json` precedence. Hardened against malformed dotenv files.
- **`--validate-config` 5-step enhancement** — Now checks Python version, core/optional dependencies, and output dir permissions alongside existing credential + API checks. Wires through `--output-dir` for accurate step-5 permission checks.
- **Narrowed exception handling (batch 2)** — 13 broad `except Exception` catches replaced with specific types; 15 intentional boundaries annotated.

### Hardening follow-ups (15 commits post-initial implementation)

- Completion/exit-codes precedence fix — completion flags now dispatch before exit-code validation to prevent spurious errors
- Completion scripts hardened for invoked entrypoint (`python -m cja_auto_sdr`)
- Dependency version helpers consolidated into single source of truth (`core/logging.py`)
- Metadata errors in validation and logging handled gracefully
- Profile listing hardened against malformed dotenv files
- Performance test stability improvements

## Stats

- **5,077 tests** (up from 4,962), all passing
- **24 files changed**, +2,222 / −137 lines (source: +554 / −99)
- **23 commits** on branch
- **Zero breaking changes**
- Version sync check passing
- Ruff lint + format clean (41 rule sets)

## Test plan

- [x] Full test suite: 5,077 collected, all passing
- [x] `scripts/check_version_sync.py` — all references match v3.3.4
- [x] `test_update_test_counts.py` — counts validated
- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] New test file: `test_completion.py` (completion fast-path, error paths, shell scripts)
- [x] Existing test files extended: `test_logging_redaction.py`, `test_quality_policy_and_run_summary.py`, `test_profiles.py`, `test_config_and_resolution.py`, `test_cli.py`, `test_main_entry_points.py`, `test_optimized_validation.py`