### PR TITLE
Release v3.3.5: hardening & polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ All notable changes to the CJA SDR Generator project will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.5] - 2026-02-26
+
+### Fixed
+- **Profile error routing**: 19 bare `print()` error calls in profile management now route through `ConsoleColors.error()` to stderr with color styling
+- **CLI help text**: Parser description corrected from "System Design Records" to "Solution Design Reference"; exit code 3 added to epilog
+- **Format fallback warnings**: Discovery and profile-list commands now warn when an unsupported format falls back to console output
+- **Console format error routing**: Console format error messages now go to stderr instead of stdout
+- **Validate-config next-step hint**: `--validate-config` now suggests next steps on success
+
+### Changed
+- **Exception narrowing (batch 3)**: 9 broad `except Exception` catches narrowed — 6 to `(RuntimeError, AttributeError)` and 3 to `RECOVERABLE_API_EXCEPTIONS`
+- **Redundant API call eliminated**: Removed `validate_data_view()` call from `process_single_dataview`; validation now occurs post-fetch, saving one API round-trip per data view
+- **Parallel inventory builds**: Inventory construction in `process_single_dataview` now uses `ThreadPoolExecutor` for concurrent builds
+- **O(1) LRU eviction**: `ValidationCache` refactored from dict + access-times to `OrderedDict` with O(1) eviction
+- **Vectorized column widths**: Excel column-width calculation uses pandas vectorized string operations instead of Python loops
+
+### Added
+- **Exception narrowing tests**: New `test_exception_narrowing.py` with 17 tests verifying narrowed boundaries catch expected types and propagate unexpected ones
+- **Coverage hardening tests**: New `test_coverage_hardening.py` with 101 tests covering previously-missed branches (output-dir access, lazy forwarding, logging init, discovery helpers, short-option clusters, config validation)
+
 ## [3.3.4] - 2026-02-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Validate-config next-step hint**: `--validate-config` now suggests next steps on success
 
 ### Changed
-- **Exception narrowing (batch 3)**: 9 broad `except Exception` catches narrowed — 6 to `(RuntimeError, AttributeError)` and 3 to `RECOVERABLE_API_EXCEPTIONS`
+- **Exception narrowing (batch 3)**: 9 broad `except Exception` catches narrowed — 6 to `(RuntimeError, AttributeError)` and 3 to `RECOVERABLE_API_EXCEPTIONS`; plus 4 broad handlers in `api/fetch.py` explicitly retained with `# Intentional:` boundary annotations
 - **Redundant API call eliminated**: Removed `validate_data_view()` call from `process_single_dataview`; validation now occurs post-fetch, saving one API round-trip per data view
 - **Parallel inventory builds**: Inventory construction in `process_single_dataview` now uses `ThreadPoolExecutor` for concurrent builds
 - **O(1) LRU eviction**: `ValidationCache` refactored from dict + access-times to `OrderedDict` with O(1) eviction

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Exception narrowing tests**: New `test_exception_narrowing.py` with 17 tests verifying narrowed boundaries catch expected types and propagate unexpected ones
-- **Coverage hardening tests**: New `test_coverage_hardening.py` with 101 tests covering previously-missed branches (output-dir access, lazy forwarding, logging init, discovery helpers, short-option clusters, config validation)
+- **Coverage hardening tests**: New `test_coverage_hardening.py` with 108 tests covering previously-missed branches (output-dir access, lazy forwarding, logging init, discovery helpers, short-option clusters, config validation)
 
 ## [3.3.4] - 2026-02-25
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ CJA SDR Generator - A tool for generating Solution Design Reference (SDR) docume
 
 - Package manager: uv
 - Entry point: `cja_auto_sdr` command (via pyproject.toml scripts)
-- Current version: v3.3.4
+- Current version: v3.3.5
 - Main script: `generator.py` (~10k lines) — subpackages use lazy forwarding via `make_getattr()` in `core/lazy.py`
 
 ## CI & Quality

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (5,227+ tests)
+├── tests/                     # Test suite (5,232+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (5,267+ tests)
+├── tests/                     # Test suite (5,273+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (5,214+ tests)
+├── tests/                     # Test suite (5,218+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (5,265+ tests)
+├── tests/                     # Test suite (5,267+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (5,077+ tests)
+├── tests/                     # Test suite (5,196+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (5,196+ tests)
+├── tests/                     # Test suite (5,209+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (5,232+ tests)
+├── tests/                     # Test suite (5,238+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (5,238+ tests)
+├── tests/                     # Test suite (5,243+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (5,263+ tests)
+├── tests/                     # Test suite (5,265+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (5,218+ tests)
+├── tests/                     # Test suite (5,224+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (5,224+ tests)
+├── tests/                     # Test suite (5,227+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (5,273+ tests)
+├── tests/                     # Test suite (5,283+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (5,247+ tests)
+├── tests/                     # Test suite (5,252+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (5,209+ tests)
+├── tests/                     # Test suite (5,214+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (5,252+ tests)
+├── tests/                     # Test suite (5,255+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (5,243+ tests)
+├── tests/                     # Test suite (5,247+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (5,283+ tests)
+├── tests/                     # Test suite (5,287+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (5,255+ tests)
+├── tests/                     # Test suite (5,263+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -924,7 +924,7 @@ cja_auto_sdr --list-dataviews --log-level DEBUG
 At launch, the tool logs diagnostic lines containing the tool version, Python version, platform, active log level, inferred run mode (batch, single, or discovery), and dependency versions. These appear automatically at `INFO` level and are useful for troubleshooting environment issues in CI/CD logs or support requests:
 
 ```text
-CJA SDR Generator v3.3.4 | Python 3.14.2 | darwin | log_level=INFO | mode=single
+CJA SDR Generator v3.3.5 | Python 3.14.2 | darwin | log_level=INFO | mode=single
 Dependencies: cjapy=0.2.4.post3, pandas=2.3.3, numpy=2.2.1, xlsxwriter=3.2.9, tqdm=4.67.0
 ```
 

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -203,7 +203,7 @@ This command:
 
 ```bash
 $ uv run cja_auto_sdr -V
-cja_auto_sdr 3.3.4
+cja_auto_sdr 3.3.5
 ```
 
 > **Important:** All commands in this guide assume you're in the `cja_auto_sdr` directory. If you see "command not found", make sure you're in the right directory and have run `uv sync`.

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Quick Reference Card
 
-Single-page command cheat sheet for CJA SDR Generator v3.3.4.
+Single-page command cheat sheet for CJA SDR Generator v3.3.5.
 
 ## Four Main Modes
 

--- a/src/cja_auto_sdr/api/cache.py
+++ b/src/cja_auto_sdr/api/cache.py
@@ -7,6 +7,7 @@ import logging
 import multiprocessing
 import threading
 import time
+from collections import OrderedDict
 from typing import Any
 
 import pandas as pd
@@ -43,10 +44,8 @@ class ValidationCache:
         self.logger = logger or logging.getLogger(__name__)
 
         # Cache storage: key -> (issues_list, timestamp)
-        self._cache: dict[str, tuple[list[dict], float]] = {}
-
-        # LRU tracking: key -> last_access_time
-        self._access_times: dict[str, float] = {}
+        # OrderedDict tracks insertion/access order for O(1) LRU eviction
+        self._cache: OrderedDict[str, tuple[list[dict], float]] = OrderedDict()
 
         # Thread safety
         self._lock = threading.Lock()
@@ -135,12 +134,11 @@ class ValidationCache:
                 if debug_enabled:
                     self.logger.debug(f"Cache EXPIRED: {item_type} (age: {age:.1f}s)")
                 del self._cache[cache_key]
-                del self._access_times[cache_key]
                 self._misses += 1
                 return None, cache_key
 
-            # Cache hit - update access time
-            self._access_times[cache_key] = time.time()
+            # Cache hit - move to end for LRU tracking
+            self._cache.move_to_end(cache_key)
             self._hits += 1
             if debug_enabled:
                 self.logger.debug(f"Cache HIT: {item_type} ({len(cached_issues)} issues)")
@@ -179,7 +177,6 @@ class ValidationCache:
             # Store issues with timestamp
             # Deep copy to prevent external mutation
             self._cache[cache_key] = ([issue.copy() for issue in issues], time.time())
-            self._access_times[cache_key] = time.time()
 
             if debug_enabled:
                 self.logger.debug(f"Cache STORE: {item_type} ({len(issues)} issues)")
@@ -190,15 +187,11 @@ class ValidationCache:
         Args:
             debug_enabled: Whether debug logging is enabled (avoids repeated checks)
         """
-        if not self._access_times:
+        if not self._cache:
             return
 
-        # Find least recently used key
-        lru_key = min(self._access_times.items(), key=lambda x: x[1])[0]
-
-        # Remove from cache
+        lru_key = next(iter(self._cache))
         del self._cache[lru_key]
-        del self._access_times[lru_key]
         self._evictions += 1
 
         if debug_enabled:
@@ -229,7 +222,6 @@ class ValidationCache:
         """Clear all cache entries (useful for testing)"""
         with self._lock:
             self._cache.clear()
-            self._access_times.clear()
             self.logger.debug("Cache cleared")
 
     def log_statistics(self):
@@ -438,14 +430,8 @@ class SharedValidationCache:
         if not self._access_times:
             return
 
-        # Find least recently used key
-        access_times_dict = dict(self._access_times)
-        if not access_times_dict:  # pragma: no cover — unreachable; guarded by line 438
-            return
+        lru_key = min(self._access_times.items(), key=lambda x: x[1])[0]
 
-        lru_key = min(access_times_dict.items(), key=lambda x: x[1])[0]
-
-        # Remove from cache
         if lru_key in self._cache:
             del self._cache[lru_key]
         if lru_key in self._access_times:

--- a/src/cja_auto_sdr/api/cache.py
+++ b/src/cja_auto_sdr/api/cache.py
@@ -178,10 +178,7 @@ class ValidationCache:
             now = time.time()
 
             if cache_key not in self._cache:
-                # Prefer reclaiming expired entries before evicting live data.
-                self._prune_expired_entries(now, debug_enabled)
-                while len(self._cache) >= self.max_size:
-                    self._evict_lru(debug_enabled)
+                self._ensure_capacity_for_new_entry(now, debug_enabled)
 
             # Store issues with timestamp
             # Deep copy to prevent external mutation
@@ -192,6 +189,26 @@ class ValidationCache:
 
             if debug_enabled:
                 self.logger.debug(f"Cache STORE: {item_type} ({len(issues)} issues)")
+
+    def _ensure_capacity_for_new_entry(self, now: float, debug_enabled: bool = False) -> None:
+        """Make room for one new entry when capacity pressure exists (must be called within lock)."""
+        if len(self._cache) < self.max_size:
+            return
+
+        # Prefer reclaiming expired entries before evicting live data, but only
+        # when the cache is already at capacity.
+        self._prune_expired_entries(now, debug_enabled)
+
+        # Defensive bound in case a future change causes eviction to stop shrinking.
+        max_eviction_attempts = len(self._cache) + 1
+        for _ in range(max_eviction_attempts):
+            if len(self._cache) < self.max_size:
+                return
+            self._evict_lru(debug_enabled)
+
+        if len(self._cache) >= self.max_size:
+            self.logger.warning("Cache capacity maintenance could not evict entries; clearing cache defensively")
+            self._cache.clear()
 
     def _prune_expired_entries(self, now: float, debug_enabled: bool = False) -> int:
         """Remove expired entries before capacity-based eviction (must be called within lock)."""
@@ -406,9 +423,7 @@ class SharedValidationCache:
             # Check TTL expiration
             age = time.time() - timestamp
             if age > self.ttl_seconds:
-                del self._cache[cache_key]
-                if cache_key in self._access_times:
-                    del self._access_times[cache_key]
+                self._remove_entry(cache_key)
                 self._stats["misses"] = self._stats.get("misses", 0) + 1
                 return None, cache_key
 
@@ -419,6 +434,12 @@ class SharedValidationCache:
             # Return copy to prevent mutation
             return [issue.copy() for issue in cached_issues], cache_key
 
+    def _remove_entry(self, cache_key: str) -> bool:
+        """Remove key from cache and access metadata (must be called within lock)."""
+        removed = self._cache.pop(cache_key, None) is not None
+        self._access_times.pop(cache_key, None)
+        return removed
+
     def _reconcile_access_times(self, now: float) -> None:
         """Keep _access_times and _cache in sync (must be called within lock)."""
         cache_keys = set(self._cache.keys())
@@ -426,7 +447,7 @@ class SharedValidationCache:
 
         # Remove stale access-time records for entries no longer in cache.
         for stale_key in access_keys - cache_keys:
-            del self._access_times[stale_key]
+            self._access_times.pop(stale_key, None)
 
         # Backfill missing access-time records so eviction always has a candidate.
         for missing_key in cache_keys - access_keys:
@@ -437,11 +458,37 @@ class SharedValidationCache:
         expired_keys = [key for key, (_issues, timestamp) in self._cache.items() if now - timestamp > self.ttl_seconds]
 
         for key in expired_keys:
-            del self._cache[key]
-            if key in self._access_times:
-                del self._access_times[key]
+            self._remove_entry(key)
 
         return len(expired_keys)
+
+    def _ensure_capacity_for_new_entry(self, now: float) -> None:
+        """Make room for one new entry when capacity pressure exists (must be called within lock)."""
+        if len(self._cache) < self.max_size:
+            return
+
+        self._prune_expired_entries(now)
+        if len(self._cache) < self.max_size:
+            return
+
+        self._reconcile_access_times(now)
+
+        # Defensive bound in case a future change causes eviction to stop shrinking.
+        max_eviction_attempts = len(self._cache) + 1
+        for _ in range(max_eviction_attempts):
+            if len(self._cache) < self.max_size:
+                return
+            if not self._evict_lru(now=now, access_times_reconciled=True):
+                break
+
+        # Last-resort fallback: drop oldest key from cache iteration to avoid
+        # blocking inserts on metadata corruption.
+        while len(self._cache) >= self.max_size:
+            fallback_key = next(iter(self._cache), None)
+            if fallback_key is None:
+                break
+            self._remove_entry(fallback_key)
+            self._stats["evictions"] = self._stats.get("evictions", 0) + 1
 
     def put(
         self,
@@ -472,16 +519,13 @@ class SharedValidationCache:
             now = time.time()
 
             if cache_key not in self._cache:
-                self._prune_expired_entries(now)
-                self._reconcile_access_times(now)
-                while len(self._cache) >= self.max_size:
-                    self._evict_lru()
+                self._ensure_capacity_for_new_entry(now)
 
             # Store issues with timestamp (deep copy for safety)
             self._cache[cache_key] = ([issue.copy() for issue in issues], now)
             self._access_times[cache_key] = now
 
-    def _evict_lru(self) -> None:
+    def _evict_lru(self, now: float | None = None, access_times_reconciled: bool = False) -> bool:
         """Evict least recently used cache entry (must be called within lock).
 
         NOTE: Manager().dict() does not provide ordered pop semantics, so this
@@ -489,10 +533,11 @@ class SharedValidationCache:
         """
         if not self._cache:
             self._access_times.clear()
-            return
+            return False
 
-        now = time.time()
-        self._reconcile_access_times(now)
+        current_time = now if now is not None else time.time()
+        if not access_times_reconciled:
+            self._reconcile_access_times(current_time)
 
         access_items = list(self._access_times.items())
         if access_items:
@@ -500,11 +545,21 @@ class SharedValidationCache:
         else:
             lru_key = next(iter(self._cache))
 
-        del self._cache[lru_key]
-        if lru_key in self._access_times:
-            del self._access_times[lru_key]
+        if self._remove_entry(lru_key):
+            self._stats["evictions"] = self._stats.get("evictions", 0) + 1
+            return True
 
-        self._stats["evictions"] = self._stats.get("evictions", 0) + 1
+        # Access metadata pointed at a missing cache key. Clean it up and
+        # fall back to evicting a concrete cache entry if possible.
+        self._access_times.pop(lru_key, None)
+        fallback_key = next(iter(self._cache), None)
+        if fallback_key is None:
+            return False
+
+        removed = self._remove_entry(fallback_key)
+        if removed:
+            self._stats["evictions"] = self._stats.get("evictions", 0) + 1
+        return removed
 
     def get_statistics(self) -> dict[str, Any]:
         """
@@ -558,6 +613,10 @@ class SharedValidationCache:
         IMPORTANT: Call this after batch processing is complete to avoid
         resource leaks. The cache cannot be used after shutdown.
         """
-        if self._manager is not None:
-            with contextlib.suppress(Exception):
-                self._manager.shutdown()
+        manager = self._manager
+        if manager is None:
+            return
+
+        self._manager = None
+        with contextlib.suppress(Exception):
+            manager.shutdown()

--- a/src/cja_auto_sdr/api/cache.py
+++ b/src/cja_auto_sdr/api/cache.py
@@ -39,6 +39,11 @@ class ValidationCache:
             ttl_seconds: Time-to-live for cache entries in seconds, >= 1 (default: 3600 = 1 hour)
             logger: Logger instance for cache statistics (default: module logger)
         """
+        if max_size < 1:
+            raise ValueError(f"max_size must be >= 1, got {max_size}")
+        if ttl_seconds <= 0:
+            raise ValueError(f"ttl_seconds must be > 0, got {ttl_seconds}")
+
         self.max_size = max_size
         self.ttl_seconds = ttl_seconds
         self.logger = logger or logging.getLogger(__name__)
@@ -170,16 +175,35 @@ class ValidationCache:
         debug_enabled = self.logger.isEnabledFor(logging.DEBUG)
 
         with self._lock:
-            # Evict oldest entry if cache is full
-            if len(self._cache) >= self.max_size and cache_key not in self._cache:
-                self._evict_lru(debug_enabled)
+            now = time.time()
+
+            # Overwrites are treated as fresh writes for LRU ordering.
+            if cache_key in self._cache:
+                self._cache.move_to_end(cache_key)
+            else:
+                # Prefer reclaiming expired entries before evicting live data.
+                self._prune_expired_entries(now, debug_enabled)
+                while len(self._cache) >= self.max_size:
+                    self._evict_lru(debug_enabled)
 
             # Store issues with timestamp
             # Deep copy to prevent external mutation
-            self._cache[cache_key] = ([issue.copy() for issue in issues], time.time())
+            self._cache[cache_key] = ([issue.copy() for issue in issues], now)
+            self._cache.move_to_end(cache_key)
 
             if debug_enabled:
                 self.logger.debug(f"Cache STORE: {item_type} ({len(issues)} issues)")
+
+    def _prune_expired_entries(self, now: float, debug_enabled: bool = False) -> int:
+        """Remove expired entries before capacity-based eviction (must be called within lock)."""
+        expired_keys = [key for key, (_issues, timestamp) in self._cache.items() if now - timestamp > self.ttl_seconds]
+        for key in expired_keys:
+            del self._cache[key]
+
+        if expired_keys and debug_enabled:
+            self.logger.debug(f"Cache PRUNE: removed {len(expired_keys)} expired entries")
+
+        return len(expired_keys)
 
     def _evict_lru(self, debug_enabled: bool = False):
         """Evict least recently used cache entry.
@@ -293,6 +317,11 @@ class SharedValidationCache:
             ttl_seconds: Time-to-live for cache entries in seconds (default: 3600)
             logger: Logger instance for cache statistics (default: module logger)
         """
+        if max_size < 1:
+            raise ValueError(f"max_size must be >= 1, got {max_size}")
+        if ttl_seconds <= 0:
+            raise ValueError(f"ttl_seconds must be > 0, got {ttl_seconds}")
+
         self.max_size = max_size
         self.ttl_seconds = ttl_seconds
         self.logger = logger or logging.getLogger(__name__)
@@ -391,6 +420,31 @@ class SharedValidationCache:
             # Return copy to prevent mutation
             return [issue.copy() for issue in cached_issues], cache_key
 
+    def _reconcile_access_times(self, now: float) -> None:
+        """Keep _access_times and _cache in sync (must be called within lock)."""
+        cache_keys = set(self._cache.keys())
+        access_keys = set(self._access_times.keys())
+
+        # Remove stale access-time records for entries no longer in cache.
+        for stale_key in access_keys - cache_keys:
+            del self._access_times[stale_key]
+
+        # Backfill missing access-time records so eviction always has a candidate.
+        for missing_key in cache_keys - access_keys:
+            self._access_times[missing_key] = now
+
+    def _prune_expired_entries(self, now: float) -> int:
+        """Drop expired entries from shared cache before capacity-based eviction."""
+        expired_keys = [key for key, (_issues, timestamp) in self._cache.items() if now - timestamp > self.ttl_seconds]
+
+        for key in expired_keys:
+            if key in self._cache:
+                del self._cache[key]
+            if key in self._access_times:
+                del self._access_times[key]
+
+        return len(expired_keys)
+
     def put(
         self,
         df: pd.DataFrame,
@@ -417,23 +471,37 @@ class SharedValidationCache:
             cache_key = self._generate_cache_key(df, item_type, required_fields, critical_fields)
 
         with self._lock:
-            # Evict oldest entry if cache is full
-            if len(self._cache) >= self.max_size and cache_key not in self._cache:
-                self._evict_lru()
+            now = time.time()
+
+            # Overwrites are treated as fresh writes for LRU ordering.
+            if cache_key in self._cache:
+                self._access_times[cache_key] = now
+            else:
+                self._prune_expired_entries(now)
+                self._reconcile_access_times(now)
+                while len(self._cache) >= self.max_size:
+                    self._evict_lru()
 
             # Store issues with timestamp (deep copy for safety)
-            self._cache[cache_key] = ([issue.copy() for issue in issues], time.time())
-            self._access_times[cache_key] = time.time()
+            self._cache[cache_key] = ([issue.copy() for issue in issues], now)
+            self._access_times[cache_key] = now
 
     def _evict_lru(self) -> None:
         """Evict least recently used cache entry (must be called within lock)."""
-        if not self._access_times:
+        if not self._cache:
+            self._access_times.clear()
             return
 
-        lru_key = min(self._access_times.items(), key=lambda x: x[1])[0]
+        now = time.time()
+        self._reconcile_access_times(now)
 
-        if lru_key in self._cache:
-            del self._cache[lru_key]
+        access_times = dict(self._access_times)
+        if access_times:
+            lru_key = min(access_times, key=access_times.get)
+        else:
+            lru_key = next(iter(self._cache))
+
+        del self._cache[lru_key]
         if lru_key in self._access_times:
             del self._access_times[lru_key]
 

--- a/src/cja_auto_sdr/api/cache.py
+++ b/src/cja_auto_sdr/api/cache.py
@@ -177,10 +177,7 @@ class ValidationCache:
         with self._lock:
             now = time.time()
 
-            # Overwrites are treated as fresh writes for LRU ordering.
-            if cache_key in self._cache:
-                self._cache.move_to_end(cache_key)
-            else:
+            if cache_key not in self._cache:
                 # Prefer reclaiming expired entries before evicting live data.
                 self._prune_expired_entries(now, debug_enabled)
                 while len(self._cache) >= self.max_size:
@@ -189,6 +186,8 @@ class ValidationCache:
             # Store issues with timestamp
             # Deep copy to prevent external mutation
             self._cache[cache_key] = ([issue.copy() for issue in issues], now)
+            # OrderedDict preserves position on overwrite, so one move_to_end()
+            # after assignment is sufficient for both inserts and overwrites.
             self._cache.move_to_end(cache_key)
 
             if debug_enabled:
@@ -438,8 +437,7 @@ class SharedValidationCache:
         expired_keys = [key for key, (_issues, timestamp) in self._cache.items() if now - timestamp > self.ttl_seconds]
 
         for key in expired_keys:
-            if key in self._cache:
-                del self._cache[key]
+            del self._cache[key]
             if key in self._access_times:
                 del self._access_times[key]
 
@@ -473,10 +471,7 @@ class SharedValidationCache:
         with self._lock:
             now = time.time()
 
-            # Overwrites are treated as fresh writes for LRU ordering.
-            if cache_key in self._cache:
-                self._access_times[cache_key] = now
-            else:
+            if cache_key not in self._cache:
                 self._prune_expired_entries(now)
                 self._reconcile_access_times(now)
                 while len(self._cache) >= self.max_size:
@@ -487,7 +482,11 @@ class SharedValidationCache:
             self._access_times[cache_key] = now
 
     def _evict_lru(self) -> None:
-        """Evict least recently used cache entry (must be called within lock)."""
+        """Evict least recently used cache entry (must be called within lock).
+
+        NOTE: Manager().dict() does not provide ordered pop semantics, so this
+        implementation necessarily scans access-time metadata in O(N).
+        """
         if not self._cache:
             self._access_times.clear()
             return
@@ -495,9 +494,9 @@ class SharedValidationCache:
         now = time.time()
         self._reconcile_access_times(now)
 
-        access_times = dict(self._access_times)
-        if access_times:
-            lru_key = min(access_times, key=access_times.get)
+        access_items = list(self._access_times.items())
+        if access_items:
+            lru_key = min(access_items, key=lambda item: item[1])[0]
         else:
             lru_key = next(iter(self._cache))
 

--- a/src/cja_auto_sdr/api/fetch.py
+++ b/src/cja_auto_sdr/api/fetch.py
@@ -114,7 +114,7 @@ class ParallelAPIFetcher:
                         results[task_name] = future.result()
                         pbar.set_postfix_str(f"\u2713 {task_name}", refresh=True)
                         self.logger.info(f"\u2713 {task_name.capitalize()} fetch completed")
-                    except Exception as e:
+                    except Exception as e:  # Intentional: per-task boundary for heterogeneous worker failures
                         errors[task_name] = str(e)
                         pbar.set_postfix_str(f"\u2717 {task_name}", refresh=True)
                         self.logger.error(f"\u2717 {task_name.capitalize()} fetch failed: {e}")
@@ -197,7 +197,7 @@ class ParallelAPIFetcher:
         except AttributeError as e:
             self.logger.error(f"API method error - getMetrics may not be available: {e!s}")
             return pd.DataFrame()
-        except Exception as e:
+        except Exception as e:  # Intentional: preserve resilient fallback-to-empty contract for metrics fetch
             self.logger.error(f"Failed to fetch metrics: {e!s}")
             return pd.DataFrame()
 
@@ -228,7 +228,7 @@ class ParallelAPIFetcher:
         except AttributeError as e:
             self.logger.error(f"API method error - getDimensions may not be available: {e!s}")
             return pd.DataFrame()
-        except Exception as e:
+        except Exception as e:  # Intentional: preserve resilient fallback-to-empty contract for dimensions fetch
             self.logger.error(f"Failed to fetch dimensions: {e!s}")
             return pd.DataFrame()
 
@@ -266,7 +266,7 @@ class ParallelAPIFetcher:
                 error_message=e.message,
                 circuit_breaker_open=True,
             )
-        except Exception as e:
+        except Exception as e:  # Intentional: preserve resilient lookup-failure payload contract
             self.logger.error(f"Failed to fetch data view information: {e!s}")
             return self._build_lookup_failure_payload(
                 data_view_id,

--- a/src/cja_auto_sdr/api/fetch.py
+++ b/src/cja_auto_sdr/api/fetch.py
@@ -14,6 +14,7 @@ from tqdm import tqdm
 from cja_auto_sdr.api.resilience import CircuitBreaker, make_api_call_with_retry
 from cja_auto_sdr.api.tuning import APIWorkerTuner
 from cja_auto_sdr.core.config import APITuningConfig
+from cja_auto_sdr.core.discovery_payloads import assess_dataview_lookup_payload
 from cja_auto_sdr.core.exceptions import CircuitBreakerOpen
 from cja_auto_sdr.core.perf import PerformanceTracker
 
@@ -239,19 +240,59 @@ class ParallelAPIFetcher:
             # Use retry for transient network errors with circuit breaker support
             lookup_data = self._timed_api_call(self.cja.getDataView, data_view_id, operation_name="getDataView")
 
-            if not lookup_data:
-                self.logger.error("Data view information returned empty")
-                return {"name": "Unknown", "id": data_view_id}
+            assessment = assess_dataview_lookup_payload(lookup_data, expected_data_view_id=data_view_id)
+            if not assessment.is_valid:
+                self.logger.error("Data view information returned invalid payload (%s)", assessment.reason)
+                detail = "invalid data view lookup payload"
+                if isinstance(lookup_data, dict):
+                    error_text = lookup_data.get("error") or lookup_data.get("message")
+                    if error_text is not None:
+                        detail = str(error_text)
+                return self._build_lookup_failure_payload(
+                    data_view_id,
+                    reason=assessment.reason,
+                    error_message=detail,
+                )
 
-            self.logger.info(f"Successfully fetched data view info: {lookup_data.get('name', 'Unknown')}")
-            return lookup_data
+            validated_payload = assessment.payload or {}
+            self.logger.info(f"Successfully fetched data view info: {validated_payload.get('name', 'Unknown')}")
+            return validated_payload
 
         except CircuitBreakerOpen as e:
             self.logger.warning(f"Circuit breaker open for data view fetch: {e.message}")
-            return {"name": "Unknown", "id": data_view_id, "circuit_breaker_open": True}
+            return self._build_lookup_failure_payload(
+                data_view_id,
+                reason="circuit_breaker_open",
+                error_message=e.message,
+                circuit_breaker_open=True,
+            )
         except Exception as e:
             self.logger.error(f"Failed to fetch data view information: {e!s}")
-            return {"name": "Unknown", "id": data_view_id, "error": str(e)}
+            return self._build_lookup_failure_payload(
+                data_view_id,
+                reason="exception",
+                error_message=str(e),
+            )
+
+    @staticmethod
+    def _build_lookup_failure_payload(
+        data_view_id: str,
+        *,
+        reason: str,
+        error_message: str | None = None,
+        circuit_breaker_open: bool = False,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "name": "Unknown",
+            "id": data_view_id,
+            "lookup_failed": True,
+            "lookup_failure_reason": reason,
+        }
+        if error_message:
+            payload["error"] = error_message
+        if circuit_breaker_open:
+            payload["circuit_breaker_open"] = True
+        return payload
 
     def get_tuner_statistics(self) -> dict[str, Any] | None:
         """Get API tuner statistics if tuning is enabled."""

--- a/src/cja_auto_sdr/cli/parser.py
+++ b/src/cja_auto_sdr/cli/parser.py
@@ -81,7 +81,7 @@ def parse_arguments(
         _bootstrap_dotenv(logging.getLogger(__name__))
 
     parser = argparse.ArgumentParser(
-        description="CJA SDR Generator - Generate System Design Records for CJA Data Views",
+        description="CJA SDR Generator - Generate Solution Design Reference for CJA Data Views",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
@@ -239,6 +239,7 @@ Exit Codes:
   0 - Success (diff: no differences found)
   1 - Error occurred
   2 - Policy threshold exceeded (diff changes, quality gate, or governance threshold)
+  3 - Diff warning threshold exceeded (--warn-threshold)
 
 Requirements:
   Python 3.14 or higher required. Verify with: python3 --version

--- a/src/cja_auto_sdr/core/discovery_exceptions.py
+++ b/src/cja_auto_sdr/core/discovery_exceptions.py
@@ -1,0 +1,102 @@
+"""Discovery exception classification for data-view inspection commands."""
+
+from __future__ import annotations
+
+import contextlib
+import re
+from typing import Any
+
+from cja_auto_sdr.core.exceptions import APIError
+
+_DATAVIEW_LOOKUP_NOT_FOUND_STATUS_CODES = frozenset({403, 404})
+_DATAVIEW_LOOKUP_STATUS_ATTRS = ("status_code", "statusCode", "status", "http_status", "httpStatus", "code")
+_DATAVIEW_LOOKUP_NOT_FOUND_MESSAGE_MARKERS = (
+    "not found",
+    "not_found",
+    "resource_not_found",
+    "forbidden",
+    "no access",
+    "access denied",
+)
+_HTTP_STATUS_CODE_RE = re.compile(r"\b([1-5]\d{2})\b")
+
+
+def coerce_http_status_code(value: Any) -> int | None:
+    """Best-effort coercion of status-like values into an HTTP status code."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if 100 <= value <= 599 else None
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        if stripped.isdigit():
+            numeric_code = int(stripped)
+            return numeric_code if 100 <= numeric_code <= 599 else None
+        match = _HTTP_STATUS_CODE_RE.search(stripped)
+        if match:
+            numeric_code = int(match.group(1))
+            return numeric_code if 100 <= numeric_code <= 599 else None
+    return None
+
+
+def iter_error_chain_nodes(error: Exception) -> list[Any]:
+    """Return error/cause/response nodes for robust status-code extraction."""
+    pending: list[Any] = [error]
+    seen: set[int] = set()
+    nodes: list[Any] = []
+    while pending:
+        node = pending.pop()
+        marker = id(node)
+        if marker in seen:
+            continue
+        seen.add(marker)
+        nodes.append(node)
+
+        if isinstance(node, dict):
+            nested = node.get("error")
+            if nested is not None:
+                pending.append(nested)
+            continue
+
+        for attr_name in ("original_error", "__cause__", "__context__", "response"):
+            with contextlib.suppress(Exception):
+                nested = getattr(node, attr_name)
+                if nested is not None:
+                    pending.append(nested)
+    return nodes
+
+
+def extract_http_status_codes(error: Exception) -> set[int]:
+    """Extract candidate HTTP status codes from nested error objects."""
+    status_codes: set[int] = set()
+    for node in iter_error_chain_nodes(error):
+        if isinstance(node, dict):
+            for key in _DATAVIEW_LOOKUP_STATUS_ATTRS:
+                code = coerce_http_status_code(node.get(key))
+                if code is not None:
+                    status_codes.add(code)
+            continue
+
+        for attr_name in _DATAVIEW_LOOKUP_STATUS_ATTRS:
+            with contextlib.suppress(Exception):
+                code = coerce_http_status_code(getattr(node, attr_name))
+                if code is not None:
+                    status_codes.add(code)
+    return status_codes
+
+
+def is_dataview_lookup_not_found_error(error: Exception) -> bool:
+    """Return True when getDataView failures should map to not_found."""
+    status_codes = extract_http_status_codes(error)
+    if any(code in _DATAVIEW_LOOKUP_NOT_FOUND_STATUS_CODES for code in status_codes):
+        return True
+
+    # Some APIError paths omit status_code but still include a stable
+    # not-found/forbidden marker in the message body.
+    if isinstance(error, APIError):
+        normalized_message = str(error).casefold()
+        return any(marker in normalized_message for marker in _DATAVIEW_LOOKUP_NOT_FOUND_MESSAGE_MARKERS)
+
+    return False

--- a/src/cja_auto_sdr/core/discovery_payloads.py
+++ b/src/cja_auto_sdr/core/discovery_payloads.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import Enum
@@ -20,6 +21,7 @@ LOOKUP_FAILURE_DETAIL_KEYS = frozenset({"lookup_failure_reason"})
 # Dataview payloads may include non-fatal diagnostic text under `error` while
 # still returning a valid object with identity fields.
 DATAVIEW_EXPLICIT_ERROR_KEYS = frozenset({"errorcode", "errordescription", "error_description"})
+logger = logging.getLogger(__name__)
 
 
 class PayloadKind(Enum):
@@ -118,7 +120,12 @@ def _is_truthy_marker(value: Any) -> bool:
         return normalized not in {"false", "0", "no", "off"}
     try:
         return bool(value)
-    except TypeError, ValueError:
+    except (TypeError, ValueError) as exc:
+        logger.debug(
+            "Treating lookup marker value as truthy after bool() coercion failure: type=%s error=%s",
+            type(value).__name__,
+            exc,
+        )
         return True
 
 
@@ -128,6 +135,8 @@ def _normalize_dataview_lookup_payload(raw_payload: Any) -> tuple[dict[str, Any]
         return None, raw_type, "none_payload"
 
     if isinstance(raw_payload, pd.DataFrame):
+        # Some cjapy pathways may hand back a one-row DataFrame for getDataView.
+        # Normalize this to a plain mapping so downstream validation is uniform.
         if raw_payload.empty:
             return None, raw_type, "empty_dataframe"
         records = raw_payload.to_dict("records")

--- a/src/cja_auto_sdr/core/discovery_payloads.py
+++ b/src/cja_auto_sdr/core/discovery_payloads.py
@@ -145,8 +145,44 @@ def has_identity_value(payload: Mapping[str, Any], identity_keys: tuple[str, ...
     return False
 
 
+def _lookup_value_has_substance(
+    value: Any,
+    *,
+    _seen_containers: set[int] | None = None,
+) -> bool:
+    """Return True when lookup values contain meaningful content.
+
+    Empty mappings/sequences (or nested containers containing only missing leaf
+    values) should be treated as absent when classifying lookup payloads.
+    """
+    if is_missing_value(value, treat_blank_string=True, treat_null_like_strings=True):
+        return False
+
+    if isinstance(value, Mapping):
+        if not value:
+            return False
+        seen = _seen_containers if _seen_containers is not None else set()
+        container_id = id(value)
+        if container_id in seen:
+            return False
+        seen.add(container_id)
+        return any(_lookup_value_has_substance(child, _seen_containers=seen) for child in value.values())
+
+    if isinstance(value, (list, tuple, set)):
+        if len(value) == 0:
+            return False
+        seen = _seen_containers if _seen_containers is not None else set()
+        container_id = id(value)
+        if container_id in seen:
+            return False
+        seen.add(container_id)
+        return any(_lookup_value_has_substance(child, _seen_containers=seen) for child in value)
+
+    return True
+
+
 def _lookup_value_is_missing(value: Any) -> bool:
-    return is_missing_value(value, treat_blank_string=True, treat_null_like_strings=True)
+    return not _lookup_value_has_substance(value)
 
 
 def _should_replace_lookup_value(current_value: Any, replacement_value: Any) -> bool:
@@ -230,7 +266,7 @@ def looks_like_error_payload(
 
 
 def _lookup_field_is_present(value: Any) -> bool:
-    return not is_missing_value(value, treat_blank_string=True, treat_null_like_strings=True)
+    return _lookup_value_has_substance(value)
 
 
 def _lookup_contains_any_present_key(
@@ -261,11 +297,7 @@ def _has_minimum_dataview_lookup_metadata(normalized_items: Mapping[str, Any]) -
         normalized_key = str(key)
         if normalized_key == "id" or _is_diagnostic_lookup_key(normalized_key):
             continue
-        if isinstance(value, Mapping):
-            if value:
-                return True
-            continue
-        if isinstance(value, (list, tuple, set)) and len(value) > 0:
+        if _lookup_field_is_present(value):
             return True
     return False
 
@@ -330,7 +362,7 @@ def _first_lookup_failure_detail_key(normalized_items: Mapping[str, Any]) -> str
     """Return first lookup-failure detail key with a present value."""
     for detail_key in LOOKUP_FAILURE_DETAIL_PRECEDENCE:
         detail_value = normalized_items.get(detail_key)
-        if is_missing_value(detail_value, treat_blank_string=True, treat_null_like_strings=True):
+        if not _lookup_field_is_present(detail_value):
             continue
         return detail_key
     return None
@@ -438,25 +470,25 @@ def _unknown_placeholder_diagnostic_key(normalized_items: Mapping[str, Any]) -> 
 
     for text_key in sorted(UNKNOWN_PLACEHOLDER_ERROR_TEXT_KEYS):
         detail_value = normalized_items.get(text_key)
-        if is_missing_value(detail_value, treat_blank_string=True, treat_null_like_strings=True):
+        if not _lookup_field_is_present(detail_value):
             continue
         return text_key
 
     status_keys_present = any(
-        not is_missing_value(normalized_items.get(status_key), treat_blank_string=True, treat_null_like_strings=True)
+        _lookup_field_is_present(normalized_items.get(status_key))
         for status_key in STATUS_KEYS
     )
     if status_keys_present:
         for text_key in sorted(ERROR_TEXT_KEYS):
             detail_value = normalized_items.get(text_key)
-            if is_missing_value(detail_value, treat_blank_string=True, treat_null_like_strings=True):
+            if not _lookup_field_is_present(detail_value):
                 continue
             return text_key
 
     for key, value in normalized_items.items():
         if not str(key).startswith("lookup_"):
             continue
-        if is_missing_value(value, treat_blank_string=True, treat_null_like_strings=True):
+        if not _lookup_field_is_present(value):
             continue
         return str(key)
 

--- a/src/cja_auto_sdr/core/discovery_payloads.py
+++ b/src/cja_auto_sdr/core/discovery_payloads.py
@@ -22,6 +22,51 @@ LOOKUP_FAILURE_DETAIL_KEYS = frozenset({"lookup_failure_reason"})
 # still returning a valid object with identity fields.
 DATAVIEW_EXPLICIT_ERROR_KEYS = frozenset({"errorcode", "errordescription", "error_description"})
 UNKNOWN_PLACEHOLDER_ERROR_TEXT_KEYS = frozenset({"error"}) | DATAVIEW_EXPLICIT_ERROR_KEYS
+_LOOKUP_MISSING_VALUE = object()
+_LOOKUP_CANONICAL_KEY_ALIASES = {
+    "id": "id",
+    "name": "name",
+    "owner": "owner",
+    "ownername": "ownerName",
+    "owner_name": "owner_name",
+    "ownerfullname": "ownerFullName",
+    "owner_full_name": "owner_full_name",
+    "description": "description",
+    "parentdatagroupid": "parentDataGroupId",
+    "connectionid": "connectionId",
+    "connection_id": "connection_id",
+    "created": "created",
+    "createddate": "createdDate",
+    "createdat": "createdAt",
+    "created_date": "created_date",
+    "modified": "modified",
+    "modifieddate": "modifiedDate",
+    "modifiedat": "modifiedAt",
+    "modified_date": "modified_date",
+    "lookup_failed": "lookup_failed",
+    "lookup_failure_reason": "lookup_failure_reason",
+    "circuit_breaker_open": "circuit_breaker_open",
+    "error": "error",
+    "errorcode": "errorCode",
+    "errordescription": "errorDescription",
+    "error_description": "error_description",
+    "status": "status",
+    "statuscode": "statusCode",
+    "status_code": "status_code",
+    "message": "message",
+    "detail": "detail",
+    "title": "title",
+}
+_LOOKUP_OWNER_CANONICAL_KEY_ALIASES = {
+    "name": "name",
+    "fullname": "fullName",
+    "full_name": "full_name",
+    "ownerfullname": "ownerFullName",
+    "login": "login",
+    "email": "email",
+    "imsuserid": "imsUserId",
+    "id": "id",
+}
 logger = logging.getLogger(__name__)
 
 
@@ -73,9 +118,61 @@ def has_identity_value(payload: Mapping[str, Any], identity_keys: tuple[str, ...
     return False
 
 
+def _lookup_value_is_missing(value: Any) -> bool:
+    return is_missing_value(value, treat_blank_string=True, treat_null_like_strings=True)
+
+
+def _should_replace_lookup_value(current_value: Any, replacement_value: Any) -> bool:
+    if current_value is _LOOKUP_MISSING_VALUE:
+        return True
+    return _lookup_value_is_missing(current_value) and not _lookup_value_is_missing(replacement_value)
+
+
 def normalize_lookup_items(payload: Mapping[str, Any]) -> dict[str, Any]:
-    """Return case-folded lookup payload keys for defensive field access."""
-    return {str(key).strip().casefold(): value for key, value in payload.items()}
+    """Return case-folded lookup payload keys for defensive field access.
+
+    When multiple source keys collapse to the same normalized key (for example,
+    ``id`` + ``ID``), prefer any non-missing value.
+    """
+    normalized_items: dict[str, Any] = {}
+    for key, value in payload.items():
+        normalized_key = str(key).strip().casefold()
+        current_value = normalized_items.get(normalized_key, _LOOKUP_MISSING_VALUE)
+        if _should_replace_lookup_value(current_value, value):
+            normalized_items[normalized_key] = value
+    return normalized_items
+
+
+def _canonicalize_lookup_owner(owner_payload: Mapping[str, Any]) -> dict[str, Any]:
+    canonical_owner = dict(owner_payload)
+    normalized_owner = normalize_lookup_items(canonical_owner)
+    for normalized_key, canonical_key in _LOOKUP_OWNER_CANONICAL_KEY_ALIASES.items():
+        if normalized_key not in normalized_owner:
+            continue
+        candidate_value = normalized_owner[normalized_key]
+        current_value = canonical_owner.get(canonical_key, _LOOKUP_MISSING_VALUE)
+        if _should_replace_lookup_value(current_value, candidate_value):
+            canonical_owner[canonical_key] = candidate_value
+    return canonical_owner
+
+
+def canonicalize_dataview_lookup_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Backfill canonical dataview lookup keys while preserving original fields."""
+    canonical_payload = dict(payload)
+    normalized_items = normalize_lookup_items(canonical_payload)
+    for normalized_key, canonical_key in _LOOKUP_CANONICAL_KEY_ALIASES.items():
+        if normalized_key not in normalized_items:
+            continue
+        candidate_value = normalized_items[normalized_key]
+        current_value = canonical_payload.get(canonical_key, _LOOKUP_MISSING_VALUE)
+        if _should_replace_lookup_value(current_value, candidate_value):
+            canonical_payload[canonical_key] = candidate_value
+
+    owner_payload = canonical_payload.get("owner")
+    if isinstance(owner_payload, Mapping):
+        canonical_payload["owner"] = _canonicalize_lookup_owner(owner_payload)
+
+    return canonical_payload
 
 
 def _schema_indicates_error(
@@ -319,13 +416,14 @@ def assess_dataview_lookup_payload(
             raw_type=raw_type,
         )
 
-    normalized_items = normalize_lookup_items(payload)
+    canonical_payload = canonicalize_dataview_lookup_payload(payload)
+    normalized_items = normalize_lookup_items(canonical_payload)
 
     for marker_key in LOOKUP_FAILURE_FLAG_KEYS:
         if _is_truthy_marker(normalized_items.get(marker_key)):
             return DataViewLookupAssessment(
                 kind=PayloadKind.ERROR,
-                payload=payload,
+                payload=canonical_payload,
                 reason=f"failure_flag:{marker_key}",
                 raw_type=raw_type,
             )
@@ -336,15 +434,15 @@ def assess_dataview_lookup_payload(
             continue
         return DataViewLookupAssessment(
             kind=PayloadKind.ERROR,
-            payload=payload,
+            payload=canonical_payload,
             reason=f"failure_detail:{detail_key}",
             raw_type=raw_type,
         )
 
-    if is_dataview_error_payload(payload):
+    if is_dataview_error_payload(canonical_payload):
         return DataViewLookupAssessment(
             kind=PayloadKind.ERROR,
-            payload=payload,
+            payload=canonical_payload,
             reason="error_shape",
             raw_type=raw_type,
         )
@@ -352,7 +450,7 @@ def assess_dataview_lookup_payload(
     if not has_identity_value(normalized_items, ("id", "name")):
         return DataViewLookupAssessment(
             kind=PayloadKind.ERROR,
-            payload=payload,
+            payload=canonical_payload,
             reason="missing_identity",
             raw_type=raw_type,
         )
@@ -361,7 +459,7 @@ def assess_dataview_lookup_payload(
     if id_reason is not None:
         return DataViewLookupAssessment(
             kind=PayloadKind.ERROR,
-            payload=payload,
+            payload=canonical_payload,
             reason=id_reason,
             raw_type=raw_type,
         )
@@ -373,14 +471,14 @@ def assess_dataview_lookup_payload(
     if unknown_placeholder_reason is not None:
         return DataViewLookupAssessment(
             kind=PayloadKind.ERROR,
-            payload=payload,
+            payload=canonical_payload,
             reason=unknown_placeholder_reason,
             raw_type=raw_type,
         )
 
     return DataViewLookupAssessment(
         kind=PayloadKind.DATA,
-        payload=payload,
+        payload=canonical_payload,
         reason="valid_lookup_payload",
         raw_type=raw_type,
     )

--- a/src/cja_auto_sdr/core/discovery_payloads.py
+++ b/src/cja_auto_sdr/core/discovery_payloads.py
@@ -161,7 +161,7 @@ def _coerce_lookup_scalar_text(value: Any) -> str | None:
     if isinstance(value, bytes):
         try:
             return value.decode("utf-8", errors="ignore")
-        except UnicodeDecodeError, AttributeError, TypeError, ValueError:
+        except UnicodeDecodeError, AttributeError, TypeError, ValueError:  # PEP 758 (Python 3.14+)
             return None
     if isinstance(value, (int, float)) and not isinstance(value, bool):
         return str(value)

--- a/src/cja_auto_sdr/core/discovery_payloads.py
+++ b/src/cja_auto_sdr/core/discovery_payloads.py
@@ -474,10 +474,7 @@ def _unknown_placeholder_diagnostic_key(normalized_items: Mapping[str, Any]) -> 
             continue
         return text_key
 
-    status_keys_present = any(
-        _lookup_field_is_present(normalized_items.get(status_key))
-        for status_key in STATUS_KEYS
-    )
+    status_keys_present = any(_lookup_field_is_present(normalized_items.get(status_key)) for status_key in STATUS_KEYS)
     if status_keys_present:
         for text_key in sorted(ERROR_TEXT_KEYS):
             detail_value = normalized_items.get(text_key)

--- a/src/cja_auto_sdr/core/discovery_payloads.py
+++ b/src/cja_auto_sdr/core/discovery_payloads.py
@@ -16,8 +16,10 @@ EXPLICIT_ERROR_KEYS = frozenset({"error", "errorcode", "errordescription", "erro
 STATUS_KEYS = frozenset({"statuscode", "status_code", "status"})
 ERROR_TEXT_KEYS = frozenset({"message", "detail", "title"})
 COMPONENT_SEQUENCE_KEYS = ("content", "items", "results", "data", "rows")
-LOOKUP_FAILURE_FLAG_KEYS = frozenset({"lookup_failed", "circuit_breaker_open"})
-LOOKUP_FAILURE_DETAIL_KEYS = frozenset({"lookup_failure_reason"})
+LOOKUP_FAILURE_FLAG_PRECEDENCE = ("lookup_failed", "circuit_breaker_open")
+LOOKUP_FAILURE_FLAG_KEYS = frozenset(LOOKUP_FAILURE_FLAG_PRECEDENCE)
+LOOKUP_FAILURE_DETAIL_PRECEDENCE = ("lookup_failure_reason",)
+LOOKUP_FAILURE_DETAIL_KEYS = frozenset(LOOKUP_FAILURE_DETAIL_PRECEDENCE)
 # Dataview payloads may include non-fatal diagnostic text under `error` while
 # still returning a valid object with identity fields.
 DATAVIEW_EXPLICIT_ERROR_KEYS = frozenset({"errorcode", "errordescription", "error_description"})
@@ -316,6 +318,24 @@ def _is_truthy_marker(value: Any) -> bool:
         return True
 
 
+def _first_lookup_failure_flag_key(normalized_items: Mapping[str, Any]) -> str | None:
+    """Return first truthy lookup-failure flag in fixed precedence order."""
+    for marker_key in LOOKUP_FAILURE_FLAG_PRECEDENCE:
+        if _is_truthy_marker(normalized_items.get(marker_key)):
+            return marker_key
+    return None
+
+
+def _first_lookup_failure_detail_key(normalized_items: Mapping[str, Any]) -> str | None:
+    """Return first lookup-failure detail key with a present value."""
+    for detail_key in LOOKUP_FAILURE_DETAIL_PRECEDENCE:
+        detail_value = normalized_items.get(detail_key)
+        if is_missing_value(detail_value, treat_blank_string=True, treat_null_like_strings=True):
+            continue
+        return detail_key
+    return None
+
+
 def _normalize_dataview_lookup_payload(raw_payload: Any) -> tuple[dict[str, Any] | None, str, str]:
     raw_type = type(raw_payload).__name__
     if raw_payload is None:
@@ -408,14 +428,12 @@ def _is_legacy_unknown_lookup_placeholder(
 
 def _unknown_placeholder_diagnostic_key(normalized_items: Mapping[str, Any]) -> str | None:
     """Return a diagnostic key when an Unknown placeholder carries lookup-failure hints."""
-    for marker_key in sorted(LOOKUP_FAILURE_FLAG_KEYS):
-        if _is_truthy_marker(normalized_items.get(marker_key)):
-            return marker_key
+    marker_key = _first_lookup_failure_flag_key(normalized_items)
+    if marker_key is not None:
+        return marker_key
 
-    for detail_key in sorted(LOOKUP_FAILURE_DETAIL_KEYS):
-        detail_value = normalized_items.get(detail_key)
-        if is_missing_value(detail_value, treat_blank_string=True, treat_null_like_strings=True):
-            continue
+    detail_key = _first_lookup_failure_detail_key(normalized_items)
+    if detail_key is not None:
         return detail_key
 
     for text_key in sorted(UNKNOWN_PLACEHOLDER_ERROR_TEXT_KEYS):
@@ -502,19 +520,17 @@ def assess_dataview_lookup_payload(
     canonical_payload = canonicalize_dataview_lookup_payload(payload)
     normalized_items = normalize_lookup_items(canonical_payload)
 
-    for marker_key in LOOKUP_FAILURE_FLAG_KEYS:
-        if _is_truthy_marker(normalized_items.get(marker_key)):
-            return DataViewLookupAssessment(
-                kind=PayloadKind.ERROR,
-                payload=canonical_payload,
-                reason=f"failure_flag:{marker_key}",
-                raw_type=raw_type,
-            )
+    marker_key = _first_lookup_failure_flag_key(normalized_items)
+    if marker_key is not None:
+        return DataViewLookupAssessment(
+            kind=PayloadKind.ERROR,
+            payload=canonical_payload,
+            reason=f"failure_flag:{marker_key}",
+            raw_type=raw_type,
+        )
 
-    for detail_key in LOOKUP_FAILURE_DETAIL_KEYS:
-        detail_value = normalized_items.get(detail_key)
-        if is_missing_value(detail_value, treat_blank_string=True, treat_null_like_strings=True):
-            continue
+    detail_key = _first_lookup_failure_detail_key(normalized_items)
+    if detail_key is not None:
         return DataViewLookupAssessment(
             kind=PayloadKind.ERROR,
             payload=canonical_payload,

--- a/src/cja_auto_sdr/core/discovery_payloads.py
+++ b/src/cja_auto_sdr/core/discovery_payloads.py
@@ -161,7 +161,7 @@ def _coerce_lookup_scalar_text(value: Any) -> str | None:
     if isinstance(value, bytes):
         try:
             return value.decode("utf-8", errors="ignore")
-        except UnicodeDecodeError, AttributeError, TypeError, ValueError:  # PEP 758 (Python 3.14+)
+        except AttributeError, TypeError, ValueError:  # PEP 758 (Python 3.14+)
             return None
     if isinstance(value, (int, float)) and not isinstance(value, bool):
         return str(value)

--- a/src/cja_auto_sdr/core/discovery_payloads.py
+++ b/src/cja_auto_sdr/core/discovery_payloads.py
@@ -73,6 +73,11 @@ def has_identity_value(payload: Mapping[str, Any], identity_keys: tuple[str, ...
     return False
 
 
+def normalize_lookup_items(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Return case-folded lookup payload keys for defensive field access."""
+    return {str(key).strip().casefold(): value for key, value in payload.items()}
+
+
 def _schema_indicates_error(
     keys: set[str],
     *,
@@ -102,8 +107,9 @@ def looks_like_error_payload(
 
 def is_dataview_error_payload(payload: Mapping[str, Any]) -> bool:
     """Return True when getDataView payload appears to be an API error object."""
+    normalized_payload = normalize_lookup_items(payload)
     return looks_like_error_payload(
-        payload,
+        normalized_payload,
         identity_keys=("id", "name"),
         explicit_error_keys=DATAVIEW_EXPLICIT_ERROR_KEYS,
     )
@@ -168,19 +174,50 @@ def _coerce_lookup_scalar_text(value: Any) -> str | None:
     return None
 
 
-def _is_legacy_unknown_lookup_placeholder(payload: Mapping[str, Any], *, expected_data_view_id: str | None) -> bool:
+def _assess_expected_lookup_id(
+    normalized_items: Mapping[str, Any],
+    *,
+    expected_data_view_id: str | None,
+) -> tuple[str | None, str | None]:
+    """Validate lookup `id` against the expected data view id."""
+    if expected_data_view_id is None:
+        return None, None
+
+    payload_id = normalized_items.get("id")
+    if is_missing_value(payload_id, treat_blank_string=True, treat_null_like_strings=True):
+        return None, "missing_expected_id"
+
+    payload_id_text = _coerce_lookup_scalar_text(payload_id)
+    if payload_id_text is None:
+        return None, "invalid_id_type"
+
+    normalized_id = payload_id_text.strip()
+    if not normalized_id:
+        return None, "missing_expected_id"
+
+    if normalized_id != expected_data_view_id:
+        return normalized_id, "id_mismatch"
+
+    return normalized_id, None
+
+
+def _is_legacy_unknown_lookup_placeholder(
+    *,
+    expected_data_view_id: str | None,
+    normalized_items: Mapping[str, Any],
+) -> bool:
     if expected_data_view_id is None:
         return False
-    payload_id = payload.get("id")
-    if is_missing_value(payload_id, treat_blank_string=True, treat_null_like_strings=True):
+
+    _, id_reason = _assess_expected_lookup_id(normalized_items, expected_data_view_id=expected_data_view_id)
+    if id_reason is not None:
         return False
-    payload_id_text = _coerce_lookup_scalar_text(payload_id)
-    if payload_id_text is None or payload_id_text.strip() != expected_data_view_id:
-        return False
-    normalized_keys = normalized_payload_keys(payload)
+
+    normalized_keys = set(normalized_items)
     if not normalized_keys.issubset({"id", "name"}):
         return False
-    name_value = payload.get("name")
+
+    name_value = normalized_items.get("name")
     if is_missing_value(name_value, treat_blank_string=True, treat_null_like_strings=True):
         return False
     name_text = _coerce_lookup_scalar_text(name_value)
@@ -229,26 +266,24 @@ def _unknown_placeholder_diagnostic_key(normalized_items: Mapping[str, Any]) -> 
 
 
 def _unknown_lookup_placeholder_reason(
-    payload: Mapping[str, Any],
-    *,
     expected_data_view_id: str | None,
     normalized_items: Mapping[str, Any],
 ) -> str | None:
     """Return placeholder failure reason when payload matches fallback Unknown lookup output."""
-    if _is_legacy_unknown_lookup_placeholder(payload, expected_data_view_id=expected_data_view_id):
+    if _is_legacy_unknown_lookup_placeholder(
+        expected_data_view_id=expected_data_view_id,
+        normalized_items=normalized_items,
+    ):
         return "legacy_unknown_placeholder"
 
     if expected_data_view_id is None:
         return None
 
-    payload_id = payload.get("id")
-    if is_missing_value(payload_id, treat_blank_string=True, treat_null_like_strings=True):
-        return None
-    payload_id_text = _coerce_lookup_scalar_text(payload_id)
-    if payload_id_text is None or payload_id_text.strip() != expected_data_view_id:
+    _, id_reason = _assess_expected_lookup_id(normalized_items, expected_data_view_id=expected_data_view_id)
+    if id_reason is not None:
         return None
 
-    name_value = payload.get("name")
+    name_value = normalized_items.get("name")
     if is_missing_value(name_value, treat_blank_string=True, treat_null_like_strings=True):
         return None
     name_text = _coerce_lookup_scalar_text(name_value)
@@ -284,7 +319,7 @@ def assess_dataview_lookup_payload(
             raw_type=raw_type,
         )
 
-    normalized_items = {str(key).strip().casefold(): value for key, value in payload.items()}
+    normalized_items = normalize_lookup_items(payload)
 
     for marker_key in LOOKUP_FAILURE_FLAG_KEYS:
         if _is_truthy_marker(normalized_items.get(marker_key)):
@@ -314,7 +349,7 @@ def assess_dataview_lookup_payload(
             raw_type=raw_type,
         )
 
-    if not has_identity_value(payload, ("id", "name")):
+    if not has_identity_value(normalized_items, ("id", "name")):
         return DataViewLookupAssessment(
             kind=PayloadKind.ERROR,
             payload=payload,
@@ -322,31 +357,16 @@ def assess_dataview_lookup_payload(
             raw_type=raw_type,
         )
 
-    payload_id = payload.get("id")
-    if expected_data_view_id is not None and not is_missing_value(
-        payload_id,
-        treat_blank_string=True,
-        treat_null_like_strings=True,
-    ):
-        payload_id_text = _coerce_lookup_scalar_text(payload_id)
-        if payload_id_text is None:
-            return DataViewLookupAssessment(
-                kind=PayloadKind.ERROR,
-                payload=payload,
-                reason="invalid_id_type",
-                raw_type=raw_type,
-            )
-        normalized_id = payload_id_text.strip()
-        if normalized_id and normalized_id != expected_data_view_id:
-            return DataViewLookupAssessment(
-                kind=PayloadKind.ERROR,
-                payload=payload,
-                reason="id_mismatch",
-                raw_type=raw_type,
-            )
+    _, id_reason = _assess_expected_lookup_id(normalized_items, expected_data_view_id=expected_data_view_id)
+    if id_reason is not None:
+        return DataViewLookupAssessment(
+            kind=PayloadKind.ERROR,
+            payload=payload,
+            reason=id_reason,
+            raw_type=raw_type,
+        )
 
     unknown_placeholder_reason = _unknown_lookup_placeholder_reason(
-        payload,
         expected_data_view_id=expected_data_view_id,
         normalized_items=normalized_items,
     )

--- a/src/cja_auto_sdr/core/discovery_payloads.py
+++ b/src/cja_auto_sdr/core/discovery_payloads.py
@@ -101,7 +101,7 @@ def _is_truthy_marker(value: Any) -> bool:
         return normalized not in {"false", "0", "no", "off"}
     try:
         return bool(value)
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         return True
 
 
@@ -127,13 +127,28 @@ def _normalize_dataview_lookup_payload(raw_payload: Any) -> tuple[dict[str, Any]
     return None, raw_type, "unsupported_payload_type"
 
 
+def _coerce_lookup_scalar_text(value: Any) -> str | None:
+    """Safely coerce primitive lookup scalar values to text."""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, bytes):
+        try:
+            return value.decode("utf-8", errors="ignore")
+        except UnicodeDecodeError, AttributeError, TypeError, ValueError:
+            return None
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return str(value)
+    return None
+
+
 def _is_legacy_unknown_lookup_placeholder(payload: Mapping[str, Any], *, expected_data_view_id: str | None) -> bool:
     if expected_data_view_id is None:
         return False
     payload_id = payload.get("id")
     if is_missing_value(payload_id, treat_blank_string=True, treat_null_like_strings=True):
         return False
-    if str(payload_id).strip() != expected_data_view_id:
+    payload_id_text = _coerce_lookup_scalar_text(payload_id)
+    if payload_id_text is None or payload_id_text.strip() != expected_data_view_id:
         return False
     normalized_keys = normalized_payload_keys(payload)
     if not normalized_keys.issubset({"id", "name"}):
@@ -141,7 +156,10 @@ def _is_legacy_unknown_lookup_placeholder(payload: Mapping[str, Any], *, expecte
     name_value = payload.get("name")
     if is_missing_value(name_value, treat_blank_string=True, treat_null_like_strings=True):
         return False
-    return str(name_value).strip().casefold() == "unknown"
+    name_text = _coerce_lookup_scalar_text(name_value)
+    if name_text is None:
+        return False
+    return name_text.strip().casefold() == "unknown"
 
 
 def assess_dataview_lookup_payload(
@@ -152,7 +170,11 @@ def assess_dataview_lookup_payload(
     """Classify getDataView payloads into DATA/EMPTY/ERROR/INVALID."""
     payload, raw_type, normalize_reason = _normalize_dataview_lookup_payload(raw_payload)
     if payload is None:
-        kind = PayloadKind.EMPTY if normalize_reason in {"none_payload", "empty_dataframe", "empty_dataframe_records"} else PayloadKind.INVALID
+        kind = (
+            PayloadKind.EMPTY
+            if normalize_reason in {"none_payload", "empty_dataframe", "empty_dataframe_records"}
+            else PayloadKind.INVALID
+        )
         return DataViewLookupAssessment(kind=kind, payload=None, reason=normalize_reason, raw_type=raw_type)
 
     if not payload:
@@ -207,7 +229,15 @@ def assess_dataview_lookup_payload(
         treat_blank_string=True,
         treat_null_like_strings=True,
     ):
-        normalized_id = str(payload_id).strip()
+        payload_id_text = _coerce_lookup_scalar_text(payload_id)
+        if payload_id_text is None:
+            return DataViewLookupAssessment(
+                kind=PayloadKind.ERROR,
+                payload=payload,
+                reason="invalid_id_type",
+                raw_type=raw_type,
+            )
+        normalized_id = payload_id_text.strip()
         if normalized_id and normalized_id != expected_data_view_id:
             return DataViewLookupAssessment(
                 kind=PayloadKind.ERROR,

--- a/src/cja_auto_sdr/core/discovery_payloads.py
+++ b/src/cja_auto_sdr/core/discovery_payloads.py
@@ -21,6 +21,7 @@ LOOKUP_FAILURE_DETAIL_KEYS = frozenset({"lookup_failure_reason"})
 # Dataview payloads may include non-fatal diagnostic text under `error` while
 # still returning a valid object with identity fields.
 DATAVIEW_EXPLICIT_ERROR_KEYS = frozenset({"errorcode", "errordescription", "error_description"})
+UNKNOWN_PLACEHOLDER_ERROR_TEXT_KEYS = frozenset({"error"}) | DATAVIEW_EXPLICIT_ERROR_KEYS
 logger = logging.getLogger(__name__)
 
 
@@ -188,6 +189,78 @@ def _is_legacy_unknown_lookup_placeholder(payload: Mapping[str, Any], *, expecte
     return name_text.strip().casefold() == "unknown"
 
 
+def _unknown_placeholder_diagnostic_key(normalized_items: Mapping[str, Any]) -> str | None:
+    """Return a diagnostic key when an Unknown placeholder carries lookup-failure hints."""
+    for marker_key in sorted(LOOKUP_FAILURE_FLAG_KEYS):
+        if _is_truthy_marker(normalized_items.get(marker_key)):
+            return marker_key
+
+    for detail_key in sorted(LOOKUP_FAILURE_DETAIL_KEYS):
+        detail_value = normalized_items.get(detail_key)
+        if is_missing_value(detail_value, treat_blank_string=True, treat_null_like_strings=True):
+            continue
+        return detail_key
+
+    for text_key in sorted(UNKNOWN_PLACEHOLDER_ERROR_TEXT_KEYS):
+        detail_value = normalized_items.get(text_key)
+        if is_missing_value(detail_value, treat_blank_string=True, treat_null_like_strings=True):
+            continue
+        return text_key
+
+    status_keys_present = any(
+        not is_missing_value(normalized_items.get(status_key), treat_blank_string=True, treat_null_like_strings=True)
+        for status_key in STATUS_KEYS
+    )
+    if status_keys_present:
+        for text_key in sorted(ERROR_TEXT_KEYS):
+            detail_value = normalized_items.get(text_key)
+            if is_missing_value(detail_value, treat_blank_string=True, treat_null_like_strings=True):
+                continue
+            return text_key
+
+    for key, value in normalized_items.items():
+        if not str(key).startswith("lookup_"):
+            continue
+        if is_missing_value(value, treat_blank_string=True, treat_null_like_strings=True):
+            continue
+        return str(key)
+
+    return None
+
+
+def _unknown_lookup_placeholder_reason(
+    payload: Mapping[str, Any],
+    *,
+    expected_data_view_id: str | None,
+    normalized_items: Mapping[str, Any],
+) -> str | None:
+    """Return placeholder failure reason when payload matches fallback Unknown lookup output."""
+    if _is_legacy_unknown_lookup_placeholder(payload, expected_data_view_id=expected_data_view_id):
+        return "legacy_unknown_placeholder"
+
+    if expected_data_view_id is None:
+        return None
+
+    payload_id = payload.get("id")
+    if is_missing_value(payload_id, treat_blank_string=True, treat_null_like_strings=True):
+        return None
+    payload_id_text = _coerce_lookup_scalar_text(payload_id)
+    if payload_id_text is None or payload_id_text.strip() != expected_data_view_id:
+        return None
+
+    name_value = payload.get("name")
+    if is_missing_value(name_value, treat_blank_string=True, treat_null_like_strings=True):
+        return None
+    name_text = _coerce_lookup_scalar_text(name_value)
+    if name_text is None or name_text.strip().casefold() != "unknown":
+        return None
+
+    diagnostic_key = _unknown_placeholder_diagnostic_key(normalized_items)
+    if diagnostic_key is None:
+        return None
+    return f"unknown_placeholder_diagnostic:{diagnostic_key}"
+
+
 def assess_dataview_lookup_payload(
     raw_payload: Any,
     *,
@@ -272,11 +345,16 @@ def assess_dataview_lookup_payload(
                 raw_type=raw_type,
             )
 
-    if _is_legacy_unknown_lookup_placeholder(payload, expected_data_view_id=expected_data_view_id):
+    unknown_placeholder_reason = _unknown_lookup_placeholder_reason(
+        payload,
+        expected_data_view_id=expected_data_view_id,
+        normalized_items=normalized_items,
+    )
+    if unknown_placeholder_reason is not None:
         return DataViewLookupAssessment(
             kind=PayloadKind.ERROR,
             payload=payload,
-            reason="legacy_unknown_placeholder",
+            reason=unknown_placeholder_reason,
             raw_type=raw_type,
         )
 

--- a/src/cja_auto_sdr/core/discovery_payloads.py
+++ b/src/cja_auto_sdr/core/discovery_payloads.py
@@ -84,6 +84,7 @@ def _schema_indicates_error(
         return False
     return bool(keys & STATUS_KEYS) and bool(keys & ERROR_TEXT_KEYS)
 
+
 def looks_like_error_payload(
     payload: Mapping[str, Any],
     *,

--- a/src/cja_auto_sdr/core/discovery_payloads.py
+++ b/src/cja_auto_sdr/core/discovery_payloads.py
@@ -15,6 +15,8 @@ EXPLICIT_ERROR_KEYS = frozenset({"error", "errorcode", "errordescription", "erro
 STATUS_KEYS = frozenset({"statuscode", "status_code", "status"})
 ERROR_TEXT_KEYS = frozenset({"message", "detail", "title"})
 COMPONENT_SEQUENCE_KEYS = ("content", "items", "results", "data", "rows")
+LOOKUP_FAILURE_FLAG_KEYS = frozenset({"lookup_failed", "circuit_breaker_open"})
+LOOKUP_FAILURE_DETAIL_KEYS = frozenset({"error", "lookup_failure_reason"})
 
 
 class PayloadKind(Enum):
@@ -34,6 +36,20 @@ class PayloadAssessment:
     rows: list[dict[str, Any]]
     reason: str
     raw_type: str
+
+
+@dataclass(frozen=True)
+class DataViewLookupAssessment:
+    """Normalized assessment for getDataView lookup payloads."""
+
+    kind: PayloadKind
+    payload: dict[str, Any] | None
+    reason: str
+    raw_type: str
+
+    @property
+    def is_valid(self) -> bool:
+        return self.kind is PayloadKind.DATA
 
 
 def normalized_payload_keys(payload: Mapping[str, Any]) -> set[str]:
@@ -71,6 +87,149 @@ def looks_like_error_payload(payload: Mapping[str, Any], *, identity_keys: tuple
 def is_dataview_error_payload(payload: Mapping[str, Any]) -> bool:
     """Return True when getDataView payload appears to be an API error object."""
     return looks_like_error_payload(payload, identity_keys=("id", "name"))
+
+
+def _is_truthy_marker(value: Any) -> bool:
+    if is_missing_value(value, treat_blank_string=True, treat_null_like_strings=True):
+        return False
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        normalized = value.strip().casefold()
+        return normalized not in {"false", "0", "no", "off"}
+    try:
+        return bool(value)
+    except (TypeError, ValueError):
+        return True
+
+
+def _normalize_dataview_lookup_payload(raw_payload: Any) -> tuple[dict[str, Any] | None, str, str]:
+    raw_type = type(raw_payload).__name__
+    if raw_payload is None:
+        return None, raw_type, "none_payload"
+
+    if isinstance(raw_payload, pd.DataFrame):
+        if raw_payload.empty:
+            return None, raw_type, "empty_dataframe"
+        records = raw_payload.to_dict("records")
+        if not records:
+            return None, raw_type, "empty_dataframe_records"
+        first_record = records[0]
+        if not isinstance(first_record, Mapping):
+            return None, raw_type, "non_mapping_dataframe_row"
+        return dict(first_record), raw_type, "dataframe_first_record"
+
+    if isinstance(raw_payload, Mapping):
+        return dict(raw_payload), raw_type, "mapping_payload"
+
+    return None, raw_type, "unsupported_payload_type"
+
+
+def _is_legacy_unknown_lookup_placeholder(payload: Mapping[str, Any], *, expected_data_view_id: str | None) -> bool:
+    if expected_data_view_id is None:
+        return False
+    payload_id = payload.get("id")
+    if is_missing_value(payload_id, treat_blank_string=True, treat_null_like_strings=True):
+        return False
+    if str(payload_id).strip() != expected_data_view_id:
+        return False
+    normalized_keys = normalized_payload_keys(payload)
+    if not normalized_keys.issubset({"id", "name"}):
+        return False
+    name_value = payload.get("name")
+    if is_missing_value(name_value, treat_blank_string=True, treat_null_like_strings=True):
+        return False
+    return str(name_value).strip().casefold() == "unknown"
+
+
+def assess_dataview_lookup_payload(
+    raw_payload: Any,
+    *,
+    expected_data_view_id: str | None = None,
+) -> DataViewLookupAssessment:
+    """Classify getDataView payloads into DATA/EMPTY/ERROR/INVALID."""
+    payload, raw_type, normalize_reason = _normalize_dataview_lookup_payload(raw_payload)
+    if payload is None:
+        kind = PayloadKind.EMPTY if normalize_reason in {"none_payload", "empty_dataframe", "empty_dataframe_records"} else PayloadKind.INVALID
+        return DataViewLookupAssessment(kind=kind, payload=None, reason=normalize_reason, raw_type=raw_type)
+
+    if not payload:
+        return DataViewLookupAssessment(
+            kind=PayloadKind.EMPTY,
+            payload=None,
+            reason="empty_mapping",
+            raw_type=raw_type,
+        )
+
+    normalized_items = {str(key).strip().casefold(): value for key, value in payload.items()}
+
+    for marker_key in LOOKUP_FAILURE_FLAG_KEYS:
+        if _is_truthy_marker(normalized_items.get(marker_key)):
+            return DataViewLookupAssessment(
+                kind=PayloadKind.ERROR,
+                payload=payload,
+                reason=f"failure_flag:{marker_key}",
+                raw_type=raw_type,
+            )
+
+    for detail_key in LOOKUP_FAILURE_DETAIL_KEYS:
+        detail_value = normalized_items.get(detail_key)
+        if is_missing_value(detail_value, treat_blank_string=True, treat_null_like_strings=True):
+            continue
+        return DataViewLookupAssessment(
+            kind=PayloadKind.ERROR,
+            payload=payload,
+            reason=f"failure_detail:{detail_key}",
+            raw_type=raw_type,
+        )
+
+    if is_dataview_error_payload(payload):
+        return DataViewLookupAssessment(
+            kind=PayloadKind.ERROR,
+            payload=payload,
+            reason="error_shape",
+            raw_type=raw_type,
+        )
+
+    if not has_identity_value(payload, ("id", "name")):
+        return DataViewLookupAssessment(
+            kind=PayloadKind.ERROR,
+            payload=payload,
+            reason="missing_identity",
+            raw_type=raw_type,
+        )
+
+    payload_id = payload.get("id")
+    if expected_data_view_id is not None and not is_missing_value(
+        payload_id,
+        treat_blank_string=True,
+        treat_null_like_strings=True,
+    ):
+        normalized_id = str(payload_id).strip()
+        if normalized_id and normalized_id != expected_data_view_id:
+            return DataViewLookupAssessment(
+                kind=PayloadKind.ERROR,
+                payload=payload,
+                reason="id_mismatch",
+                raw_type=raw_type,
+            )
+
+    if _is_legacy_unknown_lookup_placeholder(payload, expected_data_view_id=expected_data_view_id):
+        return DataViewLookupAssessment(
+            kind=PayloadKind.ERROR,
+            payload=payload,
+            reason="legacy_unknown_placeholder",
+            raw_type=raw_type,
+        )
+
+    return DataViewLookupAssessment(
+        kind=PayloadKind.DATA,
+        payload=payload,
+        reason="valid_lookup_payload",
+        raw_type=raw_type,
+    )
 
 
 def extract_component_sequence(payload: Mapping[str, Any]) -> list[Any] | None:

--- a/src/cja_auto_sdr/core/discovery_payloads.py
+++ b/src/cja_auto_sdr/core/discovery_payloads.py
@@ -22,6 +22,31 @@ LOOKUP_FAILURE_DETAIL_KEYS = frozenset({"lookup_failure_reason"})
 # still returning a valid object with identity fields.
 DATAVIEW_EXPLICIT_ERROR_KEYS = frozenset({"errorcode", "errordescription", "error_description"})
 UNKNOWN_PLACEHOLDER_ERROR_TEXT_KEYS = frozenset({"error"}) | DATAVIEW_EXPLICIT_ERROR_KEYS
+DATAVIEW_DIAGNOSTIC_KEYS = (
+    LOOKUP_FAILURE_FLAG_KEYS | LOOKUP_FAILURE_DETAIL_KEYS | STATUS_KEYS | ERROR_TEXT_KEYS | EXPLICIT_ERROR_KEYS
+)
+DATAVIEW_METADATA_HINT_KEYS = frozenset(
+    {
+        "owner",
+        "ownername",
+        "owner_name",
+        "ownerfullname",
+        "owner_full_name",
+        "description",
+        "parentdatagroupid",
+        "connectionid",
+        "connection_id",
+        "created",
+        "createddate",
+        "createdat",
+        "created_date",
+        "modified",
+        "modifieddate",
+        "modifiedat",
+        "modified_date",
+    },
+)
+_DIAGNOSTIC_KEY_PREFIXES = ("error", "lookup_", "status")
 _LOOKUP_MISSING_VALUE = object()
 _LOOKUP_CANONICAL_KEY_ALIASES = {
     "id": "id",
@@ -202,14 +227,72 @@ def looks_like_error_payload(
     return _schema_indicates_error(keys, has_identity=has_identity, explicit_error_keys=explicit_error_keys)
 
 
+def _lookup_field_is_present(value: Any) -> bool:
+    return not is_missing_value(value, treat_blank_string=True, treat_null_like_strings=True)
+
+
+def _lookup_contains_any_present_key(
+    normalized_items: Mapping[str, Any],
+    *,
+    candidate_keys: frozenset[str],
+) -> bool:
+    return any(_lookup_field_is_present(normalized_items.get(candidate_key)) for candidate_key in candidate_keys)
+
+
+def _is_diagnostic_lookup_key(normalized_key: str) -> bool:
+    if normalized_key in DATAVIEW_DIAGNOSTIC_KEYS:
+        return True
+    return normalized_key.startswith(_DIAGNOSTIC_KEY_PREFIXES)
+
+
+def _has_minimum_dataview_lookup_metadata(normalized_items: Mapping[str, Any]) -> bool:
+    """Return True when lookup payload carries more than bare identity/error hints."""
+    if _lookup_field_is_present(normalized_items.get("name")):
+        return True
+
+    if _lookup_contains_any_present_key(normalized_items, candidate_keys=DATAVIEW_METADATA_HINT_KEYS):
+        return True
+
+    # Allow future nested metadata payloads while still failing closed on sparse
+    # scalar error objects (for example: {"id": "...", "error": "..."}).
+    for key, value in normalized_items.items():
+        normalized_key = str(key)
+        if normalized_key == "id" or _is_diagnostic_lookup_key(normalized_key):
+            continue
+        if isinstance(value, Mapping):
+            if value:
+                return True
+            continue
+        if isinstance(value, (list, tuple, set)) and len(value) > 0:
+            return True
+    return False
+
+
+def _is_diagnostic_only_dataview_payload(normalized_items: Mapping[str, Any]) -> bool:
+    if not has_identity_value(normalized_items, ("id", "name")):
+        return False
+
+    has_diagnostic_signal = any(
+        _lookup_field_is_present(value) and _is_diagnostic_lookup_key(str(key))
+        for key, value in normalized_items.items()
+    )
+    if not has_diagnostic_signal:
+        return False
+
+    return not _has_minimum_dataview_lookup_metadata(normalized_items)
+
+
 def is_dataview_error_payload(payload: Mapping[str, Any]) -> bool:
     """Return True when getDataView payload appears to be an API error object."""
     normalized_payload = normalize_lookup_items(payload)
-    return looks_like_error_payload(
+    if looks_like_error_payload(
         normalized_payload,
         identity_keys=("id", "name"),
         explicit_error_keys=DATAVIEW_EXPLICIT_ERROR_KEYS,
-    )
+    ):
+        return True
+
+    return _is_diagnostic_only_dataview_payload(normalized_payload)
 
 
 def _is_truthy_marker(value: Any) -> bool:
@@ -473,6 +556,14 @@ def assess_dataview_lookup_payload(
             kind=PayloadKind.ERROR,
             payload=canonical_payload,
             reason=unknown_placeholder_reason,
+            raw_type=raw_type,
+        )
+
+    if not _has_minimum_dataview_lookup_metadata(normalized_items):
+        return DataViewLookupAssessment(
+            kind=PayloadKind.ERROR,
+            payload=canonical_payload,
+            reason="insufficient_metadata",
             raw_type=raw_type,
         )
 

--- a/src/cja_auto_sdr/core/discovery_payloads.py
+++ b/src/cja_auto_sdr/core/discovery_payloads.py
@@ -16,7 +16,10 @@ STATUS_KEYS = frozenset({"statuscode", "status_code", "status"})
 ERROR_TEXT_KEYS = frozenset({"message", "detail", "title"})
 COMPONENT_SEQUENCE_KEYS = ("content", "items", "results", "data", "rows")
 LOOKUP_FAILURE_FLAG_KEYS = frozenset({"lookup_failed", "circuit_breaker_open"})
-LOOKUP_FAILURE_DETAIL_KEYS = frozenset({"error", "lookup_failure_reason"})
+LOOKUP_FAILURE_DETAIL_KEYS = frozenset({"lookup_failure_reason"})
+# Dataview payloads may include non-fatal diagnostic text under `error` while
+# still returning a valid object with identity fields.
+DATAVIEW_EXPLICIT_ERROR_KEYS = frozenset({"errorcode", "errordescription", "error_description"})
 
 
 class PayloadKind(Enum):
@@ -67,26 +70,39 @@ def has_identity_value(payload: Mapping[str, Any], identity_keys: tuple[str, ...
     return False
 
 
-def _schema_indicates_error(keys: set[str], *, has_identity: bool) -> bool:
+def _schema_indicates_error(
+    keys: set[str],
+    *,
+    has_identity: bool,
+    explicit_error_keys: frozenset[str] = EXPLICIT_ERROR_KEYS,
+) -> bool:
     if not keys:
         return True
-    if keys & EXPLICIT_ERROR_KEYS:
+    if keys & explicit_error_keys:
         return True
     if has_identity:
         return False
     return bool(keys & STATUS_KEYS) and bool(keys & ERROR_TEXT_KEYS)
 
-
-def looks_like_error_payload(payload: Mapping[str, Any], *, identity_keys: tuple[str, ...] = ("id", "name")) -> bool:
+def looks_like_error_payload(
+    payload: Mapping[str, Any],
+    *,
+    identity_keys: tuple[str, ...] = ("id", "name"),
+    explicit_error_keys: frozenset[str] = EXPLICIT_ERROR_KEYS,
+) -> bool:
     """Return True when object keys match an API-error-like shape."""
     keys = normalized_payload_keys(payload)
     has_identity = has_identity_value(payload, identity_keys)
-    return _schema_indicates_error(keys, has_identity=has_identity)
+    return _schema_indicates_error(keys, has_identity=has_identity, explicit_error_keys=explicit_error_keys)
 
 
 def is_dataview_error_payload(payload: Mapping[str, Any]) -> bool:
     """Return True when getDataView payload appears to be an API error object."""
-    return looks_like_error_payload(payload, identity_keys=("id", "name"))
+    return looks_like_error_payload(
+        payload,
+        identity_keys=("id", "name"),
+        explicit_error_keys=DATAVIEW_EXPLICIT_ERROR_KEYS,
+    )
 
 
 def _is_truthy_marker(value: Any) -> bool:

--- a/src/cja_auto_sdr/core/version.py
+++ b/src/cja_auto_sdr/core/version.py
@@ -1,3 +1,3 @@
 """Version information for CJA Auto SDR."""
 
-__version__ = "3.3.4"
+__version__ = "3.3.5"

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -120,13 +120,10 @@ from cja_auto_sdr.core.discovery_payloads import (
     assess_component_payload as _assess_component_payload,
 )
 from cja_auto_sdr.core.discovery_payloads import (
+    assess_dataview_lookup_payload as _assess_dataview_lookup_payload,
+)
+from cja_auto_sdr.core.discovery_payloads import (
     count_component_items_or_na as _count_component_items_or_na_from_assessment,
-)
-from cja_auto_sdr.core.discovery_payloads import (
-    has_identity_value as _has_identity_discovery_value,
-)
-from cja_auto_sdr.core.discovery_payloads import (
-    is_dataview_error_payload as _is_dataview_error_payload,
 )
 from cja_auto_sdr.core.exceptions import (
     APIError,
@@ -5651,9 +5648,21 @@ def process_single_dataview(
 
         metrics, dimensions, lookup_data = fetcher.fetch_all_data(data_view_id)
 
-        # Validate fetched data view (replaces separate validate_data_view call)
-        if lookup_data is None or (isinstance(lookup_data, dict) and not lookup_data):
-            logger.error("Data view validation failed — empty payload from API")
+        # Validate fetched data view lookup metadata (defensive gate before processing).
+        lookup_assessment = _assess_dataview_lookup_payload(
+            lookup_data,
+            expected_data_view_id=data_view_id,
+        )
+        if not lookup_assessment.is_valid:
+            logger.error(
+                "Data view validation failed — invalid lookup payload (%s)",
+                lookup_assessment.reason,
+            )
+            logger.debug(
+                "Lookup payload rejected: kind=%s raw_type=%s",
+                lookup_assessment.kind.value,
+                lookup_assessment.raw_type,
+            )
             return ProcessingResult(
                 data_view_id=data_view_id,
                 data_view_name="Unknown",
@@ -5661,6 +5670,7 @@ def process_single_dataview(
                 duration=time.time() - start_time,
                 error_message="Data view validation failed",
             )
+        lookup_data = lookup_assessment.payload if lookup_assessment.payload is not None else {}
         logger.info("✓ Data view validated and fetched successfully")
 
         # Log tuner statistics if tuning was enabled
@@ -8518,10 +8528,11 @@ def _require_accessible_dataview(cja: Any, data_view_id: str) -> dict[str, Any]:
             raise DiscoveryNotFoundError(f"Data view '{data_view_id}' not found") from e
         raise
 
-    payload = _normalize_single_dataview_payload(raw_payload)
-    if payload is None or _is_dataview_error_payload(payload):
+    assessment = _assess_dataview_lookup_payload(raw_payload, expected_data_view_id=data_view_id)
+    if not assessment.is_valid:
         raise DiscoveryNotFoundError(f"Data view '{data_view_id}' not found")
-    if not _has_identity_discovery_value(payload, ("id", "name")):
+    payload = assessment.payload
+    if payload is None:
         raise DiscoveryNotFoundError(f"Data view '{data_view_id}' not found")
     return payload
 

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -5902,6 +5902,10 @@ def process_single_dataview(
         # The shared logger is intentional; stdlib logging is thread-safe, but
         # emitted lines may interleave when inventories run concurrently.
         _inventory_tasks: list[tuple[str, Callable, Callable, str]] = []
+        # Inventory builders for calculated metrics and segments both call API
+        # methods on the same `cja` instance. Serialize those calls in case the
+        # client/session object is not safe for concurrent method execution.
+        cja_inventory_lock = threading.Lock()
 
         if include_derived_inventory:
             logger.info("=" * BANNER_WIDTH)
@@ -5942,7 +5946,8 @@ def process_single_dataview(
 
                 builder = CalculatedMetricsInventoryBuilder(logger=logger)
                 dv_name = lookup_data.get("name", data_view_id) if isinstance(lookup_data, dict) else data_view_id
-                calculated_inventory = builder.build(cja, data_view_id, dv_name)
+                with cja_inventory_lock:
+                    calculated_inventory = builder.build(cja, data_view_id, dv_name)
 
                 calculated_df = calculated_inventory.get_dataframe()
 
@@ -5973,7 +5978,8 @@ def process_single_dataview(
 
                 builder = SegmentsInventoryBuilder(logger=logger)
                 dv_name = lookup_data.get("name", data_view_id) if isinstance(lookup_data, dict) else data_view_id
-                segments_inventory = builder.build(cja, data_view_id, dv_name)
+                with cja_inventory_lock:
+                    segments_inventory = builder.build(cja, data_view_id, dv_name)
 
                 segments_df = segments_inventory.get_dataframe()
 

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -2161,7 +2161,7 @@ def test_profile(profile_name: str) -> bool:
         finally:
             os.unlink(temp_config.name)
 
-    except RECOVERABLE_API_EXCEPTIONS as e:  # cjapy API calls
+    except RECOVERABLE_CONFIG_API_EXCEPTIONS as e:  # cjapy API/bootstrap calls
         print(ConsoleColors.error("   API connection: FAILED"), file=sys.stderr)
         print(ConsoleColors.error(f"   Error: {e}"), file=sys.stderr)
         print()
@@ -2319,7 +2319,7 @@ def validate_data_view(cja: cjapy.CJA, data_view_id: str, logger: logging.Logger
 
     except KeyboardInterrupt, SystemExit:
         raise
-    except RECOVERABLE_API_EXCEPTIONS as e:  # cjapy API calls
+    except RECOVERABLE_CONFIG_API_EXCEPTIONS as e:  # cjapy API/bootstrap calls
         logger.error("=" * BANNER_WIDTH)
         logger.error("DATA VIEW VALIDATION ERROR")
         logger.error("=" * BANNER_WIDTH)
@@ -5461,7 +5461,7 @@ def process_inventory_summary(
     try:
         lookup_data = cja.dataviews.get_single(data_view_id)
         dv_name = lookup_data.get("name", data_view_id) if isinstance(lookup_data, dict) else data_view_id
-    except RECOVERABLE_API_EXCEPTIONS as e:
+    except RECOVERABLE_CONFIG_API_EXCEPTIONS as e:
         print(ConsoleColors.error(f"ERROR: Failed to fetch data view: {e}"), file=sys.stderr)
         return {"error": str(e)}
     except (RuntimeError, AttributeError) as e:  # Residual non-API failures (e.g. cjapy internals)
@@ -7159,7 +7159,7 @@ def run_dry_run(data_views: list[str], config_file: str, logger: logging.Logger,
             print()
             print(ConsoleColors.warning("Validation cancelled."))
             raise
-        except RECOVERABLE_API_EXCEPTIONS as e:
+        except RECOVERABLE_CONFIG_API_EXCEPTIONS as e:
             print(f"  ✗ {dv_id}: Error - {e!s}")
             invalid_count += 1
             all_passed = False
@@ -7758,7 +7758,7 @@ def resolve_data_view_names(
             resolution_diagnostics,
             include_diagnostics=include_diagnostics,
         )
-    except RECOVERABLE_API_EXCEPTIONS as e:
+    except RECOVERABLE_CONFIG_API_EXCEPTIONS as e:
         error_message = f"Failed to resolve data view names: {e!s}"
         logger.error(error_message)
         resolution_diagnostics = NameResolutionDiagnostics(
@@ -10852,7 +10852,7 @@ def validate_config_only(
         print()
         print(ConsoleColors.warning("Validation cancelled."))
         raise
-    except RECOVERABLE_API_EXCEPTIONS as e:
+    except RECOVERABLE_CONFIG_API_EXCEPTIONS as e:
         print(f"  \u2717 API connection failed: {e!s}")
         all_passed = False
     except (RuntimeError, AttributeError) as e:  # Residual non-API failures (e.g. cjapy internals)

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -114,6 +114,9 @@ from cja_auto_sdr.core.discovery_normalization import (
     pick_first_present_text as _pick_first_present_text,
 )
 from cja_auto_sdr.core.discovery_payloads import (
+    DataViewLookupAssessment as _DataViewLookupAssessment,
+)
+from cja_auto_sdr.core.discovery_payloads import (
     PayloadKind as _PayloadKind,
 )
 from cja_auto_sdr.core.discovery_payloads import (
@@ -2234,7 +2237,7 @@ def validate_data_view(cja: cjapy.CJA, data_view_id: str, logger: logging.Logger
         # Attempt to fetch data view info
         logger.info("Fetching data view information from API...")
         try:
-            dv_info = cja.getDataView(data_view_id)
+            raw_dv_info = cja.getDataView(data_view_id)
         except AttributeError as e:
             logger.error("API method 'getDataView' not available")
             logger.error("Possible causes:")
@@ -2253,6 +2256,18 @@ def validate_data_view(cja: cjapy.CJA, data_view_id: str, logger: logging.Logger
             return False
 
         # Validate response
+        dv_info, lookup_failure_reason, lookup_raw_type = _coerce_valid_dataview_lookup_payload(
+            raw_dv_info,
+            data_view_id=data_view_id,
+        )
+        if dv_info is None:
+            logger.error("Data view lookup returned invalid payload (%s)", lookup_failure_reason)
+            logger.debug(
+                "Rejected data view lookup payload: data_view_id=%s raw_type=%s",
+                data_view_id,
+                lookup_raw_type,
+            )
+
         if not dv_info:
             # Try to list available data views to provide context
             available_count = None
@@ -5737,19 +5752,18 @@ def process_single_dataview(
         metrics, dimensions, lookup_data = fetcher.fetch_all_data(data_view_id)
 
         # Validate fetched data view lookup metadata (defensive gate before processing).
-        lookup_assessment = _assess_dataview_lookup_payload(
+        lookup_data, lookup_failure_reason, lookup_raw_type = _coerce_valid_dataview_lookup_payload(
             lookup_data,
-            expected_data_view_id=data_view_id,
+            data_view_id=data_view_id,
         )
-        if not lookup_assessment.is_valid:
+        if lookup_data is None:
             logger.error(
                 "Data view validation failed — invalid lookup payload (%s)",
-                lookup_assessment.reason,
+                lookup_failure_reason,
             )
             logger.debug(
-                "Lookup payload rejected: kind=%s raw_type=%s",
-                lookup_assessment.kind.value,
-                lookup_assessment.raw_type,
+                "Lookup payload rejected: raw_type=%s",
+                lookup_raw_type,
             )
             return ProcessingResult(
                 data_view_id=data_view_id,
@@ -5758,7 +5772,6 @@ def process_single_dataview(
                 duration=time.time() - start_time,
                 error_message="Data view validation failed",
             )
-        lookup_data = lookup_assessment.payload if lookup_assessment.payload is not None else {}
         logger.info("✓ Data view validated and fetched successfully")
 
         # Log tuner statistics if tuning was enabled
@@ -7123,13 +7136,17 @@ def run_dry_run(data_views: list[str], config_file: str, logger: logging.Logger,
     for dv_id in data_views:
         # Try to get data view info (with retry for transient errors)
         try:
-            dv_info = make_api_call_with_retry(
+            raw_dv_info = make_api_call_with_retry(
                 cja.getDataView,
                 dv_id,
                 logger=logger,
                 operation_name=f"getDataView({dv_id})",
             )
-            if dv_info:
+            dv_info, lookup_failure_reason, lookup_raw_type = _coerce_valid_dataview_lookup_payload(
+                raw_dv_info,
+                data_view_id=dv_id,
+            )
+            if dv_info is not None:
                 dv_name = dv_info.get("name", "Unknown")
 
                 # Fetch component counts for predictions
@@ -7157,6 +7174,13 @@ def run_dry_run(data_views: list[str], config_file: str, logger: logging.Logger,
                 valid_count += 1
             else:
                 print(f"  ✗ {dv_id}: Not found or no access")
+                print(f"      Lookup validation failed: {lookup_failure_reason}")
+                logger.debug(
+                    "Dry-run rejected lookup payload for %s: reason=%s raw_type=%s",
+                    dv_id,
+                    lookup_failure_reason,
+                    lookup_raw_type,
+                )
                 invalid_count += 1
                 all_passed = False
         except KeyboardInterrupt, SystemExit:
@@ -8529,6 +8553,34 @@ def _normalize_single_dataview_payload(raw_dv: Any) -> dict[str, Any] | None:
     return raw_dv if isinstance(raw_dv, dict) else None
 
 
+def _assess_dataview_lookup(
+    raw_payload: Any,
+    *,
+    data_view_id: str,
+    require_expected_id: bool = True,
+) -> _DataViewLookupAssessment:
+    """Assess a getDataView payload with a consistent expected-id policy."""
+    expected_data_view_id = data_view_id if require_expected_id else None
+    return _assess_dataview_lookup_payload(raw_payload, expected_data_view_id=expected_data_view_id)
+
+
+def _coerce_valid_dataview_lookup_payload(
+    raw_payload: Any,
+    *,
+    data_view_id: str,
+    require_expected_id: bool = True,
+) -> tuple[dict[str, Any] | None, str, str]:
+    """Return a validated lookup payload or structured failure metadata."""
+    assessment = _assess_dataview_lookup(
+        raw_payload,
+        data_view_id=data_view_id,
+        require_expected_id=require_expected_id,
+    )
+    if assessment.is_valid and assessment.payload is not None:
+        return assessment.payload, assessment.reason, assessment.raw_type
+    return None, assessment.reason, assessment.raw_type
+
+
 _DATAVIEW_LOOKUP_NOT_FOUND_STATUS_CODES = frozenset({403, 404})
 _DATAVIEW_LOOKUP_STATUS_ATTRS = ("status_code", "statusCode", "status", "http_status", "httpStatus", "code")
 _DATAVIEW_LOOKUP_NOT_FOUND_MESSAGE_MARKERS = (
@@ -8631,10 +8683,7 @@ def _require_accessible_dataview(cja: Any, data_view_id: str) -> dict[str, Any]:
             raise DiscoveryNotFoundError(f"Data view '{data_view_id}' not found") from e
         raise
 
-    assessment = _assess_dataview_lookup_payload(raw_payload, expected_data_view_id=data_view_id)
-    if not assessment.is_valid:
-        raise DiscoveryNotFoundError(f"Data view '{data_view_id}' not found")
-    payload = assessment.payload
+    payload, _, _ = _coerce_valid_dataview_lookup_payload(raw_payload, data_view_id=data_view_id)
     if payload is None:
         raise DiscoveryNotFoundError(f"Data view '{data_view_id}' not found")
     return payload
@@ -10967,8 +11016,15 @@ def _require_numeric_component_count_for_stats(
 
 def _collect_stats_row(cja: cjapy.CJA, data_view_id: str) -> dict[str, Any]:
     """Fetch one data view's stats row. Raises on API/runtime errors."""
-    dv_info = cja.getDataView(data_view_id)
-    dv_name = dv_info.get("name", "Unknown") if isinstance(dv_info, dict) else "Unknown"
+    raw_dv_info = cja.getDataView(data_view_id)
+    dv_info, lookup_failure_reason, _ = _coerce_valid_dataview_lookup_payload(
+        raw_dv_info,
+        data_view_id=data_view_id,
+        require_expected_id=False,
+    )
+    if dv_info is None:
+        raise ValueError(f"Data view validation failed for '{data_view_id}' ({lookup_failure_reason})")
+    dv_name = dv_info.get("name", "Unknown")
 
     metrics_count = _require_numeric_component_count_for_stats(
         cja,
@@ -10983,10 +11039,10 @@ def _collect_stats_row(cja: cjapy.CJA, data_view_id: str) -> dict[str, Any]:
         component_label="dimensions",
     )
 
-    owner_info = dv_info.get("owner", {}) if isinstance(dv_info, dict) else {}
+    owner_info = dv_info.get("owner", {})
     owner_name = owner_info.get("name", "N/A") if isinstance(owner_info, dict) else "N/A"
 
-    raw_description = dv_info.get("description", "") if isinstance(dv_info, dict) else ""
+    raw_description = dv_info.get("description", "")
     description_text = str(raw_description) if raw_description is not None else ""
 
     return {

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -19,7 +19,7 @@ import textwrap
 import threading
 import time
 import uuid
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Collection, Mapping
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from concurrent.futures.process import BrokenProcessPool
 from dataclasses import dataclass, field
@@ -530,6 +530,9 @@ def _resolve_command_output_format(
     fallback_format: str,
     warning_scope: str,
     logger: logging.Logger | None = None,
+    output_to_stdout: bool = False,
+    stdout_fallback_format: str | None = None,
+    stdout_allowed_formats: Collection[str] | None = None,
 ) -> str:
     """Resolve requested output format to a supported command format.
 
@@ -539,22 +542,43 @@ def _resolve_command_output_format(
         fallback_format: Canonical fallback format when input is missing/unsupported.
         warning_scope: Human-readable command scope for warning messages.
         logger: Optional logger for warning emissions.
+        output_to_stdout: Whether command output is being piped to stdout.
+        stdout_fallback_format: Fallback format override for stdout paths.
+        stdout_allowed_formats: Canonical formats allowed for stdout output.
     """
+    active_logger = logger or logging.getLogger(__name__)
+    allowed_stdout_formats = tuple(dict.fromkeys(stdout_allowed_formats or ()))
+
+    effective_fallback = fallback_format
+    if output_to_stdout and stdout_fallback_format is not None:
+        effective_fallback = stdout_fallback_format
+    if output_to_stdout and allowed_stdout_formats and effective_fallback not in allowed_stdout_formats:
+        effective_fallback = allowed_stdout_formats[0]
+
     normalized_format = _normalize_output_format(raw_format)
     if normalized_format is None:
-        return fallback_format
+        return effective_fallback
 
     resolved_format = supported_formats.get(normalized_format)
-    if resolved_format is not None:
-        return resolved_format
+    if resolved_format is None:
+        active_logger.warning(
+            "--format %s is not supported for %s; using %s",
+            raw_format,
+            warning_scope,
+            effective_fallback,
+        )
+        return effective_fallback
 
-    (logger or logging.getLogger(__name__)).warning(
-        "--format %s is not supported for %s; using %s",
-        raw_format,
-        warning_scope,
-        fallback_format,
-    )
-    return fallback_format
+    if output_to_stdout and allowed_stdout_formats and resolved_format not in allowed_stdout_formats:
+        active_logger.warning(
+            "--format %s is not supported for %s with --output stdout; using %s",
+            raw_format,
+            warning_scope,
+            effective_fallback,
+        )
+        return effective_fallback
+
+    return resolved_format
 
 
 def _print_error_list_to_stderr(
@@ -8027,12 +8051,13 @@ def _is_machine_readable_output(output_format: str | None, output_file: str | No
 
 def _resolve_discovery_output_format(raw_format: str | None, *, output_to_stdout: bool) -> str:
     """Normalize discovery output format with stdout piping semantics."""
-    if output_to_stdout:
-        return "json"
     return _resolve_command_output_format(
         raw_format,
         supported_formats={"json": "json", "csv": "csv", "console": "table", "table": "table"},
         fallback_format="table",
+        output_to_stdout=output_to_stdout,
+        stdout_fallback_format="json",
+        stdout_allowed_formats={"json", "csv"},
         warning_scope="this command",
     )
 

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -95,6 +95,18 @@ from cja_auto_sdr.core.constants import (
     infer_format_from_path,
     should_generate_format,
 )
+from cja_auto_sdr.core.discovery_exceptions import (
+    coerce_http_status_code as _coerce_http_status_code_core,
+)
+from cja_auto_sdr.core.discovery_exceptions import (
+    extract_http_status_codes as _extract_http_status_codes_core,
+)
+from cja_auto_sdr.core.discovery_exceptions import (
+    is_dataview_lookup_not_found_error as _is_inaccessible_dataview_lookup_error_core,
+)
+from cja_auto_sdr.core.discovery_exceptions import (
+    iter_error_chain_nodes as _iter_error_chain_nodes_core,
+)
 from cja_auto_sdr.core.discovery_normalization import (
     extract_owner_name as _extract_owner_name_normalized,
 )
@@ -2237,7 +2249,9 @@ def validate_data_view(cja: cjapy.CJA, data_view_id: str, logger: logging.Logger
         # Attempt to fetch data view info
         logger.info("Fetching data view information from API...")
         try:
-            raw_dv_info = cja.getDataView(data_view_id)
+            raw_dv_info = _fetch_dataview_lookup_payload(cja, data_view_id)
+        except DiscoveryNotFoundError:
+            raw_dv_info = None
         except AttributeError as e:
             logger.error("API method 'getDataView' not available")
             logger.error("Possible causes:")
@@ -8581,107 +8595,39 @@ def _coerce_valid_dataview_lookup_payload(
     return None, assessment.reason, assessment.raw_type
 
 
-_DATAVIEW_LOOKUP_NOT_FOUND_STATUS_CODES = frozenset({403, 404})
-_DATAVIEW_LOOKUP_STATUS_ATTRS = ("status_code", "statusCode", "status", "http_status", "httpStatus", "code")
-_DATAVIEW_LOOKUP_NOT_FOUND_MESSAGE_MARKERS = (
-    "not found",
-    "not_found",
-    "resource_not_found",
-    "forbidden",
-    "no access",
-    "access denied",
-)
-_HTTP_STATUS_CODE_RE = re.compile(r"\b([1-5]\d{2})\b")
-
-
 def _coerce_http_status_code(value: Any) -> int | None:
-    """Best-effort coercion of status-like values into an HTTP status code."""
-    if isinstance(value, bool):
-        return None
-    if isinstance(value, int):
-        return value if 100 <= value <= 599 else None
-    if isinstance(value, str):
-        stripped = value.strip()
-        if not stripped:
-            return None
-        if stripped.isdigit():
-            numeric_code = int(stripped)
-            return numeric_code if 100 <= numeric_code <= 599 else None
-        match = _HTTP_STATUS_CODE_RE.search(stripped)
-        if match:
-            numeric_code = int(match.group(1))
-            return numeric_code if 100 <= numeric_code <= 599 else None
-    return None
+    """Compatibility wrapper for centralized HTTP status-code coercion."""
+    return _coerce_http_status_code_core(value)
 
 
 def _iter_error_chain_nodes(error: Exception) -> list[Any]:
-    """Return error/cause/response nodes for robust status-code extraction."""
-    pending: list[Any] = [error]
-    seen: set[int] = set()
-    nodes: list[Any] = []
-    while pending:
-        node = pending.pop()
-        marker = id(node)
-        if marker in seen:
-            continue
-        seen.add(marker)
-        nodes.append(node)
-
-        if isinstance(node, dict):
-            nested = node.get("error")
-            if nested is not None:
-                pending.append(nested)
-            continue
-
-        for attr_name in ("original_error", "__cause__", "__context__", "response"):
-            with contextlib.suppress(Exception):
-                nested = getattr(node, attr_name)
-                if nested is not None:
-                    pending.append(nested)
-    return nodes
+    """Compatibility wrapper for centralized nested exception traversal."""
+    return _iter_error_chain_nodes_core(error)
 
 
 def _extract_http_status_codes(error: Exception) -> set[int]:
-    """Extract candidate HTTP status codes from nested error objects."""
-    status_codes: set[int] = set()
-    for node in _iter_error_chain_nodes(error):
-        if isinstance(node, dict):
-            for key in _DATAVIEW_LOOKUP_STATUS_ATTRS:
-                code = _coerce_http_status_code(node.get(key))
-                if code is not None:
-                    status_codes.add(code)
-            continue
-
-        for attr_name in _DATAVIEW_LOOKUP_STATUS_ATTRS:
-            with contextlib.suppress(Exception):
-                code = _coerce_http_status_code(getattr(node, attr_name))
-                if code is not None:
-                    status_codes.add(code)
-    return status_codes
+    """Compatibility wrapper for centralized HTTP status extraction."""
+    return _extract_http_status_codes_core(error)
 
 
 def _is_inaccessible_dataview_lookup_error(error: Exception) -> bool:
-    """Return True when getDataView failures should map to not_found."""
-    status_codes = _extract_http_status_codes(error)
-    if any(code in _DATAVIEW_LOOKUP_NOT_FOUND_STATUS_CODES for code in status_codes):
-        return True
+    """Compatibility wrapper for centralized dataview lookup classification."""
+    return _is_inaccessible_dataview_lookup_error_core(error)
 
-    # Some APIError paths omit status_code but still include a stable not-found/forbidden marker.
-    if isinstance(error, APIError):
-        normalized_message = str(error).casefold()
-        return any(marker in normalized_message for marker in _DATAVIEW_LOOKUP_NOT_FOUND_MESSAGE_MARKERS)
 
-    return False
+def _fetch_dataview_lookup_payload(cja: Any, data_view_id: str) -> Any:
+    """Call getDataView and normalize inaccessible lookup failures to not_found."""
+    try:
+        return cja.getDataView(data_view_id)
+    except Exception as lookup_error:
+        if _is_inaccessible_dataview_lookup_error(lookup_error):
+            raise DiscoveryNotFoundError(f"Data view '{data_view_id}' not found") from lookup_error
+        raise
 
 
 def _require_accessible_dataview(cja: Any, data_view_id: str) -> dict[str, Any]:
     """Fetch a data view and raise DiscoveryNotFoundError when inaccessible/invalid."""
-    try:
-        raw_payload = cja.getDataView(data_view_id)
-    except RECOVERABLE_API_EXCEPTIONS as e:  # cjapy API calls
-        if _is_inaccessible_dataview_lookup_error(e):
-            raise DiscoveryNotFoundError(f"Data view '{data_view_id}' not found") from e
-        raise
+    raw_payload = _fetch_dataview_lookup_payload(cja, data_view_id)
 
     payload, _, _ = _coerce_valid_dataview_lookup_payload(raw_payload, data_view_id=data_view_id)
     if payload is None:
@@ -11016,7 +10962,7 @@ def _require_numeric_component_count_for_stats(
 
 def _collect_stats_row(cja: cjapy.CJA, data_view_id: str) -> dict[str, Any]:
     """Fetch one data view's stats row. Raises on API/runtime errors."""
-    raw_dv_info = cja.getDataView(data_view_id)
+    raw_dv_info = _fetch_dataview_lookup_payload(cja, data_view_id)
     dv_info, lookup_failure_reason, _ = _coerce_valid_dataview_lookup_payload(
         raw_dv_info,
         data_view_id=data_view_id,

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -2080,7 +2080,7 @@ def test_profile(profile_name: str) -> bool:
         finally:
             os.unlink(temp_config.name)
 
-    except Exception as e:  # Intentional: wraps cjapy API calls that may raise anything
+    except RECOVERABLE_API_EXCEPTIONS as e:  # cjapy API calls
         print(ConsoleColors.error("   API connection: FAILED"), file=sys.stderr)
         print(ConsoleColors.error(f"   Error: {e}"), file=sys.stderr)
         print()
@@ -2238,7 +2238,7 @@ def validate_data_view(cja: cjapy.CJA, data_view_id: str, logger: logging.Logger
 
     except KeyboardInterrupt, SystemExit:
         raise
-    except Exception as e:  # Intentional: wraps cjapy API validation calls
+    except RECOVERABLE_API_EXCEPTIONS as e:  # cjapy API calls
         logger.error("=" * BANNER_WIDTH)
         logger.error("DATA VIEW VALIDATION ERROR")
         logger.error("=" * BANNER_WIDTH)
@@ -5383,7 +5383,7 @@ def process_inventory_summary(
     except RECOVERABLE_API_EXCEPTIONS as e:
         print(ConsoleColors.error(f"ERROR: Failed to fetch data view: {e}"), file=sys.stderr)
         return {"error": str(e)}
-    except Exception as e:  # Intentional: fallback after RECOVERABLE_API for cjapy calls
+    except (RuntimeError, AttributeError) as e:  # Residual non-API failures (e.g. cjapy internals)
         print(ConsoleColors.error(f"ERROR: Failed to fetch data view (unexpected): {e}"), file=sys.stderr)
         logger.debug("Unexpected error fetching data view", exc_info=True)
         return {"error": str(e)}
@@ -6979,9 +6979,7 @@ def run_dry_run(data_views: list[str], config_file: str, logger: logging.Logger,
         print("DRY-RUN FAILED - Cannot connect to CJA API")
         print("=" * BANNER_WIDTH)
         return False
-    except Exception as e:
-        # Defensive fallback: dry-run should surface a controlled failure, even
-        # when dependency/runtime exceptions fall outside expected API types.
+    except (RuntimeError, AttributeError) as e:  # Residual non-API failures (e.g. cjapy internals)
         logger.debug("Unexpected dry-run API connection failure", exc_info=True)
         print(f"  ✗ API connection failed: {_dry_run_error_text(e)}")
         all_passed = False
@@ -7058,7 +7056,7 @@ def run_dry_run(data_views: list[str], config_file: str, logger: logging.Logger,
             print(f"  ✗ {dv_id}: Error - {e!s}")
             invalid_count += 1
             all_passed = False
-        except Exception as e:  # Intentional: fallback after RECOVERABLE_API for cjapy calls
+        except (RuntimeError, AttributeError) as e:  # Residual non-API failures (e.g. cjapy internals)
             logger.debug(f"Unexpected dry-run validation error for {dv_id}: {e!s}", exc_info=True)
             print(f"  ✗ {dv_id}: Error - {_dry_run_error_text(e)}")
             invalid_count += 1
@@ -7666,7 +7664,7 @@ def resolve_data_view_names(
             resolution_diagnostics,
             include_diagnostics=include_diagnostics,
         )
-    except Exception as e:  # Intentional: fallback after RECOVERABLE_API for cjapy calls
+    except (RuntimeError, AttributeError) as e:  # Residual non-API failures (e.g. cjapy internals)
         error_message = f"Failed to resolve data view names (unexpected): {e!s}"
         logger.error(error_message)
         logger.debug("Unexpected error during name resolution", exc_info=True)
@@ -8515,7 +8513,7 @@ def _require_accessible_dataview(cja: Any, data_view_id: str) -> dict[str, Any]:
     """Fetch a data view and raise DiscoveryNotFoundError when inaccessible/invalid."""
     try:
         raw_payload = cja.getDataView(data_view_id)
-    except Exception as e:  # Intentional: wraps cjapy.getDataView() which may raise anything
+    except RECOVERABLE_API_EXCEPTIONS as e:  # cjapy API calls
         if _is_inaccessible_dataview_lookup_error(e):
             raise DiscoveryNotFoundError(f"Data view '{data_view_id}' not found") from e
         raise
@@ -8826,7 +8824,7 @@ def _count_component_items_for_fetch_spec_with_retry(
         logger.debug("Could not fetch %s count for %s: non-countable payload", component_label, data_view_id)
     except RECOVERABLE_API_EXCEPTIONS as e:
         logger.debug("Could not fetch %s count for %s: %s", component_label, data_view_id, e)
-    except Exception as e:  # Intentional: fallback after RECOVERABLE_API for cjapy calls
+    except (RuntimeError, AttributeError) as e:  # Residual non-API failures (e.g. cjapy internals)
         logger.debug("Unexpected %s count error for %s: %s", component_label, data_view_id, e, exc_info=True)
     return 0
 
@@ -10747,7 +10745,7 @@ def validate_config_only(
     except RECOVERABLE_API_EXCEPTIONS as e:
         print(f"  \u2717 API connection failed: {e!s}")
         all_passed = False
-    except Exception as e:  # Intentional: fallback after RECOVERABLE_API for cjapy calls
+    except (RuntimeError, AttributeError) as e:  # Residual non-API failures (e.g. cjapy internals)
         print(f"  \u2717 API connection failed (unexpected): {e!s}")
         logging.getLogger(__name__).debug("Unexpected validate-config error", exc_info=True)
         all_passed = False

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -1723,7 +1723,12 @@ def add_profile_interactive(profile_name: str) -> bool:
         try:
             secret = getpass.getpass("Client Secret: ").strip()
         except getpass.GetPassWarning:
-            print(ConsoleColors.error("Error: Cannot securely read secret (no TTY available). Use --profile-import instead."), file=sys.stderr)
+            print(
+                ConsoleColors.error(
+                    "Error: Cannot securely read secret (no TTY available). Use --profile-import instead."
+                ),
+                file=sys.stderr,
+            )
             return False
 
         if not secret:
@@ -2547,19 +2552,16 @@ def apply_excel_formatting(
             column_width_caps = {}
             default_cap = 100
 
-        # Set column widths with appropriate caps
+        # Set column widths with appropriate caps (vectorized)
         for idx, col in enumerate(df.columns):
-            series = df[col]
             col_lower = col.lower()
             max_cap = column_width_caps.get(col_lower, default_cap)
-            max_len = min(
-                max(
-                    max(len(str(val).split("\n")[0]) for val in series) if len(series) > 0 else 0,
-                    len(str(series.name)),
-                )
-                + 2,
-                max_cap,
-            )
+            series = df[col]
+            if len(series) > 0:
+                content_max = int(series.astype(str).str.split("\n").str[0].str.len().max())
+            else:
+                content_max = 0
+            max_len = min(max(content_max, len(str(series.name))) + 2, max_cap)
             worksheet.set_column(idx, idx, max_len)
 
         # Apply row formatting (offset by summary rows)
@@ -5795,9 +5797,17 @@ def process_single_dataview(
                 ),
             )
 
-        # Derived field inventory (if enabled)
+        # Optional inventory builds (parallelized when 2+ are enabled)
         derived_inventory_df = pd.DataFrame()
         derived_inventory_obj = None  # Store inventory object for JSON output
+        calculated_metrics_df = pd.DataFrame()
+        calculated_inventory_obj = None  # Store inventory object for JSON output
+        segments_inventory_df = pd.DataFrame()
+        segments_inventory_obj = None  # Store inventory object for JSON output
+
+        # Collect enabled inventory tasks — closures defined conditionally
+        _inventory_tasks: list[tuple[str, Callable, Callable, str]] = []
+
         if include_derived_inventory:
             logger.info("=" * BANNER_WIDTH)
             logger.info("Building derived field inventory")
@@ -5823,19 +5833,10 @@ def process_single_dataview(
                 logger.warning(f"Could not import derived field inventory: {error}")
                 logger.info("Skipping derived field inventory - module not available")
 
-            derived_inventory_payload = _run_optional_inventory_step(
-                logger=logger,
-                inventory_label="derived field inventory",
-                summary_mode=False,
-                build_inventory=_build_derived_inventory,
-                on_import_error=_handle_derived_import_error,
+            _inventory_tasks.append(
+                ("derived", _build_derived_inventory, _handle_derived_import_error, "derived field inventory")
             )
-            if derived_inventory_payload is not None:
-                derived_inventory_obj, derived_inventory_df = derived_inventory_payload
 
-        # Calculated metrics inventory (if enabled)
-        calculated_metrics_df = pd.DataFrame()
-        calculated_inventory_obj = None  # Store inventory object for JSON output
         if include_calculated_metrics:
             logger.info("=" * BANNER_WIDTH)
             logger.info("Building calculated metrics inventory")
@@ -5858,19 +5859,15 @@ def process_single_dataview(
                 logger.warning(f"Could not import calculated metrics inventory: {error}")
                 logger.info("Skipping calculated metrics inventory - module not available")
 
-            calculated_inventory_payload = _run_optional_inventory_step(
-                logger=logger,
-                inventory_label="calculated metrics inventory",
-                summary_mode=False,
-                build_inventory=_build_calculated_inventory,
-                on_import_error=_handle_calculated_import_error,
+            _inventory_tasks.append(
+                (
+                    "calculated",
+                    _build_calculated_inventory,
+                    _handle_calculated_import_error,
+                    "calculated metrics inventory",
+                )
             )
-            if calculated_inventory_payload is not None:
-                calculated_inventory_obj, calculated_metrics_df = calculated_inventory_payload
 
-        # Segments inventory (if enabled)
-        segments_inventory_df = pd.DataFrame()
-        segments_inventory_obj = None  # Store inventory object for JSON output
         if include_segments_inventory:
             logger.info("=" * BANNER_WIDTH)
             logger.info("Building segments inventory")
@@ -5893,15 +5890,53 @@ def process_single_dataview(
                 logger.warning(f"Could not import segments inventory: {error}")
                 logger.info("Skipping segments inventory - module not available")
 
-            segments_inventory_payload = _run_optional_inventory_step(
-                logger=logger,
-                inventory_label="segments inventory",
-                summary_mode=False,
-                build_inventory=_build_segments_inventory,
-                on_import_error=_handle_segments_import_error,
+            _inventory_tasks.append(
+                ("segments", _build_segments_inventory, _handle_segments_import_error, "segments inventory")
             )
-            if segments_inventory_payload is not None:
-                segments_inventory_obj, segments_inventory_df = segments_inventory_payload
+
+        def _assign_inventory_result(key: str, payload: Any) -> None:
+            """Assign inventory result to the correct outer variables."""
+            nonlocal derived_inventory_obj, derived_inventory_df
+            nonlocal calculated_inventory_obj, calculated_metrics_df
+            nonlocal segments_inventory_obj, segments_inventory_df
+            if payload is None:
+                return
+            if key == "derived":
+                derived_inventory_obj, derived_inventory_df = payload
+            elif key == "calculated":
+                calculated_inventory_obj, calculated_metrics_df = payload
+            elif key == "segments":
+                segments_inventory_obj, segments_inventory_df = payload
+
+        if len(_inventory_tasks) >= 2:
+            from concurrent.futures import ThreadPoolExecutor, as_completed
+
+            with ThreadPoolExecutor(max_workers=len(_inventory_tasks)) as executor:
+                futures = {}
+                for key, build_fn, err_fn, label in _inventory_tasks:
+                    future = executor.submit(
+                        _run_optional_inventory_step,
+                        logger=logger,
+                        inventory_label=label,
+                        summary_mode=False,
+                        build_inventory=build_fn,
+                        on_import_error=err_fn,
+                    )
+                    futures[future] = key
+                for future in as_completed(futures):
+                    key = futures[future]
+                    _assign_inventory_result(key, future.result())
+        else:
+            # Single inventory or none — run sequentially (no thread overhead)
+            for key, build_fn, err_fn, label in _inventory_tasks:
+                payload = _run_optional_inventory_step(
+                    logger=logger,
+                    inventory_label=label,
+                    summary_mode=False,
+                    build_inventory=build_fn,
+                    on_import_error=err_fn,
+                )
+                _assign_inventory_result(key, payload)
 
         # Data processing
         logger.info("=" * BANNER_WIDTH)
@@ -14376,7 +14411,9 @@ def _main_impl(run_state: dict[str, Any] | None = None):
     # Handle --profile-list mode (no data view required)
     if getattr(args, "profile_list", False):
         if args.format not in (None, "json", "console", "table", "excel"):
-            logging.getLogger(__name__).warning("--format %s is not supported for --profile-list; using table", args.format)
+            logging.getLogger(__name__).warning(
+                "--format %s is not supported for --profile-list; using table", args.format
+            )
         list_format = "json" if args.format == "json" else "table"
         success = list_profiles(output_format=list_format)
         if run_state is not None:

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -187,6 +187,7 @@ from cja_auto_sdr.org.models import (
 
 
 TQDM_BAR_FORMAT = "{l_bar}{bar}| {n_fmt}/{total_fmt} [{elapsed}]"
+PARALLEL_INVENTORY_MIN_TASKS = 2
 
 # ==================== OUTPUT WRITER PROTOCOL ====================
 
@@ -6013,7 +6014,7 @@ def process_single_dataview(
             elif key == "segments":
                 segments_inventory_obj, segments_inventory_df = payload
 
-        if len(_inventory_tasks) >= 2:
+        if len(_inventory_tasks) >= PARALLEL_INVENTORY_MIN_TASKS:
             from concurrent.futures import ThreadPoolExecutor, as_completed
 
             with ThreadPoolExecutor(max_workers=len(_inventory_tasks)) as executor:

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -7929,6 +7929,8 @@ def _resolve_discovery_output_format(raw_format: str | None, *, output_to_stdout
         return raw_format
     if output_to_stdout:
         return "json"
+    if raw_format is not None and raw_format not in ("console", "table"):
+        logging.getLogger(__name__).warning("--format %s is not supported for this command; using table", raw_format)
     return "table"
 
 
@@ -10745,9 +10747,16 @@ def validate_config_only(
     print("=" * BANNER_WIDTH)
     if all_passed:
         print(ConsoleColors.success("VALIDATION PASSED - Configuration is valid!"))
+        print("=" * BANNER_WIDTH)
+        print()
+        print("Next steps — run with a data view to generate SDR reports:")
+        print("  cja_auto_sdr <DATA_VIEW_ID>")
+        print()
+        print("Or list available data views:")
+        print("  cja_auto_sdr --list-dataviews")
     else:
         print(ConsoleColors.error("VALIDATION FAILED - Check errors above"))
-    print("=" * BANNER_WIDTH)
+        print("=" * BANNER_WIDTH)
 
     return all_passed
 
@@ -14366,6 +14375,8 @@ def _main_impl(run_state: dict[str, Any] | None = None):
 
     # Handle --profile-list mode (no data view required)
     if getattr(args, "profile_list", False):
+        if args.format not in (None, "json", "console", "table", "excel"):
+            logging.getLogger(__name__).warning("--format %s is not supported for --profile-list; using table", args.format)
         list_format = "json" if args.format == "json" else "table"
         success = list_profiles(output_format=list_format)
         if run_state is not None:
@@ -15640,19 +15651,19 @@ def _main_impl(run_state: dict[str, Any] | None = None):
 
     # Validate format - console is only supported for diff comparison
     if sdr_format == "console" and not quality_report_only:
-        print(ConsoleColors.error("Error: Console format is only supported for diff comparison."))
-        print()
-        print("For SDR generation, use one of these formats:")
-        print("  --format excel     Excel workbook with multiple sheets (default)")
-        print("  --format csv       CSV files (one per data type)")
-        print("  --format json      JSON file with all data")
-        print("  --format html      HTML report")
-        print("  --format markdown  Markdown document")
-        print("  --format all       Generate all formats")
-        print()
-        print("For diff comparison, console is the default:")
-        print("  cja_auto_sdr --diff dv_A dv_B              # Console output")
-        print("  cja_auto_sdr --diff dv_A dv_B --format json  # JSON output")
+        print(ConsoleColors.error("Error: Console format is only supported for diff comparison."), file=sys.stderr)
+        print(file=sys.stderr)
+        print("For SDR generation, use one of these formats:", file=sys.stderr)
+        print("  --format excel     Excel workbook with multiple sheets (default)", file=sys.stderr)
+        print("  --format csv       CSV files (one per data type)", file=sys.stderr)
+        print("  --format json      JSON file with all data", file=sys.stderr)
+        print("  --format html      HTML report", file=sys.stderr)
+        print("  --format markdown  Markdown document", file=sys.stderr)
+        print("  --format all       Generate all formats", file=sys.stderr)
+        print(file=sys.stderr)
+        print("For diff comparison, console is the default:", file=sys.stderr)
+        print("  cja_auto_sdr --diff dv_A dv_B              # Console output", file=sys.stderr)
+        print("  cja_auto_sdr --diff dv_A dv_B --format json  # JSON output", file=sys.stderr)
         sys.exit(1)
 
     # Check for conflicting component filter options

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -557,7 +557,9 @@ def _resolve_command_output_format(
     return fallback_format
 
 
-def _print_error_list_to_stderr(header: str, details: list[Any], *, fallback_detail: str = "Unknown validation error") -> None:
+def _print_error_list_to_stderr(
+    header: str, details: list[Any], *, fallback_detail: str = "Unknown validation error"
+) -> None:
     """Emit an error header and detail lines to stderr using one consistent stream."""
     print(ConsoleColors.error(header), file=sys.stderr)
 

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -5622,18 +5622,6 @@ def process_single_dataview(
 
         logger.info("✓ CJA connection established successfully")
 
-        # Validate data view
-        if not validate_data_view(cja, data_view_id, logger):
-            return ProcessingResult(
-                data_view_id=data_view_id,
-                data_view_name="Unknown",
-                success=False,
-                duration=time.time() - start_time,
-                error_message="Data view validation failed",
-            )
-
-        logger.info("✓ Data view validation complete - proceeding with data fetch")
-
         # Fetch data with parallel optimization
         logger.info("=" * BANNER_WIDTH)
         logger.info("Starting optimized data fetch operations")
@@ -5660,6 +5648,18 @@ def process_single_dataview(
             )
 
         metrics, dimensions, lookup_data = fetcher.fetch_all_data(data_view_id)
+
+        # Validate fetched data view (replaces separate validate_data_view call)
+        if lookup_data is None or (isinstance(lookup_data, dict) and not lookup_data):
+            logger.error("Data view validation failed — empty payload from API")
+            return ProcessingResult(
+                data_view_id=data_view_id,
+                data_view_name="Unknown",
+                success=False,
+                duration=time.time() - start_time,
+                error_message="Data view validation failed",
+            )
+        logger.info("✓ Data view validated and fetched successfully")
 
         # Log tuner statistics if tuning was enabled
         tuner_stats = fetcher.get_tuner_statistics()

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -1677,7 +1677,7 @@ def add_profile_interactive(profile_name: str) -> bool:
     # Validate profile name
     is_valid, error_msg = validate_profile_name(profile_name)
     if not is_valid:
-        print(f"Error: {error_msg}")
+        print(ConsoleColors.error(f"Error: {error_msg}"), file=sys.stderr)
         return False
 
     profile_path = get_profile_path(profile_name)
@@ -1694,7 +1694,7 @@ def add_profile_interactive(profile_name: str) -> bool:
     try:
         profile_path.mkdir(parents=True, exist_ok=True)
     except OSError as e:
-        print(f"Error creating profile directory: {e}")
+        print(ConsoleColors.error(f"Error creating profile directory: {e}"), file=sys.stderr)
         return False
 
     print()
@@ -1709,12 +1709,12 @@ def add_profile_interactive(profile_name: str) -> bool:
     try:
         org_id = input("Organization ID (ends with @AdobeOrg): ").strip()
         if not org_id:
-            print("Error: Organization ID is required")
+            print(ConsoleColors.error("Error: Organization ID is required"), file=sys.stderr)
             return False
 
         client_id = input("Client ID: ").strip()
         if not client_id:
-            print("Error: Client ID is required")
+            print(ConsoleColors.error("Error: Client ID is required"), file=sys.stderr)
             return False
 
         # Use getpass for secret (never fall back to echoing input)
@@ -1723,16 +1723,16 @@ def add_profile_interactive(profile_name: str) -> bool:
         try:
             secret = getpass.getpass("Client Secret: ").strip()
         except getpass.GetPassWarning:
-            print("Error: Cannot securely read secret (no TTY available). Use --profile import instead.")
+            print(ConsoleColors.error("Error: Cannot securely read secret (no TTY available). Use --profile-import instead."), file=sys.stderr)
             return False
 
         if not secret:
-            print("Error: Client Secret is required")
+            print(ConsoleColors.error("Error: Client Secret is required"), file=sys.stderr)
             return False
 
         scopes = input("OAuth Scopes (from Developer Console): ").strip()
         if not scopes:
-            print("Error: OAuth Scopes are required")
+            print(ConsoleColors.error("Error: OAuth Scopes are required"), file=sys.stderr)
             return False
 
     except KeyboardInterrupt, EOFError:
@@ -1748,7 +1748,7 @@ def add_profile_interactive(profile_name: str) -> bool:
         with open(fd, "w", encoding="utf-8") as f:
             json.dump(config, f, indent=2)
     except OSError as e:
-        print(f"Error writing config file: {e}")
+        print(ConsoleColors.error(f"Error writing config file: {e}"), file=sys.stderr)
         return False
 
     print()
@@ -1862,7 +1862,7 @@ def import_profile_non_interactive(profile_name: str, source_file: str | Path, o
     """Import a profile from JSON/.env without interactive prompts."""
     is_valid_name, error_msg = validate_profile_name(profile_name)
     if not is_valid_name:
-        print(f"Error: {error_msg}")
+        print(ConsoleColors.error(f"Error: {error_msg}"), file=sys.stderr)
         return False
 
     profile_path = get_profile_path(profile_name)
@@ -1875,7 +1875,7 @@ def import_profile_non_interactive(profile_name: str, source_file: str | Path, o
     try:
         credentials = load_profile_import_source(source_file)
     except (OSError, json.JSONDecodeError, ValueError) as e:
-        print(f"Error loading profile import source '{source_file}': {e}")
+        print(ConsoleColors.error(f"Error loading profile import source '{source_file}': {e}"), file=sys.stderr)
         return False
 
     validation_logger = logging.getLogger("profile_import")
@@ -1887,7 +1887,7 @@ def import_profile_non_interactive(profile_name: str, source_file: str | Path, o
         source=f"profile import ({source_file})",
     )
     if not is_usable:
-        print("Error: Imported credentials failed validation:")
+        print(ConsoleColors.error("Error: Imported credentials failed validation:"), file=sys.stderr)
         for issue in issues:
             print(f"  - {issue}")
         return False
@@ -1904,7 +1904,7 @@ def import_profile_non_interactive(profile_name: str, source_file: str | Path, o
             json.dump(config_payload, f, indent=2)
             f.write("\n")
     except OSError as e:
-        print(f"Error writing profile config: {e}")
+        print(ConsoleColors.error(f"Error writing profile config: {e}"), file=sys.stderr)
         return False
 
     if profile_exists and (profile_path / ".env").exists():
@@ -1957,10 +1957,10 @@ def show_profile(profile_name: str) -> bool:
         logger.setLevel(logging.WARNING)
         credentials = load_profile_credentials(profile_name, logger)
     except ProfileNotFoundError as e:
-        print(f"Error: {e}")
+        print(ConsoleColors.error(f"Error: {e}"), file=sys.stderr)
         return False
     except ProfileConfigError as e:
-        print(f"Error: {e}")
+        print(ConsoleColors.error(f"Error: {e}"), file=sys.stderr)
         return False
 
     profile_path = get_profile_path(profile_name)
@@ -2022,10 +2022,10 @@ def test_profile(profile_name: str) -> bool:
         logger.setLevel(logging.WARNING)
         credentials = load_profile_credentials(profile_name, logger)
     except ProfileNotFoundError as e:
-        print(f"FAILED: {e}")
+        print(ConsoleColors.error(f"ERROR: {e}"), file=sys.stderr)
         return False
     except ProfileConfigError as e:
-        print(f"FAILED: {e}")
+        print(ConsoleColors.error(f"ERROR: {e}"), file=sys.stderr)
         return False
 
     print("1. Profile found and loaded")
@@ -2076,10 +2076,10 @@ def test_profile(profile_name: str) -> bool:
             os.unlink(temp_config.name)
 
     except Exception as e:  # Intentional: wraps cjapy API calls that may raise anything
-        print("   API connection: FAILED")
-        print(f"   Error: {e}")
+        print(ConsoleColors.error("   API connection: FAILED"), file=sys.stderr)
+        print(ConsoleColors.error(f"   Error: {e}"), file=sys.stderr)
         print()
-        print("Profile test: FAILED")
+        print(ConsoleColors.error("Profile test: FAILED"), file=sys.stderr)
         print()
         print("Common issues:")
         print("  - Invalid client_id or secret")

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -592,11 +592,11 @@ def _print_error_list_to_stderr(
         detail_text = str(detail).strip()
         if not detail_text:
             continue
-        print(f"  - {detail_text}", file=sys.stderr)
+        print(ConsoleColors.error(f"  - {detail_text}"), file=sys.stderr)
         emitted_detail = True
 
     if not emitted_detail:
-        print(f"  - {fallback_detail}", file=sys.stderr)
+        print(ConsoleColors.error(f"  - {fallback_detail}"), file=sys.stderr)
 
 
 def _cli_option_specified(option_name: str, argv: list[str] | None = None) -> bool:
@@ -5898,7 +5898,9 @@ def process_single_dataview(
         segments_inventory_df = pd.DataFrame()
         segments_inventory_obj = None  # Store inventory object for JSON output
 
-        # Collect enabled inventory tasks — closures defined conditionally
+        # Collect enabled inventory tasks — closures defined conditionally.
+        # The shared logger is intentional; stdlib logging is thread-safe, but
+        # emitted lines may interleave when inventories run concurrently.
         _inventory_tasks: list[tuple[str, Callable, Callable, str]] = []
 
         if include_derived_inventory:
@@ -5988,7 +5990,11 @@ def process_single_dataview(
             )
 
         def _assign_inventory_result(key: str, payload: Any) -> None:
-            """Assign inventory result to the correct outer variables."""
+            """Assign inventory result to the correct outer variables.
+
+            This mutates outer state from the coordinator thread only.
+            Worker threads only build payloads.
+            """
             nonlocal derived_inventory_obj, derived_inventory_df
             nonlocal calculated_inventory_obj, calculated_metrics_df
             nonlocal segments_inventory_obj, segments_inventory_df
@@ -6016,6 +6022,7 @@ def process_single_dataview(
                         on_import_error=err_fn,
                     )
                     futures[future] = key
+                # Keep assignment on the main thread in completion order.
                 for future in as_completed(futures):
                     key = futures[future]
                     _assign_inventory_result(key, future.result())
@@ -10876,13 +10883,13 @@ def validate_config_only(
     print("=" * BANNER_WIDTH)
     if all_passed:
         print(ConsoleColors.success("VALIDATION PASSED - Configuration is valid!"))
-        print("=" * BANNER_WIDTH)
         print()
         print("Next steps — run with a data view to generate SDR reports:")
         print("  cja_auto_sdr <DATA_VIEW_ID>")
         print()
         print("Or list available data views:")
         print("  cja_auto_sdr --list-dataviews")
+        print("=" * BANNER_WIDTH)
     else:
         print(ConsoleColors.error("VALIDATION FAILED - Check errors above"))
         print("=" * BANNER_WIDTH)

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -749,6 +749,10 @@ RECOVERABLE_VALIDATION_EXCEPTIONS: tuple[type[Exception], ...] = (Exception,)
 # Per-item stats collection must be fully resilient: one broken DV must never
 # abort the stats command. Intentionally broad.
 RECOVERABLE_STATS_ROW_EXCEPTIONS: tuple[type[Exception], ...] = (Exception,)
+# Optional component-count lookups (dry-run projections, describe metadata) are
+# best-effort. Any Exception should degrade to a fallback count instead of
+# terminating the command flow.
+RECOVERABLE_OPTIONAL_COMPONENT_COUNT_EXCEPTIONS: tuple[type[Exception], ...] = (Exception,)
 
 
 def _log_optional_inventory_failure(
@@ -8903,11 +8907,48 @@ def _fetch_component_payload(cja: Any, data_view_id: str, fetch_spec: _Component
 
 def _count_component_items_for_fetch_spec(cja: Any, data_view_id: str, fetch_spec: _ComponentFetchSpec) -> int | str:
     """Return a component count for one fetch spec, falling back to 'N/A' on runtime failures."""
+    return _count_component_items_for_fetch_spec_best_effort(
+        cja,
+        data_view_id,
+        fetch_spec,
+        fallback_value="N/A",
+        use_retry=False,
+    )
+
+
+def _count_component_items_for_fetch_spec_best_effort(
+    cja: Any,
+    data_view_id: str,
+    fetch_spec: _ComponentFetchSpec,
+    *,
+    fallback_value: int | str,
+    use_retry: bool,
+    logger: logging.Logger | None = None,
+) -> int | str:
+    """Fetch one component payload and degrade failures to a caller-provided fallback value."""
+    component_label = fetch_spec.method_name
     try:
-        payload = _fetch_component_payload(cja, data_view_id, fetch_spec)
-        return _count_component_items_or_na_from_assessment(payload)
-    except Exception:  # Intentional: wraps cjapy API; best-effort count
-        return "N/A"
+        if use_retry:
+            payload = make_api_call_with_retry(
+                _fetch_component_payload,
+                cja,
+                data_view_id,
+                fetch_spec,
+                logger=logger,
+                operation_name=f"{component_label}({data_view_id})",
+            )
+        else:
+            payload = _fetch_component_payload(cja, data_view_id, fetch_spec)
+
+        count = _count_component_items_or_na_from_assessment(payload)
+        if isinstance(count, int):
+            return count
+        if logger:
+            logger.debug("Could not fetch %s count for %s: non-countable payload", component_label, data_view_id)
+    except RECOVERABLE_OPTIONAL_COMPONENT_COUNT_EXCEPTIONS as e:  # Intentional best-effort boundary
+        if logger:
+            logger.debug("Could not fetch %s count for %s: %s", component_label, data_view_id, e, exc_info=True)
+    return fallback_value
 
 
 def _count_component_items_for_fetch_spec_with_retry(
@@ -8918,25 +8959,15 @@ def _count_component_items_for_fetch_spec_with_retry(
     logger: logging.Logger,
 ) -> int:
     """Return component count via retry-aware fetches, degrading non-fatal issues to zero."""
-    component_label = fetch_spec.method_name
-    try:
-        payload = make_api_call_with_retry(
-            _fetch_component_payload,
-            cja,
-            data_view_id,
-            fetch_spec,
-            logger=logger,
-            operation_name=f"{component_label}({data_view_id})",
-        )
-        count = _count_component_items_or_na_from_assessment(payload)
-        if isinstance(count, int):
-            return count
-        logger.debug("Could not fetch %s count for %s: non-countable payload", component_label, data_view_id)
-    except RECOVERABLE_API_EXCEPTIONS as e:
-        logger.debug("Could not fetch %s count for %s: %s", component_label, data_view_id, e)
-    except (RuntimeError, AttributeError) as e:  # Residual non-API failures (e.g. cjapy internals)
-        logger.debug("Unexpected %s count error for %s: %s", component_label, data_view_id, e, exc_info=True)
-    return 0
+    count = _count_component_items_for_fetch_spec_best_effort(
+        cja,
+        data_view_id,
+        fetch_spec,
+        fallback_value=0,
+        use_retry=True,
+        logger=logger,
+    )
+    return count if isinstance(count, int) else 0
 
 
 def _build_component_list_fetcher(

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -19,7 +19,7 @@ import textwrap
 import threading
 import time
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from concurrent.futures.process import BrokenProcessPool
 from dataclasses import dataclass, field
@@ -512,6 +512,65 @@ def _exit_error(msg: str) -> NoReturn:
     """Print a coloured error message to stderr and exit with code 1."""
     print(ConsoleColors.error(f"ERROR: {msg}"), file=sys.stderr)
     sys.exit(1)
+
+
+def _normalize_output_format(raw_format: Any) -> str | None:
+    """Normalize CLI output format values defensively."""
+    if raw_format is None:
+        return None
+
+    normalized = str(raw_format).strip().lower()
+    return normalized or None
+
+
+def _resolve_command_output_format(
+    raw_format: Any,
+    *,
+    supported_formats: Mapping[str, str],
+    fallback_format: str,
+    warning_scope: str,
+    logger: logging.Logger | None = None,
+) -> str:
+    """Resolve requested output format to a supported command format.
+
+    Args:
+        raw_format: User-provided format token from CLI args.
+        supported_formats: Mapping of accepted aliases to canonical format names.
+        fallback_format: Canonical fallback format when input is missing/unsupported.
+        warning_scope: Human-readable command scope for warning messages.
+        logger: Optional logger for warning emissions.
+    """
+    normalized_format = _normalize_output_format(raw_format)
+    if normalized_format is None:
+        return fallback_format
+
+    resolved_format = supported_formats.get(normalized_format)
+    if resolved_format is not None:
+        return resolved_format
+
+    (logger or logging.getLogger(__name__)).warning(
+        "--format %s is not supported for %s; using %s",
+        raw_format,
+        warning_scope,
+        fallback_format,
+    )
+    return fallback_format
+
+
+def _print_error_list_to_stderr(header: str, details: list[Any], *, fallback_detail: str = "Unknown validation error") -> None:
+    """Emit an error header and detail lines to stderr using one consistent stream."""
+    print(ConsoleColors.error(header), file=sys.stderr)
+
+    emitted_detail = False
+    for detail in details:
+        detail_text = str(detail).strip()
+        if not detail_text:
+            continue
+        print(f"  - {detail_text}", file=sys.stderr)
+        emitted_detail = True
+
+    if not emitted_detail:
+        print(f"  - {fallback_detail}", file=sys.stderr)
 
 
 def _cli_option_specified(option_name: str, argv: list[str] | None = None) -> bool:
@@ -1889,9 +1948,7 @@ def import_profile_non_interactive(profile_name: str, source_file: str | Path, o
         source=f"profile import ({source_file})",
     )
     if not is_usable:
-        print(ConsoleColors.error("Error: Imported credentials failed validation:"), file=sys.stderr)
-        for issue in issues:
-            print(f"  - {issue}")
+        _print_error_list_to_stderr("Error: Imported credentials failed validation:", issues)
         return False
 
     config_payload = {
@@ -7968,13 +8025,14 @@ def _is_machine_readable_output(output_format: str | None, output_file: str | No
 
 def _resolve_discovery_output_format(raw_format: str | None, *, output_to_stdout: bool) -> str:
     """Normalize discovery output format with stdout piping semantics."""
-    if raw_format in ("json", "csv"):
-        return raw_format
     if output_to_stdout:
         return "json"
-    if raw_format is not None and raw_format not in ("console", "table"):
-        logging.getLogger(__name__).warning("--format %s is not supported for this command; using table", raw_format)
-    return "table"
+    return _resolve_command_output_format(
+        raw_format,
+        supported_formats={"json": "json", "csv": "csv", "console": "table", "table": "table"},
+        fallback_format="table",
+        warning_scope="this command",
+    )
 
 
 def _emit_discovery_error(
@@ -14419,11 +14477,12 @@ def _main_impl(run_state: dict[str, Any] | None = None):
 
     # Handle --profile-list mode (no data view required)
     if getattr(args, "profile_list", False):
-        if args.format not in (None, "json", "console", "table", "excel"):
-            logging.getLogger(__name__).warning(
-                "--format %s is not supported for --profile-list; using table", args.format
-            )
-        list_format = "json" if args.format == "json" else "table"
+        list_format = _resolve_command_output_format(
+            args.format,
+            supported_formats={"json": "json", "console": "table", "table": "table"},
+            fallback_format="table",
+            warning_scope="--profile-list",
+        )
         success = list_profiles(output_format=list_format)
         if run_state is not None:
             run_state["details"] = {"operation_success": success}

--- a/tests/README.md
+++ b/tests/README.md
@@ -94,7 +94,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 5,247 comprehensive tests**
+**Total: 5,252 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -116,7 +116,7 @@ tests/
 | `test_cja_initialization.py` | 46 | CJA connection and configuration validation |
 | `test_utils.py` | 50 | Utility functions and helpers |
 | `test_excel_formatting.py` | 25 | Excel sheet formatting and styling |
-| `test_parallel_api_fetcher.py` | 28 | Parallel API data fetching |
+| `test_parallel_api_fetcher.py` | 29 | Parallel API data fetching |
 | `test_api_tuning.py` | 23 | API worker auto-tuning |
 | `test_error_messages.py` | 23 | Enhanced error messages and guidance |
 | `test_circuit_breaker.py` | 22 | Circuit breaker pattern |
@@ -135,7 +135,7 @@ tests/
 | `test_parallel_validation.py` | 9 | Parallel validation operations |
 | `test_discovery_formatters.py` | 32 | Shared discovery formatters, WorkerArgs dataclass, _exit_error, BANNER_WIDTH |
 | `test_discovery_normalization.py` | 17 | Discovery normalization helpers (missing values, owner extraction, tags) |
-| `test_discovery_payloads.py` | 45 | Discovery payload classification (error detection, component extraction) |
+| `test_discovery_payloads.py` | 49 | Discovery payload classification (error detection, component extraction) |
 | `test_discovery_component_consistency.py` | 7 | Discovery component retrieval consistency |
 | `test_output_content_validation.py` | 26 | Output format content validation (CSV, JSON, HTML, Excel, Markdown roundtrip) |
 | `test_malformed_api_responses.py` | 20 | Negative tests for malformed/unexpected API responses |
@@ -187,7 +187,7 @@ tests/
 | `test_completion.py` | 43 | Shell completion flag (--completion bash/zsh/fish) |
 | `test_exception_narrowing.py` | 25 | Exception narrowing boundary tests |
 | `test_coverage_hardening.py` | 108 | Coverage hardening tests |
-| **Total** | **5,247** | **Collected via pytest --collect-only** |
+| **Total** | **5,252** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -591,7 +591,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (5,247 tests total)
+- [x] Comprehensive test coverage (5,252 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 76 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -89,10 +89,12 @@ tests/
 ├── test_parallel_validation.py      # Parallel validation operations
 ├── test_cli_smoke_modes.py          # CLI smoke tests for core command modes
 ├── test_generator_mock_contract.py  # Generator mock symbol contract tests
+├── test_exception_narrowing.py     # Exception narrowing boundary tests
+├── test_coverage_hardening.py      # Coverage hardening tests
 └── README.md                        # This file
 ```
 
-**Total: 5,077 comprehensive tests**
+**Total: 5,196 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -183,7 +185,9 @@ tests/
 | `test_cli_smoke_modes.py` | 10 | CLI smoke tests for core command modes |
 | `test_generator_mock_contract.py` | 2 | Generator mock symbol contract tests |
 | `test_completion.py` | 43 | Shell completion flag (--completion bash/zsh/fish) |
-| **Total** | **5,077** | **Collected via pytest --collect-only** |
+| `test_exception_narrowing.py` | 17 | Exception narrowing boundary tests |
+| `test_coverage_hardening.py` | 101 | Coverage hardening tests |
+| **Total** | **5,196** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -587,7 +591,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (5,077 tests total)
+- [x] Comprehensive test coverage (5,196 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 76 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -94,7 +94,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 5,263 comprehensive tests**
+**Total: 5,265 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -129,7 +129,7 @@ tests/
 | `test_shared_cache.py` | 20 | Shared validation cache |
 | `test_logging_optimization.py` | 17 | Logging performance optimizations |
 | `test_env_credentials.py` | 15 | Environment variable credentials |
-| `test_dry_run.py` | 12 | Dry-run mode functionality |
+| `test_dry_run.py` | 14 | Dry-run mode functionality |
 | `test_early_exit.py` | 11 | Early exit optimizations |
 | `test_data_quality.py` | 10 | Data quality validation logic |
 | `test_parallel_validation.py` | 9 | Parallel validation operations |
@@ -187,7 +187,7 @@ tests/
 | `test_completion.py` | 43 | Shell completion flag (--completion bash/zsh/fish) |
 | `test_exception_narrowing.py` | 25 | Exception narrowing boundary tests |
 | `test_coverage_hardening.py` | 108 | Coverage hardening tests |
-| **Total** | **5,263** | **Collected via pytest --collect-only** |
+| **Total** | **5,265** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -591,7 +591,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (5,263 tests total)
+- [x] Comprehensive test coverage (5,265 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 76 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -94,7 +94,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 5,283 comprehensive tests**
+**Total: 5,287 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -122,11 +122,11 @@ tests/
 | `test_circuit_breaker.py` | 22 | Circuit breaker pattern |
 | `test_retry.py` | 25 | Retry with exponential backoff |
 | `test_batch_processor.py` | 26 | Batch processing of multiple data views |
-| `test_validation_cache.py` | 22 | Validation result caching |
+| `test_validation_cache.py` | 24 | Validation result caching |
 | `test_process_single_dataview.py` | 27 | End-to-end single data view processing |
 | `test_optimized_validation.py` | 16 | Optimized data quality validation |
 | `test_name_resolution.py` | 24 | Data view name to ID resolution |
-| `test_shared_cache.py` | 20 | Shared validation cache |
+| `test_shared_cache.py` | 22 | Shared validation cache |
 | `test_logging_optimization.py` | 17 | Logging performance optimizations |
 | `test_env_credentials.py` | 15 | Environment variable credentials |
 | `test_dry_run.py` | 14 | Dry-run mode functionality |
@@ -187,7 +187,7 @@ tests/
 | `test_completion.py` | 43 | Shell completion flag (--completion bash/zsh/fish) |
 | `test_exception_narrowing.py` | 26 | Exception narrowing boundary tests |
 | `test_coverage_hardening.py` | 108 | Coverage hardening tests |
-| **Total** | **5,283** | **Collected via pytest --collect-only** |
+| **Total** | **5,287** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -591,13 +591,13 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (5,283 tests total)
+- [x] Comprehensive test coverage (5,287 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 76 tests
 - [x] API worker auto-tuning tests (test_api_tuning.py) - 23 tests
 - [x] Circuit breaker pattern tests (test_circuit_breaker.py) - 22 tests
-- [x] Shared validation cache tests (test_shared_cache.py) - 20 tests
+- [x] Shared validation cache tests (test_shared_cache.py) - 22 tests
 - [x] Calculated metrics inventory tests (test_calculated_metrics_inventory.py) - 285 tests
 - [x] Segments inventory tests (test_segments_inventory.py) - 48 tests
 - [x] Derived fields inventory tests (test_derived_inventory.py) - 62 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -123,7 +123,7 @@ tests/
 | `test_retry.py` | 25 | Retry with exponential backoff |
 | `test_batch_processor.py` | 26 | Batch processing of multiple data views |
 | `test_validation_cache.py` | 19 | Validation result caching |
-| `test_process_single_dataview.py` | 22 | End-to-end single data view processing |
+| `test_process_single_dataview.py` | 23 | End-to-end single data view processing |
 | `test_optimized_validation.py` | 16 | Optimized data quality validation |
 | `test_name_resolution.py` | 24 | Data view name to ID resolution |
 | `test_shared_cache.py` | 17 | Shared validation cache |

--- a/tests/README.md
+++ b/tests/README.md
@@ -94,7 +94,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 5,252 comprehensive tests**
+**Total: 5,255 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -104,7 +104,7 @@ tests/
 | `test_ux_features.py` | 123 | UX features: --open, --stats, --output, --list-dataviews formats, inventory validation, inventory summary, include-all-inventory |
 | `test_org_report.py` | 172 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
 | `test_org_report_integration.py` | 17 | Org-wide analysis integration tests: end-to-end flows, caching, filtering, governance |
-| `test_cli.py` | 401 | Command-line interface and argument parsing |
+| `test_cli.py` | 402 | Command-line interface and argument parsing |
 | `test_profiles.py` | 76 | Multi-organization profile support |
 | `test_derived_inventory.py` | 62 | Derived fields inventory feature |
 | `test_inventory_utils.py` | 47 | Inventory utilities and helpers |
@@ -116,7 +116,7 @@ tests/
 | `test_cja_initialization.py` | 46 | CJA connection and configuration validation |
 | `test_utils.py` | 50 | Utility functions and helpers |
 | `test_excel_formatting.py` | 25 | Excel sheet formatting and styling |
-| `test_parallel_api_fetcher.py` | 29 | Parallel API data fetching |
+| `test_parallel_api_fetcher.py` | 30 | Parallel API data fetching |
 | `test_api_tuning.py` | 23 | API worker auto-tuning |
 | `test_error_messages.py` | 23 | Enhanced error messages and guidance |
 | `test_circuit_breaker.py` | 22 | Circuit breaker pattern |
@@ -135,7 +135,7 @@ tests/
 | `test_parallel_validation.py` | 9 | Parallel validation operations |
 | `test_discovery_formatters.py` | 32 | Shared discovery formatters, WorkerArgs dataclass, _exit_error, BANNER_WIDTH |
 | `test_discovery_normalization.py` | 17 | Discovery normalization helpers (missing values, owner extraction, tags) |
-| `test_discovery_payloads.py` | 49 | Discovery payload classification (error detection, component extraction) |
+| `test_discovery_payloads.py` | 50 | Discovery payload classification (error detection, component extraction) |
 | `test_discovery_component_consistency.py` | 7 | Discovery component retrieval consistency |
 | `test_output_content_validation.py` | 26 | Output format content validation (CSV, JSON, HTML, Excel, Markdown roundtrip) |
 | `test_malformed_api_responses.py` | 20 | Negative tests for malformed/unexpected API responses |
@@ -187,7 +187,7 @@ tests/
 | `test_completion.py` | 43 | Shell completion flag (--completion bash/zsh/fish) |
 | `test_exception_narrowing.py` | 25 | Exception narrowing boundary tests |
 | `test_coverage_hardening.py` | 108 | Coverage hardening tests |
-| **Total** | **5,252** | **Collected via pytest --collect-only** |
+| **Total** | **5,255** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -591,7 +591,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (5,252 tests total)
+- [x] Comprehensive test coverage (5,255 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 76 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -94,7 +94,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 5,224 comprehensive tests**
+**Total: 5,227 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -135,7 +135,7 @@ tests/
 | `test_parallel_validation.py` | 9 | Parallel validation operations |
 | `test_discovery_formatters.py` | 32 | Shared discovery formatters, WorkerArgs dataclass, _exit_error, BANNER_WIDTH |
 | `test_discovery_normalization.py` | 17 | Discovery normalization helpers (missing values, owner extraction, tags) |
-| `test_discovery_payloads.py` | 36 | Discovery payload classification (error detection, component extraction) |
+| `test_discovery_payloads.py` | 39 | Discovery payload classification (error detection, component extraction) |
 | `test_discovery_component_consistency.py` | 7 | Discovery component retrieval consistency |
 | `test_output_content_validation.py` | 26 | Output format content validation (CSV, JSON, HTML, Excel, Markdown roundtrip) |
 | `test_malformed_api_responses.py` | 20 | Negative tests for malformed/unexpected API responses |
@@ -187,7 +187,7 @@ tests/
 | `test_completion.py` | 43 | Shell completion flag (--completion bash/zsh/fish) |
 | `test_exception_narrowing.py` | 17 | Exception narrowing boundary tests |
 | `test_coverage_hardening.py` | 108 | Coverage hardening tests |
-| **Total** | **5,224** | **Collected via pytest --collect-only** |
+| **Total** | **5,227** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -591,7 +591,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (5,224 tests total)
+- [x] Comprehensive test coverage (5,227 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 76 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -94,7 +94,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 5,209 comprehensive tests**
+**Total: 5,214 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -122,11 +122,11 @@ tests/
 | `test_circuit_breaker.py` | 22 | Circuit breaker pattern |
 | `test_retry.py` | 25 | Retry with exponential backoff |
 | `test_batch_processor.py` | 26 | Batch processing of multiple data views |
-| `test_validation_cache.py` | 19 | Validation result caching |
+| `test_validation_cache.py` | 21 | Validation result caching |
 | `test_process_single_dataview.py` | 26 | End-to-end single data view processing |
 | `test_optimized_validation.py` | 16 | Optimized data quality validation |
 | `test_name_resolution.py` | 24 | Data view name to ID resolution |
-| `test_shared_cache.py` | 17 | Shared validation cache |
+| `test_shared_cache.py` | 20 | Shared validation cache |
 | `test_logging_optimization.py` | 17 | Logging performance optimizations |
 | `test_env_credentials.py` | 15 | Environment variable credentials |
 | `test_dry_run.py` | 12 | Dry-run mode functionality |
@@ -187,7 +187,7 @@ tests/
 | `test_completion.py` | 43 | Shell completion flag (--completion bash/zsh/fish) |
 | `test_exception_narrowing.py` | 17 | Exception narrowing boundary tests |
 | `test_coverage_hardening.py` | 101 | Coverage hardening tests |
-| **Total** | **5,209** | **Collected via pytest --collect-only** |
+| **Total** | **5,214** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -591,13 +591,13 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (5,209 tests total)
+- [x] Comprehensive test coverage (5,214 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 76 tests
 - [x] API worker auto-tuning tests (test_api_tuning.py) - 23 tests
 - [x] Circuit breaker pattern tests (test_circuit_breaker.py) - 22 tests
-- [x] Shared validation cache tests (test_shared_cache.py) - 17 tests
+- [x] Shared validation cache tests (test_shared_cache.py) - 20 tests
 - [x] Calculated metrics inventory tests (test_calculated_metrics_inventory.py) - 285 tests
 - [x] Segments inventory tests (test_segments_inventory.py) - 48 tests
 - [x] Derived fields inventory tests (test_derived_inventory.py) - 62 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -94,7 +94,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 5,238 comprehensive tests**
+**Total: 5,243 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -185,9 +185,9 @@ tests/
 | `test_cli_smoke_modes.py` | 10 | CLI smoke tests for core command modes |
 | `test_generator_mock_contract.py` | 2 | Generator mock symbol contract tests |
 | `test_completion.py` | 43 | Shell completion flag (--completion bash/zsh/fish) |
-| `test_exception_narrowing.py` | 17 | Exception narrowing boundary tests |
+| `test_exception_narrowing.py` | 22 | Exception narrowing boundary tests |
 | `test_coverage_hardening.py` | 108 | Coverage hardening tests |
-| **Total** | **5,238** | **Collected via pytest --collect-only** |
+| **Total** | **5,243** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -591,7 +591,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (5,238 tests total)
+- [x] Comprehensive test coverage (5,243 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 76 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -94,7 +94,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 5,214 comprehensive tests**
+**Total: 5,218 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -139,7 +139,7 @@ tests/
 | `test_discovery_component_consistency.py` | 7 | Discovery component retrieval consistency |
 | `test_output_content_validation.py` | 26 | Output format content validation (CSV, JSON, HTML, Excel, Markdown roundtrip) |
 | `test_malformed_api_responses.py` | 20 | Negative tests for malformed/unexpected API responses |
-| `test_main_entry_points.py` | 20 | main() and _main_impl() entry points, dispatch, run_state, run summary |
+| `test_main_entry_points.py` | 21 | main() and _main_impl() entry points, dispatch, run_state, run summary |
 | `test_quality_policy_and_run_summary.py` | 67 | Quality policy functions and run summary/status inference |
 | `test_e2e_integration.py` | 16 | End-to-end integration tests with real pipeline, mocked API boundary |
 | `test_api_client.py` | 25 | API client exception paths and error handling |
@@ -163,7 +163,7 @@ tests/
 | `test_small_module_coverage.py` | 113 | Logging, utils, calculated metrics, constants, lazy, tuning, locks, org cache |
 | `test_diff_inventory_output.py` | 88 | Inventory diff output across all formats (console, JSON, HTML, Excel, MD, CSV) |
 | `test_cli_command_handlers.py` | 131 | CLI dispatch for --stats, --org-report, --list-snapshots, discovery inspection, diff config unpacking |
-| `test_profile_management.py` | 45 | Interactive profile creation, import, test, show |
+| `test_profile_management.py` | 46 | Interactive profile creation, import, test, show |
 | `test_snapshot_commands.py` | 58 | Snapshot creation, comparison, name resolution |
 | `test_config_and_resolution.py` | 105 | Config status, validation, stats, name resolution |
 | `test_derived_fields_edge_cases.py` | 34 | Derived fields edge cases and coverage |
@@ -186,8 +186,8 @@ tests/
 | `test_generator_mock_contract.py` | 2 | Generator mock symbol contract tests |
 | `test_completion.py` | 43 | Shell completion flag (--completion bash/zsh/fish) |
 | `test_exception_narrowing.py` | 17 | Exception narrowing boundary tests |
-| `test_coverage_hardening.py` | 101 | Coverage hardening tests |
-| **Total** | **5,214** | **Collected via pytest --collect-only** |
+| `test_coverage_hardening.py` | 103 | Coverage hardening tests |
+| **Total** | **5,218** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -591,7 +591,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (5,214 tests total)
+- [x] Comprehensive test coverage (5,218 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 76 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -94,7 +94,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 5,267 comprehensive tests**
+**Total: 5,273 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -116,7 +116,7 @@ tests/
 | `test_cja_initialization.py` | 46 | CJA connection and configuration validation |
 | `test_utils.py` | 50 | Utility functions and helpers |
 | `test_excel_formatting.py` | 25 | Excel sheet formatting and styling |
-| `test_parallel_api_fetcher.py` | 32 | Parallel API data fetching |
+| `test_parallel_api_fetcher.py` | 34 | Parallel API data fetching |
 | `test_api_tuning.py` | 23 | API worker auto-tuning |
 | `test_error_messages.py` | 23 | Enhanced error messages and guidance |
 | `test_circuit_breaker.py` | 22 | Circuit breaker pattern |
@@ -135,7 +135,7 @@ tests/
 | `test_parallel_validation.py` | 9 | Parallel validation operations |
 | `test_discovery_formatters.py` | 32 | Shared discovery formatters, WorkerArgs dataclass, _exit_error, BANNER_WIDTH |
 | `test_discovery_normalization.py` | 17 | Discovery normalization helpers (missing values, owner extraction, tags) |
-| `test_discovery_payloads.py` | 56 | Discovery payload classification (error detection, component extraction) |
+| `test_discovery_payloads.py` | 60 | Discovery payload classification (error detection, component extraction) |
 | `test_discovery_component_consistency.py` | 7 | Discovery component retrieval consistency |
 | `test_output_content_validation.py` | 26 | Output format content validation (CSV, JSON, HTML, Excel, Markdown roundtrip) |
 | `test_malformed_api_responses.py` | 20 | Negative tests for malformed/unexpected API responses |
@@ -187,7 +187,7 @@ tests/
 | `test_completion.py` | 43 | Shell completion flag (--completion bash/zsh/fish) |
 | `test_exception_narrowing.py` | 25 | Exception narrowing boundary tests |
 | `test_coverage_hardening.py` | 108 | Coverage hardening tests |
-| **Total** | **5,267** | **Collected via pytest --collect-only** |
+| **Total** | **5,273** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -591,7 +591,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (5,267 tests total)
+- [x] Comprehensive test coverage (5,273 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 76 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -94,7 +94,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 5,273 comprehensive tests**
+**Total: 5,283 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -104,7 +104,7 @@ tests/
 | `test_ux_features.py` | 123 | UX features: --open, --stats, --output, --list-dataviews formats, inventory validation, inventory summary, include-all-inventory |
 | `test_org_report.py` | 172 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
 | `test_org_report_integration.py` | 17 | Org-wide analysis integration tests: end-to-end flows, caching, filtering, governance |
-| `test_cli.py` | 404 | Command-line interface and argument parsing |
+| `test_cli.py` | 408 | Command-line interface and argument parsing |
 | `test_profiles.py` | 76 | Multi-organization profile support |
 | `test_derived_inventory.py` | 62 | Derived fields inventory feature |
 | `test_inventory_utils.py` | 47 | Inventory utilities and helpers |
@@ -185,9 +185,9 @@ tests/
 | `test_cli_smoke_modes.py` | 10 | CLI smoke tests for core command modes |
 | `test_generator_mock_contract.py` | 2 | Generator mock symbol contract tests |
 | `test_completion.py` | 43 | Shell completion flag (--completion bash/zsh/fish) |
-| `test_exception_narrowing.py` | 25 | Exception narrowing boundary tests |
+| `test_exception_narrowing.py` | 26 | Exception narrowing boundary tests |
 | `test_coverage_hardening.py` | 108 | Coverage hardening tests |
-| **Total** | **5,273** | **Collected via pytest --collect-only** |
+| **Total** | **5,283** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -591,7 +591,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (5,273 tests total)
+- [x] Comprehensive test coverage (5,283 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 76 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -94,7 +94,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 5,196 comprehensive tests**
+**Total: 5,209 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -116,14 +116,14 @@ tests/
 | `test_cja_initialization.py` | 46 | CJA connection and configuration validation |
 | `test_utils.py` | 50 | Utility functions and helpers |
 | `test_excel_formatting.py` | 25 | Excel sheet formatting and styling |
-| `test_parallel_api_fetcher.py` | 25 | Parallel API data fetching |
+| `test_parallel_api_fetcher.py` | 27 | Parallel API data fetching |
 | `test_api_tuning.py` | 23 | API worker auto-tuning |
 | `test_error_messages.py` | 23 | Enhanced error messages and guidance |
 | `test_circuit_breaker.py` | 22 | Circuit breaker pattern |
 | `test_retry.py` | 25 | Retry with exponential backoff |
 | `test_batch_processor.py` | 26 | Batch processing of multiple data views |
 | `test_validation_cache.py` | 19 | Validation result caching |
-| `test_process_single_dataview.py` | 23 | End-to-end single data view processing |
+| `test_process_single_dataview.py` | 26 | End-to-end single data view processing |
 | `test_optimized_validation.py` | 16 | Optimized data quality validation |
 | `test_name_resolution.py` | 24 | Data view name to ID resolution |
 | `test_shared_cache.py` | 17 | Shared validation cache |
@@ -135,10 +135,10 @@ tests/
 | `test_parallel_validation.py` | 9 | Parallel validation operations |
 | `test_discovery_formatters.py` | 32 | Shared discovery formatters, WorkerArgs dataclass, _exit_error, BANNER_WIDTH |
 | `test_discovery_normalization.py` | 17 | Discovery normalization helpers (missing values, owner extraction, tags) |
-| `test_discovery_payloads.py` | 29 | Discovery payload classification (error detection, component extraction) |
+| `test_discovery_payloads.py` | 36 | Discovery payload classification (error detection, component extraction) |
 | `test_discovery_component_consistency.py` | 7 | Discovery component retrieval consistency |
 | `test_output_content_validation.py` | 26 | Output format content validation (CSV, JSON, HTML, Excel, Markdown roundtrip) |
-| `test_malformed_api_responses.py` | 19 | Negative tests for malformed/unexpected API responses |
+| `test_malformed_api_responses.py` | 20 | Negative tests for malformed/unexpected API responses |
 | `test_main_entry_points.py` | 20 | main() and _main_impl() entry points, dispatch, run_state, run summary |
 | `test_quality_policy_and_run_summary.py` | 67 | Quality policy functions and run summary/status inference |
 | `test_e2e_integration.py` | 16 | End-to-end integration tests with real pipeline, mocked API boundary |
@@ -187,7 +187,7 @@ tests/
 | `test_completion.py` | 43 | Shell completion flag (--completion bash/zsh/fish) |
 | `test_exception_narrowing.py` | 17 | Exception narrowing boundary tests |
 | `test_coverage_hardening.py` | 101 | Coverage hardening tests |
-| **Total** | **5,196** | **Collected via pytest --collect-only** |
+| **Total** | **5,209** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -591,7 +591,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (5,196 tests total)
+- [x] Comprehensive test coverage (5,209 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 76 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -94,7 +94,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 5,265 comprehensive tests**
+**Total: 5,267 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -135,7 +135,7 @@ tests/
 | `test_parallel_validation.py` | 9 | Parallel validation operations |
 | `test_discovery_formatters.py` | 32 | Shared discovery formatters, WorkerArgs dataclass, _exit_error, BANNER_WIDTH |
 | `test_discovery_normalization.py` | 17 | Discovery normalization helpers (missing values, owner extraction, tags) |
-| `test_discovery_payloads.py` | 54 | Discovery payload classification (error detection, component extraction) |
+| `test_discovery_payloads.py` | 56 | Discovery payload classification (error detection, component extraction) |
 | `test_discovery_component_consistency.py` | 7 | Discovery component retrieval consistency |
 | `test_output_content_validation.py` | 26 | Output format content validation (CSV, JSON, HTML, Excel, Markdown roundtrip) |
 | `test_malformed_api_responses.py` | 20 | Negative tests for malformed/unexpected API responses |
@@ -187,7 +187,7 @@ tests/
 | `test_completion.py` | 43 | Shell completion flag (--completion bash/zsh/fish) |
 | `test_exception_narrowing.py` | 25 | Exception narrowing boundary tests |
 | `test_coverage_hardening.py` | 108 | Coverage hardening tests |
-| **Total** | **5,265** | **Collected via pytest --collect-only** |
+| **Total** | **5,267** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -591,7 +591,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (5,265 tests total)
+- [x] Comprehensive test coverage (5,267 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 76 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -94,7 +94,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 5,218 comprehensive tests**
+**Total: 5,224 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -162,7 +162,7 @@ tests/
 | `test_segments_coverage.py` | 78 | Segment comparison operators, container types, sequence variants |
 | `test_small_module_coverage.py` | 113 | Logging, utils, calculated metrics, constants, lazy, tuning, locks, org cache |
 | `test_diff_inventory_output.py` | 88 | Inventory diff output across all formats (console, JSON, HTML, Excel, MD, CSV) |
-| `test_cli_command_handlers.py` | 131 | CLI dispatch for --stats, --org-report, --list-snapshots, discovery inspection, diff config unpacking |
+| `test_cli_command_handlers.py` | 132 | CLI dispatch for --stats, --org-report, --list-snapshots, discovery inspection, diff config unpacking |
 | `test_profile_management.py` | 46 | Interactive profile creation, import, test, show |
 | `test_snapshot_commands.py` | 58 | Snapshot creation, comparison, name resolution |
 | `test_config_and_resolution.py` | 105 | Config status, validation, stats, name resolution |
@@ -186,8 +186,8 @@ tests/
 | `test_generator_mock_contract.py` | 2 | Generator mock symbol contract tests |
 | `test_completion.py` | 43 | Shell completion flag (--completion bash/zsh/fish) |
 | `test_exception_narrowing.py` | 17 | Exception narrowing boundary tests |
-| `test_coverage_hardening.py` | 103 | Coverage hardening tests |
-| **Total** | **5,218** | **Collected via pytest --collect-only** |
+| `test_coverage_hardening.py` | 108 | Coverage hardening tests |
+| **Total** | **5,224** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -591,7 +591,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (5,218 tests total)
+- [x] Comprehensive test coverage (5,224 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 76 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -94,7 +94,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 5,227 comprehensive tests**
+**Total: 5,232 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -122,7 +122,7 @@ tests/
 | `test_circuit_breaker.py` | 22 | Circuit breaker pattern |
 | `test_retry.py` | 25 | Retry with exponential backoff |
 | `test_batch_processor.py` | 26 | Batch processing of multiple data views |
-| `test_validation_cache.py` | 21 | Validation result caching |
+| `test_validation_cache.py` | 22 | Validation result caching |
 | `test_process_single_dataview.py` | 26 | End-to-end single data view processing |
 | `test_optimized_validation.py` | 16 | Optimized data quality validation |
 | `test_name_resolution.py` | 24 | Data view name to ID resolution |
@@ -135,7 +135,7 @@ tests/
 | `test_parallel_validation.py` | 9 | Parallel validation operations |
 | `test_discovery_formatters.py` | 32 | Shared discovery formatters, WorkerArgs dataclass, _exit_error, BANNER_WIDTH |
 | `test_discovery_normalization.py` | 17 | Discovery normalization helpers (missing values, owner extraction, tags) |
-| `test_discovery_payloads.py` | 39 | Discovery payload classification (error detection, component extraction) |
+| `test_discovery_payloads.py` | 42 | Discovery payload classification (error detection, component extraction) |
 | `test_discovery_component_consistency.py` | 7 | Discovery component retrieval consistency |
 | `test_output_content_validation.py` | 26 | Output format content validation (CSV, JSON, HTML, Excel, Markdown roundtrip) |
 | `test_malformed_api_responses.py` | 20 | Negative tests for malformed/unexpected API responses |
@@ -173,7 +173,7 @@ tests/
 | `test_interactive_discovery_coverage.py` | 112 | Interactive discovery and helpers coverage |
 | `test_lock_backends.py` | 46 | Lock backends edge cases and coverage |
 | `test_main_impl_cli_coverage.py` | 89 | _main_impl CLI path coverage |
-| `test_main_impl_coverage.py` | 55 | _main_impl coverage edge cases |
+| `test_main_impl_coverage.py` | 56 | _main_impl coverage edge cases |
 | `test_near_100_coverage.py` | 4 | Near-100% coverage gap tests |
 | `test_org_cache_branches.py` | 15 | Org cache branch coverage |
 | `test_org_writer_coverage.py` | 89 | Org writer edge cases and coverage |
@@ -187,7 +187,7 @@ tests/
 | `test_completion.py` | 43 | Shell completion flag (--completion bash/zsh/fish) |
 | `test_exception_narrowing.py` | 17 | Exception narrowing boundary tests |
 | `test_coverage_hardening.py` | 108 | Coverage hardening tests |
-| **Total** | **5,227** | **Collected via pytest --collect-only** |
+| **Total** | **5,232** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -591,7 +591,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (5,227 tests total)
+- [x] Comprehensive test coverage (5,232 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 76 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -94,7 +94,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 5,255 comprehensive tests**
+**Total: 5,263 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -104,7 +104,7 @@ tests/
 | `test_ux_features.py` | 123 | UX features: --open, --stats, --output, --list-dataviews formats, inventory validation, inventory summary, include-all-inventory |
 | `test_org_report.py` | 172 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
 | `test_org_report_integration.py` | 17 | Org-wide analysis integration tests: end-to-end flows, caching, filtering, governance |
-| `test_cli.py` | 402 | Command-line interface and argument parsing |
+| `test_cli.py` | 404 | Command-line interface and argument parsing |
 | `test_profiles.py` | 76 | Multi-organization profile support |
 | `test_derived_inventory.py` | 62 | Derived fields inventory feature |
 | `test_inventory_utils.py` | 47 | Inventory utilities and helpers |
@@ -116,7 +116,7 @@ tests/
 | `test_cja_initialization.py` | 46 | CJA connection and configuration validation |
 | `test_utils.py` | 50 | Utility functions and helpers |
 | `test_excel_formatting.py` | 25 | Excel sheet formatting and styling |
-| `test_parallel_api_fetcher.py` | 30 | Parallel API data fetching |
+| `test_parallel_api_fetcher.py` | 32 | Parallel API data fetching |
 | `test_api_tuning.py` | 23 | API worker auto-tuning |
 | `test_error_messages.py` | 23 | Enhanced error messages and guidance |
 | `test_circuit_breaker.py` | 22 | Circuit breaker pattern |
@@ -135,7 +135,7 @@ tests/
 | `test_parallel_validation.py` | 9 | Parallel validation operations |
 | `test_discovery_formatters.py` | 32 | Shared discovery formatters, WorkerArgs dataclass, _exit_error, BANNER_WIDTH |
 | `test_discovery_normalization.py` | 17 | Discovery normalization helpers (missing values, owner extraction, tags) |
-| `test_discovery_payloads.py` | 50 | Discovery payload classification (error detection, component extraction) |
+| `test_discovery_payloads.py` | 54 | Discovery payload classification (error detection, component extraction) |
 | `test_discovery_component_consistency.py` | 7 | Discovery component retrieval consistency |
 | `test_output_content_validation.py` | 26 | Output format content validation (CSV, JSON, HTML, Excel, Markdown roundtrip) |
 | `test_malformed_api_responses.py` | 20 | Negative tests for malformed/unexpected API responses |
@@ -187,7 +187,7 @@ tests/
 | `test_completion.py` | 43 | Shell completion flag (--completion bash/zsh/fish) |
 | `test_exception_narrowing.py` | 25 | Exception narrowing boundary tests |
 | `test_coverage_hardening.py` | 108 | Coverage hardening tests |
-| **Total** | **5,255** | **Collected via pytest --collect-only** |
+| **Total** | **5,263** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -591,7 +591,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (5,255 tests total)
+- [x] Comprehensive test coverage (5,263 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 76 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -94,7 +94,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 5,232 comprehensive tests**
+**Total: 5,238 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -104,7 +104,7 @@ tests/
 | `test_ux_features.py` | 123 | UX features: --open, --stats, --output, --list-dataviews formats, inventory validation, inventory summary, include-all-inventory |
 | `test_org_report.py` | 172 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
 | `test_org_report_integration.py` | 17 | Org-wide analysis integration tests: end-to-end flows, caching, filtering, governance |
-| `test_cli.py` | 400 | Command-line interface and argument parsing |
+| `test_cli.py` | 401 | Command-line interface and argument parsing |
 | `test_profiles.py` | 76 | Multi-organization profile support |
 | `test_derived_inventory.py` | 62 | Derived fields inventory feature |
 | `test_inventory_utils.py` | 47 | Inventory utilities and helpers |
@@ -116,14 +116,14 @@ tests/
 | `test_cja_initialization.py` | 46 | CJA connection and configuration validation |
 | `test_utils.py` | 50 | Utility functions and helpers |
 | `test_excel_formatting.py` | 25 | Excel sheet formatting and styling |
-| `test_parallel_api_fetcher.py` | 27 | Parallel API data fetching |
+| `test_parallel_api_fetcher.py` | 28 | Parallel API data fetching |
 | `test_api_tuning.py` | 23 | API worker auto-tuning |
 | `test_error_messages.py` | 23 | Enhanced error messages and guidance |
 | `test_circuit_breaker.py` | 22 | Circuit breaker pattern |
 | `test_retry.py` | 25 | Retry with exponential backoff |
 | `test_batch_processor.py` | 26 | Batch processing of multiple data views |
 | `test_validation_cache.py` | 22 | Validation result caching |
-| `test_process_single_dataview.py` | 26 | End-to-end single data view processing |
+| `test_process_single_dataview.py` | 27 | End-to-end single data view processing |
 | `test_optimized_validation.py` | 16 | Optimized data quality validation |
 | `test_name_resolution.py` | 24 | Data view name to ID resolution |
 | `test_shared_cache.py` | 20 | Shared validation cache |
@@ -135,7 +135,7 @@ tests/
 | `test_parallel_validation.py` | 9 | Parallel validation operations |
 | `test_discovery_formatters.py` | 32 | Shared discovery formatters, WorkerArgs dataclass, _exit_error, BANNER_WIDTH |
 | `test_discovery_normalization.py` | 17 | Discovery normalization helpers (missing values, owner extraction, tags) |
-| `test_discovery_payloads.py` | 42 | Discovery payload classification (error detection, component extraction) |
+| `test_discovery_payloads.py` | 45 | Discovery payload classification (error detection, component extraction) |
 | `test_discovery_component_consistency.py` | 7 | Discovery component retrieval consistency |
 | `test_output_content_validation.py` | 26 | Output format content validation (CSV, JSON, HTML, Excel, Markdown roundtrip) |
 | `test_malformed_api_responses.py` | 20 | Negative tests for malformed/unexpected API responses |
@@ -187,7 +187,7 @@ tests/
 | `test_completion.py` | 43 | Shell completion flag (--completion bash/zsh/fish) |
 | `test_exception_narrowing.py` | 17 | Exception narrowing boundary tests |
 | `test_coverage_hardening.py` | 108 | Coverage hardening tests |
-| **Total** | **5,232** | **Collected via pytest --collect-only** |
+| **Total** | **5,238** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -591,7 +591,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (5,232 tests total)
+- [x] Comprehensive test coverage (5,238 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 76 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -94,7 +94,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 5,243 comprehensive tests**
+**Total: 5,247 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -173,7 +173,7 @@ tests/
 | `test_interactive_discovery_coverage.py` | 112 | Interactive discovery and helpers coverage |
 | `test_lock_backends.py` | 46 | Lock backends edge cases and coverage |
 | `test_main_impl_cli_coverage.py` | 89 | _main_impl CLI path coverage |
-| `test_main_impl_coverage.py` | 56 | _main_impl coverage edge cases |
+| `test_main_impl_coverage.py` | 57 | _main_impl coverage edge cases |
 | `test_near_100_coverage.py` | 4 | Near-100% coverage gap tests |
 | `test_org_cache_branches.py` | 15 | Org cache branch coverage |
 | `test_org_writer_coverage.py` | 89 | Org writer edge cases and coverage |
@@ -185,9 +185,9 @@ tests/
 | `test_cli_smoke_modes.py` | 10 | CLI smoke tests for core command modes |
 | `test_generator_mock_contract.py` | 2 | Generator mock symbol contract tests |
 | `test_completion.py` | 43 | Shell completion flag (--completion bash/zsh/fish) |
-| `test_exception_narrowing.py` | 22 | Exception narrowing boundary tests |
+| `test_exception_narrowing.py` | 25 | Exception narrowing boundary tests |
 | `test_coverage_hardening.py` | 108 | Coverage hardening tests |
-| **Total** | **5,243** | **Collected via pytest --collect-only** |
+| **Total** | **5,247** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -591,7 +591,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (5,243 tests total)
+- [x] Comprehensive test coverage (5,247 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 172 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 76 tests

--- a/tests/test_cja_initialization.py
+++ b/tests/test_cja_initialization.py
@@ -500,10 +500,10 @@ class TestValidateDataView:
         assert result is False
         mock_logger.error.assert_called()
 
-    def test_fails_on_unexpected_runtime_exception(self, mock_logger):
-        """Unexpected runtime errors should return False (boolean contract), not propagate."""
+    def test_fails_on_unexpected_recoverable_exception(self, mock_logger):
+        """Recoverable API errors should return False (boolean contract), not propagate."""
         mock_cja = Mock()
-        mock_cja.getDataView.side_effect = RuntimeError("unexpected cjapy runtime failure")
+        mock_cja.getDataView.side_effect = ValueError("unexpected cjapy validation failure")
 
         result = validate_data_view(mock_cja, "dv_test_12345", mock_logger)
 

--- a/tests/test_cja_initialization.py
+++ b/tests/test_cja_initialization.py
@@ -539,7 +539,10 @@ class TestValidateDataView:
 
         assert result is False
         calls = [str(c) for c in mock_logger.error.call_args_list]
-        assert any("Malformed data view payload returned by API" in c for c in calls)
+        assert any(
+            "Malformed data view payload returned by API" in c or "Data view lookup returned invalid payload" in c
+            for c in calls
+        )
 
     @pytest.mark.parametrize(
         "description",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4820,6 +4820,33 @@ class TestDescribeDataview:
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")
     @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_describe_dataview_unknown_placeholder_with_error_diagnostic_treated_as_not_found(
+        self,
+        mock_profile,
+        mock_configure,
+        mock_cjapy,
+    ):
+        """Unknown lookup placeholders with diagnostics must fail as not_found."""
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataView.return_value = {"id": "dv_missing", "name": "Unknown", "error": "not found"}
+
+        import io
+        from contextlib import redirect_stderr, redirect_stdout
+
+        out = io.StringIO()
+        err = io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            result = describe_dataview("dv_missing", output_format="json")
+
+        assert result is False
+        payload = json.loads(err.getvalue())
+        assert payload["error_type"] == "not_found"
+        assert "dv_missing" in payload["error"]
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
     def test_describe_dataview_error_payload_treated_as_not_found(self, mock_profile, mock_configure, mock_cjapy):
         """API error-shaped payloads from getDataView should fail as not_found."""
         mock_configure.return_value = (True, "config", None)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4471,6 +4471,49 @@ class TestDescribeDataview:
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")
     @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_describe_dataview_json_mixed_case_lookup_payload_fields_are_canonicalized(
+        self,
+        mock_profile,
+        mock_configure,
+        mock_cjapy,
+    ):
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataView.return_value = {
+            "ID": "dv_1",
+            "Name": "Test View",
+            "Owner": {"NAME": "Jane"},
+            "Description": "A test view",
+            "ParentDataGroupID": "conn_1",
+            "CreatedDATE": "2025-01-01",
+            "MODIFIEDAT": "2025-06-01",
+        }
+        cja.getMetrics.return_value = [{"id": "m1"}]
+        cja.getDimensions.return_value = [{"id": "d1"}]
+        cja.getFilters.return_value = []
+        cja.getCalculatedMetrics.return_value = []
+
+        import io
+        from contextlib import redirect_stdout
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = describe_dataview("dv_1", output_format="json")
+
+        assert result is True
+        output = json.loads(f.getvalue())
+        dv = output["dataView"]
+        assert dv["id"] == "dv_1"
+        assert dv["name"] == "Test View"
+        assert dv["owner"] == "Jane"
+        assert dv["description"] == "A test view"
+        assert dv["connectionId"] == "conn_1"
+        assert dv["created"] == "2025-01-01"
+        assert dv["modified"] == "2025-06-01"
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
     def test_describe_dataview_json_counts_hidden_metrics_and_dimensions(
         self,
         mock_profile,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5241,6 +5241,51 @@ def test_list_inspection_commands_get_dataview_apierror_status_treated_as_not_fo
 @patch("cja_auto_sdr.generator.cjapy")
 @patch("cja_auto_sdr.generator.configure_cjapy")
 @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+def test_list_inspection_commands_get_dataview_non_api_wrapper_404_treated_as_not_found(
+    mock_profile,
+    mock_configure,
+    mock_cjapy,
+    command,
+    component_method,
+):
+    """Non-API wrappers with 403/404 metadata should still fail as not_found."""
+    mock_configure.return_value = (True, "config", None)
+    cja = mock_cjapy.CJA.return_value
+
+    class WrappedLookupFailure(RuntimeError):
+        pass
+
+    lookup_error = WrappedLookupFailure("wrapped cjapy failure")
+    lookup_error.response = {"error": {"statusCode": "404"}}  # type: ignore[attr-defined]
+    cja.getDataView.side_effect = lookup_error
+    getattr(cja, component_method).return_value = []
+
+    import io
+    from contextlib import redirect_stderr, redirect_stdout
+
+    out = io.StringIO()
+    err = io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        result = command("dv_hidden", output_format="json")
+
+    assert result is False
+    payload = json.loads(err.getvalue())
+    assert payload["error_type"] == "not_found"
+    assert getattr(cja, component_method).call_count == 0
+
+
+@pytest.mark.parametrize(
+    ("command", "component_method"),
+    [
+        (list_metrics, "getMetrics"),
+        (list_dimensions, "getDimensions"),
+        (list_segments, "getFilters"),
+        (list_calculated_metrics, "getCalculatedMetrics"),
+    ],
+)
+@patch("cja_auto_sdr.generator.cjapy")
+@patch("cja_auto_sdr.generator.configure_cjapy")
+@patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
 def test_list_inspection_commands_get_dataview_apierror_message_treated_as_not_found(
     mock_profile,
     mock_configure,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4890,6 +4890,68 @@ class TestDescribeDataview:
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")
     @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_describe_dataview_id_plus_error_only_payload_treated_as_not_found(
+        self,
+        mock_profile,
+        mock_configure,
+        mock_cjapy,
+    ):
+        """id+error-only lookup payloads must fail as not_found."""
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataView.return_value = {"id": "dv_missing", "error": "not found"}
+
+        import io
+        from contextlib import redirect_stderr, redirect_stdout
+
+        out = io.StringIO()
+        err = io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            result = describe_dataview("dv_missing", output_format="json")
+
+        assert result is False
+        payload = json.loads(err.getvalue())
+        assert payload["error_type"] == "not_found"
+        assert "dv_missing" in payload["error"]
+        cja.getMetrics.assert_not_called()
+        cja.getDimensions.assert_not_called()
+        cja.getFilters.assert_not_called()
+        cja.getCalculatedMetrics.assert_not_called()
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
+    def test_describe_dataview_id_only_payload_treated_as_not_found(
+        self,
+        mock_profile,
+        mock_configure,
+        mock_cjapy,
+    ):
+        """id-only lookup payloads must fail as not_found due missing metadata."""
+        mock_configure.return_value = (True, "config", None)
+        cja = mock_cjapy.CJA.return_value
+        cja.getDataView.return_value = {"id": "dv_missing"}
+
+        import io
+        from contextlib import redirect_stderr, redirect_stdout
+
+        out = io.StringIO()
+        err = io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            result = describe_dataview("dv_missing", output_format="json")
+
+        assert result is False
+        payload = json.loads(err.getvalue())
+        assert payload["error_type"] == "not_found"
+        assert "dv_missing" in payload["error"]
+        cja.getMetrics.assert_not_called()
+        cja.getDimensions.assert_not_called()
+        cja.getFilters.assert_not_called()
+        cja.getCalculatedMetrics.assert_not_called()
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    @patch("cja_auto_sdr.generator.resolve_active_profile", return_value=None)
     def test_describe_dataview_error_payload_treated_as_not_found(self, mock_profile, mock_configure, mock_cjapy):
         """API error-shaped payloads from getDataView should fail as not_found."""
         mock_configure.return_value = (True, "config", None)

--- a/tests/test_cli_command_handlers.py
+++ b/tests/test_cli_command_handlers.py
@@ -1278,18 +1278,41 @@ class TestMainImplDiscoveryFormatRouting:
     @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
     @patch("cja_auto_sdr.generator.list_dataviews")
     @patch("cja_auto_sdr.generator.configure_cjapy")
-    def test_discovery_csv_format_preserved(self, _mock_conf, mock_list_dv):
-        """Explicit csv format should be preserved for discovery commands."""
+    def test_discovery_stdout_preserves_explicit_csv(self, _mock_conf, mock_list_dv):
+        """Explicit csv format should be preserved for stdout discovery commands."""
         mock_list_dv.return_value = True
         run_state = {"mode": "unknown", "details": {}}
 
         with pytest.raises(SystemExit) as exc_info:
             with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
-                mock_pa.return_value = parse_arguments(["--list-dataviews", "--format", "csv"])
+                mock_pa.return_value = parse_arguments(["--list-dataviews", "--format", "csv", "--output", "-"])
                 _main_impl(run_state=run_state)
 
         assert exc_info.value.code == 0
         assert run_state["output_format"] == "csv"
+        assert mock_list_dv.call_args.kwargs["output_format"] == "csv"
+        assert mock_list_dv.call_args.kwargs["output_file"] == "-"
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.list_dataviews")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_discovery_stdout_unsupported_format_warns_and_defaults_to_json(
+        self, _mock_conf, mock_list_dv, caplog: pytest.LogCaptureFixture
+    ):
+        """Unsupported stdout format should warn and fall back to json."""
+        mock_list_dv.return_value = True
+        run_state = {"mode": "unknown", "details": {}}
+
+        with caplog.at_level(logging.WARNING, logger="cja_auto_sdr.generator"):
+            with pytest.raises(SystemExit) as exc_info:
+                with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                    mock_pa.return_value = parse_arguments(["--list-dataviews", "--format", "excel", "--output", "-"])
+                    _main_impl(run_state=run_state)
+
+        assert exc_info.value.code == 0
+        assert run_state["output_format"] == "json"
+        assert mock_list_dv.call_args.kwargs["output_format"] == "json"
+        assert "using json" in caplog.text
 
 
 # ==================== _main_impl: --config-status / --validate-config ====================

--- a/tests/test_cli_command_handlers.py
+++ b/tests/test_cli_command_handlers.py
@@ -136,12 +136,12 @@ class TestProcessInventorySummary:
     @patch("cja_auto_sdr.generator.with_log_context")
     @patch("cja_auto_sdr.generator.setup_logging")
     def test_data_view_fetch_unexpected_exception_returns_error(self, mock_setup, mock_ctx, mock_init, mock_display):
-        """Plain Exception during data view fetch should return error dict, not traceback."""
+        """RuntimeError during data view fetch should return error dict, not traceback."""
         mock_setup.return_value = logging.getLogger("test")
         mock_ctx.return_value = logging.getLogger("test")
 
         mock_cja = MagicMock()
-        mock_cja.dataviews.get_single.side_effect = Exception("unexpected client crash")
+        mock_cja.dataviews.get_single.side_effect = RuntimeError("unexpected client crash")
         mock_init.return_value = mock_cja
 
         result = process_inventory_summary("dv_bad_id", config_file="config.json")

--- a/tests/test_config_and_resolution.py
+++ b/tests/test_config_and_resolution.py
@@ -271,7 +271,7 @@ class TestValidateConfigOnly:
     def test_api_connection_unexpected_exception(
         self, mock_cjapy, tmp_path: Path, capsys: pytest.CaptureFixture
     ) -> None:
-        """Plain Exception from cjapy.CJA()/getDataViews() should return False, not traceback."""
+        """RuntimeError from cjapy.CJA()/getDataViews() should return False, not traceback."""
         from cja_auto_sdr.generator import validate_config_only
 
         config = tmp_path / "config.json"
@@ -279,7 +279,7 @@ class TestValidateConfigOnly:
             json.dumps({"org_id": "org@Adobe", "client_id": "abcd1234efgh", "secret": "secret12345678"}),
         )
         mock_cja = MagicMock()
-        mock_cja.getDataViews.side_effect = Exception("unexpected auth bootstrap failure")
+        mock_cja.getDataViews.side_effect = RuntimeError("unexpected auth bootstrap failure")
         mock_cjapy.CJA.return_value = mock_cja
         with patch("cja_auto_sdr.generator.load_credentials_from_env", return_value=None):
             result = validate_config_only(config_file=str(config))

--- a/tests/test_coverage_hardening.py
+++ b/tests/test_coverage_hardening.py
@@ -574,6 +574,18 @@ class TestResolveDiscoveryOutputFormat:
         result = _resolve_discovery_output_format("excel", output_to_stdout=False)
         assert result == "table"
 
+    def test_console_alias_maps_to_table(self) -> None:
+        """Console alias should normalize to table for discovery commands."""
+        from cja_auto_sdr.generator import _resolve_discovery_output_format
+
+        assert _resolve_discovery_output_format("console", output_to_stdout=False) == "table"
+
+    def test_format_tokens_are_normalized_defensively(self) -> None:
+        """Mixed-case and surrounding whitespace should still resolve correctly."""
+        from cja_auto_sdr.generator import _resolve_discovery_output_format
+
+        assert _resolve_discovery_output_format(" JSON ", output_to_stdout=False) == "json"
+
 
 # ---------------------------------------------------------------------------
 # Tier 2a — _approved_display and _tags_display (lines 9117-9128)

--- a/tests/test_coverage_hardening.py
+++ b/tests/test_coverage_hardening.py
@@ -1,0 +1,907 @@
+"""Coverage hardening tests targeting missed statements across generator.py, __main__.py, and helpers.
+
+These tests focus on high-value gaps with real user-facing code paths.
+Part of the v3.3.5 hardening release.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+# ---------------------------------------------------------------------------
+# Tier 1a — Output-dir access failure branches (generator.py ~lines 10486-10502)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckOutputDirAccess:
+    """Test _check_output_dir_access for not_directory, parent_not_directory, parent_not_writable."""
+
+    def test_output_dir_not_directory(self, tmp_path: Path) -> None:
+        """--output-dir pointing to a file triggers 'not_directory' reason."""
+        from cja_auto_sdr.generator import _check_output_dir_access
+
+        fake_file = tmp_path / "not_a_dir.txt"
+        fake_file.write_text("x")
+
+        ok, _resolved, reason, parent = _check_output_dir_access(str(fake_file))
+        assert not ok
+        assert reason == "not_directory"
+        assert parent is None
+
+    def test_output_dir_parent_not_directory(self, tmp_path: Path) -> None:
+        """--output-dir whose parent is a file triggers 'parent_not_directory' reason."""
+        from cja_auto_sdr.generator import _check_output_dir_access
+
+        fake_file = tmp_path / "file.txt"
+        fake_file.write_text("x")
+        # The target is fake_file/child — parent (fake_file) is not a dir
+        ok, _resolved, reason, parent = _check_output_dir_access(str(fake_file / "child"))
+        assert not ok
+        assert reason == "parent_not_directory"
+        assert parent is not None
+
+    @pytest.mark.skipif(os.getuid() == 0, reason="root bypasses permission checks")
+    def test_output_dir_parent_not_writable(self, tmp_path: Path) -> None:
+        """--output-dir under read-only parent triggers 'parent_not_writable' reason."""
+        from cja_auto_sdr.generator import _check_output_dir_access
+
+        readonly = tmp_path / "readonly"
+        readonly.mkdir()
+        readonly.chmod(0o444)
+        try:
+            ok, _resolved, reason, parent = _check_output_dir_access(str(readonly / "newdir"))
+            assert not ok
+            assert reason == "parent_not_writable"
+            assert parent is not None
+        finally:
+            readonly.chmod(0o755)
+
+    def test_output_dir_not_writable(self, tmp_path: Path) -> None:
+        """Existing dir without write permission triggers 'not_writable' reason."""
+        from cja_auto_sdr.generator import _check_output_dir_access
+
+        if os.getuid() == 0:
+            pytest.skip("root bypasses permission checks")
+
+        readonly_dir = tmp_path / "noperm"
+        readonly_dir.mkdir()
+        readonly_dir.chmod(0o444)
+        try:
+            ok, _resolved, reason, _parent = _check_output_dir_access(str(readonly_dir))
+            assert not ok
+            assert reason == "not_writable"
+        finally:
+            readonly_dir.chmod(0o755)
+
+    def test_output_dir_writable(self, tmp_path: Path) -> None:
+        """Writable existing directory returns ok with 'writable' reason."""
+        from cja_auto_sdr.generator import _check_output_dir_access
+
+        ok, _resolved, reason, _parent = _check_output_dir_access(str(tmp_path))
+        assert ok
+        assert reason == "writable"
+
+    def test_output_dir_creatable(self, tmp_path: Path) -> None:
+        """Non-existent directory under writable parent returns ok with 'creatable' reason."""
+        from cja_auto_sdr.generator import _check_output_dir_access
+
+        new_dir = tmp_path / "newdir"
+        ok, _resolved, reason, parent = _check_output_dir_access(str(new_dir))
+        assert ok
+        assert reason == "creatable"
+        assert parent is not None
+
+
+# ---------------------------------------------------------------------------
+# Tier 2a — _is_missing_sort_value and _to_numeric_sort_value (lines 8059-8061)
+# ---------------------------------------------------------------------------
+
+
+class TestSortHelpers:
+    """Test _is_missing_sort_value and _to_numeric_sort_value edge cases."""
+
+    def test_is_missing_sort_value_none(self) -> None:
+        from cja_auto_sdr.generator import _is_missing_sort_value
+
+        assert _is_missing_sort_value(None) is True
+
+    def test_is_missing_sort_value_empty_string(self) -> None:
+        from cja_auto_sdr.generator import _is_missing_sort_value
+
+        assert _is_missing_sort_value("") is True
+        assert _is_missing_sort_value("   ") is True
+
+    def test_is_missing_sort_value_nan(self) -> None:
+        from cja_auto_sdr.generator import _is_missing_sort_value
+
+        assert _is_missing_sort_value(float("nan")) is True
+
+    def test_is_missing_sort_value_concrete(self) -> None:
+        from cja_auto_sdr.generator import _is_missing_sort_value
+
+        assert _is_missing_sort_value("hello") is False
+        assert _is_missing_sort_value(42) is False
+
+    def test_is_missing_sort_value_non_checkable_type(self) -> None:
+        """Types that raise on pd.isna should return False."""
+        from cja_auto_sdr.generator import _is_missing_sort_value
+
+        # A dict raises TypeError in pd.isna for ambiguous truth value
+        assert _is_missing_sort_value({"key": "value"}) is False
+
+    def test_to_numeric_sort_value_none(self) -> None:
+        from cja_auto_sdr.generator import _to_numeric_sort_value
+
+        assert _to_numeric_sort_value(None) is None
+
+    def test_to_numeric_sort_value_bool(self) -> None:
+        from cja_auto_sdr.generator import _to_numeric_sort_value
+
+        assert _to_numeric_sort_value(True) is None
+        assert _to_numeric_sort_value(False) is None
+
+    def test_to_numeric_sort_value_int(self) -> None:
+        from cja_auto_sdr.generator import _to_numeric_sort_value
+
+        assert _to_numeric_sort_value(42) == 42.0
+
+    def test_to_numeric_sort_value_float(self) -> None:
+        from cja_auto_sdr.generator import _to_numeric_sort_value
+
+        assert _to_numeric_sort_value(3.14) == 3.14
+
+    def test_to_numeric_sort_value_nan_float(self) -> None:
+        from cja_auto_sdr.generator import _to_numeric_sort_value
+
+        assert _to_numeric_sort_value(float("nan")) is None
+
+    def test_to_numeric_sort_value_string_numeric(self) -> None:
+        from cja_auto_sdr.generator import _to_numeric_sort_value
+
+        assert _to_numeric_sort_value("3.14") == 3.14
+
+    def test_to_numeric_sort_value_string_non_numeric(self) -> None:
+        from cja_auto_sdr.generator import _to_numeric_sort_value
+
+        assert _to_numeric_sort_value("abc") is None
+
+    def test_to_numeric_sort_value_unsupported_type(self) -> None:
+        from cja_auto_sdr.generator import _to_numeric_sort_value
+
+        assert _to_numeric_sort_value([1, 2]) is None
+
+
+# ---------------------------------------------------------------------------
+# Tier 2a — _fetch_component_payload missing method (line 8783)
+# ---------------------------------------------------------------------------
+
+
+class TestFetchComponentPayload:
+    """Test _fetch_component_payload when the CJA client is missing expected methods."""
+
+    def test_missing_method_raises_discovery_not_found_error(self) -> None:
+        from cja_auto_sdr.generator import DiscoveryNotFoundError, _fetch_component_payload
+
+        # A mock CJA client without the expected method
+        cja = MagicMock(spec=[])
+        cja.getMetrics = None  # Not callable
+
+        fetch_spec = SimpleNamespace(
+            method_name="nonexistent_method",
+            kwargs={},
+            data_view_arg_name="dataViewId",
+        )
+
+        with pytest.raises(DiscoveryNotFoundError, match="missing expected method"):
+            _fetch_component_payload(cja, "dv_123", fetch_spec)
+
+
+# ---------------------------------------------------------------------------
+# Tier 1b — Lazy forwarding stubs (cli/interactive.py, cli/main.py)
+# ---------------------------------------------------------------------------
+
+
+class TestLazyForwarding:
+    """Verify lazy forwarding modules resolve their advertised symbols."""
+
+    def test_cli_interactive_lazy_forwarding(self) -> None:
+        """cli.interactive exposes interactive_select_dataviews as callable."""
+        from cja_auto_sdr.cli.interactive import interactive_select_dataviews
+
+        assert callable(interactive_select_dataviews)
+
+    def test_cli_interactive_wizard_forwarding(self) -> None:
+        """cli.interactive exposes interactive_wizard as callable."""
+        from cja_auto_sdr.cli.interactive import interactive_wizard
+
+        assert callable(interactive_wizard)
+
+    def test_cli_interactive_prompt_forwarding(self) -> None:
+        """cli.interactive exposes prompt_for_selection as callable."""
+        from cja_auto_sdr.cli.interactive import prompt_for_selection
+
+        assert callable(prompt_for_selection)
+
+    def test_cli_main_lazy_forwarding(self) -> None:
+        """cli.main exposes main as callable."""
+        from cja_auto_sdr.cli.main import main
+
+        assert callable(main)
+
+
+# ---------------------------------------------------------------------------
+# Tier 1c — core/logging.py console-only init (line 555)
+# ---------------------------------------------------------------------------
+
+
+class TestLoggingConsoleOnly:
+    """Test setup_logging console-only initialization path."""
+
+    def test_logging_console_only_init(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """setup_logging with no log file covers the console-only log message."""
+        import cja_auto_sdr.core.logging as log_mod
+
+        # Reset initialization state so we actually enter the setup path.
+        monkeypatch.setattr(log_mod, "_logging_initialized", False)
+        monkeypatch.setattr(log_mod, "_current_log_file", None)
+        # Use tmp_path as working directory so "logs" subdir is created there.
+        monkeypatch.chdir(tmp_path)
+
+        logger = log_mod.setup_logging(data_view_id=None, batch_mode=True, log_level="INFO")
+        assert logger is not None
+        assert isinstance(logger, logging.Logger)
+
+
+# ---------------------------------------------------------------------------
+# Tier 2a — _normalize_optional_component_int edge cases (lines 8924-8940)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeOptionalComponentInt:
+    """Test _normalize_optional_component_int with bool, float, str inputs."""
+
+    def test_bool_true(self) -> None:
+        from cja_auto_sdr.generator import _normalize_optional_component_int
+
+        assert _normalize_optional_component_int(True) == 1
+
+    def test_bool_false(self) -> None:
+        from cja_auto_sdr.generator import _normalize_optional_component_int
+
+        assert _normalize_optional_component_int(False) == 0
+
+    def test_float_integer_value(self) -> None:
+        from cja_auto_sdr.generator import _normalize_optional_component_int
+
+        assert _normalize_optional_component_int(3.0) == 3
+
+    def test_float_non_integer_value(self) -> None:
+        """Non-integer float returns default."""
+        from cja_auto_sdr.generator import _normalize_optional_component_int
+
+        assert _normalize_optional_component_int(3.5) == 0
+
+    def test_string_numeric(self) -> None:
+        from cja_auto_sdr.generator import _normalize_optional_component_int
+
+        assert _normalize_optional_component_int("42") == 42
+
+    def test_string_non_numeric(self) -> None:
+        """Non-numeric string returns default."""
+        from cja_auto_sdr.generator import _normalize_optional_component_int
+
+        assert _normalize_optional_component_int("abc") == 0
+
+    def test_string_empty(self) -> None:
+        """Empty string returns default."""
+        from cja_auto_sdr.generator import _normalize_optional_component_int
+
+        assert _normalize_optional_component_int("") == 0
+
+    def test_string_whitespace(self) -> None:
+        """Whitespace-only string returns default."""
+        from cja_auto_sdr.generator import _normalize_optional_component_int
+
+        assert _normalize_optional_component_int("   ") == 0
+
+    def test_non_matching_type(self) -> None:
+        """Unsupported type (e.g. list) returns default."""
+        from cja_auto_sdr.generator import _normalize_optional_component_int
+
+        assert _normalize_optional_component_int([1, 2]) == 0
+
+
+# ---------------------------------------------------------------------------
+# Tier 2a — _coerce_http_status_code edge cases (lines 8434-8448)
+# ---------------------------------------------------------------------------
+
+
+class TestCoerceHttpStatusCode:
+    """Test _coerce_http_status_code edge cases for bool, out-of-range, string patterns."""
+
+    def test_bool_returns_none(self) -> None:
+        from cja_auto_sdr.generator import _coerce_http_status_code
+
+        assert _coerce_http_status_code(True) is None
+        assert _coerce_http_status_code(False) is None
+
+    def test_int_out_of_range_high(self) -> None:
+        from cja_auto_sdr.generator import _coerce_http_status_code
+
+        assert _coerce_http_status_code(999) is None
+
+    def test_int_out_of_range_low(self) -> None:
+        from cja_auto_sdr.generator import _coerce_http_status_code
+
+        assert _coerce_http_status_code(50) is None
+
+    def test_int_valid(self) -> None:
+        from cja_auto_sdr.generator import _coerce_http_status_code
+
+        assert _coerce_http_status_code(404) == 404
+
+    def test_string_digit_valid(self) -> None:
+        from cja_auto_sdr.generator import _coerce_http_status_code
+
+        assert _coerce_http_status_code("200") == 200
+
+    def test_string_digit_out_of_range(self) -> None:
+        from cja_auto_sdr.generator import _coerce_http_status_code
+
+        assert _coerce_http_status_code("999") is None
+
+    def test_string_empty(self) -> None:
+        from cja_auto_sdr.generator import _coerce_http_status_code
+
+        assert _coerce_http_status_code("") is None
+
+    def test_string_with_embedded_code(self) -> None:
+        """String like 'HTTP 403 Forbidden' extracts the status code."""
+        from cja_auto_sdr.generator import _coerce_http_status_code
+
+        assert _coerce_http_status_code("HTTP 403 Forbidden") == 403
+
+    def test_string_with_out_of_range_embedded(self) -> None:
+        """Embedded numeric code outside range returns None."""
+        from cja_auto_sdr.generator import _coerce_http_status_code
+
+        assert _coerce_http_status_code("Error code 999") is None
+
+    def test_non_matching_type(self) -> None:
+        """Unsupported types (e.g. list) return None."""
+        from cja_auto_sdr.generator import _coerce_http_status_code
+
+        assert _coerce_http_status_code([404]) is None
+
+
+# ---------------------------------------------------------------------------
+# Tier 2a — _iter_error_chain_nodes and _extract_http_status_codes (lines 8460-8488)
+# ---------------------------------------------------------------------------
+
+
+class TestIterErrorChainNodes:
+    """Test _iter_error_chain_nodes traversal through dicts, chained errors, and responses."""
+
+    def test_dict_node_with_nested_error(self) -> None:
+        """Dict node with 'error' key traverses into the nested error."""
+        from cja_auto_sdr.generator import _iter_error_chain_nodes
+
+        inner_error = {"status_code": 403}
+        outer_error = Exception("wrapper")
+        outer_error.response = {"error": inner_error}  # type: ignore[attr-defined]
+
+        nodes = _iter_error_chain_nodes(outer_error)
+        # Should find the outer exception, the response dict, and the inner dict
+        assert any(isinstance(n, dict) and n.get("status_code") == 403 for n in nodes)
+
+    def test_chained_cause(self) -> None:
+        """Exception with __cause__ traverses the chain."""
+        from cja_auto_sdr.generator import _iter_error_chain_nodes
+
+        cause = ValueError("root cause")
+        wrapper = RuntimeError("wrapper")
+        wrapper.__cause__ = cause
+
+        nodes = _iter_error_chain_nodes(wrapper)
+        assert cause in nodes
+        assert wrapper in nodes
+
+    def test_circular_reference_avoided(self) -> None:
+        """Circular references do not cause infinite loops."""
+        from cja_auto_sdr.generator import _iter_error_chain_nodes
+
+        a = Exception("a")
+        b = Exception("b")
+        a.__cause__ = b
+        b.__cause__ = a
+
+        nodes = _iter_error_chain_nodes(a)
+        assert a in nodes
+        assert b in nodes
+
+
+class TestExtractHttpStatusCodes:
+    """Test _extract_http_status_codes extracting codes from nested errors."""
+
+    def test_extracts_from_dict_node(self) -> None:
+        """Status code in a dict node is extracted."""
+        from cja_auto_sdr.generator import _extract_http_status_codes
+
+        error = Exception("api error")
+        error.response = {"status_code": 403}  # type: ignore[attr-defined]
+
+        codes = _extract_http_status_codes(error)
+        assert 403 in codes
+
+    def test_extracts_from_attribute(self) -> None:
+        """Status code in an attribute of the error object is extracted."""
+        from cja_auto_sdr.generator import _extract_http_status_codes
+
+        error = Exception("api error")
+        error.status_code = 404  # type: ignore[attr-defined]
+
+        codes = _extract_http_status_codes(error)
+        assert 404 in codes
+
+    def test_bool_status_code_ignored(self) -> None:
+        """Boolean status_code attributes are ignored (not coerced)."""
+        from cja_auto_sdr.generator import _extract_http_status_codes
+
+        error = Exception("api error")
+        error.status_code = True  # type: ignore[attr-defined]
+
+        codes = _extract_http_status_codes(error)
+        assert len(codes) == 0
+
+
+# ---------------------------------------------------------------------------
+# Tier 2a — _normalize_exit_code with bool input (line 972)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeExitCode:
+    """Test _normalize_exit_code with edge-case inputs."""
+
+    def test_none_returns_zero(self) -> None:
+        from cja_auto_sdr.generator import _normalize_exit_code
+
+        assert _normalize_exit_code(None) == 0
+
+    def test_int_passthrough(self) -> None:
+        from cja_auto_sdr.generator import _normalize_exit_code
+
+        assert _normalize_exit_code(42) == 42
+
+    def test_bool_true(self) -> None:
+        """Bool True normalizes to 1."""
+        from cja_auto_sdr.generator import _normalize_exit_code
+
+        assert _normalize_exit_code(True) == 1
+
+    def test_bool_false(self) -> None:
+        """Bool False normalizes to 0."""
+        from cja_auto_sdr.generator import _normalize_exit_code
+
+        assert _normalize_exit_code(False) == 0
+
+    def test_string_returns_one(self) -> None:
+        """Non-int, non-bool, non-None value normalizes to 1."""
+        from cja_auto_sdr.generator import _normalize_exit_code
+
+        assert _normalize_exit_code("error message") == 1
+
+
+# ---------------------------------------------------------------------------
+# Tier 2a — _normalize_single_dataview_payload edge cases (lines 8409-8413)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeSingleDataviewPayload:
+    """Test _normalize_single_dataview_payload with DataFrame and dict inputs."""
+
+    def test_none_returns_none(self) -> None:
+        from cja_auto_sdr.generator import _normalize_single_dataview_payload
+
+        assert _normalize_single_dataview_payload(None) is None
+
+    def test_empty_dataframe_returns_none(self) -> None:
+        from cja_auto_sdr.generator import _normalize_single_dataview_payload
+
+        assert _normalize_single_dataview_payload(pd.DataFrame()) is None
+
+    def test_dataframe_with_empty_records(self) -> None:
+        """DataFrame that produces empty records list returns None."""
+        from cja_auto_sdr.generator import _normalize_single_dataview_payload
+
+        # A DataFrame with columns but no rows
+        df = pd.DataFrame(columns=["id", "name"])
+        assert _normalize_single_dataview_payload(df) is None
+
+    def test_dataframe_with_valid_record(self) -> None:
+        from cja_auto_sdr.generator import _normalize_single_dataview_payload
+
+        df = pd.DataFrame([{"id": "dv_123", "name": "Test DV"}])
+        result = _normalize_single_dataview_payload(df)
+        assert result is not None
+        assert result["id"] == "dv_123"
+
+    def test_dict_passthrough(self) -> None:
+        from cja_auto_sdr.generator import _normalize_single_dataview_payload
+
+        d = {"id": "dv_123", "name": "Test DV"}
+        assert _normalize_single_dataview_payload(d) is d
+
+    def test_unsupported_type_returns_none(self) -> None:
+        from cja_auto_sdr.generator import _normalize_single_dataview_payload
+
+        assert _normalize_single_dataview_payload("not a dict") is None
+
+
+# ---------------------------------------------------------------------------
+# Tier 2a — _resolve_discovery_output_format (line 7966)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveDiscoveryOutputFormat:
+    """Test _resolve_discovery_output_format unsupported format warning path."""
+
+    def test_json_passthrough(self) -> None:
+        from cja_auto_sdr.generator import _resolve_discovery_output_format
+
+        assert _resolve_discovery_output_format("json", output_to_stdout=False) == "json"
+
+    def test_csv_passthrough(self) -> None:
+        from cja_auto_sdr.generator import _resolve_discovery_output_format
+
+        assert _resolve_discovery_output_format("csv", output_to_stdout=False) == "csv"
+
+    def test_stdout_defaults_to_json(self) -> None:
+        from cja_auto_sdr.generator import _resolve_discovery_output_format
+
+        assert _resolve_discovery_output_format(None, output_to_stdout=True) == "json"
+
+    def test_unsupported_format_warns_and_defaults_to_table(self) -> None:
+        """Unsupported format like 'excel' triggers a warning and falls back to 'table'."""
+        from cja_auto_sdr.generator import _resolve_discovery_output_format
+
+        result = _resolve_discovery_output_format("excel", output_to_stdout=False)
+        assert result == "table"
+
+
+# ---------------------------------------------------------------------------
+# Tier 2a — _approved_display and _tags_display (lines 9117-9128)
+# ---------------------------------------------------------------------------
+
+
+class TestApprovedAndTagsDisplay:
+    """Test _approved_display and _tags_display edge cases."""
+
+    def test_approved_display_none(self) -> None:
+        from cja_auto_sdr.generator import _approved_display
+
+        assert _approved_display(None) == "N/A"
+
+    def test_approved_display_true(self) -> None:
+        from cja_auto_sdr.generator import _approved_display
+
+        assert _approved_display(True) == "Yes"
+
+    def test_approved_display_false(self) -> None:
+        from cja_auto_sdr.generator import _approved_display
+
+        assert _approved_display(False) == "No"
+
+    def test_approved_display_string(self) -> None:
+        from cja_auto_sdr.generator import _approved_display
+
+        assert _approved_display("custom") == "custom"
+
+    def test_tags_display_non_list(self) -> None:
+        from cja_auto_sdr.generator import _tags_display
+
+        assert _tags_display(None) == ""
+        assert _tags_display("not-a-list") == ""
+
+    def test_tags_display_list(self) -> None:
+        from cja_auto_sdr.generator import _tags_display
+
+        assert _tags_display(["a", "b", "c"]) == "a, b, c"
+
+    def test_tags_display_filters_non_strings(self) -> None:
+        from cja_auto_sdr.generator import _tags_display
+
+        assert _tags_display(["a", 123, "b"]) == "a, b"
+
+
+# ---------------------------------------------------------------------------
+# Tier 2b — __main__.py _minimum_option_arity (lines 100-103)
+# ---------------------------------------------------------------------------
+
+
+class TestMinimumOptionArity:
+    """Test _minimum_option_arity with nargs='+' and default fallback."""
+
+    def test_nargs_none(self) -> None:
+        from cja_auto_sdr.__main__ import _minimum_option_arity
+
+        assert _minimum_option_arity(None) == 1
+
+    def test_nargs_int(self) -> None:
+        from cja_auto_sdr.__main__ import _minimum_option_arity
+
+        assert _minimum_option_arity(2) == 2
+        assert _minimum_option_arity(0) == 0
+
+    def test_nargs_plus(self) -> None:
+        """nargs='+' returns 1 (at least one value required)."""
+        from cja_auto_sdr.__main__ import _minimum_option_arity
+
+        assert _minimum_option_arity("+") == 1
+
+    def test_nargs_question_mark(self) -> None:
+        """nargs='?' returns 0."""
+        from cja_auto_sdr.__main__ import _minimum_option_arity
+
+        assert _minimum_option_arity("?") == 0
+
+    def test_nargs_star(self) -> None:
+        """nargs='*' returns 0."""
+        from cja_auto_sdr.__main__ import _minimum_option_arity
+
+        assert _minimum_option_arity("*") == 0
+
+
+# ---------------------------------------------------------------------------
+# Tier 2b — __main__.py _scan_option_tokens compound short flags (lines 183-199)
+# ---------------------------------------------------------------------------
+
+
+class TestScanOptionTokensCompound:
+    """Test _scan_option_tokens with compound short flags."""
+
+    def test_compound_short_flags_qV(self) -> None:
+        """Compound -qV resolves both -q and -V."""
+        from cja_auto_sdr.__main__ import _scan_option_tokens
+
+        result = _scan_option_tokens(["-qV"])
+        assert "-V" in result.options
+        assert "-q" in result.options
+        assert not result.has_parse_error
+
+    def test_single_short_option_with_arity(self) -> None:
+        """Short option with min_arity > 0 consumes next token."""
+        from cja_auto_sdr.__main__ import _scan_option_tokens
+
+        # -p takes a value; the next token should be consumed
+        result = _scan_option_tokens(["-p", "default"])
+        assert "-p" in result.options
+        assert not result.has_parse_error
+
+    def test_double_dash_stops_scanning(self) -> None:
+        """-- terminates option scanning."""
+        from cja_auto_sdr.__main__ import _scan_option_tokens
+
+        result = _scan_option_tokens(["--", "--version"])
+        assert "--version" not in result.options
+        assert not result.has_parse_error
+
+
+# ---------------------------------------------------------------------------
+# Tier 2b — __main__.py _render_completion_script unsupported shell (line 358)
+# ---------------------------------------------------------------------------
+
+
+class TestRenderCompletionScript:
+    """Test _render_completion_script error path."""
+
+    def test_unsupported_shell_raises(self) -> None:
+        from cja_auto_sdr.__main__ import _render_completion_script
+
+        with pytest.raises(ValueError, match="Unsupported shell"):
+            _render_completion_script("powershell", "cja_auto_sdr")
+
+    def test_supported_shell_returns_script(self) -> None:
+        from cja_auto_sdr.__main__ import _render_completion_script
+
+        script = _render_completion_script("bash", "cja_auto_sdr")
+        assert "cja_auto_sdr" in script
+
+
+# ---------------------------------------------------------------------------
+# Tier 2a — _extract_dataset_info scalar fallback (line 7705)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractDatasetInfo:
+    """Test _extract_dataset_info with non-dict inputs."""
+
+    def test_none_returns_na(self) -> None:
+        from cja_auto_sdr.generator import _extract_dataset_info
+
+        result = _extract_dataset_info(None)
+        assert result["id"] == "N/A"
+        assert result["name"] == "N/A"
+
+    def test_falsey_int_returns_na(self) -> None:
+        """Falsey int (0) returns N/A for both fields."""
+        from cja_auto_sdr.generator import _extract_dataset_info
+
+        result = _extract_dataset_info(0)
+        assert result["id"] == "N/A"
+
+    def test_string_becomes_id(self) -> None:
+        """Plain string is used as the id value."""
+        from cja_auto_sdr.generator import _extract_dataset_info
+
+        result = _extract_dataset_info("ds_12345")
+        assert result["id"] == "ds_12345"
+        assert result["name"] == "N/A"
+
+    def test_dict_extracts_fields(self) -> None:
+        from cja_auto_sdr.generator import _extract_dataset_info
+
+        result = _extract_dataset_info({"id": "ds_1", "name": "Dataset 1"})
+        assert result["id"] == "ds_1"
+        assert result["name"] == "Dataset 1"
+
+
+# ---------------------------------------------------------------------------
+# Tier 2a — _read_config_status_file edge cases (lines 10297-10303)
+# ---------------------------------------------------------------------------
+
+
+class TestReadConfigStatusFile:
+    """Test _read_config_status_file error handling paths."""
+
+    def test_valid_json_returns_payload(self, tmp_path: Path) -> None:
+        from cja_auto_sdr.generator import _read_config_status_file
+
+        config = tmp_path / "config.json"
+        config.write_text('{"org_id": "test123"}')
+        logger = logging.getLogger("test")
+        payload, err = _read_config_status_file(str(config), logger)
+        assert payload is not None
+        assert err is None
+        assert payload["org_id"] == "test123"
+
+    def test_invalid_json_returns_error(self, tmp_path: Path) -> None:
+        from cja_auto_sdr.generator import _read_config_status_file
+
+        config = tmp_path / "config.json"
+        config.write_text("{invalid json")
+        logger = logging.getLogger("test")
+        payload, err = _read_config_status_file(str(config), logger)
+        assert payload is None
+        assert "not valid JSON" in err
+
+    def test_not_a_dict_returns_error(self, tmp_path: Path) -> None:
+        from cja_auto_sdr.generator import _read_config_status_file
+
+        config = tmp_path / "config.json"
+        config.write_text("[1, 2, 3]")
+        logger = logging.getLogger("test")
+        payload, err = _read_config_status_file(str(config), logger)
+        assert payload is None
+        assert "must contain a JSON object" in err
+
+    def test_missing_file_returns_error(self) -> None:
+        from cja_auto_sdr.generator import _read_config_status_file
+
+        logger = logging.getLogger("test")
+        payload, err = _read_config_status_file("/nonexistent/config.json", logger)
+        assert payload is None
+        assert "Cannot read" in err
+
+
+# ---------------------------------------------------------------------------
+# Tier 2a — _describe_dataview_ignored_options (lines 14236-14243)
+# ---------------------------------------------------------------------------
+
+
+class TestDescribeDataviewIgnoredOptions:
+    """Test _describe_dataview_ignored_options detects filtering flags."""
+
+    def test_no_ignored_options(self) -> None:
+        from cja_auto_sdr.generator import _describe_dataview_ignored_options
+
+        args = SimpleNamespace(org_filter=None, org_exclude=None, discovery_sort=None, org_limit=None)
+        assert _describe_dataview_ignored_options(args) == []
+
+    def test_filter_ignored(self) -> None:
+        from cja_auto_sdr.generator import _describe_dataview_ignored_options
+
+        args = SimpleNamespace(org_filter="pattern", org_exclude=None, discovery_sort=None, org_limit=None)
+        result = _describe_dataview_ignored_options(args)
+        assert "--filter" in result
+
+    def test_exclude_ignored(self) -> None:
+        from cja_auto_sdr.generator import _describe_dataview_ignored_options
+
+        args = SimpleNamespace(org_filter=None, org_exclude="pattern", discovery_sort=None, org_limit=None)
+        result = _describe_dataview_ignored_options(args)
+        assert "--exclude" in result
+
+    def test_all_ignored(self) -> None:
+        from cja_auto_sdr.generator import _describe_dataview_ignored_options
+
+        args = SimpleNamespace(org_filter="f", org_exclude="e", discovery_sort="name", org_limit=10)
+        result = _describe_dataview_ignored_options(args)
+        assert "--filter" in result
+        assert "--exclude" in result
+        assert "--sort" in result
+        assert "--limit" in result
+
+
+# ---------------------------------------------------------------------------
+# Tier 2b — _is_argcomplete_completion_active (line 80-86 in __main__.py)
+# ---------------------------------------------------------------------------
+
+
+class TestIsArgcompleteCompletionActive:
+    """Test _is_argcomplete_completion_active edge cases."""
+
+    def test_not_set(self) -> None:
+        from cja_auto_sdr.__main__ import _is_argcomplete_completion_active
+
+        assert _is_argcomplete_completion_active({}) is False
+
+    def test_set_truthy(self) -> None:
+        from cja_auto_sdr.__main__ import _is_argcomplete_completion_active
+
+        assert _is_argcomplete_completion_active({"_ARGCOMPLETE": "1"}) is True
+
+    def test_set_falsey(self) -> None:
+        from cja_auto_sdr.__main__ import _is_argcomplete_completion_active
+
+        assert _is_argcomplete_completion_active({"_ARGCOMPLETE": "0"}) is False
+        assert _is_argcomplete_completion_active({"_ARGCOMPLETE": ""}) is False
+        assert _is_argcomplete_completion_active({"_ARGCOMPLETE": "false"}) is False
+
+
+# ---------------------------------------------------------------------------
+# Tier 2a — _resolve_output_dir_path fallback (lines 10474-10475)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveOutputDirPath:
+    """Test _resolve_output_dir_path resolution and fallback."""
+
+    def test_simple_path(self, tmp_path: Path) -> None:
+        from cja_auto_sdr.generator import _resolve_output_dir_path
+
+        result = _resolve_output_dir_path(str(tmp_path))
+        assert result == tmp_path.resolve()
+
+    def test_tilde_expansion(self) -> None:
+        from cja_auto_sdr.generator import _resolve_output_dir_path
+
+        result = _resolve_output_dir_path("~/somedir")
+        assert "~" not in str(result)
+
+
+# ---------------------------------------------------------------------------
+# Tier 2b — _accepts_inline_option_value (line 91 in __main__.py)
+# ---------------------------------------------------------------------------
+
+
+class TestAcceptsInlineOptionValue:
+    """Test _accepts_inline_option_value."""
+
+    def test_zero_nargs(self) -> None:
+        from cja_auto_sdr.__main__ import _accepts_inline_option_value
+
+        assert _accepts_inline_option_value(0) is False
+
+    def test_nonzero_nargs(self) -> None:
+        from cja_auto_sdr.__main__ import _accepts_inline_option_value
+
+        assert _accepts_inline_option_value(1) is True
+        assert _accepts_inline_option_value(None) is True
+        assert _accepts_inline_option_value("?") is True

--- a/tests/test_coverage_hardening.py
+++ b/tests/test_coverage_hardening.py
@@ -549,6 +549,56 @@ class TestNormalizeSingleDataviewPayload:
 # ---------------------------------------------------------------------------
 
 
+class TestResolveCommandOutputFormat:
+    """Test _resolve_command_output_format stdout and fallback policies."""
+
+    def test_stdout_defaults_to_stdout_fallback_when_missing(self) -> None:
+        from cja_auto_sdr.generator import _resolve_command_output_format
+
+        result = _resolve_command_output_format(
+            None,
+            supported_formats={"json": "json", "csv": "csv", "table": "table"},
+            fallback_format="table",
+            output_to_stdout=True,
+            stdout_fallback_format="json",
+            stdout_allowed_formats=("json", "csv"),
+            warning_scope="test command",
+        )
+        assert result == "json"
+
+    def test_stdout_preserves_explicit_allowed_format(self) -> None:
+        from cja_auto_sdr.generator import _resolve_command_output_format
+
+        result = _resolve_command_output_format(
+            "csv",
+            supported_formats={"json": "json", "csv": "csv", "table": "table"},
+            fallback_format="table",
+            output_to_stdout=True,
+            stdout_fallback_format="json",
+            stdout_allowed_formats=("json", "csv"),
+            warning_scope="test command",
+        )
+        assert result == "csv"
+
+    def test_stdout_disallowed_supported_format_warns_and_falls_back(self, caplog: pytest.LogCaptureFixture) -> None:
+        from cja_auto_sdr.generator import _resolve_command_output_format
+
+        with caplog.at_level(logging.WARNING, logger="cja_auto_sdr.generator"):
+            result = _resolve_command_output_format(
+                "table",
+                supported_formats={"json": "json", "csv": "csv", "table": "table"},
+                fallback_format="table",
+                output_to_stdout=True,
+                stdout_fallback_format="json",
+                stdout_allowed_formats=("json", "csv"),
+                warning_scope="test command",
+            )
+
+        assert result == "json"
+        assert "with --output stdout" in caplog.text
+        assert "using json" in caplog.text
+
+
 class TestResolveDiscoveryOutputFormat:
     """Test _resolve_discovery_output_format unsupported format warning path."""
 
@@ -567,12 +617,26 @@ class TestResolveDiscoveryOutputFormat:
 
         assert _resolve_discovery_output_format(None, output_to_stdout=True) == "json"
 
+    def test_stdout_preserves_explicit_csv(self) -> None:
+        from cja_auto_sdr.generator import _resolve_discovery_output_format
+
+        assert _resolve_discovery_output_format("csv", output_to_stdout=True) == "csv"
+
     def test_unsupported_format_warns_and_defaults_to_table(self) -> None:
         """Unsupported format like 'excel' triggers a warning and falls back to 'table'."""
         from cja_auto_sdr.generator import _resolve_discovery_output_format
 
         result = _resolve_discovery_output_format("excel", output_to_stdout=False)
         assert result == "table"
+
+    def test_stdout_unsupported_format_warns_and_defaults_to_json(self, caplog: pytest.LogCaptureFixture) -> None:
+        from cja_auto_sdr.generator import _resolve_discovery_output_format
+
+        with caplog.at_level(logging.WARNING, logger="cja_auto_sdr.generator"):
+            result = _resolve_discovery_output_format("excel", output_to_stdout=True)
+
+        assert result == "json"
+        assert "using json" in caplog.text
 
     def test_console_alias_maps_to_table(self) -> None:
         """Console alias should normalize to table for discovery commands."""

--- a/tests/test_discovery_component_consistency.py
+++ b/tests/test_discovery_component_consistency.py
@@ -167,7 +167,7 @@ def test_run_dry_run_uses_hidden_inclusive_component_fetch_contract(
     mock_cja = MagicMock()
     mock_cjapy.CJA.return_value = mock_cja
     mock_cja.getDataViews.return_value = []
-    mock_cja.getDataView.return_value = {"name": "DryRun View"}
+    mock_cja.getDataView.return_value = {"id": "dv_1", "name": "DryRun View"}
     mock_cja.getMetrics.return_value = [{"id": "m_visible"}, {"id": "m_hidden"}]
     mock_cja.getDimensions.return_value = [{"id": "d_visible"}, {"id": "d_hidden"}]
 

--- a/tests/test_discovery_exceptions.py
+++ b/tests/test_discovery_exceptions.py
@@ -1,0 +1,41 @@
+"""Tests for discovery exception classification contracts."""
+
+from cja_auto_sdr.core.discovery_exceptions import is_dataview_lookup_not_found_error
+from cja_auto_sdr.core.exceptions import APIError
+
+
+class _RuntimeLookupError(RuntimeError):
+    """Custom runtime error used to simulate non-whitelisted cjapy wrappers."""
+
+
+def test_non_api_error_with_status_code_404_maps_to_not_found() -> None:
+    error = _RuntimeLookupError("wrapped failure")
+    error.status_code = 404  # type: ignore[attr-defined]
+
+    assert is_dataview_lookup_not_found_error(error) is True
+
+
+def test_non_api_error_with_nested_response_status_403_maps_to_not_found() -> None:
+    error = _RuntimeLookupError("wrapped failure")
+    error.response = {"error": {"statusCode": "403"}}  # type: ignore[attr-defined]
+
+    assert is_dataview_lookup_not_found_error(error) is True
+
+
+def test_non_api_error_5xx_status_remains_non_not_found() -> None:
+    error = _RuntimeLookupError("backend unavailable")
+    error.status_code = 503  # type: ignore[attr-defined]
+
+    assert is_dataview_lookup_not_found_error(error) is False
+
+
+def test_api_error_message_markers_map_to_not_found_without_status_code() -> None:
+    error = APIError("resource_not_found while resolving data view")
+
+    assert is_dataview_lookup_not_found_error(error) is True
+
+
+def test_non_api_error_message_marker_does_not_map_without_status_signal() -> None:
+    error = _RuntimeLookupError("resource_not_found while resolving data view")
+
+    assert is_dataview_lookup_not_found_error(error) is False

--- a/tests/test_discovery_payloads.py
+++ b/tests/test_discovery_payloads.py
@@ -205,6 +205,37 @@ def test_assess_dataview_lookup_payload_accepts_mixed_case_identity_keys() -> No
     assert assessment.kind is PayloadKind.DATA
     assert assessment.reason == "valid_lookup_payload"
     assert assessment.is_valid is True
+    assert assessment.payload is not None
+    assert assessment.payload["id"] == "dv_1"
+    assert assessment.payload["name"] == "Valid View"
+
+
+def test_assess_dataview_lookup_payload_canonicalizes_mixed_case_metadata_fields() -> None:
+    payload = {
+        "ID": "dv_1",
+        "Name": "Valid View",
+        "Owner": {"NAME": "Owner Name", "IMSUSERID": "owner@example.com"},
+        "Description": "A test view",
+        "ParentDataGroupID": "conn_1",
+        "CreatedDATE": "2025-01-01",
+        "MODIFIEDAT": "2025-06-01",
+    }
+    assessment = assess_dataview_lookup_payload(payload, expected_data_view_id="dv_1")
+
+    assert assessment.kind is PayloadKind.DATA
+    assert assessment.payload is not None
+    assert assessment.payload["id"] == "dv_1"
+    assert assessment.payload["name"] == "Valid View"
+    assert assessment.payload["description"] == "A test view"
+    assert assessment.payload["parentDataGroupId"] == "conn_1"
+    assert assessment.payload["createdDate"] == "2025-01-01"
+    assert assessment.payload["modifiedAt"] == "2025-06-01"
+    assert assessment.payload["owner"] == {
+        "NAME": "Owner Name",
+        "IMSUSERID": "owner@example.com",
+        "name": "Owner Name",
+        "imsUserId": "owner@example.com",
+    }
 
 
 def test_assess_dataview_lookup_payload_handles_non_stringifiable_name_value() -> None:

--- a/tests/test_discovery_payloads.py
+++ b/tests/test_discovery_payloads.py
@@ -87,6 +87,11 @@ def test_dataview_payload_with_identity_not_error() -> None:
     assert is_dataview_error_payload(payload) is False
 
 
+def test_dataview_payload_with_mixed_case_identity_not_error() -> None:
+    payload = {"ID": "dv_1", "Name": "Test View", "statusCode": 200, "message": "ok"}
+    assert is_dataview_error_payload(payload) is False
+
+
 def test_dataview_payload_with_na_identity_values_is_treated_as_error() -> None:
     payload = {"statusCode": 404, "message": "missing", "id": pd.NA, "name": pd.NA}
     assert is_dataview_error_payload(payload) is True
@@ -178,6 +183,28 @@ def test_assess_dataview_lookup_payload_rejects_id_mismatch() -> None:
     assessment = assess_dataview_lookup_payload(payload, expected_data_view_id="dv_1")
     assert assessment.kind is PayloadKind.ERROR
     assert assessment.reason == "id_mismatch"
+
+
+def test_assess_dataview_lookup_payload_rejects_missing_id_when_expected() -> None:
+    payload = {"name": "Some Name", "error": "not found"}
+    assessment = assess_dataview_lookup_payload(payload, expected_data_view_id="dv_1")
+    assert assessment.kind is PayloadKind.ERROR
+    assert assessment.reason == "missing_expected_id"
+
+
+def test_assess_dataview_lookup_payload_rejects_blank_id_when_expected() -> None:
+    payload = {"id": "  ", "name": "Some Name"}
+    assessment = assess_dataview_lookup_payload(payload, expected_data_view_id="dv_1")
+    assert assessment.kind is PayloadKind.ERROR
+    assert assessment.reason == "missing_expected_id"
+
+
+def test_assess_dataview_lookup_payload_accepts_mixed_case_identity_keys() -> None:
+    payload = {"ID": "dv_1", "Name": "Valid View", "owner": {"name": "Owner"}}
+    assessment = assess_dataview_lookup_payload(payload, expected_data_view_id="dv_1")
+    assert assessment.kind is PayloadKind.DATA
+    assert assessment.reason == "valid_lookup_payload"
+    assert assessment.is_valid is True
 
 
 def test_assess_dataview_lookup_payload_handles_non_stringifiable_name_value() -> None:

--- a/tests/test_discovery_payloads.py
+++ b/tests/test_discovery_payloads.py
@@ -117,6 +117,28 @@ def test_assess_dataview_lookup_payload_accepts_valid_payload_with_error_field()
     assert assessment.is_valid is True
 
 
+def test_assess_dataview_lookup_payload_rejects_unknown_placeholder_with_error_field() -> None:
+    payload = {"id": "dv_1", "name": "Unknown", "error": "not found"}
+    assessment = assess_dataview_lookup_payload(payload, expected_data_view_id="dv_1")
+    assert assessment.kind is PayloadKind.ERROR
+    assert assessment.reason == "unknown_placeholder_diagnostic:error"
+
+
+def test_assess_dataview_lookup_payload_rejects_unknown_placeholder_with_status_and_message() -> None:
+    payload = {"id": "dv_1", "name": "Unknown", "statusCode": 404, "message": "not found"}
+    assessment = assess_dataview_lookup_payload(payload, expected_data_view_id="dv_1")
+    assert assessment.kind is PayloadKind.ERROR
+    assert assessment.reason == "unknown_placeholder_diagnostic:message"
+
+
+def test_assess_dataview_lookup_payload_allows_unknown_named_dataview_without_diagnostics() -> None:
+    payload = {"id": "dv_1", "name": "Unknown", "owner": {"name": "Owner"}}
+    assessment = assess_dataview_lookup_payload(payload, expected_data_view_id="dv_1")
+    assert assessment.kind is PayloadKind.DATA
+    assert assessment.reason == "valid_lookup_payload"
+    assert assessment.is_valid is True
+
+
 def test_assess_dataview_lookup_payload_rejects_explicit_lookup_failed_marker() -> None:
     payload = {
         "id": "dv_1",

--- a/tests/test_discovery_payloads.py
+++ b/tests/test_discovery_payloads.py
@@ -137,6 +137,28 @@ def test_assess_dataview_lookup_payload_rejects_id_mismatch() -> None:
     assert assessment.reason == "id_mismatch"
 
 
+def test_assess_dataview_lookup_payload_handles_non_stringifiable_name_value() -> None:
+    class _ExplodingName:
+        def __str__(self) -> str:  # pragma: no cover - explicit failure path
+            raise RuntimeError("boom")
+
+    payload = {"id": "dv_1", "name": _ExplodingName()}
+    assessment = assess_dataview_lookup_payload(payload, expected_data_view_id="dv_1")
+    assert assessment.kind is PayloadKind.DATA
+    assert assessment.is_valid is True
+
+
+def test_assess_dataview_lookup_payload_rejects_invalid_id_type() -> None:
+    class _ExplodingId:
+        def __str__(self) -> str:  # pragma: no cover - explicit failure path
+            raise RuntimeError("boom")
+
+    payload = {"id": _ExplodingId(), "name": "Valid View"}
+    assessment = assess_dataview_lookup_payload(payload, expected_data_view_id="dv_1")
+    assert assessment.kind is PayloadKind.ERROR
+    assert assessment.reason == "invalid_id_type"
+
+
 # ---------------------------------------------------------------------------
 # looks_like_error_payload — empty dict (line 56)
 # ---------------------------------------------------------------------------

--- a/tests/test_discovery_payloads.py
+++ b/tests/test_discovery_payloads.py
@@ -4,6 +4,7 @@ import pandas as pd
 
 from cja_auto_sdr.core.discovery_payloads import (
     PayloadKind,
+    _normalize_dataview_lookup_payload,
     assess_component_payload,
     assess_dataview_lookup_payload,
     coerce_component_rows_or_none,
@@ -177,6 +178,46 @@ def test_assess_dataview_lookup_payload_rejects_invalid_id_type() -> None:
     assessment = assess_dataview_lookup_payload(payload, expected_data_view_id="dv_1")
     assert assessment.kind is PayloadKind.ERROR
     assert assessment.reason == "invalid_id_type"
+
+
+def test_normalize_dataview_lookup_payload_uses_first_dataframe_record() -> None:
+    frame = pd.DataFrame([{"id": "dv_1", "name": "Valid View", "owner": "Owner"}])
+    payload, raw_type, reason = _normalize_dataview_lookup_payload(frame)
+    assert payload == {"id": "dv_1", "name": "Valid View", "owner": "Owner"}
+    assert raw_type == "DataFrame"
+    assert reason == "dataframe_first_record"
+
+
+def test_normalize_dataview_lookup_payload_rejects_non_mapping_dataframe_rows() -> None:
+    class _BadRecordFrame(pd.DataFrame):
+        @property
+        def _constructor(self):
+            return _BadRecordFrame
+
+        def to_dict(self, orient="dict", *args, **kwargs):
+            if orient == "records":
+                return [42]
+            return super().to_dict(orient=orient, *args, **kwargs)
+
+    frame = _BadRecordFrame({"id": ["dv_1"]})
+    payload, raw_type, reason = _normalize_dataview_lookup_payload(frame)
+    assert payload is None
+    assert raw_type == "_BadRecordFrame"
+    assert reason == "non_mapping_dataframe_row"
+
+
+def test_truthy_marker_fallback_logs_debug_and_treats_value_as_truthy(caplog) -> None:
+    class _ExplodingBool:
+        def __bool__(self):  # pragma: no cover - explicit failure path
+            raise TypeError("cannot coerce to bool")
+
+    payload = {"id": "dv_1", "name": "Unknown", "lookup_failed": _ExplodingBool()}
+    with caplog.at_level("DEBUG", logger="cja_auto_sdr.core.discovery_payloads"):
+        assessment = assess_dataview_lookup_payload(payload, expected_data_view_id="dv_1")
+
+    assert assessment.kind is PayloadKind.ERROR
+    assert assessment.reason == "failure_flag:lookup_failed"
+    assert any("Treating lookup marker value as truthy" in record.message for record in caplog.records)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_discovery_payloads.py
+++ b/tests/test_discovery_payloads.py
@@ -184,6 +184,30 @@ def test_assess_dataview_lookup_payload_rejects_explicit_lookup_failed_marker() 
     assert assessment.reason == "failure_flag:lookup_failed"
 
 
+def test_assess_dataview_lookup_payload_prefers_lookup_failed_when_multiple_failure_flags_present() -> None:
+    payload = {
+        "id": "dv_1",
+        "name": "Unknown",
+        "lookup_failed": True,
+        "circuit_breaker_open": True,
+    }
+    assessment = assess_dataview_lookup_payload(payload, expected_data_view_id="dv_1")
+    assert assessment.kind is PayloadKind.ERROR
+    assert assessment.reason == "failure_flag:lookup_failed"
+
+
+def test_assess_dataview_lookup_payload_uses_next_failure_flag_when_higher_precedence_is_falsey() -> None:
+    payload = {
+        "id": "dv_1",
+        "name": "Unknown",
+        "lookup_failed": "false",
+        "circuit_breaker_open": "true",
+    }
+    assessment = assess_dataview_lookup_payload(payload, expected_data_view_id="dv_1")
+    assert assessment.kind is PayloadKind.ERROR
+    assert assessment.reason == "failure_flag:circuit_breaker_open"
+
+
 def test_assess_dataview_lookup_payload_rejects_circuit_breaker_marker() -> None:
     payload = {"id": "dv_1", "name": "Unknown", "circuit_breaker_open": "true"}
     assessment = assess_dataview_lookup_payload(payload, expected_data_view_id="dv_1")

--- a/tests/test_discovery_payloads.py
+++ b/tests/test_discovery_payloads.py
@@ -135,6 +135,34 @@ def test_assess_dataview_lookup_payload_accepts_owner_only_metadata_with_error_f
     assert assessment.is_valid is True
 
 
+def test_assess_dataview_lookup_payload_rejects_empty_owner_container_with_error_field() -> None:
+    payload = {"id": "dv_1", "owner": {}, "error": "not found"}
+    assessment = assess_dataview_lookup_payload(payload, expected_data_view_id="dv_1")
+    assert assessment.kind is PayloadKind.ERROR
+    assert assessment.reason == "error_shape"
+
+
+def test_assess_dataview_lookup_payload_rejects_owner_container_with_only_blank_values() -> None:
+    payload = {"id": "dv_1", "owner": {"name": "  ", "email": "null"}, "error": "not found"}
+    assessment = assess_dataview_lookup_payload(payload, expected_data_view_id="dv_1")
+    assert assessment.kind is PayloadKind.ERROR
+    assert assessment.reason == "error_shape"
+
+
+def test_assess_dataview_lookup_payload_prefers_non_empty_case_collided_owner_payload() -> None:
+    payload = {
+        "id": "dv_1",
+        "owner": {},
+        "Owner": {"NAME": "Owner Name"},
+        "error": "transient warning",
+    }
+    assessment = assess_dataview_lookup_payload(payload, expected_data_view_id="dv_1")
+    assert assessment.kind is PayloadKind.DATA
+    assert assessment.reason == "valid_lookup_payload"
+    assert assessment.payload is not None
+    assert assessment.payload["owner"]["name"] == "Owner Name"
+
+
 def test_assess_dataview_lookup_payload_rejects_id_plus_error_only_payload() -> None:
     payload = {"id": "dv_1", "error": "not found"}
     assessment = assess_dataview_lookup_payload(payload, expected_data_view_id="dv_1")
@@ -298,6 +326,15 @@ def test_assess_dataview_lookup_payload_handles_non_stringifiable_name_value() -
     assessment = assess_dataview_lookup_payload(payload, expected_data_view_id="dv_1")
     assert assessment.kind is PayloadKind.DATA
     assert assessment.is_valid is True
+
+
+def test_assess_dataview_lookup_payload_handles_recursive_owner_container() -> None:
+    owner_payload: dict[str, object] = {}
+    owner_payload["self"] = owner_payload
+    payload = {"id": "dv_1", "owner": owner_payload, "error": "not found"}
+    assessment = assess_dataview_lookup_payload(payload, expected_data_view_id="dv_1")
+    assert assessment.kind is PayloadKind.ERROR
+    assert assessment.reason == "error_shape"
 
 
 def test_assess_dataview_lookup_payload_rejects_invalid_id_type() -> None:

--- a/tests/test_discovery_payloads.py
+++ b/tests/test_discovery_payloads.py
@@ -96,10 +96,23 @@ def test_dataview_payload_with_na_id_and_present_name_is_not_error() -> None:
     assert is_dataview_error_payload(payload) is False
 
 
+def test_dataview_payload_with_identity_and_error_field_is_not_error() -> None:
+    payload = {"id": "dv_1", "name": "Test View", "error": "non-fatal detail"}
+    assert is_dataview_error_payload(payload) is False
+
+
 def test_assess_dataview_lookup_payload_accepts_valid_payload() -> None:
     payload = {"id": "dv_1", "name": "Valid View", "owner": {"name": "Owner"}}
     assessment = assess_dataview_lookup_payload(payload, expected_data_view_id="dv_1")
     assert assessment.kind is PayloadKind.DATA
+    assert assessment.is_valid is True
+
+
+def test_assess_dataview_lookup_payload_accepts_valid_payload_with_error_field() -> None:
+    payload = {"id": "dv_1", "name": "Valid View", "error": "temporary warning"}
+    assessment = assess_dataview_lookup_payload(payload, expected_data_view_id="dv_1")
+    assert assessment.kind is PayloadKind.DATA
+    assert assessment.reason == "valid_lookup_payload"
     assert assessment.is_valid is True
 
 
@@ -121,6 +134,13 @@ def test_assess_dataview_lookup_payload_rejects_circuit_breaker_marker() -> None
     assessment = assess_dataview_lookup_payload(payload, expected_data_view_id="dv_1")
     assert assessment.kind is PayloadKind.ERROR
     assert assessment.reason == "failure_flag:circuit_breaker_open"
+
+
+def test_assess_dataview_lookup_payload_rejects_lookup_failure_reason_detail() -> None:
+    payload = {"id": "dv_1", "name": "Unknown", "lookup_failure_reason": "exception"}
+    assessment = assess_dataview_lookup_payload(payload, expected_data_view_id="dv_1")
+    assert assessment.kind is PayloadKind.ERROR
+    assert assessment.reason == "failure_detail:lookup_failure_reason"
 
 
 def test_assess_dataview_lookup_payload_rejects_legacy_unknown_placeholder() -> None:

--- a/tests/test_discovery_payloads.py
+++ b/tests/test_discovery_payloads.py
@@ -107,6 +107,11 @@ def test_dataview_payload_with_identity_and_error_field_is_not_error() -> None:
     assert is_dataview_error_payload(payload) is False
 
 
+def test_dataview_payload_with_id_and_error_only_is_treated_as_error() -> None:
+    payload = {"id": "dv_missing", "error": "not found"}
+    assert is_dataview_error_payload(payload) is True
+
+
 def test_assess_dataview_lookup_payload_accepts_valid_payload() -> None:
     payload = {"id": "dv_1", "name": "Valid View", "owner": {"name": "Owner"}}
     assessment = assess_dataview_lookup_payload(payload, expected_data_view_id="dv_1")
@@ -120,6 +125,28 @@ def test_assess_dataview_lookup_payload_accepts_valid_payload_with_error_field()
     assert assessment.kind is PayloadKind.DATA
     assert assessment.reason == "valid_lookup_payload"
     assert assessment.is_valid is True
+
+
+def test_assess_dataview_lookup_payload_accepts_owner_only_metadata_with_error_field() -> None:
+    payload = {"id": "dv_1", "owner": {"name": "Owner"}, "error": "transient warning"}
+    assessment = assess_dataview_lookup_payload(payload, expected_data_view_id="dv_1")
+    assert assessment.kind is PayloadKind.DATA
+    assert assessment.reason == "valid_lookup_payload"
+    assert assessment.is_valid is True
+
+
+def test_assess_dataview_lookup_payload_rejects_id_plus_error_only_payload() -> None:
+    payload = {"id": "dv_1", "error": "not found"}
+    assessment = assess_dataview_lookup_payload(payload, expected_data_view_id="dv_1")
+    assert assessment.kind is PayloadKind.ERROR
+    assert assessment.reason == "error_shape"
+
+
+def test_assess_dataview_lookup_payload_rejects_id_only_payload_as_insufficient_metadata() -> None:
+    payload = {"id": "dv_1"}
+    assessment = assess_dataview_lookup_payload(payload, expected_data_view_id="dv_1")
+    assert assessment.kind is PayloadKind.ERROR
+    assert assessment.reason == "insufficient_metadata"
 
 
 def test_assess_dataview_lookup_payload_rejects_unknown_placeholder_with_error_field() -> None:

--- a/tests/test_discovery_payloads.py
+++ b/tests/test_discovery_payloads.py
@@ -5,6 +5,7 @@ import pandas as pd
 from cja_auto_sdr.core.discovery_payloads import (
     PayloadKind,
     assess_component_payload,
+    assess_dataview_lookup_payload,
     coerce_component_rows_or_none,
     count_component_items_or_na,
     extract_component_sequence,
@@ -93,6 +94,47 @@ def test_dataview_payload_with_na_identity_values_is_treated_as_error() -> None:
 def test_dataview_payload_with_na_id_and_present_name_is_not_error() -> None:
     payload = {"statusCode": 200, "message": "ok", "id": pd.NA, "name": "Test View"}
     assert is_dataview_error_payload(payload) is False
+
+
+def test_assess_dataview_lookup_payload_accepts_valid_payload() -> None:
+    payload = {"id": "dv_1", "name": "Valid View", "owner": {"name": "Owner"}}
+    assessment = assess_dataview_lookup_payload(payload, expected_data_view_id="dv_1")
+    assert assessment.kind is PayloadKind.DATA
+    assert assessment.is_valid is True
+
+
+def test_assess_dataview_lookup_payload_rejects_explicit_lookup_failed_marker() -> None:
+    payload = {
+        "id": "dv_1",
+        "name": "Unknown",
+        "lookup_failed": True,
+        "lookup_failure_reason": "exception",
+        "error": "network timeout",
+    }
+    assessment = assess_dataview_lookup_payload(payload, expected_data_view_id="dv_1")
+    assert assessment.kind is PayloadKind.ERROR
+    assert assessment.reason == "failure_flag:lookup_failed"
+
+
+def test_assess_dataview_lookup_payload_rejects_circuit_breaker_marker() -> None:
+    payload = {"id": "dv_1", "name": "Unknown", "circuit_breaker_open": "true"}
+    assessment = assess_dataview_lookup_payload(payload, expected_data_view_id="dv_1")
+    assert assessment.kind is PayloadKind.ERROR
+    assert assessment.reason == "failure_flag:circuit_breaker_open"
+
+
+def test_assess_dataview_lookup_payload_rejects_legacy_unknown_placeholder() -> None:
+    payload = {"id": "dv_1", "name": "Unknown"}
+    assessment = assess_dataview_lookup_payload(payload, expected_data_view_id="dv_1")
+    assert assessment.kind is PayloadKind.ERROR
+    assert assessment.reason == "legacy_unknown_placeholder"
+
+
+def test_assess_dataview_lookup_payload_rejects_id_mismatch() -> None:
+    payload = {"id": "dv_other", "name": "Valid View"}
+    assessment = assess_dataview_lookup_payload(payload, expected_data_view_id="dv_1")
+    assert assessment.kind is PayloadKind.ERROR
+    assert assessment.reason == "id_mismatch"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -99,6 +99,37 @@ class TestDryRunMode:
         assert result is False
 
     @patch("cja_auto_sdr.generator.cjapy")
+    def test_dry_run_fails_for_lookup_failure_placeholder(self, mock_cjapy, valid_config_file, logger):
+        """Error-shaped lookup placeholders must fail dry-run validation."""
+        mock_cja_instance = MagicMock()
+        mock_cjapy.CJA.return_value = mock_cja_instance
+        mock_cja_instance.getDataViews.return_value = []
+        mock_cja_instance.getDataView.return_value = {
+            "id": "dv_12345",
+            "name": "Unknown",
+            "lookup_failed": True,
+            "lookup_failure_reason": "exception",
+        }
+
+        result = run_dry_run(data_views=["dv_12345"], config_file=valid_config_file, logger=logger)
+        assert result is False
+        mock_cja_instance.getMetrics.assert_not_called()
+        mock_cja_instance.getDimensions.assert_not_called()
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    def test_dry_run_fails_for_id_plus_error_lookup_payload(self, mock_cjapy, valid_config_file, logger):
+        """id+error lookup payloads must fail dry-run validation."""
+        mock_cja_instance = MagicMock()
+        mock_cjapy.CJA.return_value = mock_cja_instance
+        mock_cja_instance.getDataViews.return_value = []
+        mock_cja_instance.getDataView.return_value = {"id": "dv_12345", "error": "not found"}
+
+        result = run_dry_run(data_views=["dv_12345"], config_file=valid_config_file, logger=logger)
+        assert result is False
+        mock_cja_instance.getMetrics.assert_not_called()
+        mock_cja_instance.getDimensions.assert_not_called()
+
+    @patch("cja_auto_sdr.generator.cjapy")
     def test_dry_run_partial_success(self, mock_cjapy, valid_config_file, logger):
         """Test dry-run reports partial success when some data views fail"""
         # Mock CJA instance

--- a/tests/test_e2e_integration.py
+++ b/tests/test_e2e_integration.py
@@ -159,7 +159,6 @@ def e2e_dataview_info():
 def _setup_api_mocks(
     mock_setup_logging,
     mock_init_cja,
-    mock_validate_dv,
     mock_fetcher_class,
     metrics_df,
     dimensions_df,
@@ -173,7 +172,6 @@ def _setup_api_mocks(
 
     mock_cja = Mock()
     mock_init_cja.return_value = mock_cja
-    mock_validate_dv.return_value = True
 
     mock_fetcher = Mock()
     mock_fetcher.fetch_all_data.return_value = (
@@ -191,7 +189,6 @@ def _setup_api_mocks(
 _api_boundary_patches = [
     patch("cja_auto_sdr.generator.setup_logging"),
     patch("cja_auto_sdr.generator.initialize_cja"),
-    patch("cja_auto_sdr.generator.validate_data_view"),
     patch("cja_auto_sdr.generator.ParallelAPIFetcher"),
 ]
 
@@ -236,7 +233,6 @@ class TestEndToEndPipeline:
     def test_excel_output_produces_valid_workbook(
         self,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         e2e_config_file,
@@ -248,7 +244,6 @@ class TestEndToEndPipeline:
         _setup_api_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
             mock_fetcher_class,
             e2e_metrics_df,
             e2e_dimensions_df,
@@ -294,7 +289,6 @@ class TestEndToEndPipeline:
     def test_csv_output_produces_parseable_files(
         self,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         e2e_config_file,
@@ -306,7 +300,6 @@ class TestEndToEndPipeline:
         _setup_api_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
             mock_fetcher_class,
             e2e_metrics_df,
             e2e_dimensions_df,
@@ -355,7 +348,6 @@ class TestEndToEndPipeline:
     def test_json_output_has_correct_structure_and_data(
         self,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         e2e_config_file,
@@ -367,7 +359,6 @@ class TestEndToEndPipeline:
         _setup_api_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
             mock_fetcher_class,
             e2e_metrics_df,
             e2e_dimensions_df,
@@ -423,7 +414,6 @@ class TestEndToEndPipeline:
     def test_html_output_is_well_formed_and_contains_data(
         self,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         e2e_config_file,
@@ -435,7 +425,6 @@ class TestEndToEndPipeline:
         _setup_api_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
             mock_fetcher_class,
             e2e_metrics_df,
             e2e_dimensions_df,
@@ -478,7 +467,6 @@ class TestEndToEndPipeline:
     def test_markdown_output_contains_tables_and_data(
         self,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         e2e_config_file,
@@ -490,7 +478,6 @@ class TestEndToEndPipeline:
         _setup_api_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
             mock_fetcher_class,
             e2e_metrics_df,
             e2e_dimensions_df,
@@ -527,7 +514,6 @@ class TestEndToEndPipeline:
     def test_all_formats_generates_every_format(
         self,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         e2e_config_file,
@@ -539,7 +525,6 @@ class TestEndToEndPipeline:
         _setup_api_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
             mock_fetcher_class,
             e2e_metrics_df,
             e2e_dimensions_df,
@@ -573,7 +558,6 @@ class TestEndToEndPipeline:
     def test_data_quality_issues_detected_in_output(
         self,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         e2e_config_file,
@@ -586,7 +570,6 @@ class TestEndToEndPipeline:
         _setup_api_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
             mock_fetcher_class,
             e2e_metrics_df,
             e2e_dimensions_df,
@@ -617,7 +600,6 @@ class TestEndToEndPipeline:
     def test_skip_validation_produces_output_without_dq(
         self,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         e2e_config_file,
@@ -629,7 +611,6 @@ class TestEndToEndPipeline:
         _setup_api_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
             mock_fetcher_class,
             e2e_metrics_df,
             e2e_dimensions_df,
@@ -656,7 +637,6 @@ class TestEndToEndPipeline:
     def test_quality_report_only_returns_issues_without_files(
         self,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         e2e_config_file,
@@ -668,7 +648,6 @@ class TestEndToEndPipeline:
         _setup_api_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
             mock_fetcher_class,
             e2e_metrics_df,
             e2e_dimensions_df,
@@ -697,7 +676,6 @@ class TestEndToEndPipeline:
     def test_cja_init_failure_returns_failed_result(
         self,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         e2e_config_file,
@@ -728,7 +706,6 @@ class TestEndToEndPipeline:
     def test_dataview_validation_failure(
         self,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         e2e_config_file,
@@ -741,7 +718,12 @@ class TestEndToEndPipeline:
         logger.handlers = []
         mock_setup_logging.return_value = logger
         mock_init_cja.return_value = Mock()
-        mock_validate_dv.return_value = False  # Simulate invalid DV
+
+        # Simulate invalid DV by returning empty lookup_data
+        mock_fetcher = Mock()
+        mock_fetcher.fetch_all_data.return_value = (pd.DataFrame(), pd.DataFrame(), {})
+        mock_fetcher.get_tuner_statistics.return_value = None
+        mock_fetcher_class.return_value = mock_fetcher
 
         result = process_single_dataview(
             data_view_id=DV_ID,
@@ -759,7 +741,6 @@ class TestEndToEndPipeline:
     def test_empty_dataview_returns_failure(
         self,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         e2e_config_file,
@@ -772,7 +753,6 @@ class TestEndToEndPipeline:
         logger.handlers = []
         mock_setup_logging.return_value = logger
         mock_init_cja.return_value = Mock()
-        mock_validate_dv.return_value = True
 
         mock_fetcher = Mock()
         mock_fetcher.fetch_all_data.return_value = (
@@ -799,7 +779,6 @@ class TestEndToEndPipeline:
     def test_metrics_only_excludes_dimensions_from_excel(
         self,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         e2e_config_file,
@@ -811,7 +790,6 @@ class TestEndToEndPipeline:
         _setup_api_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
             mock_fetcher_class,
             e2e_metrics_df,
             e2e_dimensions_df,
@@ -836,7 +814,6 @@ class TestEndToEndPipeline:
     def test_dimensions_only_excludes_metrics_from_excel(
         self,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         e2e_config_file,
@@ -848,7 +825,6 @@ class TestEndToEndPipeline:
         _setup_api_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
             mock_fetcher_class,
             e2e_metrics_df,
             e2e_dimensions_df,
@@ -875,7 +851,6 @@ class TestEndToEndPipeline:
     def test_max_issues_limits_reported_count(
         self,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         e2e_config_file,
@@ -887,7 +862,6 @@ class TestEndToEndPipeline:
         _setup_api_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
             mock_fetcher_class,
             e2e_metrics_df,
             e2e_dimensions_df,
@@ -929,7 +903,6 @@ class TestEndToEndPipeline:
     def test_special_characters_handled_in_all_formats(
         self,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         e2e_config_file,
@@ -942,7 +915,6 @@ class TestEndToEndPipeline:
         _setup_api_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
             mock_fetcher_class,
             e2e_metrics_df,
             e2e_dimensions_df,

--- a/tests/test_exception_contracts.py
+++ b/tests/test_exception_contracts.py
@@ -137,9 +137,9 @@ def test_show_stats_continues_after_unexpected_runtime_error(capsys: pytest.Capt
     assert ok_row["name"] == "Name dv_ok"
 
 
-def test_validate_data_view_unexpected_runtime_error_returns_false() -> None:
+def test_validate_data_view_recoverable_api_error_returns_false() -> None:
     mock_cja = MagicMock()
-    mock_cja.getDataView.side_effect = RuntimeError("unexpected validation runtime failure")
+    mock_cja.getDataView.side_effect = ValueError("unexpected validation failure")
 
     result = generator.validate_data_view(mock_cja, "dv_contract", logging.getLogger(__name__))
 

--- a/tests/test_exception_narrowing.py
+++ b/tests/test_exception_narrowing.py
@@ -1,19 +1,9 @@
-"""Tests verifying narrowed exception boundaries in generator.py.
+"""Tests verifying command-boundary exception handling in generator.py.
 
-After narrowing 8 broad ``except Exception`` handlers (v3.3.5), these tests
-ensure that:
-  - Exception types *inside* each handler's tuple are still caught gracefully.
-  - Exception types *outside* the tuple now propagate as expected.
-
-Boundaries tested:
-  Group A (fallback after RECOVERABLE_API_EXCEPTIONS -> (RuntimeError, AttributeError)):
-    - process_inventory_summary
-    - validate_config_only
-
-  Group B (sole handler -> RECOVERABLE_API_EXCEPTIONS):
-    - test_profile
-    - validate_data_view
-    - _require_accessible_dataview
+These tests enforce a strict CLI boundary contract:
+  - recoverable API/bootstrap failures (including ConfigurationError) are
+    surfaced as controlled user-facing failures.
+  - non-recoverable failures outside the configured tuples still propagate.
 """
 
 import logging
@@ -22,6 +12,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from cja_auto_sdr import generator
+from cja_auto_sdr.core.exceptions import ConfigurationError
 from cja_auto_sdr.generator import (
     _require_accessible_dataview,
     validate_data_view,
@@ -41,12 +32,12 @@ def _make_logger() -> logging.Logger:
 
 
 # ===========================================================================
-# Group B: test_profile  (now catches RECOVERABLE_API_EXCEPTIONS)
+# Group B: test_profile  (catches RECOVERABLE_CONFIG_API_EXCEPTIONS)
 # ===========================================================================
 
 
 class TestTestProfileExceptionNarrowing:
-    """Verify test_profile catches RECOVERABLE_API_EXCEPTIONS and propagates others."""
+    """Verify test_profile catches recoverable API/bootstrap failures and propagates others."""
 
     def _run_with_side_effect(self, exc, tmp_path, capsys):
         """Helper: invoke test_profile with cjapy.importConfigFile raising *exc*."""
@@ -74,6 +65,12 @@ class TestTestProfileExceptionNarrowing:
         result = self._run_with_side_effect(ValueError("bad token"), tmp_path, capsys)
         assert result is False
 
+    def test_configuration_error_caught(self, tmp_path, capsys):
+        """ConfigurationError should return a controlled failure, not a traceback."""
+        result = self._run_with_side_effect(ConfigurationError("invalid profile credentials"), tmp_path, capsys)
+        assert result is False
+        assert "FAILED" in capsys.readouterr().err
+
     def test_runtime_error_propagates(self, tmp_path, capsys):
         """RuntimeError is NOT in RECOVERABLE_API_EXCEPTIONS -> propagates."""
         with pytest.raises(RuntimeError, match="should escape"):
@@ -86,12 +83,12 @@ class TestTestProfileExceptionNarrowing:
 
 
 # ===========================================================================
-# Group B: validate_data_view  (now catches RECOVERABLE_API_EXCEPTIONS)
+# Group B: validate_data_view  (outer guard catches RECOVERABLE_CONFIG_API_EXCEPTIONS)
 # ===========================================================================
 
 
 class TestValidateDataViewExceptionNarrowing:
-    """Verify validate_data_view catches RECOVERABLE_API_EXCEPTIONS and propagates others."""
+    """Verify validate_data_view catches recoverable failures and propagates others."""
 
     def test_type_error_caught(self):
         """TypeError (in RECOVERABLE_API_EXCEPTIONS) is caught -> returns False."""
@@ -118,6 +115,13 @@ class TestValidateDataViewExceptionNarrowing:
         mock_cja.getDataView.side_effect = SystemError("should escape")
         with pytest.raises(SystemError, match="should escape"):
             validate_data_view(mock_cja, "dv_test", _make_logger())
+
+    def test_configuration_error_while_listing_available_views_caught(self):
+        """ConfigurationError from fallback list call should not escape."""
+        mock_cja = MagicMock()
+        mock_cja.getDataView.return_value = None
+        mock_cja.getDataViews.side_effect = ConfigurationError("token bootstrap failed")
+        assert validate_data_view(mock_cja, "dv_test", _make_logger()) is False
 
 
 # ===========================================================================
@@ -185,6 +189,12 @@ class TestProcessInventorySummaryExceptionNarrowing:
         # AttributeError is in BOTH tuples — first handler catches it
         assert "error" in result
 
+    def test_configuration_error_caught(self):
+        """ConfigurationError should be returned as structured summary error payload."""
+        result = self._run_with_side_effect(ConfigurationError("invalid auth bootstrap"))
+        assert "error" in result
+        assert "invalid auth bootstrap" in result["error"]
+
     def test_system_error_propagates(self):
         """SystemError is NOT in either handler -> propagates."""
         with pytest.raises(SystemError, match="should escape"):
@@ -223,7 +233,29 @@ class TestValidateConfigOnlyExceptionNarrowing:
         # AttributeError is in BOTH RECOVERABLE_API and fallback; first handler catches
         assert result is False
 
+    def test_configuration_error_caught(self):
+        """ConfigurationError should return False (controlled validation failure)."""
+        result = self._run_with_cja_side_effect(ConfigurationError("invalid oauth configuration"))
+        assert result is False
+
     def test_system_error_propagates(self):
         """SystemError is NOT in either handler -> propagates."""
         with pytest.raises(SystemError, match="should escape"):
             self._run_with_cja_side_effect(SystemError("should escape"))
+
+
+class TestResolveDataViewNamesExceptionBoundary:
+    """Verify resolve_data_view_names handles recoverable bootstrap failures."""
+
+    def test_configuration_error_returns_connectivity_diagnostics(self):
+        """ConfigurationError should produce controlled connectivity diagnostics."""
+        with patch("cja_auto_sdr.generator.configure_cjapy", side_effect=ConfigurationError("bad org credentials")):
+            ids, name_map, diagnostics = generator.resolve_data_view_names(
+                ["My DV"],
+                include_diagnostics=True,
+            )
+
+        assert ids == []
+        assert name_map == {}
+        assert diagnostics.error_type == "connectivity_error"
+        assert "bad org credentials" in diagnostics.error_message

--- a/tests/test_exception_narrowing.py
+++ b/tests/test_exception_narrowing.py
@@ -32,6 +32,7 @@ from cja_auto_sdr.generator import test_profile as run_test_profile
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _make_logger() -> logging.Logger:
     """Return a quiet logger for test use."""
     logger = logging.getLogger("test_exception_narrowing")
@@ -199,9 +200,12 @@ class TestValidateConfigOnlyExceptionNarrowing:
     """Verify validate_config_only fallback catches (RuntimeError, AttributeError)."""
 
     def _run_with_cja_side_effect(self, exc):
-        """Mock configure_cjapy success then cjapy.CJA() raising *exc*."""
+        """Mock credential resolution + cjapy.CJA() raising *exc*."""
+        fake_creds = {"org_id": "X@AdobeOrg", "client_id": "cid", "secret": "sec"}
         with (
-            patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "config.json", {})),
+            patch("cja_auto_sdr.generator.load_credentials_from_env", return_value=fake_creds),
+            patch("cja_auto_sdr.generator.validate_env_credentials", return_value=True),
+            patch("cja_auto_sdr.generator._config_from_env"),
             patch("cja_auto_sdr.generator.cjapy") as mock_cjapy,
             patch("cja_auto_sdr.generator._check_output_dir_access", return_value=(True, ".", None, None)),
         ):

--- a/tests/test_exception_narrowing.py
+++ b/tests/test_exception_narrowing.py
@@ -1,0 +1,225 @@
+"""Tests verifying narrowed exception boundaries in generator.py.
+
+After narrowing 8 broad ``except Exception`` handlers (v3.3.5), these tests
+ensure that:
+  - Exception types *inside* each handler's tuple are still caught gracefully.
+  - Exception types *outside* the tuple now propagate as expected.
+
+Boundaries tested:
+  Group A (fallback after RECOVERABLE_API_EXCEPTIONS -> (RuntimeError, AttributeError)):
+    - process_inventory_summary
+    - validate_config_only
+
+  Group B (sole handler -> RECOVERABLE_API_EXCEPTIONS):
+    - test_profile
+    - validate_data_view
+    - _require_accessible_dataview
+"""
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cja_auto_sdr import generator
+from cja_auto_sdr.generator import (
+    _require_accessible_dataview,
+    validate_data_view,
+)
+from cja_auto_sdr.generator import test_profile as run_test_profile
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_logger() -> logging.Logger:
+    """Return a quiet logger for test use."""
+    logger = logging.getLogger("test_exception_narrowing")
+    logger.setLevel(logging.CRITICAL)
+    return logger
+
+
+# ===========================================================================
+# Group B: test_profile  (now catches RECOVERABLE_API_EXCEPTIONS)
+# ===========================================================================
+
+
+class TestTestProfileExceptionNarrowing:
+    """Verify test_profile catches RECOVERABLE_API_EXCEPTIONS and propagates others."""
+
+    def _run_with_side_effect(self, exc, tmp_path, capsys):
+        """Helper: invoke test_profile with cjapy.importConfigFile raising *exc*."""
+        profile_dir = tmp_path / "orgs" / "narrowing"
+        profile_dir.mkdir(parents=True)
+        (profile_dir / "config.json").write_text('{"client_id":"x","secret":"s","org_id":"o@AdobeOrg"}')
+
+        with (
+            patch("cja_auto_sdr.generator.get_profile_path", return_value=profile_dir),
+            patch("cja_auto_sdr.generator.cjapy") as mock_cjapy,
+            patch("cja_auto_sdr.generator.ConfigValidator") as mock_validator,
+        ):
+            mock_cjapy.importConfigFile.side_effect = exc
+            mock_validator.validate_all.return_value = []
+            return run_test_profile("narrowing")
+
+    def test_os_error_caught(self, tmp_path, capsys):
+        """OSError (in RECOVERABLE_API_EXCEPTIONS) is caught -> returns False."""
+        result = self._run_with_side_effect(OSError("network down"), tmp_path, capsys)
+        assert result is False
+        assert "FAILED" in capsys.readouterr().err
+
+    def test_value_error_caught(self, tmp_path, capsys):
+        """ValueError (in RECOVERABLE_API_EXCEPTIONS) is caught -> returns False."""
+        result = self._run_with_side_effect(ValueError("bad token"), tmp_path, capsys)
+        assert result is False
+
+    def test_runtime_error_propagates(self, tmp_path, capsys):
+        """RuntimeError is NOT in RECOVERABLE_API_EXCEPTIONS -> propagates."""
+        with pytest.raises(RuntimeError, match="should escape"):
+            self._run_with_side_effect(RuntimeError("should escape"), tmp_path, capsys)
+
+    def test_system_error_propagates(self, tmp_path, capsys):
+        """SystemError is NOT in RECOVERABLE_API_EXCEPTIONS -> propagates."""
+        with pytest.raises(SystemError, match="should escape"):
+            self._run_with_side_effect(SystemError("should escape"), tmp_path, capsys)
+
+
+# ===========================================================================
+# Group B: validate_data_view  (now catches RECOVERABLE_API_EXCEPTIONS)
+# ===========================================================================
+
+
+class TestValidateDataViewExceptionNarrowing:
+    """Verify validate_data_view catches RECOVERABLE_API_EXCEPTIONS and propagates others."""
+
+    def test_type_error_caught(self):
+        """TypeError (in RECOVERABLE_API_EXCEPTIONS) is caught -> returns False."""
+        mock_cja = MagicMock()
+        mock_cja.getDataView.side_effect = TypeError("bad payload")
+        assert validate_data_view(mock_cja, "dv_test", _make_logger()) is False
+
+    def test_key_error_caught(self):
+        """KeyError (in RECOVERABLE_API_EXCEPTIONS) is caught -> returns False."""
+        mock_cja = MagicMock()
+        mock_cja.getDataView.side_effect = KeyError("missing key")
+        assert validate_data_view(mock_cja, "dv_test", _make_logger()) is False
+
+    def test_runtime_error_propagates(self):
+        """RuntimeError is NOT in RECOVERABLE_API_EXCEPTIONS -> propagates."""
+        mock_cja = MagicMock()
+        mock_cja.getDataView.side_effect = RuntimeError("should escape")
+        with pytest.raises(RuntimeError, match="should escape"):
+            validate_data_view(mock_cja, "dv_test", _make_logger())
+
+    def test_system_error_propagates(self):
+        """SystemError is NOT in RECOVERABLE_API_EXCEPTIONS -> propagates."""
+        mock_cja = MagicMock()
+        mock_cja.getDataView.side_effect = SystemError("should escape")
+        with pytest.raises(SystemError, match="should escape"):
+            validate_data_view(mock_cja, "dv_test", _make_logger())
+
+
+# ===========================================================================
+# Group B: _require_accessible_dataview  (now catches RECOVERABLE_API_EXCEPTIONS)
+# ===========================================================================
+
+
+class TestRequireAccessibleDataviewExceptionNarrowing:
+    """Verify _require_accessible_dataview catches RECOVERABLE_API_EXCEPTIONS and re-raises."""
+
+    def test_os_error_reraises(self):
+        """OSError (in RECOVERABLE_API_EXCEPTIONS) is caught and re-raised."""
+        mock_cja = MagicMock()
+        mock_cja.getDataView.side_effect = OSError("connection reset")
+        # The handler re-raises if _is_inaccessible_dataview_lookup_error returns False
+        with pytest.raises(OSError, match="connection reset"):
+            _require_accessible_dataview(mock_cja, "dv_test")
+
+    def test_value_error_reraises(self):
+        """ValueError (in RECOVERABLE_API_EXCEPTIONS) is caught and re-raised."""
+        mock_cja = MagicMock()
+        mock_cja.getDataView.side_effect = ValueError("bad id")
+        with pytest.raises(ValueError, match="bad id"):
+            _require_accessible_dataview(mock_cja, "dv_test")
+
+    def test_runtime_error_propagates(self):
+        """RuntimeError is NOT in RECOVERABLE_API_EXCEPTIONS -> propagates uncaught."""
+        mock_cja = MagicMock()
+        mock_cja.getDataView.side_effect = RuntimeError("should escape")
+        with pytest.raises(RuntimeError, match="should escape"):
+            _require_accessible_dataview(mock_cja, "dv_test")
+
+
+# ===========================================================================
+# Group A: process_inventory_summary  (fallback -> (RuntimeError, AttributeError))
+# ===========================================================================
+
+
+class TestProcessInventorySummaryExceptionNarrowing:
+    """Verify process_inventory_summary fallback catches (RuntimeError, AttributeError)."""
+
+    def _run_with_side_effect(self, exc):
+        """Mock CJA init + dataviews.get_single raising *exc*."""
+        mock_cja = MagicMock()
+        mock_cja.dataviews.get_single.side_effect = exc
+
+        with (
+            patch("cja_auto_sdr.generator.initialize_cja", return_value=mock_cja),
+            patch("cja_auto_sdr.generator.setup_logging", return_value=_make_logger()),
+            patch("cja_auto_sdr.generator.with_log_context", return_value=_make_logger()),
+        ):
+            return generator.process_inventory_summary(
+                data_view_id="dv_test",
+                config_file="config.json",
+            )
+
+    def test_runtime_error_caught(self):
+        """RuntimeError (in fallback tuple) is caught -> returns error dict."""
+        result = self._run_with_side_effect(RuntimeError("cjapy internal"))
+        assert "error" in result
+
+    def test_attribute_error_caught(self):
+        """AttributeError (in fallback tuple) is caught -> returns error dict."""
+        result = self._run_with_side_effect(AttributeError("no attribute"))
+        # AttributeError is in BOTH tuples — first handler catches it
+        assert "error" in result
+
+    def test_system_error_propagates(self):
+        """SystemError is NOT in either handler -> propagates."""
+        with pytest.raises(SystemError, match="should escape"):
+            self._run_with_side_effect(SystemError("should escape"))
+
+
+# ===========================================================================
+# Group A: validate_config_only  (fallback -> (RuntimeError, AttributeError))
+# ===========================================================================
+
+
+class TestValidateConfigOnlyExceptionNarrowing:
+    """Verify validate_config_only fallback catches (RuntimeError, AttributeError)."""
+
+    def _run_with_cja_side_effect(self, exc):
+        """Mock configure_cjapy success then cjapy.CJA() raising *exc*."""
+        with (
+            patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "config.json", {})),
+            patch("cja_auto_sdr.generator.cjapy") as mock_cjapy,
+            patch("cja_auto_sdr.generator._check_output_dir_access", return_value=(True, ".", None, None)),
+        ):
+            mock_cjapy.CJA.side_effect = exc
+            return generator.validate_config_only(config_file="config.json")
+
+    def test_runtime_error_caught(self):
+        """RuntimeError (in fallback tuple) is caught -> returns False."""
+        result = self._run_with_cja_side_effect(RuntimeError("cjapy init failed"))
+        assert result is False
+
+    def test_attribute_error_caught(self):
+        """AttributeError (in fallback tuple) is caught -> returns False."""
+        result = self._run_with_cja_side_effect(AttributeError("missing method"))
+        # AttributeError is in BOTH RECOVERABLE_API and fallback; first handler catches
+        assert result is False
+
+    def test_system_error_propagates(self):
+        """SystemError is NOT in either handler -> propagates."""
+        with pytest.raises(SystemError, match="should escape"):
+            self._run_with_cja_side_effect(SystemError("should escape"))

--- a/tests/test_exception_narrowing.py
+++ b/tests/test_exception_narrowing.py
@@ -259,3 +259,39 @@ class TestResolveDataViewNamesExceptionBoundary:
         assert name_map == {}
         assert diagnostics.error_type == "connectivity_error"
         assert "bad org credentials" in diagnostics.error_message
+
+
+# ===========================================================================
+# Group A: _count_component_items_for_fetch_spec_with_retry (best-effort)
+# ===========================================================================
+
+
+class TestComponentCountRetryExceptionBoundary:
+    """Verify retry-based component counting degrades recoverable optional failures."""
+
+    def _run_count_with_retry_side_effect(self, exc):
+        """Run component count helper with a patched retry call that raises *exc*."""
+        with patch("cja_auto_sdr.generator.make_api_call_with_retry", side_effect=exc):
+            return generator._count_component_items_for_fetch_spec_with_retry(
+                MagicMock(),
+                "dv_test",
+                generator._METRICS_COMPONENT_FETCH_SPEC,
+                logger=_make_logger(),
+            )
+
+    def test_discovery_not_found_error_degrades_to_zero(self):
+        """Missing component methods should degrade to zero instead of raising."""
+        result = self._run_count_with_retry_side_effect(
+            generator.DiscoveryNotFoundError("missing getMetrics"),
+        )
+        assert result == 0
+
+    def test_runtime_error_degrades_to_zero(self):
+        """Unexpected runtime errors in optional count collection should degrade to zero."""
+        result = self._run_count_with_retry_side_effect(RuntimeError("cjapy internal bug"))
+        assert result == 0
+
+    def test_keyboard_interrupt_propagates(self):
+        """BaseException subclasses must still propagate through the helper."""
+        with pytest.raises(KeyboardInterrupt):
+            self._run_count_with_retry_side_effect(KeyboardInterrupt())

--- a/tests/test_exception_narrowing.py
+++ b/tests/test_exception_narrowing.py
@@ -125,12 +125,12 @@ class TestValidateDataViewExceptionNarrowing:
 
 
 # ===========================================================================
-# Group B: _require_accessible_dataview  (now catches RECOVERABLE_API_EXCEPTIONS)
+# Group B: _require_accessible_dataview  (centralized dataview lookup classification)
 # ===========================================================================
 
 
 class TestRequireAccessibleDataviewExceptionNarrowing:
-    """Verify _require_accessible_dataview catches RECOVERABLE_API_EXCEPTIONS and re-raises."""
+    """Verify _require_accessible_dataview maps inaccessible lookups and re-raises others."""
 
     def test_os_error_reraises(self):
         """OSError (in RECOVERABLE_API_EXCEPTIONS) is caught and re-raised."""
@@ -148,10 +148,20 @@ class TestRequireAccessibleDataviewExceptionNarrowing:
             _require_accessible_dataview(mock_cja, "dv_test")
 
     def test_runtime_error_propagates(self):
-        """RuntimeError is NOT in RECOVERABLE_API_EXCEPTIONS -> propagates uncaught."""
+        """RuntimeError without lookup metadata should propagate unchanged."""
         mock_cja = MagicMock()
         mock_cja.getDataView.side_effect = RuntimeError("should escape")
         with pytest.raises(RuntimeError, match="should escape"):
+            _require_accessible_dataview(mock_cja, "dv_test")
+
+    def test_runtime_error_with_404_metadata_maps_to_not_found(self):
+        """Non-whitelisted wrappers with 403/404 metadata must still map to not_found."""
+        mock_cja = MagicMock()
+        lookup_error = RuntimeError("wrapped lookup failure")
+        lookup_error.response = {"error": {"statusCode": "404"}}  # type: ignore[attr-defined]
+        mock_cja.getDataView.side_effect = lookup_error
+
+        with pytest.raises(generator.DiscoveryNotFoundError, match="Data view 'dv_test' not found"):
             _require_accessible_dataview(mock_cja, "dv_test")
 
 

--- a/tests/test_generator_remaining_coverage.py
+++ b/tests/test_generator_remaining_coverage.py
@@ -1946,7 +1946,6 @@ class TestMainImplSingleModeResults:
 class TestProcessSingleDataviewExceptions:
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
     @patch("cja_auto_sdr.generator.apply_excel_formatting")
@@ -1957,7 +1956,6 @@ class TestProcessSingleDataviewExceptions:
         mock_apply_fmt,
         mock_dq_cls,
         mock_fetcher_cls,
-        mock_validate,
         mock_init_cja,
         mock_setup_log,
         tmp_path,
@@ -1970,7 +1968,6 @@ class TestProcessSingleDataviewExceptions:
 
         mock_cja = MagicMock()
         mock_init_cja.return_value = mock_cja
-        mock_validate.return_value = True
 
         metrics_df = pd.DataFrame({"id": ["m1"], "name": ["Met 1"], "type": ["std"]})
         dims_df = pd.DataFrame({"id": ["d1"], "name": ["Dim 1"], "type": ["str"]})

--- a/tests/test_generator_remaining_coverage.py
+++ b/tests/test_generator_remaining_coverage.py
@@ -226,10 +226,10 @@ class TestParseEnvCredentialsContent:
 
 
 class TestValidateDataViewException:
-    def test_unexpected_exception_returns_false(self):
-        """An unexpected exception in validate_data_view is caught and logged."""
+    def test_recoverable_api_exception_returns_false(self):
+        """A recoverable API exception in validate_data_view is caught and logged."""
         mock_cja = MagicMock()
-        mock_cja.getDataView.side_effect = RuntimeError("Unexpected crash")
+        mock_cja.getDataView.side_effect = ValueError("Unexpected crash")
         logger = _make_logger()
         logger.setLevel(logging.DEBUG)
 
@@ -239,7 +239,7 @@ class TestValidateDataViewException:
     def test_exception_with_non_string_id(self):
         """Edge case: validate_data_view with a non-standard ID that causes issues."""
         mock_cja = MagicMock()
-        mock_cja.getDataView.side_effect = RuntimeError("NoneType has no attribute")
+        mock_cja.getDataView.side_effect = TypeError("NoneType has no attribute")
         logger = _make_logger()
         result = validate_data_view(mock_cja, "dv_bad", logger)
         assert result is False

--- a/tests/test_main_entry_points.py
+++ b/tests/test_main_entry_points.py
@@ -5,6 +5,7 @@ handle exit codes, track run_state, and emit run summary JSON.
 """
 
 import json
+import logging
 import os
 import sys
 from contextlib import redirect_stderr, redirect_stdout
@@ -137,6 +138,23 @@ class TestMainImplProfileManagement:
 
         assert exc_info.value.code == 0
         mock_list.assert_called_once()
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.list_profiles")
+    def test_profile_list_excel_warns_and_falls_back_to_table(self, mock_list, caplog):
+        """Unsupported --profile-list formats should warn and route to table output."""
+        mock_list.return_value = True
+
+        with caplog.at_level(logging.WARNING, logger="cja_auto_sdr.generator"):
+            with pytest.raises(SystemExit) as exc_info:
+                with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                    mock_pa.return_value = parse_arguments(["--profile-list", "--format", "excel"])
+                    _main_impl()
+
+        assert exc_info.value.code == 0
+        mock_list.assert_called_once_with(output_format="table")
+        assert "--profile-list" in caplog.text
+        assert "using table" in caplog.text
 
     @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
     @patch("cja_auto_sdr.generator.test_profile")

--- a/tests/test_main_impl_cli_coverage.py
+++ b/tests/test_main_impl_cli_coverage.py
@@ -1934,8 +1934,8 @@ class TestAdditionalValidation:
             with pytest.raises(SystemExit) as exc_info:
                 _main_impl()
         assert exc_info.value.code == 1
-        out = capsys.readouterr().out
-        assert "Console format is only supported for diff comparison" in out
+        err = capsys.readouterr().err
+        assert "Console format is only supported for diff comparison" in err
 
     @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
     @patch("cja_auto_sdr.generator.resolve_data_view_names", return_value=(["dv_123"], {}))

--- a/tests/test_main_impl_coverage.py
+++ b/tests/test_main_impl_coverage.py
@@ -1836,7 +1836,7 @@ class TestRunDryRunAPIValidation:
 
             mock_retry.side_effect = [
                 [],  # getDataViews
-                {"name": "Test DV"},  # getDataView
+                {"id": "dv_test", "name": "Test DV"},  # getDataView
                 OSError("metrics fetch fail"),  # getMetrics
                 ValueError("dimensions fetch fail"),  # getDimensions
             ]
@@ -1862,7 +1862,7 @@ class TestRunDryRunAPIValidation:
                 if op == "getDataViews (dry-run)":
                     return []
                 if op == "getDataView(dv_partial)":
-                    return {"name": "Partial DV"}
+                    return {"id": "dv_partial", "name": "Partial DV"}
                 if op == "getMetrics(dv_partial)":
                     raise DiscoveryNotFoundError("missing getMetrics")
                 if op == "getDimensions(dv_partial)":
@@ -1963,7 +1963,7 @@ class TestRunDryRunAPIValidation:
                 if op == "getDataView(dv_flaky)":
                     raise RetryableHTTPError(504, "gateway timeout")
                 if op == "getDataView(dv_ok)":
-                    return {"name": "Healthy DV"}
+                    return {"id": "dv_ok", "name": "Healthy DV"}
                 if op == "getMetrics(dv_ok)":
                     return []
                 if op == "getDimensions(dv_ok)":
@@ -2214,7 +2214,7 @@ class TestRunDryRunAPIReturnsNone:
 
             mock_retry.side_effect = [
                 None,  # getDataViews (unstable)
-                {"name": "Found DV"},  # getDataView
+                {"id": "dv_test", "name": "Found DV"},  # getDataView
                 [],  # getMetrics
                 [],  # getDimensions
             ]

--- a/tests/test_main_impl_coverage.py
+++ b/tests/test_main_impl_coverage.py
@@ -42,6 +42,7 @@ from cja_auto_sdr.core.exceptions import (
 )
 from cja_auto_sdr.generator import (
     BatchProcessor,
+    DiscoveryNotFoundError,
     ProcessingResult,
     process_single_dataview,
     run_dry_run,
@@ -1843,6 +1844,39 @@ class TestRunDryRunAPIValidation:
             result = run_dry_run(["dv_test"], "config.json", logger)
         # Still passes because the DV was found
         assert result is True
+
+    def test_dv_validation_missing_component_method_degrades_to_zero(self, capsys):
+        """Missing metric/dimension methods should not abort dry-run validation."""
+        logger = logging.getLogger("test_dry_run_missing_component_method")
+        with (
+            patch("cja_auto_sdr.generator.validate_config_file", return_value=True),
+            patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "config", {})),
+            patch("cja_auto_sdr.generator.cjapy") as mock_cjapy,
+            patch("cja_auto_sdr.generator.make_api_call_with_retry") as mock_retry,
+        ):
+            mock_cja = MagicMock()
+            mock_cjapy.CJA.return_value = mock_cja
+
+            def _mock_retry_call(*_args, **kwargs):
+                op = kwargs.get("operation_name")
+                if op == "getDataViews (dry-run)":
+                    return []
+                if op == "getDataView(dv_partial)":
+                    return {"name": "Partial DV"}
+                if op == "getMetrics(dv_partial)":
+                    raise DiscoveryNotFoundError("missing getMetrics")
+                if op == "getDimensions(dv_partial)":
+                    return [{"id": "d1"}, {"id": "d2"}]
+                raise AssertionError(f"Unexpected operation: {op}")
+
+            mock_retry.side_effect = _mock_retry_call
+
+            result = run_dry_run(["dv_partial"], "config.json", logger)
+
+        assert result is True
+        captured = capsys.readouterr()
+        assert "dv_partial: Partial DV" in captured.out
+        assert "Components: 0 metrics, 2 dimensions" in captured.out
 
     def test_dv_not_found(self, capsys):
         """Lines 6636-6638: data view getDataView returns None."""

--- a/tests/test_main_impl_coverage.py
+++ b/tests/test_main_impl_coverage.py
@@ -22,6 +22,8 @@ Targets uncovered line ranges:
 import argparse
 import json
 import logging
+import threading
+import time
 from itertools import count
 from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
@@ -791,6 +793,91 @@ class TestProcessSingleDataviewInventoryBuilding:
         assert result.segments_count == 0
         assert _mock_call_contains(mock_logger.error, "Error during segments inventory: segments transport fail")
         assert _mock_call_contains(mock_logger.info, "Continuing with SDR generation despite segments inventory errors")
+
+    @patch("cja_auto_sdr.generator.setup_logging")
+    @patch("cja_auto_sdr.generator.initialize_cja")
+    @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
+    @patch("cja_auto_sdr.generator.DataQualityChecker")
+    @patch("cja_auto_sdr.generator.apply_excel_formatting")
+    @patch("pandas.ExcelWriter")
+    def test_parallel_inventory_serializes_shared_cja_calls(
+        self,
+        mock_excel_writer,
+        mock_apply_formatting,
+        mock_dq_checker_class,
+        mock_fetcher_class,
+        mock_init_cja,
+        mock_setup_logging,
+        mock_config_file,
+        temp_output_dir,
+        sample_metrics_df,
+        sample_dimensions_df,
+        sample_dataview_info,
+    ):
+        """Calculated/segments inventory builders should not call the shared CJA client concurrently."""
+        _configure_standard_mocks(
+            mock_setup_logging,
+            mock_init_cja,
+            mock_fetcher_class,
+            mock_dq_checker_class,
+            mock_excel_writer,
+            sample_metrics_df,
+            sample_dimensions_df,
+            sample_dataview_info,
+        )
+
+        calc_inv = _make_mock_inventory_obj(total_calculated_metrics=5)
+        seg_inv = _make_mock_inventory_obj(total_segments=7)
+
+        state_lock = threading.Lock()
+        active_calls = 0
+        max_active_calls = 0
+        first_call_claimed = False
+        release_first_call = threading.Event()
+
+        def _probe_build(return_inventory):
+            nonlocal active_calls, max_active_calls, first_call_claimed
+
+            with state_lock:
+                active_calls += 1
+                max_active_calls = max(max_active_calls, active_calls)
+                is_first = not first_call_claimed
+                if is_first:
+                    first_call_claimed = True
+
+            try:
+                if is_first:
+                    # Without serialization, the second builder enters and releases this wait.
+                    # With serialization, this times out because the second call is blocked.
+                    release_first_call.wait(timeout=0.30)
+                else:
+                    release_first_call.set()
+                time.sleep(0.05)
+                return return_inventory
+            finally:
+                with state_lock:
+                    active_calls -= 1
+
+        with (
+            patch("cja_auto_sdr.inventory.calculated_metrics.CalculatedMetricsInventoryBuilder") as mock_calc_cls,
+            patch("cja_auto_sdr.inventory.segments.SegmentsInventoryBuilder") as mock_seg_cls,
+        ):
+            mock_calc_cls.return_value.build.side_effect = lambda *_args, **_kwargs: _probe_build(calc_inv)
+            mock_seg_cls.return_value.build.side_effect = lambda *_args, **_kwargs: _probe_build(seg_inv)
+
+            result = process_single_dataview(
+                data_view_id="dv_test_12345",
+                config_file=mock_config_file,
+                output_dir=temp_output_dir,
+                include_calculated_metrics=True,
+                include_segments_inventory=True,
+                skip_validation=True,
+            )
+
+        assert result.success is True
+        assert result.calculated_metrics_count == 5
+        assert result.segments_count == 7
+        assert max_active_calls == 1
 
 
 # ============================================================================

--- a/tests/test_main_impl_coverage.py
+++ b/tests/test_main_impl_coverage.py
@@ -229,7 +229,7 @@ class TestProcessSingleDataviewCircuitBreakerAndTuning:
         _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-                mock_fetcher_class,
+            mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -272,7 +272,7 @@ class TestProcessSingleDataviewCircuitBreakerAndTuning:
         _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-                mock_fetcher_class,
+            mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -314,7 +314,7 @@ class TestProcessSingleDataviewCircuitBreakerAndTuning:
         _mock_logger, mock_fetcher, _ = _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-                mock_fetcher_class,
+            mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -370,7 +370,7 @@ class TestProcessSingleDataviewSharedCache:
         _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-                mock_fetcher_class,
+            mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -424,7 +424,7 @@ class TestProcessSingleDataviewInventoryBuilding:
         mock_logger, _, _ = _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-                mock_fetcher_class,
+            mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -472,7 +472,7 @@ class TestProcessSingleDataviewInventoryBuilding:
         mock_logger, _, _ = _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-                mock_fetcher_class,
+            mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -522,7 +522,7 @@ class TestProcessSingleDataviewInventoryBuilding:
         mock_logger, _, _ = _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-                mock_fetcher_class,
+            mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -570,7 +570,7 @@ class TestProcessSingleDataviewInventoryBuilding:
         mock_logger, _, _ = _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-                mock_fetcher_class,
+            mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -621,7 +621,7 @@ class TestProcessSingleDataviewInventoryBuilding:
         mock_logger, _, _ = _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-                mock_fetcher_class,
+            mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -672,7 +672,7 @@ class TestProcessSingleDataviewInventoryBuilding:
         mock_logger, _, _ = _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-                mock_fetcher_class,
+            mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -720,7 +720,7 @@ class TestProcessSingleDataviewInventoryBuilding:
         mock_logger, _, _ = _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-                mock_fetcher_class,
+            mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -768,7 +768,7 @@ class TestProcessSingleDataviewInventoryBuilding:
         mock_logger, _, _ = _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-                mock_fetcher_class,
+            mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -825,7 +825,7 @@ class TestProcessSingleDataviewMetadataWithInventory:
         _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-                mock_fetcher_class,
+            mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -883,7 +883,7 @@ class TestProcessSingleDataviewMetadataWithInventory:
         _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-                mock_fetcher_class,
+            mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -1013,7 +1013,7 @@ class TestProcessSingleDataviewJSONFormatException:
         _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-                mock_fetcher_class,
+            mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             # Use a DataFrame whose .map() will raise
@@ -1141,7 +1141,7 @@ class TestProcessSingleDataviewOutputFormats:
         _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-                mock_fetcher_class,
+            mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -1182,7 +1182,7 @@ class TestProcessSingleDataviewOutputFormats:
         _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-                mock_fetcher_class,
+            mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -1238,7 +1238,7 @@ class TestProcessSingleDataviewOutputFormats:
         _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-                mock_fetcher_class,
+            mock_fetcher_class,
             mock_dq_checker_class,
             MagicMock(),  # not used for non-excel
             sample_metrics_df,
@@ -1301,7 +1301,7 @@ class TestProcessSingleDataviewExcelPlaceholders:
         _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-                mock_fetcher_class,
+            mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -1362,7 +1362,7 @@ class TestProcessSingleDataviewExcelPlaceholders:
         _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-                mock_fetcher_class,
+            mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -1413,7 +1413,7 @@ class TestProcessSingleDataviewTimingsAndSummary:
         _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-                mock_fetcher_class,
+            mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -1468,7 +1468,7 @@ class TestProcessSingleDataviewFileWriteErrors:
         _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-                mock_fetcher_class,
+            mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -1510,7 +1510,7 @@ class TestProcessSingleDataviewFileWriteErrors:
         _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-                mock_fetcher_class,
+            mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -2143,7 +2143,7 @@ class TestProcessSingleDataviewMultipleFormats:
         _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-                mock_fetcher_class,
+            mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -2190,7 +2190,7 @@ class TestProcessSingleDataviewMultipleFormats:
         _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-                mock_fetcher_class,
+            mock_fetcher_class,
             mock_dq_checker_class,
             MagicMock(),
             sample_metrics_df,
@@ -2238,7 +2238,7 @@ class TestProcessSingleDataviewMultipleFormats:
         _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-                mock_fetcher_class,
+            mock_fetcher_class,
             mock_dq_checker_class,
             MagicMock(),
             sample_metrics_df,

--- a/tests/test_main_impl_coverage.py
+++ b/tests/test_main_impl_coverage.py
@@ -138,7 +138,6 @@ def _standard_process_mocks():
     return {
         "setup_logging": "cja_auto_sdr.generator.setup_logging",
         "initialize_cja": "cja_auto_sdr.generator.initialize_cja",
-        "validate_data_view": "cja_auto_sdr.generator.validate_data_view",
         "fetcher_class": "cja_auto_sdr.generator.ParallelAPIFetcher",
         "dq_checker_class": "cja_auto_sdr.generator.DataQualityChecker",
         "apply_excel": "cja_auto_sdr.generator.apply_excel_formatting",
@@ -149,7 +148,6 @@ def _standard_process_mocks():
 def _configure_standard_mocks(
     mock_setup_logging,
     mock_init_cja,
-    mock_validate_dv,
     mock_fetcher_class,
     mock_dq_checker_class,
     mock_excel_writer,
@@ -164,7 +162,6 @@ def _configure_standard_mocks(
 
     mock_cja = Mock()
     mock_init_cja.return_value = mock_cja
-    mock_validate_dv.return_value = True
 
     mock_fetcher = Mock()
     mock_fetcher.fetch_all_data.return_value = (metrics_df, dimensions_df, dataview_info)
@@ -208,7 +205,6 @@ class TestProcessSingleDataviewCircuitBreakerAndTuning:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
     @patch("cja_auto_sdr.generator.apply_excel_formatting")
@@ -221,7 +217,6 @@ class TestProcessSingleDataviewCircuitBreakerAndTuning:
         mock_apply_formatting,
         mock_dq_checker_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -234,8 +229,7 @@ class TestProcessSingleDataviewCircuitBreakerAndTuning:
         _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
-            mock_fetcher_class,
+                mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -256,7 +250,6 @@ class TestProcessSingleDataviewCircuitBreakerAndTuning:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
     @patch("cja_auto_sdr.generator.apply_excel_formatting")
@@ -267,7 +260,6 @@ class TestProcessSingleDataviewCircuitBreakerAndTuning:
         mock_apply_formatting,
         mock_dq_checker_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -280,8 +272,7 @@ class TestProcessSingleDataviewCircuitBreakerAndTuning:
         _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
-            mock_fetcher_class,
+                mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -301,7 +292,6 @@ class TestProcessSingleDataviewCircuitBreakerAndTuning:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
     @patch("cja_auto_sdr.generator.apply_excel_formatting")
@@ -312,7 +302,6 @@ class TestProcessSingleDataviewCircuitBreakerAndTuning:
         mock_apply_formatting,
         mock_dq_checker_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -325,8 +314,7 @@ class TestProcessSingleDataviewCircuitBreakerAndTuning:
         _mock_logger, mock_fetcher, _ = _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
-            mock_fetcher_class,
+                mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -360,7 +348,6 @@ class TestProcessSingleDataviewSharedCache:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
     @patch("cja_auto_sdr.generator.apply_excel_formatting")
@@ -371,7 +358,6 @@ class TestProcessSingleDataviewSharedCache:
         mock_apply_formatting,
         mock_dq_checker_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -384,8 +370,7 @@ class TestProcessSingleDataviewSharedCache:
         _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
-            mock_fetcher_class,
+                mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -417,7 +402,6 @@ class TestProcessSingleDataviewInventoryBuilding:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
     @patch("cja_auto_sdr.generator.apply_excel_formatting")
@@ -428,7 +412,6 @@ class TestProcessSingleDataviewInventoryBuilding:
         mock_apply_formatting,
         mock_dq_checker_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -441,8 +424,7 @@ class TestProcessSingleDataviewInventoryBuilding:
         mock_logger, _, _ = _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
-            mock_fetcher_class,
+                mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -468,7 +450,6 @@ class TestProcessSingleDataviewInventoryBuilding:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
     @patch("cja_auto_sdr.generator.apply_excel_formatting")
@@ -479,7 +460,6 @@ class TestProcessSingleDataviewInventoryBuilding:
         mock_apply_formatting,
         mock_dq_checker_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -492,8 +472,7 @@ class TestProcessSingleDataviewInventoryBuilding:
         mock_logger, _, _ = _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
-            mock_fetcher_class,
+                mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -521,7 +500,6 @@ class TestProcessSingleDataviewInventoryBuilding:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
     @patch("cja_auto_sdr.generator.apply_excel_formatting")
@@ -532,7 +510,6 @@ class TestProcessSingleDataviewInventoryBuilding:
         mock_apply_formatting,
         mock_dq_checker_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -545,8 +522,7 @@ class TestProcessSingleDataviewInventoryBuilding:
         mock_logger, _, _ = _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
-            mock_fetcher_class,
+                mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -572,7 +548,6 @@ class TestProcessSingleDataviewInventoryBuilding:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
     @patch("cja_auto_sdr.generator.apply_excel_formatting")
@@ -583,7 +558,6 @@ class TestProcessSingleDataviewInventoryBuilding:
         mock_apply_formatting,
         mock_dq_checker_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -596,8 +570,7 @@ class TestProcessSingleDataviewInventoryBuilding:
         mock_logger, _, _ = _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
-            mock_fetcher_class,
+                mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -626,7 +599,6 @@ class TestProcessSingleDataviewInventoryBuilding:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
     @patch("cja_auto_sdr.generator.apply_excel_formatting")
@@ -637,7 +609,6 @@ class TestProcessSingleDataviewInventoryBuilding:
         mock_apply_formatting,
         mock_dq_checker_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -650,8 +621,7 @@ class TestProcessSingleDataviewInventoryBuilding:
         mock_logger, _, _ = _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
-            mock_fetcher_class,
+                mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -680,7 +650,6 @@ class TestProcessSingleDataviewInventoryBuilding:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
     @patch("cja_auto_sdr.generator.apply_excel_formatting")
@@ -691,7 +660,6 @@ class TestProcessSingleDataviewInventoryBuilding:
         mock_apply_formatting,
         mock_dq_checker_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -704,8 +672,7 @@ class TestProcessSingleDataviewInventoryBuilding:
         mock_logger, _, _ = _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
-            mock_fetcher_class,
+                mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -731,7 +698,6 @@ class TestProcessSingleDataviewInventoryBuilding:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
     @patch("cja_auto_sdr.generator.apply_excel_formatting")
@@ -742,7 +708,6 @@ class TestProcessSingleDataviewInventoryBuilding:
         mock_apply_formatting,
         mock_dq_checker_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -755,8 +720,7 @@ class TestProcessSingleDataviewInventoryBuilding:
         mock_logger, _, _ = _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
-            mock_fetcher_class,
+                mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -782,7 +746,6 @@ class TestProcessSingleDataviewInventoryBuilding:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
     @patch("cja_auto_sdr.generator.apply_excel_formatting")
@@ -793,7 +756,6 @@ class TestProcessSingleDataviewInventoryBuilding:
         mock_apply_formatting,
         mock_dq_checker_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -806,8 +768,7 @@ class TestProcessSingleDataviewInventoryBuilding:
         mock_logger, _, _ = _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
-            mock_fetcher_class,
+                mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -842,7 +803,6 @@ class TestProcessSingleDataviewMetadataWithInventory:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
     @patch("cja_auto_sdr.generator.apply_excel_formatting")
@@ -853,7 +813,6 @@ class TestProcessSingleDataviewMetadataWithInventory:
         mock_apply_formatting,
         mock_dq_checker_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -866,8 +825,7 @@ class TestProcessSingleDataviewMetadataWithInventory:
         _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
-            mock_fetcher_class,
+                mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -904,7 +862,6 @@ class TestProcessSingleDataviewMetadataWithInventory:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
     @patch("cja_auto_sdr.generator.apply_excel_formatting")
@@ -915,7 +872,6 @@ class TestProcessSingleDataviewMetadataWithInventory:
         mock_apply_formatting,
         mock_dq_checker_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -927,8 +883,7 @@ class TestProcessSingleDataviewMetadataWithInventory:
         _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
-            mock_fetcher_class,
+                mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -970,7 +925,6 @@ class TestProcessSingleDataviewLookupDataException:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
     @patch("cja_auto_sdr.generator.apply_excel_formatting")
@@ -981,7 +935,6 @@ class TestProcessSingleDataviewLookupDataException:
         mock_apply_formatting,
         mock_dq_checker_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -995,15 +948,16 @@ class TestProcessSingleDataviewLookupDataException:
         mock_setup_logging.return_value = mock_logger
         mock_cja = Mock()
         mock_init_cja.return_value = mock_cja
-        mock_validate_dv.return_value = True
 
         mock_fetcher = Mock()
-        # Return lookup_data that will cause issues: values that error on iteration
-        bad_lookup = MagicMock(spec=dict)
-        bad_lookup.__iter__ = Mock(side_effect=TypeError("bad iter"))
-        bad_lookup.items.side_effect = TypeError("bad items")
-        bad_lookup.get.return_value = "Unknown"
-        bad_lookup.__isinstance__ = Mock(return_value=True)
+        # Return lookup_data that passes post-fetch validation (non-empty real dict)
+        # but has a value that causes errors during metadata DataFrame creation.
+        # The metadata processing iterates over lookup_data items and tries to
+        # build a DataFrame; a value that errors on str() will trigger the fallback.
+        bad_value = MagicMock()
+        bad_value.__str__ = Mock(side_effect=TypeError("bad str"))
+        bad_value.__repr__ = Mock(side_effect=TypeError("bad repr"))
+        bad_lookup = {"id": "dv_test_12345", "name": "Unknown", "bad_key": bad_value}
         mock_fetcher.fetch_all_data.return_value = (sample_metrics_df, sample_dimensions_df, bad_lookup)
         mock_fetcher.get_tuner_statistics.return_value = None
         mock_fetcher_class.return_value = mock_fetcher
@@ -1039,7 +993,6 @@ class TestProcessSingleDataviewJSONFormatException:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
     @patch("cja_auto_sdr.generator.apply_excel_formatting")
@@ -1050,7 +1003,6 @@ class TestProcessSingleDataviewJSONFormatException:
         mock_apply_formatting,
         mock_dq_checker_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -1061,8 +1013,7 @@ class TestProcessSingleDataviewJSONFormatException:
         _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
-            mock_fetcher_class,
+                mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             # Use a DataFrame whose .map() will raise
@@ -1102,7 +1053,6 @@ class TestProcessSingleDataviewFilenameException:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
     @patch("cja_auto_sdr.generator.apply_excel_formatting")
@@ -1113,7 +1063,6 @@ class TestProcessSingleDataviewFilenameException:
         mock_apply_formatting,
         mock_dq_checker_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -1127,7 +1076,6 @@ class TestProcessSingleDataviewFilenameException:
         mock_setup_logging.return_value = mock_logger
         mock_cja = Mock()
         mock_init_cja.return_value = mock_cja
-        mock_validate_dv.return_value = True
 
         mock_fetcher = Mock()
         # lookup_data returns something that causes .get("name") to raise
@@ -1171,7 +1119,6 @@ class TestProcessSingleDataviewOutputFormats:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
     @patch("cja_auto_sdr.generator.apply_excel_formatting")
@@ -1182,7 +1129,6 @@ class TestProcessSingleDataviewOutputFormats:
         mock_apply_formatting,
         mock_dq_checker_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -1195,8 +1141,7 @@ class TestProcessSingleDataviewOutputFormats:
         _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
-            mock_fetcher_class,
+                mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -1215,7 +1160,6 @@ class TestProcessSingleDataviewOutputFormats:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
     @patch("cja_auto_sdr.generator.apply_excel_formatting")
@@ -1226,7 +1170,6 @@ class TestProcessSingleDataviewOutputFormats:
         mock_apply_formatting,
         mock_dq_checker_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -1239,8 +1182,7 @@ class TestProcessSingleDataviewOutputFormats:
         _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
-            mock_fetcher_class,
+                mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -1276,7 +1218,6 @@ class TestProcessSingleDataviewOutputFormats:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
     @patch("cja_auto_sdr.generator.write_json_output")
@@ -1285,7 +1226,6 @@ class TestProcessSingleDataviewOutputFormats:
         mock_write_json,
         mock_dq_checker_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -1298,8 +1238,7 @@ class TestProcessSingleDataviewOutputFormats:
         _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
-            mock_fetcher_class,
+                mock_fetcher_class,
             mock_dq_checker_class,
             MagicMock(),  # not used for non-excel
             sample_metrics_df,
@@ -1340,7 +1279,6 @@ class TestProcessSingleDataviewExcelPlaceholders:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
     @patch("cja_auto_sdr.generator.apply_excel_formatting")
@@ -1351,7 +1289,6 @@ class TestProcessSingleDataviewExcelPlaceholders:
         mock_apply_formatting,
         mock_dq_checker_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -1364,8 +1301,7 @@ class TestProcessSingleDataviewExcelPlaceholders:
         _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
-            mock_fetcher_class,
+                mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -1404,7 +1340,6 @@ class TestProcessSingleDataviewExcelPlaceholders:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
     @patch("cja_auto_sdr.generator.apply_excel_formatting")
@@ -1415,7 +1350,6 @@ class TestProcessSingleDataviewExcelPlaceholders:
         mock_apply_formatting,
         mock_dq_checker_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -1428,8 +1362,7 @@ class TestProcessSingleDataviewExcelPlaceholders:
         _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
-            mock_fetcher_class,
+                mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -1457,7 +1390,6 @@ class TestProcessSingleDataviewTimingsAndSummary:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
     @patch("cja_auto_sdr.generator.apply_excel_formatting")
@@ -1468,7 +1400,6 @@ class TestProcessSingleDataviewTimingsAndSummary:
         mock_apply_formatting,
         mock_dq_checker_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -1482,8 +1413,7 @@ class TestProcessSingleDataviewTimingsAndSummary:
         _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
-            mock_fetcher_class,
+                mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -1516,7 +1446,6 @@ class TestProcessSingleDataviewFileWriteErrors:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
     @patch("cja_auto_sdr.generator.apply_excel_formatting")
@@ -1527,7 +1456,6 @@ class TestProcessSingleDataviewFileWriteErrors:
         mock_apply_formatting,
         mock_dq_checker_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -1540,8 +1468,7 @@ class TestProcessSingleDataviewFileWriteErrors:
         _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
-            mock_fetcher_class,
+                mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -1561,7 +1488,6 @@ class TestProcessSingleDataviewFileWriteErrors:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
     @patch("cja_auto_sdr.generator.apply_excel_formatting")
@@ -1572,7 +1498,6 @@ class TestProcessSingleDataviewFileWriteErrors:
         mock_apply_formatting,
         mock_dq_checker_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -1585,8 +1510,7 @@ class TestProcessSingleDataviewFileWriteErrors:
         _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
-            mock_fetcher_class,
+                mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -2189,7 +2113,6 @@ class TestProcessSingleDataviewMultipleFormats:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
     @patch("cja_auto_sdr.generator.apply_excel_formatting")
@@ -2208,7 +2131,6 @@ class TestProcessSingleDataviewMultipleFormats:
         mock_apply_formatting,
         mock_dq_checker_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -2221,8 +2143,7 @@ class TestProcessSingleDataviewMultipleFormats:
         _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
-            mock_fetcher_class,
+                mock_fetcher_class,
             mock_dq_checker_class,
             mock_excel_writer,
             sample_metrics_df,
@@ -2249,7 +2170,6 @@ class TestProcessSingleDataviewMultipleFormats:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
     @patch("cja_auto_sdr.generator.write_html_output")
@@ -2258,7 +2178,6 @@ class TestProcessSingleDataviewMultipleFormats:
         mock_html,
         mock_dq_checker_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -2271,8 +2190,7 @@ class TestProcessSingleDataviewMultipleFormats:
         _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
-            mock_fetcher_class,
+                mock_fetcher_class,
             mock_dq_checker_class,
             MagicMock(),
             sample_metrics_df,
@@ -2300,7 +2218,6 @@ class TestProcessSingleDataviewMultipleFormats:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
     @patch("cja_auto_sdr.generator.write_markdown_output")
@@ -2309,7 +2226,6 @@ class TestProcessSingleDataviewMultipleFormats:
         mock_md,
         mock_dq_checker_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -2322,8 +2238,7 @@ class TestProcessSingleDataviewMultipleFormats:
         _configure_standard_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
-            mock_fetcher_class,
+                mock_fetcher_class,
             mock_dq_checker_class,
             MagicMock(),
             sample_metrics_df,

--- a/tests/test_malformed_api_responses.py
+++ b/tests/test_malformed_api_responses.py
@@ -174,6 +174,42 @@ class TestAPIReturnsWrongTypes:
         assert "validation failed" in result.error_message.lower()
         assert result.data_view_name == "Unknown"
 
+    @_apply
+    def test_dataview_info_is_error_placeholder_dict(
+        self,
+        mock_fetcher_class,
+        mock_init_cja,
+        mock_setup_logging,
+        malformed_config,
+        output_dir,
+    ):
+        """Non-empty error placeholders are rejected by dataview validation."""
+        _setup_mocks(
+            mock_setup_logging,
+            mock_init_cja,
+            mock_fetcher_class,
+            pd.DataFrame([{"id": "m1", "name": "M1", "type": "int", "title": "M1", "description": "d"}]),
+            pd.DataFrame([{"id": "d1", "name": "D1", "type": "string", "title": "D1", "description": "d"}]),
+            {
+                "id": "dv_test",
+                "name": "Unknown",
+                "lookup_failed": True,
+                "lookup_failure_reason": "exception",
+                "error": "getDataView failed",
+            },
+        )
+
+        result = process_single_dataview(
+            data_view_id="dv_test",
+            config_file=malformed_config,
+            output_dir=output_dir,
+            output_format="json",
+            quiet=True,
+        )
+        assert result.success is False
+        assert "validation failed" in result.error_message.lower()
+        assert result.data_view_name == "Unknown"
+
 
 # ===================================================================
 # Tests for DataFrames with unexpected schemas

--- a/tests/test_malformed_api_responses.py
+++ b/tests/test_malformed_api_responses.py
@@ -45,7 +45,6 @@ def _api_patches():
     return [
         patch("cja_auto_sdr.generator.setup_logging"),
         patch("cja_auto_sdr.generator.initialize_cja"),
-        patch("cja_auto_sdr.generator.validate_data_view"),
         patch("cja_auto_sdr.generator.ParallelAPIFetcher"),
     ]
 
@@ -59,7 +58,6 @@ def _apply(func):
 def _setup_mocks(
     mock_setup_logging,
     mock_init_cja,
-    mock_validate_dv,
     mock_fetcher_class,
     metrics_df,
     dimensions_df,
@@ -70,7 +68,6 @@ def _setup_mocks(
     logger.setLevel(logging.DEBUG)
     mock_setup_logging.return_value = logger
     mock_init_cja.return_value = Mock()
-    mock_validate_dv.return_value = True
 
     mock_fetcher = Mock()
     mock_fetcher.fetch_all_data.return_value = (metrics_df, dimensions_df, dataview_info)
@@ -91,7 +88,6 @@ class TestAPIReturnsWrongTypes:
     def test_metrics_as_list_instead_of_dataframe(
         self,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         malformed_config,
@@ -104,7 +100,6 @@ class TestAPIReturnsWrongTypes:
         _setup_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
             mock_fetcher_class,
             pd.DataFrame(raw_list),  # Convert so fetcher returns valid DF
             pd.DataFrame([{"id": "d1", "name": "Dim 1", "type": "string", "title": "D1", "description": "d"}]),
@@ -125,7 +120,6 @@ class TestAPIReturnsWrongTypes:
     def test_dataview_info_missing_owner_key(
         self,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         malformed_config,
@@ -135,7 +129,6 @@ class TestAPIReturnsWrongTypes:
         _setup_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
             mock_fetcher_class,
             pd.DataFrame([{"id": "m1", "name": "M1", "type": "int", "title": "M1", "description": "d"}]),
             pd.DataFrame([{"id": "d1", "name": "D1", "type": "string", "title": "D1", "description": "d"}]),
@@ -155,17 +148,15 @@ class TestAPIReturnsWrongTypes:
     def test_dataview_info_is_empty_dict(
         self,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         malformed_config,
         output_dir,
     ):
-        """API returns an empty dict for dataview info."""
+        """API returns an empty dict for dataview info — now triggers validation failure."""
         _setup_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
             mock_fetcher_class,
             pd.DataFrame([{"id": "m1", "name": "M1", "type": "int", "title": "M1", "description": "d"}]),
             pd.DataFrame([{"id": "d1", "name": "D1", "type": "string", "title": "D1", "description": "d"}]),
@@ -179,7 +170,8 @@ class TestAPIReturnsWrongTypes:
             output_format="json",
             quiet=True,
         )
-        assert result.success is True
+        assert result.success is False
+        assert "validation failed" in result.error_message.lower()
         assert result.data_view_name == "Unknown"
 
 
@@ -195,7 +187,6 @@ class TestMalformedDataFrameSchemas:
     def test_metrics_missing_description_column(
         self,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         malformed_config,
@@ -205,7 +196,6 @@ class TestMalformedDataFrameSchemas:
         _setup_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
             mock_fetcher_class,
             pd.DataFrame([{"id": "m1", "name": "M1", "type": "int", "title": "M1"}]),  # No description
             pd.DataFrame([{"id": "d1", "name": "D1", "type": "string", "title": "D1", "description": "d"}]),
@@ -226,7 +216,6 @@ class TestMalformedDataFrameSchemas:
     def test_metrics_with_extra_unknown_columns(
         self,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         malformed_config,
@@ -236,7 +225,6 @@ class TestMalformedDataFrameSchemas:
         _setup_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
             mock_fetcher_class,
             pd.DataFrame(
                 [
@@ -269,7 +257,6 @@ class TestMalformedDataFrameSchemas:
     def test_dimensions_all_null_descriptions(
         self,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         malformed_config,
@@ -279,7 +266,6 @@ class TestMalformedDataFrameSchemas:
         _setup_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
             mock_fetcher_class,
             pd.DataFrame([{"id": "m1", "name": "M1", "type": "int", "title": "M1", "description": "d"}]),
             pd.DataFrame(
@@ -306,7 +292,6 @@ class TestMalformedDataFrameSchemas:
     def test_metrics_with_mixed_types_in_columns(
         self,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         malformed_config,
@@ -316,7 +301,6 @@ class TestMalformedDataFrameSchemas:
         _setup_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
             mock_fetcher_class,
             pd.DataFrame(
                 [
@@ -351,7 +335,6 @@ class TestAPIExceptionsDuringFetch:
     def test_fetcher_raises_connection_error(
         self,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         malformed_config,
@@ -362,7 +345,6 @@ class TestAPIExceptionsDuringFetch:
         logger.handlers = []
         mock_setup_logging.return_value = logger
         mock_init_cja.return_value = Mock()
-        mock_validate_dv.return_value = True
 
         mock_fetcher = Mock()
         mock_fetcher.fetch_all_data.side_effect = ConnectionError("Network unreachable")
@@ -381,7 +363,6 @@ class TestAPIExceptionsDuringFetch:
     def test_fetcher_raises_timeout_error(
         self,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         malformed_config,
@@ -392,7 +373,6 @@ class TestAPIExceptionsDuringFetch:
         logger.handlers = []
         mock_setup_logging.return_value = logger
         mock_init_cja.return_value = Mock()
-        mock_validate_dv.return_value = True
 
         mock_fetcher = Mock()
         mock_fetcher.fetch_all_data.side_effect = TimeoutError("API timed out")
@@ -410,7 +390,6 @@ class TestAPIExceptionsDuringFetch:
     def test_fetcher_raises_attribute_error(
         self,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         malformed_config,
@@ -421,7 +400,6 @@ class TestAPIExceptionsDuringFetch:
         logger.handlers = []
         mock_setup_logging.return_value = logger
         mock_init_cja.return_value = Mock()
-        mock_validate_dv.return_value = True
 
         mock_fetcher = Mock()
         mock_fetcher.fetch_all_data.side_effect = AttributeError("'NoneType' has no attribute 'getMetrics'")
@@ -448,7 +426,6 @@ class TestPartialAPIResponses:
     def test_metrics_only_no_dimensions(
         self,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         malformed_config,
@@ -458,7 +435,6 @@ class TestPartialAPIResponses:
         _setup_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
             mock_fetcher_class,
             pd.DataFrame([{"id": "m1", "name": "M1", "type": "int", "title": "M1", "description": "d"}]),
             pd.DataFrame(),  # Empty dimensions
@@ -481,7 +457,6 @@ class TestPartialAPIResponses:
     def test_dimensions_only_no_metrics(
         self,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         malformed_config,
@@ -491,7 +466,6 @@ class TestPartialAPIResponses:
         _setup_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
             mock_fetcher_class,
             pd.DataFrame(),  # Empty metrics
             pd.DataFrame([{"id": "d1", "name": "D1", "type": "string", "title": "D1", "description": "d"}]),
@@ -513,7 +487,6 @@ class TestPartialAPIResponses:
     def test_single_row_dataframes(
         self,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         malformed_config,
@@ -523,7 +496,6 @@ class TestPartialAPIResponses:
         _setup_mocks(
             mock_setup_logging,
             mock_init_cja,
-            mock_validate_dv,
             mock_fetcher_class,
             pd.DataFrame([{"id": "m1", "name": "M1", "type": "int", "title": "M1", "description": "d"}]),
             pd.DataFrame([{"id": "d1", "name": "D1", "type": "string", "title": "D1", "description": "d"}]),

--- a/tests/test_name_resolution.py
+++ b/tests/test_name_resolution.py
@@ -267,9 +267,9 @@ class TestDataViewNameResolution:
 
     @patch("cja_auto_sdr.generator.cjapy")
     def test_resolve_with_unexpected_exception(self, mock_cjapy):
-        """Plain Exception from cjapy bootstrap should return controlled failure."""
+        """RuntimeError from cjapy bootstrap should return controlled failure."""
         mock_cja_instance = MagicMock()
-        mock_cja_instance.getDataViews.side_effect = Exception("unexpected auth failure")
+        mock_cja_instance.getDataViews.side_effect = RuntimeError("unexpected auth failure")
         mock_cjapy.CJA.return_value = mock_cja_instance
         mock_cjapy.importConfigFile.return_value = None
 

--- a/tests/test_output_content_validation.py
+++ b/tests/test_output_content_validation.py
@@ -38,7 +38,7 @@ def rich_data_dict():
         "Metadata": pd.DataFrame(
             {
                 "Property": ["Generated At", "Data View ID", "Tool Version", "Total Metrics"],
-                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.3.4", 3],
+                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.3.5", 3],
             },
         ),
         "Data Quality": pd.DataFrame(
@@ -104,7 +104,7 @@ def rich_metadata_dict():
         "Generated At": "2025-01-15 10:30:00 PST",
         "Data View ID": "dv_content_test",
         "Data View Name": "Test DataView",
-        "Tool Version": "3.3.4",
+        "Tool Version": "3.3.5",
         "Metrics Count": "3",
         "Dimensions Count": "4",
     }
@@ -224,7 +224,7 @@ class TestJSONContentValidation:
             data = json.load(f)
 
         assert data["metadata"]["Data View ID"] == "dv_content_test"
-        assert data["metadata"]["Tool Version"] == "3.3.4"
+        assert data["metadata"]["Tool Version"] == "3.3.5"
 
 
 # ===================================================================

--- a/tests/test_parallel_api_fetcher.py
+++ b/tests/test_parallel_api_fetcher.py
@@ -520,6 +520,44 @@ class TestParallelAPIFetcherFetchDataviewInfo:
         assert result["lookup_failure_reason"] == "unknown_placeholder_diagnostic:error"
 
     @patch("cja_auto_sdr.api.fetch.make_api_call_with_retry")
+    def test_fetch_dataview_info_rejects_id_plus_error_only_payload(
+        self,
+        mock_api_call,
+        mock_cja,
+        mock_logger,
+        mock_perf_tracker,
+    ):
+        """Lookup payload with only id+error should fail closed."""
+        mock_api_call.return_value = {"id": "dv_test_12345", "error": "not found"}
+
+        fetcher = ParallelAPIFetcher(mock_cja, mock_logger, mock_perf_tracker)
+        result = fetcher._fetch_dataview_info("dv_test_12345")
+
+        assert result["name"] == "Unknown"
+        assert result["id"] == "dv_test_12345"
+        assert result["lookup_failed"] is True
+        assert result["lookup_failure_reason"] == "error_shape"
+
+    @patch("cja_auto_sdr.api.fetch.make_api_call_with_retry")
+    def test_fetch_dataview_info_rejects_id_only_payload_as_insufficient_metadata(
+        self,
+        mock_api_call,
+        mock_cja,
+        mock_logger,
+        mock_perf_tracker,
+    ):
+        """Lookup payload with only id should fail closed as insufficient metadata."""
+        mock_api_call.return_value = {"id": "dv_test_12345"}
+
+        fetcher = ParallelAPIFetcher(mock_cja, mock_logger, mock_perf_tracker)
+        result = fetcher._fetch_dataview_info("dv_test_12345")
+
+        assert result["name"] == "Unknown"
+        assert result["id"] == "dv_test_12345"
+        assert result["lookup_failed"] is True
+        assert result["lookup_failure_reason"] == "insufficient_metadata"
+
+    @patch("cja_auto_sdr.api.fetch.make_api_call_with_retry")
     def test_fetch_dataview_info_rejects_payload_missing_expected_id(
         self,
         mock_api_call,

--- a/tests/test_parallel_api_fetcher.py
+++ b/tests/test_parallel_api_fetcher.py
@@ -433,6 +433,28 @@ class TestParallelAPIFetcherFetchDataviewInfo:
         assert result["name"] == "Test Data View"
 
     @patch("cja_auto_sdr.api.fetch.make_api_call_with_retry")
+    def test_fetch_dataview_info_canonicalizes_mixed_case_identity_and_owner(
+        self,
+        mock_api_call,
+        mock_cja,
+        mock_logger,
+        mock_perf_tracker,
+    ):
+        """Successful mixed-case payloads should expose canonical keys downstream."""
+        mock_api_call.return_value = {
+            "ID": "dv_test_12345",
+            "Name": "Test Data View",
+            "Owner": {"NAME": "Test Owner"},
+        }
+
+        fetcher = ParallelAPIFetcher(mock_cja, mock_logger, mock_perf_tracker)
+        result = fetcher._fetch_dataview_info("dv_test_12345")
+
+        assert result["id"] == "dv_test_12345"
+        assert result["name"] == "Test Data View"
+        assert result["owner"]["name"] == "Test Owner"
+
+    @patch("cja_auto_sdr.api.fetch.make_api_call_with_retry")
     def test_fetch_dataview_info_returns_none(self, mock_api_call, mock_cja, mock_logger, mock_perf_tracker):
         """Test handling of None response"""
         mock_api_call.return_value = None

--- a/tests/test_parallel_api_fetcher.py
+++ b/tests/test_parallel_api_fetcher.py
@@ -484,6 +484,25 @@ class TestParallelAPIFetcherFetchDataviewInfo:
         assert result["lookup_failure_reason"] == "legacy_unknown_placeholder"
 
     @patch("cja_auto_sdr.api.fetch.make_api_call_with_retry")
+    def test_fetch_dataview_info_rejects_unknown_placeholder_with_error_diagnostic(
+        self,
+        mock_api_call,
+        mock_cja,
+        mock_logger,
+        mock_perf_tracker,
+    ):
+        """Unknown placeholder with diagnostic keys should be normalized into failure payload."""
+        mock_api_call.return_value = {"id": "dv_test_12345", "name": "Unknown", "error": "not found"}
+
+        fetcher = ParallelAPIFetcher(mock_cja, mock_logger, mock_perf_tracker)
+        result = fetcher._fetch_dataview_info("dv_test_12345")
+
+        assert result["name"] == "Unknown"
+        assert result["id"] == "dv_test_12345"
+        assert result["lookup_failed"] is True
+        assert result["lookup_failure_reason"] == "unknown_placeholder_diagnostic:error"
+
+    @patch("cja_auto_sdr.api.fetch.make_api_call_with_retry")
     def test_fetch_dataview_info_circuit_breaker_open(
         self,
         mock_api_call,

--- a/tests/test_parallel_api_fetcher.py
+++ b/tests/test_parallel_api_fetcher.py
@@ -498,6 +498,25 @@ class TestParallelAPIFetcherFetchDataviewInfo:
         assert result["lookup_failure_reason"] == "unknown_placeholder_diagnostic:error"
 
     @patch("cja_auto_sdr.api.fetch.make_api_call_with_retry")
+    def test_fetch_dataview_info_rejects_payload_missing_expected_id(
+        self,
+        mock_api_call,
+        mock_cja,
+        mock_logger,
+        mock_perf_tracker,
+    ):
+        """Lookup payload with name/error but missing id should fail closed."""
+        mock_api_call.return_value = {"name": "Some Name", "error": "not found"}
+
+        fetcher = ParallelAPIFetcher(mock_cja, mock_logger, mock_perf_tracker)
+        result = fetcher._fetch_dataview_info("dv_test_12345")
+
+        assert result["name"] == "Unknown"
+        assert result["id"] == "dv_test_12345"
+        assert result["lookup_failed"] is True
+        assert result["lookup_failure_reason"] == "missing_expected_id"
+
+    @patch("cja_auto_sdr.api.fetch.make_api_call_with_retry")
     def test_fetch_dataview_info_circuit_breaker_open(
         self,
         mock_api_call,

--- a/tests/test_parallel_api_fetcher.py
+++ b/tests/test_parallel_api_fetcher.py
@@ -1,15 +1,10 @@
 """Tests for ParallelAPIFetcher class"""
 
 import logging
-import os
-import sys
 from unittest.mock import MagicMock, Mock, patch
 
 import pandas as pd
 import pytest
-
-# Add parent directory to path for imports
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from cja_auto_sdr.core.config import APITuningConfig
 from cja_auto_sdr.core.exceptions import CircuitBreakerOpen

--- a/tests/test_parallel_api_fetcher.py
+++ b/tests/test_parallel_api_fetcher.py
@@ -12,6 +12,7 @@ import pytest
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from cja_auto_sdr.core.config import APITuningConfig
+from cja_auto_sdr.core.exceptions import CircuitBreakerOpen
 from cja_auto_sdr.generator import ParallelAPIFetcher, PerformanceTracker
 
 
@@ -299,6 +300,8 @@ class TestParallelAPIFetcherFetchAllData:
         # When dataview info fetch fails, it returns a fallback dict with Unknown name
         assert dataview["name"] == "Unknown"
         assert dataview["id"] == "dv_test_12345"
+        assert dataview["lookup_failed"] is True
+        assert dataview["lookup_failure_reason"] == "none_payload"
 
 
 class TestParallelAPIFetcherFetchMetrics:
@@ -444,6 +447,8 @@ class TestParallelAPIFetcherFetchDataviewInfo:
 
         assert result["name"] == "Unknown"
         assert result["id"] == "dv_test_12345"
+        assert result["lookup_failed"] is True
+        assert result["lookup_failure_reason"] == "none_payload"
         mock_logger.error.assert_called()
 
     @patch("cja_auto_sdr.api.fetch.make_api_call_with_retry")
@@ -456,6 +461,48 @@ class TestParallelAPIFetcherFetchDataviewInfo:
 
         assert result["name"] == "Unknown"
         assert result["id"] == "dv_test_12345"
+        assert result["lookup_failed"] is True
+        assert result["lookup_failure_reason"] == "empty_mapping"
+
+    @patch("cja_auto_sdr.api.fetch.make_api_call_with_retry")
+    def test_fetch_dataview_info_rejects_legacy_unknown_placeholder(
+        self,
+        mock_api_call,
+        mock_cja,
+        mock_logger,
+        mock_perf_tracker,
+    ):
+        """Legacy fallback payload shape should be normalized into explicit failure payload."""
+        mock_api_call.return_value = {"id": "dv_test_12345", "name": "Unknown"}
+
+        fetcher = ParallelAPIFetcher(mock_cja, mock_logger, mock_perf_tracker)
+        result = fetcher._fetch_dataview_info("dv_test_12345")
+
+        assert result["name"] == "Unknown"
+        assert result["id"] == "dv_test_12345"
+        assert result["lookup_failed"] is True
+        assert result["lookup_failure_reason"] == "legacy_unknown_placeholder"
+
+    @patch("cja_auto_sdr.api.fetch.make_api_call_with_retry")
+    def test_fetch_dataview_info_circuit_breaker_open(
+        self,
+        mock_api_call,
+        mock_cja,
+        mock_logger,
+        mock_perf_tracker,
+    ):
+        """Circuit breaker opens should return explicit failure payload."""
+        mock_api_call.side_effect = CircuitBreakerOpen("breaker open", time_until_retry=10)
+
+        fetcher = ParallelAPIFetcher(mock_cja, mock_logger, mock_perf_tracker)
+        result = fetcher._fetch_dataview_info("dv_test_12345")
+
+        assert result["name"] == "Unknown"
+        assert result["id"] == "dv_test_12345"
+        assert result["lookup_failed"] is True
+        assert result["lookup_failure_reason"] == "circuit_breaker_open"
+        assert result["circuit_breaker_open"] is True
+        assert "error" in result
 
     @patch("cja_auto_sdr.api.fetch.make_api_call_with_retry")
     def test_fetch_dataview_info_exception(self, mock_api_call, mock_cja, mock_logger, mock_perf_tracker):
@@ -467,6 +514,8 @@ class TestParallelAPIFetcherFetchDataviewInfo:
 
         assert result["name"] == "Unknown"
         assert result["id"] == "dv_test_12345"
+        assert result["lookup_failed"] is True
+        assert result["lookup_failure_reason"] == "exception"
         assert "error" in result
 
 
@@ -530,6 +579,8 @@ class TestParallelAPIFetcherErrorHandling:
         assert dimensions.empty
         # On failure, dataview returns fallback dict with error
         assert dataview["name"] == "Unknown"
+        assert dataview["lookup_failed"] is True
+        assert dataview["lookup_failure_reason"] == "exception"
         assert "error" in dataview
 
 

--- a/tests/test_parallel_api_fetcher.py
+++ b/tests/test_parallel_api_fetcher.py
@@ -539,6 +539,48 @@ class TestParallelAPIFetcherFetchDataviewInfo:
         assert result["lookup_failure_reason"] == "error_shape"
 
     @patch("cja_auto_sdr.api.fetch.make_api_call_with_retry")
+    def test_fetch_dataview_info_rejects_empty_owner_container_with_error(
+        self,
+        mock_api_call,
+        mock_cja,
+        mock_logger,
+        mock_perf_tracker,
+    ):
+        """Lookup payload with empty owner container should fail closed."""
+        mock_api_call.return_value = {"id": "dv_test_12345", "owner": {}, "error": "not found"}
+
+        fetcher = ParallelAPIFetcher(mock_cja, mock_logger, mock_perf_tracker)
+        result = fetcher._fetch_dataview_info("dv_test_12345")
+
+        assert result["name"] == "Unknown"
+        assert result["id"] == "dv_test_12345"
+        assert result["lookup_failed"] is True
+        assert result["lookup_failure_reason"] == "error_shape"
+
+    @patch("cja_auto_sdr.api.fetch.make_api_call_with_retry")
+    def test_fetch_dataview_info_prefers_non_empty_case_collided_owner_payload(
+        self,
+        mock_api_call,
+        mock_cja,
+        mock_logger,
+        mock_perf_tracker,
+    ):
+        """Case-collided owner keys should keep richer values over empty placeholders."""
+        mock_api_call.return_value = {
+            "id": "dv_test_12345",
+            "owner": {},
+            "Owner": {"NAME": "Test Owner"},
+            "error": "transient warning",
+        }
+
+        fetcher = ParallelAPIFetcher(mock_cja, mock_logger, mock_perf_tracker)
+        result = fetcher._fetch_dataview_info("dv_test_12345")
+
+        assert result["id"] == "dv_test_12345"
+        assert result["owner"]["name"] == "Test Owner"
+        assert "lookup_failed" not in result
+
+    @patch("cja_auto_sdr.api.fetch.make_api_call_with_retry")
     def test_fetch_dataview_info_rejects_id_only_payload_as_insufficient_metadata(
         self,
         mock_api_call,

--- a/tests/test_process_single_dataview.py
+++ b/tests/test_process_single_dataview.py
@@ -99,7 +99,6 @@ class TestProcessSingleDataviewSuccess:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
     @patch("cja_auto_sdr.generator.apply_excel_formatting")
@@ -110,7 +109,6 @@ class TestProcessSingleDataviewSuccess:
         mock_apply_formatting,
         mock_dq_checker_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -126,7 +124,6 @@ class TestProcessSingleDataviewSuccess:
 
         mock_cja = Mock()
         mock_init_cja.return_value = mock_cja
-        mock_validate_dv.return_value = True
 
         # Setup fetcher
         mock_fetcher = Mock()
@@ -160,7 +157,6 @@ class TestProcessSingleDataviewSuccess:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
     @patch("cja_auto_sdr.generator.apply_excel_formatting")
@@ -171,7 +167,6 @@ class TestProcessSingleDataviewSuccess:
         mock_apply_formatting,
         mock_dq_checker_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -186,7 +181,6 @@ class TestProcessSingleDataviewSuccess:
         mock_setup_logging.return_value = mock_logger
         mock_cja = Mock()
         mock_init_cja.return_value = mock_cja
-        mock_validate_dv.return_value = True
 
         mock_fetcher = Mock()
         mock_fetcher.fetch_all_data.return_value = (sample_metrics_df, sample_dimensions_df, sample_dataview_info)
@@ -237,21 +231,24 @@ class TestProcessSingleDataviewFailures:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
+    @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     def test_data_view_validation_failure(
         self,
-        mock_validate_dv,
+        mock_fetcher_class,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
         temp_output_dir,
     ):
-        """Test handling of data view validation failure"""
+        """Test handling of data view validation failure (empty lookup_data)"""
         mock_logger = Mock()
         mock_setup_logging.return_value = mock_logger
         mock_cja = Mock()
         mock_init_cja.return_value = mock_cja
-        mock_validate_dv.return_value = False
+
+        mock_fetcher = Mock()
+        mock_fetcher.fetch_all_data.return_value = (pd.DataFrame(), pd.DataFrame(), {})
+        mock_fetcher_class.return_value = mock_fetcher
 
         result = process_single_dataview(
             data_view_id="dv_invalid",
@@ -264,12 +261,40 @@ class TestProcessSingleDataviewFailures:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
+    @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
+    def test_data_view_validation_failure_none_lookup(
+        self,
+        mock_fetcher_class,
+        mock_init_cja,
+        mock_setup_logging,
+        mock_config_file,
+        temp_output_dir,
+    ):
+        """Test handling of data view validation failure (None lookup_data)"""
+        mock_logger = Mock()
+        mock_setup_logging.return_value = mock_logger
+        mock_cja = Mock()
+        mock_init_cja.return_value = mock_cja
+
+        mock_fetcher = Mock()
+        mock_fetcher.fetch_all_data.return_value = (pd.DataFrame(), pd.DataFrame(), None)
+        mock_fetcher_class.return_value = mock_fetcher
+
+        result = process_single_dataview(
+            data_view_id="dv_invalid",
+            config_file=mock_config_file,
+            output_dir=temp_output_dir,
+        )
+
+        assert result.success is False
+        assert "validation failed" in result.error_message.lower()
+
+    @patch("cja_auto_sdr.generator.setup_logging")
+    @patch("cja_auto_sdr.generator.initialize_cja")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     def test_empty_data_fetched(
         self,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -282,7 +307,6 @@ class TestProcessSingleDataviewFailures:
         mock_setup_logging.return_value = mock_logger
         mock_cja = Mock()
         mock_init_cja.return_value = mock_cja
-        mock_validate_dv.return_value = True
 
         mock_fetcher = Mock()
         mock_fetcher.fetch_all_data.return_value = (pd.DataFrame(), pd.DataFrame(), sample_dataview_info)
@@ -299,7 +323,6 @@ class TestProcessSingleDataviewFailures:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
     @patch("pandas.ExcelWriter")
@@ -308,7 +331,6 @@ class TestProcessSingleDataviewFailures:
         mock_excel_writer,
         mock_dq_checker_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -323,7 +345,6 @@ class TestProcessSingleDataviewFailures:
         mock_setup_logging.return_value = mock_logger
         mock_cja = Mock()
         mock_init_cja.return_value = mock_cja
-        mock_validate_dv.return_value = True
 
         mock_fetcher = Mock()
         mock_fetcher.fetch_all_data.return_value = (sample_metrics_df, sample_dimensions_df, sample_dataview_info)
@@ -353,7 +374,6 @@ class TestProcessSingleDataviewOutputFormats:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
     @patch("cja_auto_sdr.generator.write_csv_output")
@@ -362,7 +382,6 @@ class TestProcessSingleDataviewOutputFormats:
         mock_write_csv,
         mock_dq_checker_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -376,7 +395,6 @@ class TestProcessSingleDataviewOutputFormats:
         mock_setup_logging.return_value = mock_logger
         mock_cja = Mock()
         mock_init_cja.return_value = mock_cja
-        mock_validate_dv.return_value = True
 
         mock_fetcher = Mock()
         mock_fetcher.fetch_all_data.return_value = (sample_metrics_df, sample_dimensions_df, sample_dataview_info)
@@ -403,7 +421,6 @@ class TestProcessSingleDataviewOutputFormats:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
     @patch("cja_auto_sdr.generator.write_json_output")
@@ -412,7 +429,6 @@ class TestProcessSingleDataviewOutputFormats:
         mock_write_json,
         mock_dq_checker_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -426,7 +442,6 @@ class TestProcessSingleDataviewOutputFormats:
         mock_setup_logging.return_value = mock_logger
         mock_cja = Mock()
         mock_init_cja.return_value = mock_cja
-        mock_validate_dv.return_value = True
 
         mock_fetcher = Mock()
         mock_fetcher.fetch_all_data.return_value = (sample_metrics_df, sample_dimensions_df, sample_dataview_info)
@@ -453,7 +468,6 @@ class TestProcessSingleDataviewOutputFormats:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
     @patch("cja_auto_sdr.generator.write_html_output")
@@ -462,7 +476,6 @@ class TestProcessSingleDataviewOutputFormats:
         mock_write_html,
         mock_dq_checker_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -476,7 +489,6 @@ class TestProcessSingleDataviewOutputFormats:
         mock_setup_logging.return_value = mock_logger
         mock_cja = Mock()
         mock_init_cja.return_value = mock_cja
-        mock_validate_dv.return_value = True
 
         mock_fetcher = Mock()
         mock_fetcher.fetch_all_data.return_value = (sample_metrics_df, sample_dimensions_df, sample_dataview_info)
@@ -503,7 +515,6 @@ class TestProcessSingleDataviewOutputFormats:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
     @patch("cja_auto_sdr.generator.write_markdown_output")
@@ -512,7 +523,6 @@ class TestProcessSingleDataviewOutputFormats:
         mock_write_md,
         mock_dq_checker_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -526,7 +536,6 @@ class TestProcessSingleDataviewOutputFormats:
         mock_setup_logging.return_value = mock_logger
         mock_cja = Mock()
         mock_init_cja.return_value = mock_cja
-        mock_validate_dv.return_value = True
 
         mock_fetcher = Mock()
         mock_fetcher.fetch_all_data.return_value = (sample_metrics_df, sample_dimensions_df, sample_dataview_info)
@@ -557,7 +566,6 @@ class TestProcessSingleDataviewCaching:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.ValidationCache")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
@@ -570,7 +578,6 @@ class TestProcessSingleDataviewCaching:
         mock_dq_checker_class,
         mock_cache_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -584,7 +591,6 @@ class TestProcessSingleDataviewCaching:
         mock_setup_logging.return_value = mock_logger
         mock_cja = Mock()
         mock_init_cja.return_value = mock_cja
-        mock_validate_dv.return_value = True
 
         mock_fetcher = Mock()
         mock_fetcher.fetch_all_data.return_value = (sample_metrics_df, sample_dimensions_df, sample_dataview_info)
@@ -618,7 +624,6 @@ class TestProcessSingleDataviewCaching:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.ValidationCache")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
@@ -631,7 +636,6 @@ class TestProcessSingleDataviewCaching:
         mock_dq_checker_class,
         mock_cache_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -645,7 +649,6 @@ class TestProcessSingleDataviewCaching:
         mock_setup_logging.return_value = mock_logger
         mock_cja = Mock()
         mock_init_cja.return_value = mock_cja
-        mock_validate_dv.return_value = True
 
         mock_fetcher = Mock()
         mock_fetcher.fetch_all_data.return_value = (sample_metrics_df, sample_dimensions_df, sample_dataview_info)
@@ -737,7 +740,6 @@ class TestProcessSingleDataviewFilenaming:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
     @patch("cja_auto_sdr.generator.apply_excel_formatting")
@@ -748,7 +750,6 @@ class TestProcessSingleDataviewFilenaming:
         mock_apply_formatting,
         mock_dq_checker_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -761,7 +762,6 @@ class TestProcessSingleDataviewFilenaming:
         mock_setup_logging.return_value = mock_logger
         mock_cja = Mock()
         mock_init_cja.return_value = mock_cja
-        mock_validate_dv.return_value = True
 
         # Data view with special characters in name
         special_name_info = {
@@ -803,7 +803,6 @@ class TestProcessSingleDataviewMaxIssues:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
     @patch("cja_auto_sdr.generator.apply_excel_formatting")
@@ -814,7 +813,6 @@ class TestProcessSingleDataviewMaxIssues:
         mock_apply_formatting,
         mock_dq_checker_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -828,7 +826,6 @@ class TestProcessSingleDataviewMaxIssues:
         mock_setup_logging.return_value = mock_logger
         mock_cja = Mock()
         mock_init_cja.return_value = mock_cja
-        mock_validate_dv.return_value = True
 
         mock_fetcher = Mock()
         mock_fetcher.fetch_all_data.return_value = (sample_metrics_df, sample_dimensions_df, sample_dataview_info)
@@ -857,14 +854,12 @@ class TestProcessSingleDataviewMaxIssues:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
     def test_quality_report_only_respects_max_issues(
         self,
         mock_dq_checker_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -878,7 +873,6 @@ class TestProcessSingleDataviewMaxIssues:
         mock_setup_logging.return_value = mock_logger
         mock_cja = Mock()
         mock_init_cja.return_value = mock_cja
-        mock_validate_dv.return_value = True
 
         mock_fetcher = Mock()
         mock_fetcher.fetch_all_data.return_value = (sample_metrics_df, sample_dimensions_df, sample_dataview_info)
@@ -932,7 +926,6 @@ class TestProcessSingleDataviewMaxIssues:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
     @patch("cja_auto_sdr.generator.write_json_output")
@@ -941,7 +934,6 @@ class TestProcessSingleDataviewMaxIssues:
         mock_write_json,
         mock_dq_checker_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -955,7 +947,6 @@ class TestProcessSingleDataviewMaxIssues:
         mock_setup_logging.return_value = mock_logger
         mock_cja = Mock()
         mock_init_cja.return_value = mock_cja
-        mock_validate_dv.return_value = True
 
         mock_fetcher = Mock()
         mock_fetcher.fetch_all_data.return_value = (sample_metrics_df, sample_dimensions_df, sample_dataview_info)
@@ -989,14 +980,12 @@ class TestProcessSingleDataviewMaxIssues:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
     def test_quality_report_only_fails_when_validation_runtime_errors(
         self,
         mock_dq_checker_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -1010,7 +999,6 @@ class TestProcessSingleDataviewMaxIssues:
         mock_setup_logging.return_value = mock_logger
         mock_cja = Mock()
         mock_init_cja.return_value = mock_cja
-        mock_validate_dv.return_value = True
 
         mock_fetcher = Mock()
         mock_fetcher.fetch_all_data.return_value = (sample_metrics_df, sample_dimensions_df, sample_dataview_info)
@@ -1037,14 +1025,12 @@ class TestProcessSingleDataviewMaxIssues:
 
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
-    @patch("cja_auto_sdr.generator.validate_data_view")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     @patch("cja_auto_sdr.generator.DataQualityChecker")
     def test_quality_report_only_fails_when_validation_errors(
         self,
         mock_dq_checker_class,
         mock_fetcher_class,
-        mock_validate_dv,
         mock_init_cja,
         mock_setup_logging,
         mock_config_file,
@@ -1058,7 +1044,6 @@ class TestProcessSingleDataviewMaxIssues:
         mock_setup_logging.return_value = mock_logger
         mock_cja = Mock()
         mock_init_cja.return_value = mock_cja
-        mock_validate_dv.return_value = True
 
         mock_fetcher = Mock()
         mock_fetcher.fetch_all_data.return_value = (sample_metrics_df, sample_dimensions_df, sample_dataview_info)

--- a/tests/test_process_single_dataview.py
+++ b/tests/test_process_single_dataview.py
@@ -292,6 +292,121 @@ class TestProcessSingleDataviewFailures:
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
+    def test_data_view_validation_failure_error_placeholder(
+        self,
+        mock_fetcher_class,
+        mock_init_cja,
+        mock_setup_logging,
+        mock_config_file,
+        temp_output_dir,
+    ):
+        """Error placeholders from dataview lookup must fail validation."""
+        mock_logger = Mock()
+        mock_setup_logging.return_value = mock_logger
+        mock_cja = Mock()
+        mock_init_cja.return_value = mock_cja
+
+        mock_fetcher = Mock()
+        mock_fetcher.fetch_all_data.return_value = (
+            pd.DataFrame(),
+            pd.DataFrame(),
+            {
+                "id": "dv_invalid",
+                "name": "Unknown",
+                "lookup_failed": True,
+                "lookup_failure_reason": "exception",
+                "error": "upstream failure",
+            },
+        )
+        mock_fetcher_class.return_value = mock_fetcher
+
+        result = process_single_dataview(
+            data_view_id="dv_invalid",
+            config_file=mock_config_file,
+            output_dir=temp_output_dir,
+        )
+
+        assert result.success is False
+        assert "validation failed" in result.error_message.lower()
+
+    @patch("cja_auto_sdr.generator.setup_logging")
+    @patch("cja_auto_sdr.generator.initialize_cja")
+    @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
+    def test_data_view_validation_failure_legacy_unknown_placeholder(
+        self,
+        mock_fetcher_class,
+        mock_init_cja,
+        mock_setup_logging,
+        mock_config_file,
+        temp_output_dir,
+    ):
+        """Legacy Unknown/id-only placeholders must fail validation."""
+        mock_logger = Mock()
+        mock_setup_logging.return_value = mock_logger
+        mock_cja = Mock()
+        mock_init_cja.return_value = mock_cja
+
+        mock_fetcher = Mock()
+        mock_fetcher.fetch_all_data.return_value = (
+            pd.DataFrame(),
+            pd.DataFrame(),
+            {"id": "dv_invalid", "name": "Unknown"},
+        )
+        mock_fetcher_class.return_value = mock_fetcher
+
+        result = process_single_dataview(
+            data_view_id="dv_invalid",
+            config_file=mock_config_file,
+            output_dir=temp_output_dir,
+        )
+
+        assert result.success is False
+        assert "validation failed" in result.error_message.lower()
+
+    @patch("cja_auto_sdr.generator.setup_logging")
+    @patch("cja_auto_sdr.generator.initialize_cja")
+    @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
+    def test_data_view_validation_failure_circuit_breaker_placeholder(
+        self,
+        mock_fetcher_class,
+        mock_init_cja,
+        mock_setup_logging,
+        mock_config_file,
+        temp_output_dir,
+    ):
+        """Circuit-breaker placeholders from dataview lookup must fail validation."""
+        mock_logger = Mock()
+        mock_setup_logging.return_value = mock_logger
+        mock_cja = Mock()
+        mock_init_cja.return_value = mock_cja
+
+        mock_fetcher = Mock()
+        mock_fetcher.fetch_all_data.return_value = (
+            pd.DataFrame(),
+            pd.DataFrame(),
+            {
+                "id": "dv_invalid",
+                "name": "Unknown",
+                "lookup_failed": True,
+                "lookup_failure_reason": "circuit_breaker_open",
+                "circuit_breaker_open": True,
+                "error": "breaker open",
+            },
+        )
+        mock_fetcher_class.return_value = mock_fetcher
+
+        result = process_single_dataview(
+            data_view_id="dv_invalid",
+            config_file=mock_config_file,
+            output_dir=temp_output_dir,
+        )
+
+        assert result.success is False
+        assert "validation failed" in result.error_message.lower()
+
+    @patch("cja_auto_sdr.generator.setup_logging")
+    @patch("cja_auto_sdr.generator.initialize_cja")
+    @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     def test_empty_data_fetched(
         self,
         mock_fetcher_class,

--- a/tests/test_process_single_dataview.py
+++ b/tests/test_process_single_dataview.py
@@ -292,6 +292,44 @@ class TestProcessSingleDataviewFailures:
     @patch("cja_auto_sdr.generator.setup_logging")
     @patch("cja_auto_sdr.generator.initialize_cja")
     @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
+    def test_data_view_validation_failure_unknown_placeholder_with_error_diagnostic(
+        self,
+        mock_fetcher_class,
+        mock_init_cja,
+        mock_setup_logging,
+        mock_config_file,
+        temp_output_dir,
+    ):
+        """Unknown placeholder + diagnostic keys must fail validation even without explicit failure markers."""
+        mock_logger = Mock()
+        mock_setup_logging.return_value = mock_logger
+        mock_cja = Mock()
+        mock_init_cja.return_value = mock_cja
+
+        mock_fetcher = Mock()
+        mock_fetcher.fetch_all_data.return_value = (
+            pd.DataFrame(),
+            pd.DataFrame(),
+            {
+                "id": "dv_invalid",
+                "name": "Unknown",
+                "error": "not found",
+            },
+        )
+        mock_fetcher_class.return_value = mock_fetcher
+
+        result = process_single_dataview(
+            data_view_id="dv_invalid",
+            config_file=mock_config_file,
+            output_dir=temp_output_dir,
+        )
+
+        assert result.success is False
+        assert "validation failed" in result.error_message.lower()
+
+    @patch("cja_auto_sdr.generator.setup_logging")
+    @patch("cja_auto_sdr.generator.initialize_cja")
+    @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
     def test_data_view_validation_failure_error_placeholder(
         self,
         mock_fetcher_class,

--- a/tests/test_profile_management.py
+++ b/tests/test_profile_management.py
@@ -465,6 +465,28 @@ class TestImportProfileNonInteractiveExtended:
         captured = capsys.readouterr()
         assert "failed validation" in captured.err
 
+    def test_validation_failure_details_stay_on_stderr(self, tmp_path, capsys):
+        """Validation issue detail lines should stay on stderr with the error header."""
+        source = tmp_path / "credentials.json"
+        source.write_text(json.dumps(VALID_CREDENTIALS))
+
+        profile_dir = tmp_path / "orgs" / "bad-creds"
+        expected_issues = ["org_id: invalid format", "client_id: too short"]
+
+        with (
+            patch("cja_auto_sdr.generator.get_profile_path", return_value=profile_dir),
+            patch("cja_auto_sdr.generator.validate_credentials", return_value=(False, expected_issues)),
+        ):
+            result = import_profile_non_interactive("bad-creds", source)
+
+        assert result is False
+        captured = capsys.readouterr()
+        assert "Imported credentials failed validation" in captured.err
+        assert "org_id: invalid format" in captured.err
+        assert "client_id: too short" in captured.err
+        assert "org_id: invalid format" not in captured.out
+        assert "client_id: too short" not in captured.out
+
     def test_success_message_includes_source_and_location(self, tmp_path, capsys):
         """Successful import prints source path and profile location."""
         source = tmp_path / "credentials.json"

--- a/tests/test_profile_management.py
+++ b/tests/test_profile_management.py
@@ -576,7 +576,7 @@ class TestTestProfile:
             patch("cja_auto_sdr.generator.cjapy") as mock_cjapy,
             patch("cja_auto_sdr.generator.ConfigValidator") as mock_validator,
         ):
-            mock_cjapy.importConfigFile.side_effect = Exception("Connection refused")
+            mock_cjapy.importConfigFile.side_effect = OSError("Connection refused")
             mock_validator.validate_all.return_value = []
             result = run_test_profile("api-fail")
 
@@ -620,7 +620,7 @@ class TestTestProfile:
             patch("cja_auto_sdr.generator.ConfigValidator") as mock_validator,
         ):
             mock_cjapy.importConfigFile.return_value = None
-            mock_cjapy.CJA.side_effect = Exception("Auth failed: invalid credentials")
+            mock_cjapy.CJA.side_effect = OSError("Auth failed: invalid credentials")
             mock_validator.validate_all.return_value = []
             result = run_test_profile("cja-fail")
 

--- a/tests/test_profile_management.py
+++ b/tests/test_profile_management.py
@@ -61,7 +61,7 @@ class TestAddProfileInteractive:
         result = add_profile_interactive("bad name!")
         assert result is False
         captured = capsys.readouterr()
-        assert "Error" in captured.out
+        assert "Error" in captured.err
 
     def test_existing_profile_overwrite_declined(self, tmp_path, capsys):
         """Declining overwrite of existing profile returns False."""
@@ -138,7 +138,7 @@ class TestAddProfileInteractive:
 
         assert result is False
         captured = capsys.readouterr()
-        assert "Organization ID is required" in captured.out
+        assert "Organization ID is required" in captured.err
 
     def test_empty_client_id_aborts(self, tmp_path, capsys):
         """Empty client ID causes early exit."""
@@ -153,7 +153,7 @@ class TestAddProfileInteractive:
 
         assert result is False
         captured = capsys.readouterr()
-        assert "Client ID is required" in captured.out
+        assert "Client ID is required" in captured.err
 
     def test_empty_secret_aborts(self, tmp_path, capsys):
         """Empty client secret causes early exit."""
@@ -169,7 +169,7 @@ class TestAddProfileInteractive:
 
         assert result is False
         captured = capsys.readouterr()
-        assert "Client Secret is required" in captured.out
+        assert "Client Secret is required" in captured.err
 
     def test_empty_scopes_aborts(self, tmp_path, capsys):
         """Empty scopes causes early exit."""
@@ -185,7 +185,7 @@ class TestAddProfileInteractive:
 
         assert result is False
         captured = capsys.readouterr()
-        assert "OAuth Scopes are required" in captured.out
+        assert "OAuth Scopes are required" in captured.err
 
     def test_keyboard_interrupt_aborts(self, tmp_path, capsys):
         """KeyboardInterrupt during input aborts gracefully."""
@@ -231,7 +231,7 @@ class TestAddProfileInteractive:
 
         assert result is False
         captured = capsys.readouterr()
-        assert "Cannot securely read secret" in captured.out
+        assert "Cannot securely read secret" in captured.err
 
     def test_mkdir_failure(self, tmp_path, capsys):
         """OSError during directory creation returns False."""
@@ -246,7 +246,7 @@ class TestAddProfileInteractive:
 
         assert result is False
         captured = capsys.readouterr()
-        assert "Error creating profile directory" in captured.out
+        assert "Error creating profile directory" in captured.err
 
     def test_config_write_failure(self, tmp_path, capsys):
         """OSError during config.json write returns False."""
@@ -266,7 +266,7 @@ class TestAddProfileInteractive:
 
         assert result is False
         captured = capsys.readouterr()
-        assert "Error writing config file" in captured.out
+        assert "Error writing config file" in captured.err
 
 
 # ===========================================================================
@@ -380,7 +380,7 @@ class TestImportProfileNonInteractiveExtended:
         result = import_profile_non_interactive("bad name!", "/some/file.json")
         assert result is False
         captured = capsys.readouterr()
-        assert "Error" in captured.out
+        assert "Error" in captured.err
 
     def test_source_file_not_found(self, tmp_path, capsys):
         """Non-existent source file returns False with error message."""
@@ -391,7 +391,7 @@ class TestImportProfileNonInteractiveExtended:
 
         assert result is False
         captured = capsys.readouterr()
-        assert "Error loading profile import source" in captured.out
+        assert "Error loading profile import source" in captured.err
 
     def test_overwrite_existing_profile(self, tmp_path, capsys):
         """Overwrite=True should replace an existing profile."""
@@ -440,7 +440,7 @@ class TestImportProfileNonInteractiveExtended:
 
         assert result is False
         captured = capsys.readouterr()
-        assert "Error writing profile config" in captured.out
+        assert "Error writing profile config" in captured.err
 
     def test_validation_failure(self, tmp_path, capsys):
         """Credentials that fail strict validation should be rejected."""
@@ -463,7 +463,7 @@ class TestImportProfileNonInteractiveExtended:
 
         assert result is False
         captured = capsys.readouterr()
-        assert "failed validation" in captured.out
+        assert "failed validation" in captured.err
 
     def test_success_message_includes_source_and_location(self, tmp_path, capsys):
         """Successful import prints source path and profile location."""
@@ -492,7 +492,7 @@ class TestTestProfile:
     """Tests for the profile connectivity test function."""
 
     def test_profile_not_found(self, tmp_path, capsys):
-        """Non-existent profile should fail with FAILED message."""
+        """Non-existent profile should fail with ERROR message."""
         nonexistent = tmp_path / "orgs" / "nonexistent"
 
         with patch("cja_auto_sdr.generator.get_profile_path", return_value=nonexistent):
@@ -500,10 +500,10 @@ class TestTestProfile:
 
         assert result is False
         captured = capsys.readouterr()
-        assert "FAILED" in captured.out
+        assert "ERROR" in captured.err
 
     def test_profile_config_error(self, tmp_path, capsys):
-        """Profile with config error should fail with FAILED message."""
+        """Profile with config error should fail with ERROR message."""
         profile_dir = tmp_path / "orgs" / "bad-config"
         profile_dir.mkdir(parents=True)
         # Empty directory = no config files => ProfileConfigError
@@ -513,7 +513,7 @@ class TestTestProfile:
 
         assert result is False
         captured = capsys.readouterr()
-        assert "FAILED" in captured.out
+        assert "ERROR" in captured.err
 
     def test_successful_api_connection(self, tmp_path, capsys):
         """Successful API test should return True with SUCCESS."""
@@ -582,9 +582,9 @@ class TestTestProfile:
 
         assert result is False
         captured = capsys.readouterr()
-        assert "API connection: FAILED" in captured.out
-        assert "Connection refused" in captured.out
-        assert "Profile test: FAILED" in captured.out
+        assert "API connection: FAILED" in captured.err
+        assert "Connection refused" in captured.err
+        assert "Profile test: FAILED" in captured.err
         assert "Common issues:" in captured.out
 
     def test_validation_warnings_displayed(self, tmp_path, capsys):
@@ -626,8 +626,8 @@ class TestTestProfile:
 
         assert result is False
         captured = capsys.readouterr()
-        assert "FAILED" in captured.out
-        assert "invalid credentials" in captured.out
+        assert "FAILED" in captured.err
+        assert "invalid credentials" in captured.err
 
     def test_temp_file_cleaned_up_on_success(self, tmp_path):
         """Temp config file should be cleaned up after successful test."""
@@ -679,7 +679,7 @@ class TestShowProfileExtended:
 
         assert result is False
         captured = capsys.readouterr()
-        assert "Error" in captured.out
+        assert "Error" in captured.err
 
     def test_show_profile_not_found(self, tmp_path, capsys):
         """ProfileNotFoundError path should print error and return False."""
@@ -690,7 +690,7 @@ class TestShowProfileExtended:
 
         assert result is False
         captured = capsys.readouterr()
-        assert "Error" in captured.out
+        assert "Error" in captured.err
 
     def test_show_profile_with_both_sources(self, tmp_path, capsys):
         """Profile with config.json and .env should list both sources."""

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -438,7 +438,7 @@ class TestShowProfile:
             result = show_profile("nonexistent")
             assert result is False
             captured = capsys.readouterr()
-            assert "Error" in captured.out
+            assert "Error" in captured.err
 
 
 class TestProfileImport:

--- a/tests/test_shared_cache.py
+++ b/tests/test_shared_cache.py
@@ -11,15 +11,12 @@ Validates that SharedValidationCache:
 8. Properly shuts down Manager resources
 """
 
-import os
-import sys
 import time
 from concurrent.futures import ProcessPoolExecutor
 
 import pandas as pd
 import pytest
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from cja_auto_sdr.generator import SharedValidationCache, ValidationCache
 
 

--- a/tests/test_shared_cache.py
+++ b/tests/test_shared_cache.py
@@ -310,7 +310,9 @@ class TestSharedValidationCacheEviction:
 
                 fake_now[0] += 1.5
 
-                with patch.object(cache, "_reconcile_access_times", wraps=cache._reconcile_access_times) as mock_reconcile:
+                with patch.object(
+                    cache, "_reconcile_access_times", wraps=cache._reconcile_access_times
+                ) as mock_reconcile:
                     _, key3 = cache.get(df3, "Metrics", ["id"], ["id"])
                     cache.put(df3, "Metrics", ["id"], ["id"], [{"v": 3}], key3)
                     assert mock_reconcile.call_count == 0

--- a/tests/test_shared_cache.py
+++ b/tests/test_shared_cache.py
@@ -13,6 +13,7 @@ Validates that SharedValidationCache:
 
 import time
 from concurrent.futures import ProcessPoolExecutor
+from unittest.mock import patch
 
 import pandas as pd
 import pytest
@@ -255,6 +256,70 @@ class TestSharedValidationCacheEviction:
         assert result2 is None
 
         cache.shutdown()
+
+    def test_put_defers_full_scans_until_capacity_pressure(self):
+        """New keys below capacity should not trigger prune/reconcile full scans."""
+        cache = SharedValidationCache(max_size=3, ttl_seconds=3600)
+
+        try:
+            dfs = [pd.DataFrame({"id": [f"item{idx}"]}) for idx in range(4)]
+
+            with (
+                patch.object(cache, "_prune_expired_entries", wraps=cache._prune_expired_entries) as mock_prune,
+                patch.object(cache, "_reconcile_access_times", wraps=cache._reconcile_access_times) as mock_reconcile,
+            ):
+                for idx in range(3):
+                    _, key = cache.get(dfs[idx], "Metrics", ["id"], ["id"])
+                    cache.put(dfs[idx], "Metrics", ["id"], ["id"], [{"v": idx}], key)
+
+                assert mock_prune.call_count == 0
+                assert mock_reconcile.call_count == 0
+
+                _, key = cache.get(dfs[3], "Metrics", ["id"], ["id"])
+                cache.put(dfs[3], "Metrics", ["id"], ["id"], [{"v": 3}], key)
+
+                assert mock_prune.call_count == 1
+                assert mock_reconcile.call_count == 1
+
+            stats = cache.get_statistics()
+            assert stats["size"] == 3
+            assert stats["evictions"] >= 1
+        finally:
+            cache.shutdown()
+
+    def test_capacity_pressure_skips_reconcile_when_prune_frees_space(self):
+        """Reconciliation should be skipped if expiration pruning already frees capacity."""
+        fake_now = [1000000.0]
+
+        def mock_time():
+            return fake_now[0]
+
+        with patch("cja_auto_sdr.api.cache.time") as mock_time_module:
+            mock_time_module.time = mock_time
+            cache = SharedValidationCache(max_size=2, ttl_seconds=1)
+
+            try:
+                df1 = pd.DataFrame({"id": ["expired-1"]})
+                df2 = pd.DataFrame({"id": ["expired-2"]})
+                df3 = pd.DataFrame({"id": ["fresh"]})
+
+                _, key1 = cache.get(df1, "Metrics", ["id"], ["id"])
+                cache.put(df1, "Metrics", ["id"], ["id"], [{"v": 1}], key1)
+                _, key2 = cache.get(df2, "Metrics", ["id"], ["id"])
+                cache.put(df2, "Metrics", ["id"], ["id"], [{"v": 2}], key2)
+
+                fake_now[0] += 1.5
+
+                with patch.object(cache, "_reconcile_access_times", wraps=cache._reconcile_access_times) as mock_reconcile:
+                    _, key3 = cache.get(df3, "Metrics", ["id"], ["id"])
+                    cache.put(df3, "Metrics", ["id"], ["id"], [{"v": 3}], key3)
+                    assert mock_reconcile.call_count == 0
+
+                stats = cache.get_statistics()
+                assert stats["size"] == 1
+                assert stats["evictions"] == 0
+            finally:
+                cache.shutdown()
 
     def test_overwrite_refreshes_recency_before_eviction(self):
         """Overwriting an entry should refresh recency so it is not evicted next."""

--- a/tests/test_shared_cache.py
+++ b/tests/test_shared_cache.py
@@ -65,6 +65,14 @@ def sample_dimensions_df():
 class TestSharedValidationCacheBasics:
     """Test basic shared cache functionality"""
 
+    def test_invalid_cache_configuration_raises(self):
+        """Invalid size/TTL should fail fast during initialization."""
+        with pytest.raises(ValueError, match="max_size must be >= 1"):
+            SharedValidationCache(max_size=0, ttl_seconds=3600)
+
+        with pytest.raises(ValueError, match="ttl_seconds must be > 0"):
+            SharedValidationCache(max_size=10, ttl_seconds=0)
+
     def test_cache_miss_on_first_call(self, sample_metrics_df):
         """First lookup should be cache miss"""
         cache = SharedValidationCache(max_size=100, ttl_seconds=3600)
@@ -250,6 +258,66 @@ class TestSharedValidationCacheEviction:
         assert result2 is None
 
         cache.shutdown()
+
+    def test_overwrite_refreshes_recency_before_eviction(self):
+        """Overwriting an entry should refresh recency so it is not evicted next."""
+        cache = SharedValidationCache(max_size=2, ttl_seconds=3600)
+
+        try:
+            df1 = pd.DataFrame({"id": ["a"]})
+            df2 = pd.DataFrame({"id": ["b"]})
+            df3 = pd.DataFrame({"id": ["c"]})
+
+            _, key1 = cache.get(df1, "Metrics", ["id"], ["id"])
+            cache.put(df1, "Metrics", ["id"], ["id"], [{"v": 1}], key1)
+
+            _, key2 = cache.get(df2, "Metrics", ["id"], ["id"])
+            cache.put(df2, "Metrics", ["id"], ["id"], [{"v": 2}], key2)
+
+            # Overwrite df1 to refresh its recency.
+            cache.put(df1, "Metrics", ["id"], ["id"], [{"v": 10}], key1)
+
+            _, key3 = cache.get(df3, "Metrics", ["id"], ["id"])
+            cache.put(df3, "Metrics", ["id"], ["id"], [{"v": 3}], key3)
+
+            result1, _ = cache.get(df1, "Metrics", ["id"], ["id"])
+            result2, _ = cache.get(df2, "Metrics", ["id"], ["id"])
+            result3, _ = cache.get(df3, "Metrics", ["id"], ["id"])
+
+            assert result1 is not None
+            assert result1[0]["v"] == 10
+            assert result2 is None
+            assert result3 is not None
+        finally:
+            cache.shutdown()
+
+    def test_put_recovers_when_access_times_missing(self):
+        """Defensive path: put() should restore LRU metadata before eviction."""
+        cache = SharedValidationCache(max_size=1, ttl_seconds=3600)
+
+        try:
+            df1 = pd.DataFrame({"id": ["stale"]})
+            df2 = pd.DataFrame({"id": ["fresh"]})
+
+            _, key1 = cache.get(df1, "Metrics", ["id"], ["id"])
+            cache.put(df1, "Metrics", ["id"], ["id"], [{"v": "old"}], key1)
+
+            # Simulate metadata drift/corruption where access tracking is lost.
+            cache._access_times.clear()
+
+            _, key2 = cache.get(df2, "Metrics", ["id"], ["id"])
+            cache.put(df2, "Metrics", ["id"], ["id"], [{"v": "new"}], key2)
+
+            result1, _ = cache.get(df1, "Metrics", ["id"], ["id"])
+            result2, _ = cache.get(df2, "Metrics", ["id"], ["id"])
+            stats = cache.get_statistics()
+
+            assert result1 is None
+            assert result2 is not None
+            assert stats["size"] == 1
+            assert stats["evictions"] >= 1
+        finally:
+            cache.shutdown()
 
 
 class TestSharedValidationCacheTTL:

--- a/tests/test_ux_features.py
+++ b/tests/test_ux_features.py
@@ -344,11 +344,11 @@ class TestCombinedFeatures:
 class TestVersionUpdated:
     """Test that version is correct"""
 
-    def test_version_is_3_3_4(self):
-        """Test that version is 3.3.4"""
+    def test_version_is_3_3_5(self):
+        """Test that version is 3.3.5"""
         from cja_auto_sdr.generator import __version__
 
-        assert __version__ == "3.3.4"
+        assert __version__ == "3.3.5"
 
 
 class TestFormatAutoDetection:

--- a/tests/test_validation_cache.py
+++ b/tests/test_validation_cache.py
@@ -158,6 +158,32 @@ class TestValidationCache:
         assert result2 is None
         assert result3 is not None
 
+    def test_lru_overwrite_refreshes_recency(self):
+        """Overwriting an existing key should refresh it to MRU for later eviction decisions."""
+        cache = ValidationCache(max_size=2, ttl_seconds=3600)
+
+        df1 = pd.DataFrame({"id": [1], "name": ["a"], "type": ["x"]})
+        df2 = pd.DataFrame({"id": [2], "name": ["b"], "type": ["y"]})
+        df3 = pd.DataFrame({"id": [3], "name": ["c"], "type": ["z"]})
+
+        cache.put(df1, "Metrics", ["id", "name", "type"], [], [{"issue": "1"}])
+        cache.put(df2, "Metrics", ["id", "name", "type"], [], [{"issue": "2"}])
+
+        # Overwrite df1; this write should refresh recency to MRU.
+        cache.put(df1, "Metrics", ["id", "name", "type"], [], [{"issue": "1-updated"}])
+
+        # Adding df3 should evict df2, not the recently updated df1.
+        cache.put(df3, "Metrics", ["id", "name", "type"], [], [{"issue": "3"}])
+
+        result1, _ = cache.get(df1, "Metrics", ["id", "name", "type"], [])
+        result2, _ = cache.get(df2, "Metrics", ["id", "name", "type"], [])
+        result3, _ = cache.get(df3, "Metrics", ["id", "name", "type"], [])
+
+        assert result1 is not None
+        assert result1[0]["issue"] == "1-updated"
+        assert result2 is None
+        assert result3 is not None
+
     def test_thread_safety(self, sample_metrics_df):
         """Cache should be thread-safe"""
         logger = logging.getLogger("test")
@@ -552,3 +578,11 @@ class TestValidationCache:
         assert result is not None
         assert len(result) == 1
         assert result[0]["severity"] == "HIGH"
+
+    def test_invalid_cache_configuration_raises(self):
+        """Invalid size/TTL should fail fast during initialization."""
+        with pytest.raises(ValueError, match="max_size must be >= 1"):
+            ValidationCache(max_size=0, ttl_seconds=3600)
+
+        with pytest.raises(ValueError, match="ttl_seconds must be > 0"):
+            ValidationCache(max_size=10, ttl_seconds=0)

--- a/tests/test_validation_cache.py
+++ b/tests/test_validation_cache.py
@@ -15,6 +15,7 @@ import os
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import patch
 
 import pandas as pd
 import pytest
@@ -91,8 +92,6 @@ class TestValidationCache:
 
     def test_cache_ttl_expiration(self, sample_metrics_df):
         """Cache entries should expire after TTL (deterministic, no sleep)"""
-        from unittest.mock import patch
-
         fake_now = [1000000.0]
 
         def mock_time():
@@ -183,6 +182,21 @@ class TestValidationCache:
         assert result1[0]["issue"] == "1-updated"
         assert result2 is None
         assert result3 is not None
+
+    def test_overwrite_moves_to_end_only_once(self):
+        """Overwrite path should perform a single move_to_end after assignment."""
+        cache = ValidationCache(max_size=2, ttl_seconds=3600)
+        df1 = pd.DataFrame({"id": [1], "name": ["a"], "type": ["x"]})
+
+        with patch.object(cache._cache, "move_to_end", wraps=cache._cache.move_to_end) as mock_move_to_end:
+            cache.put(df1, "Metrics", ["id", "name", "type"], [], [{"issue": "1"}])
+            first_put_calls = mock_move_to_end.call_count
+
+            cache.put(df1, "Metrics", ["id", "name", "type"], [], [{"issue": "1-updated"}])
+            second_put_calls = mock_move_to_end.call_count - first_put_calls
+
+        assert first_put_calls == 1
+        assert second_put_calls == 1
 
     def test_thread_safety(self, sample_metrics_df):
         """Cache should be thread-safe"""

--- a/tests/test_validation_cache.py
+++ b/tests/test_validation_cache.py
@@ -157,6 +157,52 @@ class TestValidationCache:
         assert result2 is None
         assert result3 is not None
 
+    def test_put_defers_prune_until_capacity_pressure(self):
+        """Inserts below capacity should not trigger full-cache expiration scans."""
+        cache = ValidationCache(max_size=3, ttl_seconds=3600)
+        dfs = [pd.DataFrame({"id": [idx], "name": [f"n{idx}"], "type": ["x"]}) for idx in range(4)]
+
+        with patch.object(cache, "_prune_expired_entries", wraps=cache._prune_expired_entries) as mock_prune:
+            cache.put(dfs[0], "Metrics", ["id", "name", "type"], [], [{"issue": "0"}])
+            cache.put(dfs[1], "Metrics", ["id", "name", "type"], [], [{"issue": "1"}])
+            cache.put(dfs[2], "Metrics", ["id", "name", "type"], [], [{"issue": "2"}])
+            assert mock_prune.call_count == 0
+
+            # First insert under pressure should trigger capacity maintenance once.
+            cache.put(dfs[3], "Metrics", ["id", "name", "type"], [], [{"issue": "3"}])
+            assert mock_prune.call_count == 1
+
+        stats = cache.get_statistics()
+        assert stats["size"] == 3
+        assert stats["evictions"] == 1
+
+    def test_capacity_pressure_prunes_expired_before_evicting(self):
+        """When full, expired entries should be reclaimed before any live-key eviction."""
+        fake_now = [1000000.0]
+
+        def mock_time():
+            return fake_now[0]
+
+        with patch("cja_auto_sdr.api.cache.time") as mock_time_module:
+            mock_time_module.time = mock_time
+            cache = ValidationCache(max_size=2, ttl_seconds=1)
+            df1 = pd.DataFrame({"id": [1], "name": ["a"], "type": ["x"]})
+            df2 = pd.DataFrame({"id": [2], "name": ["b"], "type": ["y"]})
+            df3 = pd.DataFrame({"id": [3], "name": ["c"], "type": ["z"]})
+
+            cache.put(df1, "Metrics", ["id", "name", "type"], [], [{"issue": "1"}])
+            cache.put(df2, "Metrics", ["id", "name", "type"], [], [{"issue": "2"}])
+
+            fake_now[0] += 1.5
+
+            with patch.object(cache, "_evict_lru", wraps=cache._evict_lru) as mock_evict:
+                cache.put(df3, "Metrics", ["id", "name", "type"], [], [{"issue": "3"}])
+                assert mock_evict.call_count == 0
+
+            stats = cache.get_statistics()
+            assert stats["size"] == 1
+            assert stats["evictions"] == 0
+
     def test_lru_overwrite_refreshes_recency(self):
         """Overwriting an existing key should refresh it to MRU for later eviction decisions."""
         cache = ValidationCache(max_size=2, ttl_seconds=3600)


### PR DESCRIPTION
## Summary

Release v3.3.5 — performance improvements, bug fixes, hardening, and coverage expansion across 40 files (+4,077 / -599 lines).

### Performance
- **Parallel inventory builds**: inventory construction in `process_single_dataview` now uses `ThreadPoolExecutor` for concurrent builds (`generator.py`)
- **O(1) LRU eviction**: `ValidationCache` refactored from `dict` + access-times to `OrderedDict` with O(1) eviction (`api/cache.py`)
- **Redundant API call eliminated**: removed `validate_data_view()` call from `process_single_dataview`; validation now occurs post-fetch via `assess_dataview_lookup_payload`, saving one API round-trip per data view (`api/fetch.py`, `generator.py`)
- **Vectorized column widths**: Excel column-width calculation uses pandas vectorized string operations instead of Python loops

### Bug Fixes
- **Profile error routing**: 19 bare `print()` error calls in profile management now route through `ConsoleColors.error()` to stderr with color styling
- **CLI help text**: parser description corrected from "System Design Records" to "Solution Design Reference"; exit code 3 added to epilog
- **Format fallback warnings**: discovery and profile-list commands now warn when an unsupported format falls back to console output
- **Console format error routing**: console format error messages now go to stderr instead of stdout
- **Validate-config next-step hint**: `--validate-config` now suggests next steps on success

### Hardening
- **Dataview lookup validation**: new `DataViewLookupAssessment` dataclass with multi-layered validation — failure flags, error shape detection, missing identity, id mismatch, unknown placeholders (`core/discovery_payloads.py`, +303 lines)
- **LRU overwrite behavior**: `put()` correctly handles insert and overwrite cases with `move_to_end()` after assignment (`api/cache.py`)
- **Cache capacity maintenance**: `_ensure_capacity_for_new_entry()` extracted with defensive eviction bound and fallback clear; `_remove_entry()` helper for consistent cache+metadata cleanup; `_evict_lru()` returns success indicator with fallback eviction when access metadata drifts; shutdown race condition fixed (`api/cache.py`)
- **Cache and inventory concurrency**: `SharedValidationCache._reconcile_access_times()` handles metadata drift between Manager dicts; inventory parallelization with safe main-thread assignment
- **Dataview payload error detection**: `DATAVIEW_EXPLICIT_ERROR_KEYS` + `is_dataview_error_payload` for structured error classification
- **Placeholder detection**: `_unknown_lookup_placeholder_reason` + legacy placeholder detection for backwards compatibility
- **Profile format fallback and stderr diagnostics**: `_resolve_command_output_format` with warning emissions
- **Config/bootstrap exception boundaries**: `_load_cja_config` and `_bootstrap_cja` narrowed from bare `Exception` to `(FileNotFoundError, KeyError, ValueError, TypeError)`
- **Optional component count fallbacks**: component count extraction in `process_single_dataview` hardened with safe `int` coercion and fallback defaults
- **Dataview lookup ID validation**: type checking and string coercion for dataview ID fields in assessment payloads
- **Dataview lookup canonicalization**: canonical ID extraction handles nested structures, null values, and type-inconsistent payloads
- **Dataview lookup payload shape validation**: multi-layered shape validation with explicit failure flags for missing/malformed fields
- **Dataview lookup metadata presence checks**: metadata field validation with graceful degradation for missing keys
- **Dataview lookup failure-flag precedence**: deterministic priority ordering for conflicting failure flags in assessment results
- **Dataview lookup error classification**: new `discovery_exceptions.py` module — robust HTTP status-code extraction from nested error chains, `is_dataview_lookup_not_found_error()` for 403/404 detection

### Refactoring
- **Exception narrowing (batch 3)**: 9 broad `except Exception` catches narrowed — 6 to `(RuntimeError, AttributeError)` and 3 to `RECOVERABLE_API_EXCEPTIONS`
- **Dataview lookup validation unification**: runtime and dry-run paths now share `assess_dataview_lookup_payload`, eliminating duplicated validation logic
- **Error classification extraction**: dataview not-found detection extracted from `generator.py` into `core/discovery_exceptions.py` with `coerce_http_status_code()`, `iter_error_chain_nodes()`, `extract_http_status_codes()` helpers
- **Cache capacity extraction**: inline eviction logic in `put()` and `SharedValidationCache` extracted into dedicated methods (`_ensure_capacity_for_new_entry`, `_remove_entry`) for clarity and testability

### Coverage & Tests
- **108 coverage hardening tests**: new `test_coverage_hardening.py` — output-dir access, lazy forwarding, logging init, discovery helpers, short-option clusters, config validation
- **26 exception narrowing tests**: new `test_exception_narrowing.py` — verifies narrowed boundaries catch expected types and propagate unexpected ones, including config/bootstrap and component count fallbacks
- **60 discovery payload tests**: new `test_discovery_payloads.py` — edge cases including exotic types (`_ExplodingName`, `_ExplodingBool`), ID validation, canonicalization, metadata presence, failure-flag precedence
- **5 discovery exception tests**: new `test_discovery_exceptions.py` — HTTP status code extraction from nested error chains, not-found classification
- **14 dry-run hardening tests**: expanded `test_dry_run.py` — dataview lookup validation in dry-run mode
- **Shared cache tests**: additional tests for eviction, overwrite, cross-process recovery, and capacity-maintenance regression guards
- **Parallel API fetcher tests**: additional tests for payload validation, canonicalization, and metadata presence
- **Process single dataview tests**: expanded with post-fetch validation cases (empty lookup, None lookup, unknown placeholders, error placeholders, legacy unknown placeholders, id mismatch)
- **CLI integration tests**: expanded with dataview lookup error routing, canonicalization fallbacks, and payload shape validation end-to-end

### Housekeeping
- Version bump v3.3.4 → v3.3.5 across all 7 locations
- Changelog test count corrected (101 → 108)
- PEP 758 comment annotations for consistency
- Removed unnecessary `sys.path.insert` hacks from test files

## Commits (41)

| SHA | Message |
|-----|---------|
| `b89d938` | Fix CI formatting and synchronize test-count docs |
| `7ae3bd3` | Refactor cache capacity maintenance and add regression guards |
| `28648b2` | Refresh documented test counts |
| `3e310f3` | Refactor dataview lookup error classification and harden not-found mapping |
| `ff7e7dd` | Fix CI: format file and refresh test counts |
| `3d6ff6f` | Harden dataview lookup metadata presence checks |
| `71bbc43` | Update README test counts after discovery payload tests |
| `16e9268` | Make dataview lookup failure-flag precedence deterministic |
| `fae8de6` | Update test count docs after dry-run hardening |
| `77bc1e2` | Refactor dataview lookup validation across runtime and dry-run |
| `98861d2` | Sync documented test counts |
| `d4393e9` | Harden dataview lookup payload validation and add regressions |
| `39227bf` | Update documented test counts |
| `af0d77d` | Harden dataview lookup canonicalization and add regressions |
| `543e080` | Update documented test counts |
| `a398ed2` | Harden dataview lookup ID validation and add regressions |
| `76027d0` | refactor: harden optional component count fallbacks |
| `7eed408` | docs: refresh generated test counts |
| `68acfb0` | fix(cli): harden config/bootstrap exception boundaries |
| `adbc9c0` | Clarify exception-changelog accounting and apply minor cleanup follow-ups |
| `a720d17` | Fix stale changelog count, add PEP 758 comment, remove unnecessary sys.path hacks |
| `03fd573` | Update generated test counts in README docs |
| `c98ced3` | Harden dataview lookup placeholder detection and regressions |
| `86dad50` | Sync documented test counts |
| `7847f88` | Harden cache and inventory concurrency boundaries |
| `2075e7b` | Fix CI: apply ruff formatting and refresh test counts |
| `4f34a5f` | Refine dataview payload error detection and messaging |
| `a97e15a` | fix(discovery): preserve stdout csv format and harden resolver policy |
| `9f8d46b` | style: format generator helpers for lint check |
| `3e5ff54` | fix(cli): harden profile format fallback and stderr diagnostics |
| `b6ab7c1` | fix(cache): harden LRU overwrite behavior and add regressions |
| `27ea666` | Fix CI regressions for lookup hardening changes |
| `df59af0` | Harden dataview lookup validation and add regressions |
| `61c9687` | fix: CI failures — ruff format, test mock setup, test counts |
| `fe46eb4` | chore: bump version to v3.3.5 and update changelog |
| `7f41a8e` | test: cover missed coverage statements in generator.py and helpers |
| `327d9b3` | refactor: narrow 8 broad exception boundaries in generator.py |
| `1a9cd71` | perf: parallelize inventory builds and fix O(N) LRU eviction |
| `021d29f` | perf: eliminate redundant validate_data_view API call |
| `6a469d1` | fix: CLI help text corrections and format fallback warnings |
| `7c0ebb9` | fix: route profile errors to stderr with color styling |

## Files changed (40)

`CHANGELOG.md`, `CLAUDE.md`, `README.md`, `docs/CONFIGURATION.md`, `docs/QUICKSTART_GUIDE.md`, `docs/QUICK_REFERENCE.md`, `src/cja_auto_sdr/api/cache.py`, `src/cja_auto_sdr/api/fetch.py`, `src/cja_auto_sdr/cli/parser.py`, `src/cja_auto_sdr/core/discovery_exceptions.py` (new), `src/cja_auto_sdr/core/discovery_payloads.py`, `src/cja_auto_sdr/core/version.py`, `src/cja_auto_sdr/generator.py`, `tests/README.md`, `tests/test_cja_initialization.py`, `tests/test_cli.py`, `tests/test_cli_command_handlers.py`, `tests/test_config_and_resolution.py`, `tests/test_coverage_hardening.py` (new), `tests/test_discovery_component_consistency.py`, `tests/test_discovery_exceptions.py` (new), `tests/test_discovery_payloads.py` (new), `tests/test_dry_run.py`, `tests/test_e2e_integration.py`, `tests/test_exception_contracts.py`, `tests/test_exception_narrowing.py` (new), `tests/test_generator_remaining_coverage.py`, `tests/test_main_entry_points.py`, `tests/test_main_impl_cli_coverage.py`, `tests/test_main_impl_coverage.py`, `tests/test_malformed_api_responses.py`, `tests/test_name_resolution.py`, `tests/test_output_content_validation.py`, `tests/test_parallel_api_fetcher.py`, `tests/test_process_single_dataview.py`, `tests/test_profile_management.py`, `tests/test_profiles.py`, `tests/test_shared_cache.py`, `tests/test_ux_features.py`, `tests/test_validation_cache.py`

## Test plan
- [x] Full test suite passes (5,287 tests, 1 expected skip)
- [x] Ruff lint and format clean
- [x] Version sync validated across all 7 locations
- [x] Code review completed — all issues addressed