### PR TITLE
v3.4.2: Agent automation enablement

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,9 +6,17 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   ruff:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
@@ -20,3 +28,33 @@ jobs:
         run: uv run ruff check src/ tests/ scripts/check_version_sync.py scripts/update_test_counts.py scripts/orchestrator.py scripts/github_actions_audit.py examples/
       - name: Ruff format check
         run: uv run ruff format --check src/ tests/ scripts/check_version_sync.py scripts/update_test_counts.py scripts/orchestrator.py scripts/github_actions_audit.py examples/
+
+  actionlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rhysd/actionlint@v1
+
+  shellcheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install shellcheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+      - name: Lint shell scripts
+        run: shellcheck examples/automation/*.sh
+
+  lockfile:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.14"
+      - name: Verify lockfile is in sync
+        run: uv lock --check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,6 @@ jobs:
       - name: Sync dependencies
         run: uv sync --dev
       - name: Ruff check
-        run: uv run ruff check src/ tests/ scripts/check_version_sync.py scripts/update_test_counts.py
+        run: uv run ruff check src/ tests/ scripts/check_version_sync.py scripts/update_test_counts.py scripts/orchestrator.py examples/
       - name: Ruff format check
-        run: uv run ruff format --check src/ tests/ scripts/check_version_sync.py scripts/update_test_counts.py
+        run: uv run ruff format --check src/ tests/ scripts/check_version_sync.py scripts/update_test_counts.py scripts/orchestrator.py examples/

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,7 +34,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: rhysd/actionlint@v1
+      - uses: rhysd/actionlint@v1.7.8
 
   shellcheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,6 @@ jobs:
       - name: Sync dependencies
         run: uv sync --dev
       - name: Ruff check
-        run: uv run ruff check src/ tests/ scripts/check_version_sync.py scripts/update_test_counts.py scripts/orchestrator.py examples/
+        run: uv run ruff check src/ tests/ scripts/check_version_sync.py scripts/update_test_counts.py scripts/orchestrator.py scripts/github_actions_audit.py examples/
       - name: Ruff format check
-        run: uv run ruff format --check src/ tests/ scripts/check_version_sync.py scripts/update_test_counts.py scripts/orchestrator.py examples/
+        run: uv run ruff format --check src/ tests/ scripts/check_version_sync.py scripts/update_test_counts.py scripts/orchestrator.py scripts/github_actions_audit.py examples/

--- a/.github/workflows/patch-release-gate.yml
+++ b/.github/workflows/patch-release-gate.yml
@@ -12,9 +12,17 @@ on:
         required: false
         default: false
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   patch-release-gate:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test-counts.yml
+++ b/.github/workflows/test-counts.yml
@@ -3,13 +3,23 @@ name: Test Count Sync
 on:
   pull_request:
     paths:
+      - 'README.md'
       - 'tests/**'
+      - 'tests/README.md'
       - 'scripts/update_test_counts.py'
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   test-counts:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,10 +6,18 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   release-gate-change-detect:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       release_gate_related: ${{ steps.filter.outputs.release_gate_related }}
     steps:
@@ -27,6 +35,7 @@ jobs:
     if: github.event_name == 'pull_request' && needs.release-gate-change-detect.outputs.release_gate_related == 'true'
     needs: release-gate-change-detect
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       matrix:
         python-version: ["3.14"]
@@ -42,6 +51,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         python-version: ["3.14"]
@@ -59,6 +69,7 @@ jobs:
 
   run-summary-contract:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       matrix:
         python-version: ["3.14"]
@@ -74,6 +85,7 @@ jobs:
 
   smoke-test:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     strategy:
       matrix:
         os: [windows-latest, macos-latest]
@@ -97,15 +109,24 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
         with:
           python-version: "3.14"
+      - name: Clean build artifacts
+        run: rm -f dist/*.whl dist/*.tar.gz
       - name: Build package
         run: uv build
       - name: Verify wheel installs
+        shell: bash
         run: |
           uv venv /tmp/test-install
-          uv pip install dist/*.whl --python /tmp/test-install/bin/python
+          wheels=(dist/*.whl)
+          if [ "${#wheels[@]}" -ne 1 ]; then
+            echo "Expected exactly one wheel artifact, found ${#wheels[@]}" >&2
+            exit 1
+          fi
+          uv pip install "${wheels[0]}" --python /tmp/test-install/bin/python
           /tmp/test-install/bin/python -c "from cja_auto_sdr.core.version import __version__; print(f'v{__version__}')"

--- a/.github/workflows/version-sync.yml
+++ b/.github/workflows/version-sync.yml
@@ -6,9 +6,17 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   version-sync:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,205 @@
+# AGENTS.md — CJA Auto SDR Tool Contract
+
+`cja_auto_sdr` generates Solution Design Reference (SDR) documentation from Adobe Customer Journey Analytics data views.
+
+---
+
+## Setup
+
+```bash
+uv sync
+```
+
+### Auth: Environment Variables
+
+| Variable   | Required | Description            |
+|------------|----------|------------------------|
+| `ORG_ID`   | Yes      | Adobe Organization ID  |
+| `CLIENT_ID`| Yes      | OAuth Client ID        |
+| `SECRET`   | Yes      | Client Secret          |
+| `SCOPES`   | Yes      | OAuth scopes (from Adobe Developer Console) |
+| `SANDBOX`  | No       | Sandbox name           |
+
+### Auth: Profile Alternative
+
+```bash
+uv run cja_auto_sdr --profile-add <name>   # create interactively
+uv run cja_auto_sdr --profile <name> ...   # use profile
+export CJA_PROFILE=<name>                  # set default
+```
+
+Profiles stored in `~/.cja/orgs/<name>/`. Profile overrides env vars.
+
+---
+
+## Command Reference
+
+### Discovery
+
+```bash
+uv run cja_auto_sdr --list-dataviews [--format json|csv] [--output -]
+uv run cja_auto_sdr --list-connections [--format json|csv] [--output -]
+uv run cja_auto_sdr --list-datasets [--format json|csv] [--output -]
+```
+
+Supports `--filter PATTERN`, `--exclude PATTERN`, `--limit N`, `--sort FIELD`.
+
+### Inspection (per data view)
+
+```bash
+uv run cja_auto_sdr <dv_id> --describe-dataview
+uv run cja_auto_sdr <dv_id> --list-metrics    [--format json|csv] [--output -]
+uv run cja_auto_sdr <dv_id> --list-dimensions [--format json|csv] [--output -]
+uv run cja_auto_sdr <dv_id> --list-segments   [--format json|csv] [--output -]
+uv run cja_auto_sdr <dv_id> --list-calculated-metrics [--format json|csv] [--output -]
+uv run cja_auto_sdr <dv_id> --stats
+```
+
+`--list-metrics`, `--list-dimensions`, `--list-segments`, `--list-calculated-metrics` support `--filter`, `--exclude`, `--sort`, `--limit`.
+
+### Generation
+
+| Format value | Output produced                        |
+|--------------|----------------------------------------|
+| `excel`      | `.xlsx` workbook (default)             |
+| `csv`        | CSV file(s)                            |
+| `json`       | JSON file                              |
+| `html`       | HTML report                            |
+| `markdown`   | Markdown file                          |
+| `all`        | All file formats + console             |
+| `reports`    | Alias: excel + markdown                |
+| `data`       | Alias: csv + json                      |
+| `ci`         | Alias: json + markdown                 |
+
+```bash
+# Generate default Excel SDR
+uv run cja_auto_sdr <dv_id>
+
+# Machine-readable JSON to stdout
+uv run cja_auto_sdr <dv_id> --format json --output -
+
+# Write to specific directory
+uv run cja_auto_sdr <dv_id> --format excel --output-dir /reports
+
+# Batch: multiple data views
+uv run cja_auto_sdr <dv_id1> <dv_id2> --format ci --continue-on-error
+
+# Run summary for observability
+uv run cja_auto_sdr <dv_id> --format json --run-summary-json -
+```
+
+### Comparison
+
+```bash
+# Live diff of two data views
+uv run cja_auto_sdr --diff <dv1_id> <dv2_id> [--format json] [--output -]
+
+# Save snapshot to file (dv_id is positional BEFORE the flag)
+uv run cja_auto_sdr <dv_id> --snapshot <output_file.json>
+
+# Compare data view against snapshot file
+uv run cja_auto_sdr <dv_id> --diff-snapshot <snapshot_file.json>
+
+# Compare against most recent snapshot in snapshot-dir
+uv run cja_auto_sdr <dv_id> --compare-with-prev
+
+# Compare two snapshot files (no API calls)
+uv run cja_auto_sdr --compare-snapshots <file1.json> <file2.json>
+
+# List snapshots
+uv run cja_auto_sdr --list-snapshots [<dv_id>]
+
+# Prune snapshots by retention policy
+uv run cja_auto_sdr --prune-snapshots --keep-last 20 --keep-since 30d
+```
+
+Key flags: `--changes-only`, `--summary`, `--format json --output -`, `--warn-threshold PERCENT`,
+`--auto-snapshot`, `--auto-prune`, `--snapshot-dir DIR`, `--keep-last N`, `--keep-since PERIOD`.
+
+### Governance (Org-Wide)
+
+```bash
+# Basic org-wide report
+uv run cja_auto_sdr --org-report [--format json] [--output -]
+
+# With clustering
+uv run cja_auto_sdr --org-report --cluster
+
+# Force similarity matrix
+uv run cja_auto_sdr --org-report --force-similarity
+
+# CI/CD governance gates
+uv run cja_auto_sdr --org-report --duplicate-threshold 5 --fail-on-threshold
+uv run cja_auto_sdr --org-report --isolated-threshold 0.3 --fail-on-threshold
+
+# Trending
+uv run cja_auto_sdr --org-report --trending-window 10
+
+# Compare to previous report
+uv run cja_auto_sdr --org-report --compare-org-report prev.json
+```
+
+### Validation
+
+```bash
+# Validate config and API connectivity (no data view required)
+uv run cja_auto_sdr --validate-config
+
+# Dry-run: validate config without generating reports (requires dv_id)
+uv run cja_auto_sdr <dv_id> --dry-run
+
+# Machine-readable config status
+uv run cja_auto_sdr --config-status --config-json
+```
+
+---
+
+## Exit Codes
+
+| Code | Meaning                                                                 | Agent Action                                      |
+|------|-------------------------------------------------------------------------|---------------------------------------------------|
+| `0`  | Success                                                                 | Continue; consume stdout output                   |
+| `1`  | General error (auth, API failure, data view not found, I/O error)       | Abort; parse stderr JSON for `error`/`error_type` |
+| `2`  | Policy threshold exceeded (diff changes found, quality gate, governance) | Flag for review; do not treat as crash            |
+| `3`  | Diff warn-threshold exceeded (`--warn-threshold`)                       | Notify; optionally escalate                       |
+| `130`| KeyboardInterrupt (SIGINT)                                              | Treat as cancelled; retry if appropriate          |
+
+Exit code 1 takes precedence over 2 if both conditions apply.
+
+---
+
+## Output Conventions
+
+- Use `--format json --output -` for machine-parseable stdout.
+- Only `json` and `csv` formats are valid with `--output -` (stdout).
+- `--output -` implies `--quiet` (suppresses banner/progress to stderr).
+- On failure, stderr receives a JSON error envelope:
+  ```json
+  {"error": "Configuration error: Missing credentials", "error_type": "configuration_error"}
+  ```
+- `--run-summary-json -` writes a structured run summary to stdout regardless of output format.
+
+---
+
+## File Conventions
+
+| Artifact          | Location                          | Override flag        |
+|-------------------|-----------------------------------|----------------------|
+| SDR reports       | Current directory (default)       | `--output-dir PATH`  |
+| Snapshots         | `./snapshots/`                    | `--snapshot-dir DIR` |
+| Log output        | stderr (structured or text)       | `--log-level`, `--log-format json` |
+| Org-report cache  | `~/.cja_auto_sdr/cache/`          | n/a                  |
+| Profiles          | `~/.cja/orgs/<name>/`             | `--profile`, `CJA_PROFILE`, `CJA_HOME` |
+
+Log levels: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`. Log formats: `text` (default), `json`.
+
+---
+
+## See Also
+
+- [`docs/AGENT_AUTOMATION.md`](docs/AGENT_AUTOMATION.md) — scheduling patterns, agent framework integration, notifications, security
+- [`scripts/orchestrator.py`](scripts/orchestrator.py) — multi-org orchestration script
+- [`docs/CLI_REFERENCE.md`](docs/CLI_REFERENCE.md) — full human-facing CLI documentation
+- [`docs/DIFF_COMPARISON.md`](docs/DIFF_COMPARISON.md) — snapshot and diff deep-dive
+- [`docs/ORG_WIDE_ANALYSIS.md`](docs/ORG_WIDE_ANALYSIS.md) — governance analysis guide
+- [`docs/FAILURE_CODES.md`](docs/FAILURE_CODES.md) — stable `failure_code` registry for `--run-summary-json`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ uv run cja_auto_sdr <dv_id> --format json --run-summary-json -
 # Live diff of two data views
 uv run cja_auto_sdr --diff <dv1_id> <dv2_id> [--format json] [--output -]
 
-# Save snapshot to file (dv_id is positional BEFORE the flag)
+# Save snapshot to file (convention: place dv_id before flags)
 uv run cja_auto_sdr <dv_id> --snapshot <output_file.json>
 
 # Compare data view against snapshot file

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,6 +179,7 @@ Exit code 1 takes precedence over 2 if both conditions apply.
   {"error": "Configuration error: Missing credentials", "error_type": "configuration_error"}
   ```
 - `--run-summary-json -` writes a structured run summary to stdout regardless of output format.
+- Wrapper note: `scripts/orchestrator.py` is a higher-level JSON wrapper and always emits its own success/error envelope to stdout so callers can parse one stream. The stderr contract above applies to direct `cja_auto_sdr` CLI invocations.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,6 +173,7 @@ Exit code 1 takes precedence over 2 if both conditions apply.
 - Use `--format json --output -` for machine-parseable stdout.
 - Only `json` and `csv` formats are valid with `--output -` (stdout).
 - `--output -` implies `--quiet` (suppresses banner/progress to stderr).
+- For scheduled/agent runs, prefer retry settings such as `--max-retries 5 --retry-max-delay 60` to absorb transient Adobe API rate limits.
 - On failure, stderr receives a JSON error envelope:
   ```json
   {"error": "Configuration error: Missing credentials", "error_type": "configuration_error"}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the CJA SDR Generator project will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.4.2] - 2026-03-13
+## [3.4.2] - Unreleased
 
 ### Added
 - **AGENTS.md** (repo root): Agent-facing tool contract with command reference, exit codes, and output conventions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Ruff Config** (`pyproject.toml`): Added per-file-ignores for `scripts/orchestrator.py` and `examples/` (INP001, T201)
 - **README.md**: Added Agent & Automation feature category
 - **USE_CASES.md**: Added cross-reference to Agent Automation Guide
+- **Atomic JSON writes** (`core/json_io.py`, snapshot/profile writers): now reject existing symlink destinations before replacement and fsync parent directories after rename for stronger local durability guarantees.
+- **Automation examples** (`scripts/github_actions_audit.py`, `examples/automation/*.sh`, `examples/github-actions/cja-sdr-audit.yml`): standalone audit runs now return the aggregate audit exit code outside GitHub Actions, shell examples preserve baselines on snapshot refresh failures instead of aborting mid-run, and the example workflow now matches CI's `setup-uv@v5` usage.
 
 ## [3.4.1] - 2026-03-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **GitHub Actions Template** (`examples/github-actions/cja-sdr-audit.yml`): Workflow template for automated SDR auditing
 
 ### Changed
-- **CI Lint** (`.github/workflows/lint.yml`): Expanded lint targets to cover `scripts/orchestrator.py` and `examples/`
+- **CI Lint** (`.github/workflows/lint.yml`): Expanded lint targets to cover `scripts/orchestrator.py`, `scripts/github_actions_audit.py`, and `examples/`
 - **Ruff Config** (`pyproject.toml`): Added per-file-ignores for `scripts/orchestrator.py` and `examples/` (INP001, T201)
 - **README.md**: Added Agent & Automation feature category
 - **USE_CASES.md**: Added cross-reference to Agent Automation Guide

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ All notable changes to the CJA SDR Generator project will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.2] - 2026-03-13
+
+### Added
+- **AGENTS.md** (repo root): Agent-facing tool contract with command reference, exit codes, and output conventions
+- **Agent Automation Guide** (`docs/AGENT_AUTOMATION.md`): Human-readable guide for scheduling, CI/CD, and AI agent integration
+- **Python Orchestrator** (`scripts/orchestrator.py`): Subprocess wrapper for programmatic automation
+- **Weekly SDR Script** (`examples/automation/weekly_sdr.sh`): Cron-ready weekly SDR generation with drift detection
+- **Daily Drift Check** (`examples/automation/daily_drift_check.sh`): Daily drift detection with Slack notification
+- **Quarterly Maintenance** (`examples/automation/quarterly_maintenance.sh`): Quarterly baseline refresh, governance review, snapshot pruning, and compliance export
+- **GitHub Actions Template** (`examples/github-actions/cja-sdr-audit.yml`): Workflow template for automated SDR auditing
+
+### Changed
+- **CI Lint** (`.github/workflows/lint.yml`): Expanded lint targets to cover `scripts/orchestrator.py` and `examples/`
+- **Ruff Config** (`pyproject.toml`): Added per-file-ignores for `scripts/orchestrator.py` and `examples/` (INP001, T201)
+- **README.md**: Added Agent & Automation feature category
+- **USE_CASES.md**: Added cross-reference to Agent Automation Guide
+
 ## [3.4.1] - 2026-03-13
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ CJA SDR Generator - A tool for generating Solution Design Reference (SDR) docume
 
 - Package manager: uv
 - Entry point: `cja_auto_sdr` command (via pyproject.toml scripts)
-- Current version: v3.4.1
+- Current version: v3.4.2
 - Main script: `generator.py` (~10k lines) — subpackages use lazy forwarding via `make_getattr()` in `core/lazy.py`
 
 ## CI & Quality

--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (6,237+ tests)
+├── tests/                     # Test suite (6,250+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ cja_auto_sdr "Production Analytics"
 | [Data View Comparison](docs/DIFF_COMPARISON.md) | Compare Data Views, snapshots, CI/CD integration |
 | [Git Integration](docs/GIT_INTEGRATION.md) | Version-controlled snapshots, audit trails, team collaboration |
 | [Org-Wide Analysis](docs/ORG_WIDE_ANALYSIS.md) | Cross-data view component analysis, similarity detection, governance |
+| [Agent Automation](docs/AGENT_AUTOMATION.md) | CI/CD pipelines, AI agent integration, scheduling patterns |
 | [Testing](tests/README.md) | Running and writing tests |
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (6,269+ tests)
+├── tests/                     # Test suite (6,286+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ A **Solution Design Reference** is the essential documentation that bridges your
 | | Color-Coded Output | Global color controls via `--no-color`, `NO_COLOR`, and `FORCE_COLOR` |
 | | Enhanced Error Messages | Contextual error messages with actionable fix suggestions |
 | | Comprehensive Logging | Timestamped logs with rotation for audit trails |
+| **Agent & Automation** | AGENTS.md Contract | Machine-parseable tool contract for AI agents (Claude Code, LangChain, etc.) |
+| | Python Orchestrator | Subprocess wrapper for programmatic automation (`scripts/orchestrator.py`) |
+| | Shell Script Templates | Cron-ready weekly, daily, and quarterly automation examples |
+| | GitHub Actions Template | Copy-paste workflow for scheduled SDR auditing |
+| | Exit Code Conventions | Structured exit codes (0/1/2/3) for agent decision-making |
 
 ### Who It's For
 

--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (6,266+ tests)
+├── tests/                     # Test suite (6,269+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ cja_auto_sdr/
 │   ├── GIT_INTEGRATION.md     # Git integration guide
 │   ├── ORG_WIDE_ANALYSIS.md   # Org-wide report guide
 │   └── ...                    # Additional guides
-├── tests/                     # Test suite (6,250+ tests)
+├── tests/                     # Test suite (6,266+ tests)
 ├── sample_outputs/            # Example output files
 │   ├── excel/                 # Sample Excel SDR
 │   ├── csv/                   # Sample CSV output

--- a/docs/AGENT_AUTOMATION.md
+++ b/docs/AGENT_AUTOMATION.md
@@ -215,9 +215,10 @@ uv run cja_auto_sdr --org-report --fail-on-threshold --duplicate-threshold 5 \
 EXIT=$?
 
 if [ $EXIT -eq 2 ]; then
-  curl -X POST "$SLACK_WEBHOOK" \
+  PAYLOAD=$(jq -n --arg text "CJA governance threshold exceeded. See report.json." '{text: $text}')
+  curl -s -X POST "$SLACK_WEBHOOK" \
     -H 'Content-Type: application/json' \
-    -d "{\"text\":\"CJA governance threshold exceeded. See report.json.\"}"
+    -d "$PAYLOAD"
 fi
 ```
 

--- a/docs/AGENT_AUTOMATION.md
+++ b/docs/AGENT_AUTOMATION.md
@@ -1,0 +1,249 @@
+# Agent Automation Guide
+
+This guide covers how to automate `cja_auto_sdr` in CI/CD pipelines, scheduled jobs, and agent frameworks.
+
+## Table of Contents
+
+1. [Why Automate](#why-automate)
+2. [Prerequisites](#prerequisites)
+3. [Agent-Friendly CLI Features](#agent-friendly-cli-features)
+4. [Configuration for Automation](#configuration-for-automation)
+5. [Scheduling Patterns](#scheduling-patterns)
+6. [Agent Framework Integration](#agent-framework-integration)
+7. [Notification Integration](#notification-integration)
+8. [Security Considerations](#security-considerations)
+9. [Troubleshooting](#troubleshooting)
+
+---
+
+## Why Automate
+
+| Use Case                             | Recommended Cadence          |
+|--------------------------------------|------------------------------|
+| SDR generation for governance        | Weekly                       |
+| Data quality monitoring              | Daily                        |
+| Drift detection                      | Daily or on deploy           |
+| Multi-org audits                     | Weekly                       |
+| Change audit trail                   | Event-driven or nightly      |
+| Full SDR regeneration (all views)    | Quarterly                    |
+| Cross-org governance review          | Quarterly                    |
+| Snapshot pruning & baseline rotation | Quarterly                    |
+| Compliance documentation export      | Quarterly or on audit        |
+
+---
+
+## Prerequisites
+
+- **Service account credentials**: An Adobe IMS OAuth server-to-server service account with CJA read access.
+- **Auth via environment variables**: Automation must supply credentials through env vars (`ORG_ID`, `CLIENT_ID`, `SECRET`, `SCOPES`), not `config.json`. See [Configuration for Automation](#configuration-for-automation).
+- **Python + uv**: Python 3.14+ and `uv` installed on the runner/agent. Run `uv sync` once after checkout.
+- **Adobe API access**: The service account must have the CJA product profile assigned in Adobe Admin Console.
+
+---
+
+## Agent-Friendly CLI Features
+
+### Machine-readable output
+
+```bash
+# JSON to stdout — parse with jq, Python json.loads(), etc.
+uv run cja_auto_sdr <dv_id> --format json --output -
+
+# Discovery as JSON
+uv run cja_auto_sdr --list-dataviews --format json --output -
+
+# Structured run summary (includes per-DV status, failure codes, output paths)
+uv run cja_auto_sdr <dv_id> --format json --run-summary-json -
+```
+
+`--output -` implies `--quiet`, so stdout contains only the payload and stderr contains any log output.
+
+### Exit codes
+
+Agents should branch on exit codes rather than parsing human-readable output:
+
+| Code | Meaning                          | Recommended action                      |
+|------|----------------------------------|-----------------------------------------|
+| `0`  | Success                          | Consume output, continue pipeline       |
+| `1`  | Error                            | Abort; parse stderr JSON for diagnosis  |
+| `2`  | Policy violation                 | Notify; open issue or alert             |
+| `3`  | Warn threshold exceeded          | Log warning; optionally escalate        |
+| `130`| Interrupted                      | Retry or mark as cancelled              |
+
+### Pre-flight validation
+
+Always run config validation before your first API call in a new environment:
+
+```bash
+# Non-interactive config + connectivity check
+uv run cja_auto_sdr --validate-config
+echo "exit: $?"
+
+# Dry-run without generating output
+uv run cja_auto_sdr <dv_id> --dry-run
+```
+
+---
+
+## Configuration for Automation
+
+### Environment variable setup
+
+```bash
+export ORG_ID="XXXXXXXX@AdobeOrg"
+export CLIENT_ID="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+export SECRET="p8e-XXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+export SCOPES="openid,AdobeID,read_organizations,additional_info.projectedProductContext"
+```
+
+### Secrets managers
+
+Inject credentials from your secrets manager before invoking the tool:
+
+```bash
+# AWS Secrets Manager
+export SECRET=$(aws secretsmanager get-secret-value --secret-id cja/prod/secret --query SecretString --output text)
+
+# HashiCorp Vault
+export SECRET=$(vault kv get -field=secret secret/cja/prod)
+
+# GitHub Actions — use environment secrets (see Scheduling Patterns)
+```
+
+### Rules
+
+- Never hardcode credentials in scripts, config files, or source control.
+- Never commit `config.json` containing live credentials.
+- Use short-lived tokens or rotate secrets on a defined schedule.
+- Scope service accounts to read-only CJA access.
+
+---
+
+## Scheduling Patterns
+
+### Shell script (cron / systemd timer)
+
+See `examples/automation/weekly_sdr.sh` for a reference weekly SDR generation script covering:
+- Env var injection from a secrets file
+- Drift detection with `--diff-snapshot`
+- Exit code branching
+- Slack notification on policy violation (exit 2)
+
+### GitHub Actions
+
+See `examples/github-actions/cja-sdr-audit.yml` for a reference workflow covering:
+- Scheduled weekly trigger
+- Credential injection from repository secrets
+- Artifact upload of generated SDR files
+- PR comment posting for diff results (`--format-pr-comment`)
+
+### Multi-org orchestration
+
+See `scripts/orchestrator.py` for a Python orchestration script that:
+- Iterates over multiple org profiles
+- Runs org-wide governance checks per org
+- Aggregates exit codes and failure summaries
+- Emits a consolidated JSON report
+
+---
+
+## Agent Framework Integration
+
+Agents should use `AGENTS.md` (repo root) as the primary tool contract. It provides:
+- Complete command syntax
+- Exit code table with agent actions
+- Output format guidance
+- File convention defaults
+
+### Inline JSON tool definition
+
+If your agent framework requires a tool schema, use this minimal definition:
+
+```json
+{
+  "name": "cja_auto_sdr",
+  "description": "Generate SDR documentation from Adobe CJA data views. Use --format json --output - for machine output.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "data_view_id": {
+        "type": "string",
+        "description": "Data view ID (e.g. dv_12345) or exact name"
+      },
+      "format": {
+        "type": "string",
+        "enum": ["excel", "csv", "json", "html", "markdown", "all", "reports", "data", "ci"],
+        "default": "json"
+      },
+      "output": {
+        "type": "string",
+        "description": "Output path. Use '-' for stdout (json/csv only).",
+        "default": "-"
+      },
+      "extra_flags": {
+        "type": "array",
+        "items": {"type": "string"},
+        "description": "Additional CLI flags, e.g. ['--dry-run', '--quiet']"
+      }
+    },
+    "required": ["data_view_id"]
+  }
+}
+```
+
+### Orchestrator
+
+`scripts/orchestrator.py` implements the multi-org loop pattern and is the recommended starting point for agent-driven batch workflows.
+
+---
+
+## Notification Integration
+
+| Channel       | Mechanism                  | Trigger condition               | Example                                       |
+|---------------|----------------------------|---------------------------------|-----------------------------------------------|
+| Slack         | Incoming webhook           | Exit code 2 or 3               | `curl -X POST $SLACK_WEBHOOK -d '{"text":"..."}'` |
+| Email         | SMTP / `mail` command      | Exit code 1 (error)             | `echo "body" \| mail -s "subject" ops@example.com` |
+| PagerDuty     | Events API v2              | Exit code 2 (policy violation)  | `curl -X POST https://events.pagerduty.com/v2/enqueue` |
+| Microsoft Teams | Incoming webhook          | Exit code 2 or 3               | `curl -X POST $TEAMS_WEBHOOK -d '{"text":"..."}'` |
+| GitHub Issues | `gh issue create`          | Exit code 2 (governance alert)  | `gh issue create --title "SDR drift detected" --body "$(cat summary.json)"` |
+
+Pattern:
+
+```bash
+uv run cja_auto_sdr --org-report --fail-on-threshold --duplicate-threshold 5 \
+  --format json --output report.json
+EXIT=$?
+
+if [ $EXIT -eq 2 ]; then
+  curl -X POST "$SLACK_WEBHOOK" \
+    -H 'Content-Type: application/json' \
+    -d "{\"text\":\"CJA governance threshold exceeded. See report.json.\"}"
+fi
+```
+
+---
+
+## Security Considerations
+
+- **Env vars over files**: Supply credentials through environment variables, not `config.json`. Env vars are process-scoped and do not persist to disk.
+- **Secrets managers**: Prefer AWS Secrets Manager, HashiCorp Vault, or your platform's native secret store over `.env` files in CI runners.
+- **Service accounts**: Create a dedicated Adobe IMS service account for automation. Do not reuse personal developer credentials.
+- **Secret rotation**: Rotate `CLIENT_ID` and `SECRET` on a defined schedule (quarterly minimum). Update secrets manager entries before old credentials expire.
+- **Read-only scoping**: Scope the service account to the minimum required product profiles. CJA read access is sufficient; do not grant admin or write privileges.
+- **Audit logging**: Enable structured logging with `--log-format json --log-level INFO` and ship logs to your SIEM or log aggregator for audit trail purposes.
+- **No secrets in logs**: The tool masks credentials in `--config-status` output, but never pass raw `SECRET` values as positional arguments or embed them in log messages in your wrapper scripts.
+
+---
+
+## Troubleshooting
+
+| Symptom                                  | Likely Cause                                   | Fix                                                                                              |
+|------------------------------------------|------------------------------------------------|--------------------------------------------------------------------------------------------------|
+| Exit 1 with `error_type: configuration_error` | Missing or expired credentials             | Verify `ORG_ID`, `CLIENT_ID`, `SECRET` env vars are set and the secret has not expired           |
+| Exit 1 with `error_type: api_error`      | API connectivity failure or rate limit         | Check network access to Adobe IMS/CJA endpoints; implement retry with `--max-retries` and `--retry-max-delay` |
+| Stale snapshot comparison misses changes | Snapshot file is too old or wrong data view    | Re-run `uv run cja_auto_sdr <dv_id> --snapshot <file>` to refresh; check `--snapshot-dir` path  |
+| Git commit step fails in CI              | Missing git identity on runner                 | Set `git config user.email` and `git config user.name` in the workflow before any git steps      |
+| Rate limiting (429 errors)               | Too many concurrent requests                   | Reduce `--workers` count; increase `--retry-base-delay`; use `--org-report --use-cache`          |
+| JSON parse error on `--output -`         | Banner or progress text mixed into stdout      | Ensure `--output -` is used (it implies `--quiet`); do not use `--format console` with stdout    |
+| `--validate-config` passes but SDR fails | Data view ID not accessible to service account | Confirm data view ID exists and the service account has the correct CJA product profile access   |
+| Exit 2 on governance run without alert   | `--fail-on-threshold` not set                  | Add `--fail-on-threshold` to enable exit code 2 on threshold breach                             |

--- a/docs/AGENT_AUTOMATION.md
+++ b/docs/AGENT_AUTOMATION.md
@@ -135,15 +135,15 @@ See `examples/github-actions/cja-sdr-audit.yml` for a reference workflow coverin
 - Scheduled weekly trigger
 - Credential injection from repository secrets
 - Artifact upload of generated SDR files
-- PR comment posting for diff results (`--format-pr-comment`)
+- Snapshot commits when the job has `contents: write`
 
 ### Multi-org orchestration
 
 See `scripts/orchestrator.py` for a Python orchestration script that:
-- Iterates over multiple org profiles
-- Runs org-wide governance checks per org
-- Aggregates exit codes and failure summaries
-- Emits a consolidated JSON report
+- Forwards `--profile` / `--config-file` into wrapped CLI calls
+- Uses explicit IDs, `DATA_VIEWS`, or `--discover` for data view selection
+- Anchors `uv` project resolution to this repository without changing caller-relative file semantics
+- Emits a consolidated JSON report with aggregated exit codes
 
 ---
 
@@ -193,7 +193,7 @@ If your agent framework requires a tool schema, use this minimal definition:
 
 ### Orchestrator
 
-`scripts/orchestrator.py` implements the multi-org loop pattern and is the recommended starting point for agent-driven batch workflows.
+`scripts/orchestrator.py` is the recommended starting point for agent-driven batch workflows when you want a thin JSON-emitting wrapper around repeated CLI runs.
 
 ---
 

--- a/docs/AGENT_AUTOMATION.md
+++ b/docs/AGENT_AUTOMATION.md
@@ -144,6 +144,7 @@ See `scripts/orchestrator.py` for a Python orchestration script that:
 - Uses explicit IDs, `DATA_VIEWS`, or `--discover` for data view selection
 - Anchors `uv` project resolution to this repository without changing caller-relative file semantics
 - Emits a consolidated JSON report with aggregated exit codes
+- Uses a per-command timeout of 300 seconds by default; pass `--timeout SECONDS` for larger orgs or slower environments
 
 ---
 
@@ -194,6 +195,13 @@ If your agent framework requires a tool schema, use this minimal definition:
 ### Orchestrator
 
 `scripts/orchestrator.py` is the recommended starting point for agent-driven batch workflows when you want a thin JSON-emitting wrapper around repeated CLI runs.
+
+```bash
+# Discover data views, allow 15 minutes per wrapped CLI command
+uv run python scripts/orchestrator.py --discover --timeout 900
+```
+
+Unlike the direct CLI, the orchestrator writes both success payloads and its own machine-readable error envelopes to stdout so callers can consume a single JSON stream per invocation. Wrapped child-command stdout/stderr are preserved inside the JSON result objects.
 
 ---
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -924,7 +924,7 @@ cja_auto_sdr --list-dataviews --log-level DEBUG
 At launch, the tool logs diagnostic lines containing the tool version, Python version, platform, active log level, inferred run mode (batch, single, or discovery), and dependency versions. These appear automatically at `INFO` level and are useful for troubleshooting environment issues in CI/CD logs or support requests:
 
 ```text
-CJA SDR Generator v3.4.1 | Python 3.14.2 | darwin | log_level=INFO | mode=single
+CJA SDR Generator v3.4.2 | Python 3.14.2 | darwin | log_level=INFO | mode=single
 Dependencies: cjapy=0.2.4.post3, pandas=2.3.3, numpy=2.2.1, xlsxwriter=3.2.9, tqdm=4.67.0
 ```
 

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -203,7 +203,7 @@ This command:
 
 ```bash
 $ uv run cja_auto_sdr -V
-cja_auto_sdr 3.4.1
+cja_auto_sdr 3.4.2
 ```
 
 > **Important:** All commands in this guide assume you're in the `cja_auto_sdr` directory. If you see "command not found", make sure you're in the right directory and have run `uv sync`.

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Quick Reference Card
 
-Single-page command cheat sheet for CJA SDR Generator v3.4.1.
+Single-page command cheat sheet for CJA SDR Generator v3.4.2.
 
 ## Four Main Modes
 

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -1056,3 +1056,4 @@ cja_auto_sdr dv_12345 \
 - [Performance Guide](PERFORMANCE.md) - Optimization tips
 - [Batch Processing Guide](BATCH_PROCESSING_GUIDE.md) - Multi-view processing
 - [Data Quality](DATA_QUALITY.md) - Understanding validation
+- [Agent Automation Guide](AGENT_AUTOMATION.md) - Scheduling, CI/CD, and AI agent integration

--- a/examples/automation/_common.sh
+++ b/examples/automation/_common.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Shared helpers for example automation wrappers.
+
+CJA_SIGNAL_EXIT_BASE=128
+CJA_MAX_SIGNAL_NUMBER=64
+
+is_signal_exit_code() {
+    local code="${1:-0}"
+
+    [[ "$code" =~ ^[0-9]+$ ]] || return 1
+    (( code > CJA_SIGNAL_EXIT_BASE && code <= CJA_SIGNAL_EXIT_BASE + CJA_MAX_SIGNAL_NUMBER ))
+}
+
+capture_command_exit() {
+    local exit_var_name="$1"
+    shift
+
+    local exit_code=0
+    if "$@"; then
+        exit_code=0
+    else
+        exit_code=$?
+    fi
+
+    printf -v "$exit_var_name" '%s' "$exit_code"
+}
+
+capture_command_output() {
+    local exit_var_name="$1"
+    local output_var_name="$2"
+    shift 2
+
+    local exit_code=0
+    local output=""
+    if output="$("$@")"; then
+        exit_code=0
+    else
+        exit_code=$?
+    fi
+
+    printf -v "$exit_var_name" '%s' "$exit_code"
+    printf -v "$output_var_name" '%s' "$output"
+}
+
+exit_on_signal_exit() {
+    local code="${1:-0}"
+    shift
+
+    if is_signal_exit_code "$code"; then
+        if [[ $# -gt 0 ]]; then
+            echo "$* (exit $code)" >&2
+        fi
+        exit "$code"
+    fi
+}

--- a/examples/automation/daily_drift_check.sh
+++ b/examples/automation/daily_drift_check.sh
@@ -81,12 +81,14 @@ except Exception:
             -d "$PAYLOAD" > /dev/null
         echo "$LOG_PREFIX Slack notification sent"
     fi
-else
+elif [[ $DIFF_EXIT -eq 0 ]]; then
     # Only update baseline when no drift detected
     uv run cja_auto_sdr "$DATA_VIEW_ID" --snapshot "$BASELINE"
     echo "$LOG_PREFIX Baseline updated (no drift)"
+else
+    echo "$LOG_PREFIX ERROR: Diff comparison failed; baseline preserved" >&2
 fi
 
 # Propagate the drift exit code so cron/monitoring can detect policy violations.
-# 0 = no drift, 2 = policy threshold exceeded, 3 = warning threshold exceeded.
+# 0 = no drift, 1 = diff failed, 2 = policy threshold exceeded, 3 = warning threshold exceeded.
 exit $DIFF_EXIT

--- a/examples/automation/daily_drift_check.sh
+++ b/examples/automation/daily_drift_check.sh
@@ -47,7 +47,10 @@ DIFF_OUTPUT=$(uv run cja_auto_sdr "$DATA_VIEW_ID" --diff-snapshot "$BASELINE" \
 
 echo "$LOG_PREFIX Drift check exit code: $DIFF_EXIT"
 
-# Notify on drift (exit code 2) or warning (exit code 3)
+# Notify on drift (exit code 2) or warning (exit code 3).
+# Baseline is NOT updated when drift is detected — this is intentional so that
+# alerts keep firing until the drift is acknowledged.  To reset the baseline
+# after reviewing changes, re-run: uv run cja_auto_sdr "$DATA_VIEW_ID" --snapshot "$BASELINE"
 if [[ $DIFF_EXIT -eq 2 || $DIFF_EXIT -eq 3 ]]; then
     SUMMARY=$(echo "$DIFF_OUTPUT" | python3 -c "
 import sys, json
@@ -84,4 +87,6 @@ else
     echo "$LOG_PREFIX Baseline updated (no drift)"
 fi
 
-exit 0
+# Propagate the drift exit code so cron/monitoring can detect policy violations.
+# 0 = no drift, 2 = policy threshold exceeded, 3 = warning threshold exceeded.
+exit $DIFF_EXIT

--- a/examples/automation/daily_drift_check.sh
+++ b/examples/automation/daily_drift_check.sh
@@ -66,23 +66,22 @@ except Exception:
         SEVERITY="warning"
         [[ $DIFF_EXIT -eq 2 ]] && SEVERITY="danger"
 
+        PAYLOAD=$(jq -n \
+            --arg color "$SEVERITY" \
+            --arg title "CJA Data View Drift Detected" \
+            --arg text "Data view: $DATA_VIEW_ID\n$SUMMARY" \
+            --arg footer "cja_auto_sdr drift check" \
+            --argjson ts "$(date +%s)" \
+            '{attachments: [{color: $color, title: $title, text: $text, footer: $footer, ts: $ts}]}')
         curl -s -X POST "$SLACK_WEBHOOK" \
             -H 'Content-Type: application/json' \
-            -d "{
-                \"attachments\": [{
-                    \"color\": \"$SEVERITY\",
-                    \"title\": \"CJA Data View Drift Detected\",
-                    \"text\": \"Data view: $DATA_VIEW_ID\n$SUMMARY\",
-                    \"footer\": \"cja_auto_sdr drift check\",
-                    \"ts\": $(date +%s)
-                }]
-            }" > /dev/null
+            -d "$PAYLOAD" > /dev/null
         echo "$LOG_PREFIX Slack notification sent"
     fi
+else
+    # Only update baseline when no drift detected
+    uv run cja_auto_sdr "$DATA_VIEW_ID" --snapshot "$BASELINE"
+    echo "$LOG_PREFIX Baseline updated (no drift)"
 fi
-
-# Update baseline after check
-uv run cja_auto_sdr "$DATA_VIEW_ID" --snapshot "$BASELINE"
-echo "$LOG_PREFIX Baseline updated"
 
 exit 0

--- a/examples/automation/daily_drift_check.sh
+++ b/examples/automation/daily_drift_check.sh
@@ -103,7 +103,7 @@ if [[ ! -f "$BASELINE" ]]; then
             echo "$LOG_PREFIX ERROR: Initial baseline creation failed (exit $SNAPSHOT_EXIT)" >&2
             ;;
     esac
-    exit $SNAPSHOT_EXIT
+    exit "$SNAPSHOT_EXIT"
 fi
 
 # Run drift detection while preserving non-zero exits for policy handling.
@@ -169,11 +169,11 @@ elif [[ $DIFF_EXIT -eq 0 ]]; then
             echo "$LOG_PREFIX ERROR: Baseline refresh failed (exit $SNAPSHOT_EXIT)" >&2
             ;;
     esac
-    exit $SNAPSHOT_EXIT
+    exit "$SNAPSHOT_EXIT"
 else
     echo "$LOG_PREFIX ERROR: Diff comparison failed; baseline preserved" >&2
 fi
 
 # Propagate the drift exit code so cron/monitoring can detect policy violations.
 # 0 = no drift, 1 = diff failed, 2 = policy threshold exceeded, 3 = warning threshold exceeded.
-exit $DIFF_EXIT
+exit "$DIFF_EXIT"

--- a/examples/automation/daily_drift_check.sh
+++ b/examples/automation/daily_drift_check.sh
@@ -57,7 +57,12 @@ import sys, json
 try:
     data = json.load(sys.stdin)
     summary = data.get('summary', {})
-    print(f\"Metrics: {summary.get('metrics_changed', '?')} changed, Dimensions: {summary.get('dimensions_changed', '?')} changed\")
+    def changed_total(prefix):
+        explicit_total = summary.get(f'{prefix}_changed')
+        if explicit_total is not None:
+            return explicit_total
+        return sum(int(summary.get(f'{prefix}_{suffix}', 0) or 0) for suffix in ('added', 'removed', 'modified'))
+    print(f\"Metrics: {changed_total('metrics')} changed, Dimensions: {changed_total('dimensions')} changed\")
 except Exception:
     print('Unable to parse diff summary')
 " 2>/dev/null)

--- a/examples/automation/daily_drift_check.sh
+++ b/examples/automation/daily_drift_check.sh
@@ -21,12 +21,15 @@ if [[ -z "${DATA_VIEW_ID:-}" ]]; then
     exit 1
 fi
 
-# Load credentials
-if [[ -f "$PROJECT_ROOT/.env" ]]; then
-    set -a
-    # shellcheck source=/dev/null
-    source "$PROJECT_ROOT/.env"
-    set +a
+# Prefer credentials injected by the caller/CI. Fall back to a repo-local
+# .env only for workstation-style usage of this example script.
+if [[ -z "${ORG_ID:-}" || -z "${CLIENT_ID:-}" || -z "${SECRET:-}" || -z "${SCOPES:-}" ]]; then
+    if [[ -f "$PROJECT_ROOT/.env" ]]; then
+        set -a
+        # shellcheck source=/dev/null
+        source "$PROJECT_ROOT/.env"
+        set +a
+    fi
 fi
 
 cd "$PROJECT_ROOT"

--- a/examples/automation/daily_drift_check.sh
+++ b/examples/automation/daily_drift_check.sh
@@ -74,20 +74,24 @@ except Exception:
 
     # Post to Slack if webhook is configured
     if [[ -n "${SLACK_WEBHOOK:-}" ]]; then
-        SEVERITY="warning"
-        [[ $DIFF_EXIT -eq 2 ]] && SEVERITY="danger"
+        if ! command -v jq >/dev/null 2>&1; then
+            echo "$LOG_PREFIX WARNING: jq not installed; skipping Slack notification" >&2
+        else
+            SEVERITY="warning"
+            [[ $DIFF_EXIT -eq 2 ]] && SEVERITY="danger"
 
-        PAYLOAD=$(jq -n \
-            --arg color "$SEVERITY" \
-            --arg title "CJA Data View Drift Detected" \
-            --arg text "Data view: $DATA_VIEW_ID\n$SUMMARY" \
-            --arg footer "cja_auto_sdr drift check" \
-            --argjson ts "$(date +%s)" \
-            '{attachments: [{color: $color, title: $title, text: $text, footer: $footer, ts: $ts}]}')
-        curl -s -X POST "$SLACK_WEBHOOK" \
-            -H 'Content-Type: application/json' \
-            -d "$PAYLOAD" > /dev/null
-        echo "$LOG_PREFIX Slack notification sent"
+            PAYLOAD=$(jq -n \
+                --arg color "$SEVERITY" \
+                --arg title "CJA Data View Drift Detected" \
+                --arg text "Data view: $DATA_VIEW_ID\n$SUMMARY" \
+                --arg footer "cja_auto_sdr drift check" \
+                --argjson ts "$(date +%s)" \
+                '{attachments: [{color: $color, title: $title, text: $text, footer: $footer, ts: $ts}]}')
+            curl -s -X POST "$SLACK_WEBHOOK" \
+                -H 'Content-Type: application/json' \
+                -d "$PAYLOAD" > /dev/null
+            echo "$LOG_PREFIX Slack notification sent"
+        fi
     fi
 elif [[ $DIFF_EXIT -eq 0 ]]; then
     # Only update baseline when no drift detected

--- a/examples/automation/daily_drift_check.sh
+++ b/examples/automation/daily_drift_check.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# daily_drift_check.sh — Daily drift detection with Slack notification
+#
+# Cron entry (daily 6am):
+#   0 6 * * * /path/to/daily_drift_check.sh >> /var/log/cja_sdr/drift.log 2>&1
+#
+# Environment variables:
+#   DATA_VIEW_ID    — data view to monitor (required)
+#   SLACK_WEBHOOK   — Slack incoming webhook URL (optional)
+#   SNAPSHOT_DIR    — snapshot directory (default: ./snapshots)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SNAPSHOT_DIR="${SNAPSHOT_DIR:-$PROJECT_ROOT/snapshots}"
+LOG_PREFIX="[$(date '+%Y-%m-%d %H:%M:%S')]"
+
+if [[ -z "${DATA_VIEW_ID:-}" ]]; then
+    echo "$LOG_PREFIX ERROR: DATA_VIEW_ID not set" >&2
+    exit 1
+fi
+
+# Load credentials
+if [[ -f "$PROJECT_ROOT/.env" ]]; then
+    set -a
+    # shellcheck source=/dev/null
+    source "$PROJECT_ROOT/.env"
+    set +a
+fi
+
+cd "$PROJECT_ROOT"
+
+BASELINE="$SNAPSHOT_DIR/${DATA_VIEW_ID}_baseline.json"
+
+# Ensure baseline exists
+if [[ ! -f "$BASELINE" ]]; then
+    echo "$LOG_PREFIX No baseline found. Creating initial snapshot."
+    uv run cja_auto_sdr "$DATA_VIEW_ID" --snapshot "$BASELINE"
+    exit 0
+fi
+
+# Run drift detection (capture exit code before || true consumes it)
+DIFF_EXIT=0
+DIFF_OUTPUT=$(uv run cja_auto_sdr "$DATA_VIEW_ID" --diff-snapshot "$BASELINE" \
+    --format json --output - 2>/dev/null) || DIFF_EXIT=$?
+
+echo "$LOG_PREFIX Drift check exit code: $DIFF_EXIT"
+
+# Notify on drift (exit code 2) or warning (exit code 3)
+if [[ $DIFF_EXIT -eq 2 || $DIFF_EXIT -eq 3 ]]; then
+    SUMMARY=$(echo "$DIFF_OUTPUT" | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+    summary = data.get('summary', {})
+    print(f\"Metrics: {summary.get('metrics_changed', '?')} changed, Dimensions: {summary.get('dimensions_changed', '?')} changed\")
+except Exception:
+    print('Unable to parse diff summary')
+" 2>/dev/null)
+
+    echo "$LOG_PREFIX DRIFT DETECTED: $SUMMARY"
+
+    # Post to Slack if webhook is configured
+    if [[ -n "${SLACK_WEBHOOK:-}" ]]; then
+        SEVERITY="warning"
+        [[ $DIFF_EXIT -eq 2 ]] && SEVERITY="danger"
+
+        curl -s -X POST "$SLACK_WEBHOOK" \
+            -H 'Content-Type: application/json' \
+            -d "{
+                \"attachments\": [{
+                    \"color\": \"$SEVERITY\",
+                    \"title\": \"CJA Data View Drift Detected\",
+                    \"text\": \"Data view: $DATA_VIEW_ID\n$SUMMARY\",
+                    \"footer\": \"cja_auto_sdr drift check\",
+                    \"ts\": $(date +%s)
+                }]
+            }" > /dev/null
+        echo "$LOG_PREFIX Slack notification sent"
+    fi
+fi
+
+# Update baseline after check
+uv run cja_auto_sdr "$DATA_VIEW_ID" --snapshot "$BASELINE"
+echo "$LOG_PREFIX Baseline updated"
+
+exit 0

--- a/examples/automation/daily_drift_check.sh
+++ b/examples/automation/daily_drift_check.sh
@@ -15,6 +15,61 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 SNAPSHOT_DIR="${SNAPSHOT_DIR:-$PROJECT_ROOT/snapshots}"
 LOG_PREFIX="[$(date '+%Y-%m-%d %H:%M:%S')]"
+# Keep the example self-contained when copied as a single cron script.
+if [[ -f "$SCRIPT_DIR/_common.sh" ]]; then
+    # shellcheck source=/dev/null
+    source "$SCRIPT_DIR/_common.sh"
+else
+    is_signal_exit_code() {
+        local code="${1:-0}"
+
+        [[ "$code" =~ ^[0-9]+$ ]] || return 1
+        (( code > 128 && code <= 192 ))
+    }
+
+    capture_command_exit() {
+        local exit_var_name="$1"
+        shift
+
+        local exit_code=0
+        if "$@"; then
+            exit_code=0
+        else
+            exit_code=$?
+        fi
+
+        printf -v "$exit_var_name" '%s' "$exit_code"
+    }
+
+    capture_command_output() {
+        local exit_var_name="$1"
+        local output_var_name="$2"
+        shift 2
+
+        local exit_code=0
+        local output=""
+        if output="$("$@")"; then
+            exit_code=0
+        else
+            exit_code=$?
+        fi
+
+        printf -v "$exit_var_name" '%s' "$exit_code"
+        printf -v "$output_var_name" '%s' "$output"
+    }
+
+    exit_on_signal_exit() {
+        local code="${1:-0}"
+        shift
+
+        if is_signal_exit_code "$code"; then
+            if [[ $# -gt 0 ]]; then
+                echo "$* (exit $code)" >&2
+            fi
+            exit "$code"
+        fi
+    }
+fi
 
 if [[ -z "${DATA_VIEW_ID:-}" ]]; then
     echo "$LOG_PREFIX ERROR: DATA_VIEW_ID not set" >&2
@@ -33,20 +88,28 @@ if [[ -z "${ORG_ID:-}" || -z "${CLIENT_ID:-}" || -z "${SECRET:-}" || -z "${SCOPE
 fi
 
 cd "$PROJECT_ROOT"
+mkdir -p "$SNAPSHOT_DIR"
 
 BASELINE="$SNAPSHOT_DIR/${DATA_VIEW_ID}_baseline.json"
 
 # Ensure baseline exists
 if [[ ! -f "$BASELINE" ]]; then
     echo "$LOG_PREFIX No baseline found. Creating initial snapshot."
-    uv run cja_auto_sdr "$DATA_VIEW_ID" --snapshot "$BASELINE"
-    exit 0
+    capture_command_exit SNAPSHOT_EXIT uv run cja_auto_sdr "$DATA_VIEW_ID" --snapshot "$BASELINE"
+    case $SNAPSHOT_EXIT in
+        0) exit 0 ;;
+        *)
+            exit_on_signal_exit "$SNAPSHOT_EXIT" "$LOG_PREFIX ERROR: Baseline creation interrupted"
+            echo "$LOG_PREFIX ERROR: Initial baseline creation failed (exit $SNAPSHOT_EXIT)" >&2
+            ;;
+    esac
+    exit $SNAPSHOT_EXIT
 fi
 
-# Run drift detection (capture exit code before || true consumes it)
-DIFF_EXIT=0
-DIFF_OUTPUT=$(uv run cja_auto_sdr "$DATA_VIEW_ID" --diff-snapshot "$BASELINE" \
-    --format json --output - 2>/dev/null) || DIFF_EXIT=$?
+# Run drift detection while preserving non-zero exits for policy handling.
+capture_command_output DIFF_EXIT DIFF_OUTPUT uv run cja_auto_sdr "$DATA_VIEW_ID" --diff-snapshot "$BASELINE" \
+    --format json --output - 2>/dev/null
+exit_on_signal_exit "$DIFF_EXIT" "$LOG_PREFIX ERROR: Drift comparison interrupted"
 
 echo "$LOG_PREFIX Drift check exit code: $DIFF_EXIT"
 
@@ -55,7 +118,7 @@ echo "$LOG_PREFIX Drift check exit code: $DIFF_EXIT"
 # alerts keep firing until the drift is acknowledged.  To reset the baseline
 # after reviewing changes, re-run: uv run cja_auto_sdr "$DATA_VIEW_ID" --snapshot "$BASELINE"
 if [[ $DIFF_EXIT -eq 2 || $DIFF_EXIT -eq 3 ]]; then
-    SUMMARY=$(echo "$DIFF_OUTPUT" | python3 -c "
+    SUMMARY=$(printf '%s' "$DIFF_OUTPUT" | python3 -c "
 import sys, json
 try:
     data = json.load(sys.stdin)
@@ -87,16 +150,26 @@ except Exception:
                 --arg footer "cja_auto_sdr drift check" \
                 --argjson ts "$(date +%s)" \
                 '{attachments: [{color: $color, title: $title, text: $text, footer: $footer, ts: $ts}]}')
-            curl -s -X POST "$SLACK_WEBHOOK" \
+            if curl -fsS -X POST "$SLACK_WEBHOOK" \
                 -H 'Content-Type: application/json' \
-                -d "$PAYLOAD" > /dev/null
-            echo "$LOG_PREFIX Slack notification sent"
+                -d "$PAYLOAD" > /dev/null; then
+                echo "$LOG_PREFIX Slack notification sent"
+            else
+                echo "$LOG_PREFIX WARNING: Slack notification failed" >&2
+            fi
         fi
     fi
 elif [[ $DIFF_EXIT -eq 0 ]]; then
     # Only update baseline when no drift detected
-    uv run cja_auto_sdr "$DATA_VIEW_ID" --snapshot "$BASELINE"
-    echo "$LOG_PREFIX Baseline updated (no drift)"
+    capture_command_exit SNAPSHOT_EXIT uv run cja_auto_sdr "$DATA_VIEW_ID" --snapshot "$BASELINE"
+    case $SNAPSHOT_EXIT in
+        0) echo "$LOG_PREFIX Baseline updated (no drift)" ;;
+        *)
+            exit_on_signal_exit "$SNAPSHOT_EXIT" "$LOG_PREFIX ERROR: Baseline refresh interrupted"
+            echo "$LOG_PREFIX ERROR: Baseline refresh failed (exit $SNAPSHOT_EXIT)" >&2
+            ;;
+    esac
+    exit $SNAPSHOT_EXIT
 else
     echo "$LOG_PREFIX ERROR: Diff comparison failed; baseline preserved" >&2
 fi

--- a/examples/automation/quarterly_maintenance.sh
+++ b/examples/automation/quarterly_maintenance.sh
@@ -27,6 +27,16 @@ QUARTER="Q$(( ($(date +%-m) - 1) / 3 + 1 ))-$(date +%Y)"
 QUARTER_DIR="$REPORT_DIR/$QUARTER"
 LOG_PREFIX="[$(date '+%Y-%m-%d %H:%M:%S')]"
 
+update_overall_exit() {
+    local code="${1:-0}"
+
+    case "$code" in
+        1) OVERALL_EXIT=1 ;;
+        2) [[ $OVERALL_EXIT -ne 1 ]] && OVERALL_EXIT=2 ;;
+        3) [[ $OVERALL_EXIT -eq 0 ]] && OVERALL_EXIT=3 ;;
+    esac
+}
+
 # Load credentials
 if [[ -f "$PROJECT_ROOT/.env" ]]; then
     set -a
@@ -47,7 +57,7 @@ fi
 
 # Get data view list
 DATA_VIEWS=$(uv run cja_auto_sdr --list-dataviews --format json --output - | \
-    python3 -c "import sys,json; [print(dv['id']) for dv in json.load(sys.stdin)]" 2>/dev/null) || {
+    python3 -c "import sys,json; data=json.load(sys.stdin); views=data if isinstance(data, list) else data.get('dataViews', []); [print(dv['id']) for dv in views if isinstance(dv, dict) and dv.get('id')]" 2>/dev/null) || {
     echo "$LOG_PREFIX ERROR: Failed to list data views" >&2
     exit 1
 }
@@ -66,8 +76,8 @@ for DV_ID in $DATA_VIEWS; do
 
     case $SDR_EXIT in
         0) echo "$LOG_PREFIX  OK" ;;
-        2) echo "$LOG_PREFIX  WARNING: Quality threshold exceeded for $DV_ID"; OVERALL_EXIT=2 ;;
-        *) echo "$LOG_PREFIX  ERROR: SDR generation failed for $DV_ID (exit $SDR_EXIT)" >&2; OVERALL_EXIT=1 ;;
+        2) echo "$LOG_PREFIX  WARNING: Quality threshold exceeded for $DV_ID"; update_overall_exit 2 ;;
+        *) echo "$LOG_PREFIX  ERROR: SDR generation failed for $DV_ID (exit $SDR_EXIT)" >&2; update_overall_exit 1 ;;
     esac
 
     # Update baseline snapshot
@@ -83,13 +93,18 @@ uv run cja_auto_sdr --org-report --cluster --force-similarity \
 
 case $GOV_EXIT in
     0) echo "$LOG_PREFIX  Governance review: PASS" ;;
-    2) echo "$LOG_PREFIX  Governance review: THRESHOLDS EXCEEDED — see org_governance.json" ;;
-    *) echo "$LOG_PREFIX  ERROR: Governance review failed (exit $GOV_EXIT)" >&2; OVERALL_EXIT=1 ;;
+    2) echo "$LOG_PREFIX  Governance review: THRESHOLDS EXCEEDED — see org_governance.json"; update_overall_exit 2 ;;
+    *) echo "$LOG_PREFIX  ERROR: Governance review failed (exit $GOV_EXIT)" >&2; update_overall_exit 1 ;;
 esac
 
 # Also generate human-readable governance report
+GOV_MD_EXIT=0
 uv run cja_auto_sdr --org-report --cluster --force-similarity \
-    --format markdown --output - > "$QUARTER_DIR/org_governance.md" 2>/dev/null || true
+    --format markdown --output "$QUARTER_DIR/org_governance.md" || GOV_MD_EXIT=$?
+if [[ $GOV_MD_EXIT -ne 0 ]]; then
+    echo "$LOG_PREFIX  ERROR: Governance markdown export failed (exit $GOV_MD_EXIT)" >&2
+    update_overall_exit 1
+fi
 
 # --- Phase 3: Snapshot pruning ---
 echo "$LOG_PREFIX Phase 3: Snapshot pruning (keeping last $KEEP_LAST)"

--- a/examples/automation/quarterly_maintenance.sh
+++ b/examples/automation/quarterly_maintenance.sh
@@ -122,17 +122,16 @@ if [[ -n "${SLACK_WEBHOOK:-}" ]]; then
     COLOR="good"
     [[ $OVERALL_EXIT -ne 0 ]] && COLOR="warning"
 
+    PAYLOAD=$(jq -n \
+        --arg color "$COLOR" \
+        --arg title "$QUARTER Quarterly Maintenance Complete" \
+        --arg text "Exit code: $OVERALL_EXIT\nReports: $QUARTER_DIR" \
+        --arg footer "cja_auto_sdr quarterly maintenance" \
+        --argjson ts "$(date +%s)" \
+        '{attachments: [{color: $color, title: $title, text: $text, footer: $footer, ts: $ts}]}')
     curl -s -X POST "$SLACK_WEBHOOK" \
         -H 'Content-Type: application/json' \
-        -d "{
-            \"attachments\": [{
-                \"color\": \"$COLOR\",
-                \"title\": \"$QUARTER Quarterly Maintenance Complete\",
-                \"text\": \"Exit code: $OVERALL_EXIT\nReports: $QUARTER_DIR\",
-                \"footer\": \"cja_auto_sdr quarterly maintenance\",
-                \"ts\": $(date +%s)
-            }]
-        }" > /dev/null
+        -d "$PAYLOAD" > /dev/null
     echo "$LOG_PREFIX Slack notification sent"
 fi
 

--- a/examples/automation/quarterly_maintenance.sh
+++ b/examples/automation/quarterly_maintenance.sh
@@ -37,12 +37,15 @@ update_overall_exit() {
     esac
 }
 
-# Load credentials
-if [[ -f "$PROJECT_ROOT/.env" ]]; then
-    set -a
-    # shellcheck source=/dev/null
-    source "$PROJECT_ROOT/.env"
-    set +a
+# Prefer credentials injected by the caller/CI. Fall back to a repo-local
+# .env only for workstation-style usage of this example script.
+if [[ -z "${ORG_ID:-}" || -z "${CLIENT_ID:-}" || -z "${SECRET:-}" || -z "${SCOPES:-}" ]]; then
+    if [[ -f "$PROJECT_ROOT/.env" ]]; then
+        set -a
+        # shellcheck source=/dev/null
+        source "$PROJECT_ROOT/.env"
+        set +a
+    fi
 fi
 
 cd "$PROJECT_ROOT"
@@ -134,20 +137,24 @@ echo "$LOG_PREFIX === Quarterly maintenance complete (exit: $OVERALL_EXIT) ==="
 
 # Notify on completion
 if [[ -n "${SLACK_WEBHOOK:-}" ]]; then
-    COLOR="good"
-    [[ $OVERALL_EXIT -ne 0 ]] && COLOR="warning"
+    if ! command -v jq >/dev/null 2>&1; then
+        echo "$LOG_PREFIX WARNING: jq not installed; skipping Slack notification" >&2
+    else
+        COLOR="good"
+        [[ $OVERALL_EXIT -ne 0 ]] && COLOR="warning"
 
-    PAYLOAD=$(jq -n \
-        --arg color "$COLOR" \
-        --arg title "$QUARTER Quarterly Maintenance Complete" \
-        --arg text "Exit code: $OVERALL_EXIT\nReports: $QUARTER_DIR" \
-        --arg footer "cja_auto_sdr quarterly maintenance" \
-        --argjson ts "$(date +%s)" \
-        '{attachments: [{color: $color, title: $title, text: $text, footer: $footer, ts: $ts}]}')
-    curl -s -X POST "$SLACK_WEBHOOK" \
-        -H 'Content-Type: application/json' \
-        -d "$PAYLOAD" > /dev/null
-    echo "$LOG_PREFIX Slack notification sent"
+        PAYLOAD=$(jq -n \
+            --arg color "$COLOR" \
+            --arg title "$QUARTER Quarterly Maintenance Complete" \
+            --arg text "Exit code: $OVERALL_EXIT\nReports: $QUARTER_DIR" \
+            --arg footer "cja_auto_sdr quarterly maintenance" \
+            --argjson ts "$(date +%s)" \
+            '{attachments: [{color: $color, title: $title, text: $text, footer: $footer, ts: $ts}]}')
+        curl -s -X POST "$SLACK_WEBHOOK" \
+            -H 'Content-Type: application/json' \
+            -d "$PAYLOAD" > /dev/null
+        echo "$LOG_PREFIX Slack notification sent"
+    fi
 fi
 
 exit $OVERALL_EXIT

--- a/examples/automation/quarterly_maintenance.sh
+++ b/examples/automation/quarterly_maintenance.sh
@@ -52,23 +52,6 @@ else
         printf -v "$exit_var_name" '%s' "$exit_code"
     }
 
-    capture_command_output() {
-        local exit_var_name="$1"
-        local output_var_name="$2"
-        shift 2
-
-        local exit_code=0
-        local output=""
-        if output="$("$@")"; then
-            exit_code=0
-        else
-            exit_code=$?
-        fi
-
-        printf -v "$exit_var_name" '%s' "$exit_code"
-        printf -v "$output_var_name" '%s' "$output"
-    }
-
     exit_on_signal_exit() {
         local code="${1:-0}"
         shift
@@ -272,4 +255,4 @@ if [[ -n "${SLACK_WEBHOOK:-}" ]]; then
     fi
 fi
 
-exit $OVERALL_EXIT
+exit "$OVERALL_EXIT"

--- a/examples/automation/quarterly_maintenance.sh
+++ b/examples/automation/quarterly_maintenance.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# quarterly_maintenance.sh — Quarterly baseline refresh, governance review, and cleanup
+#
+# Cron entry (1st of Jan/Apr/Jul/Oct at 3am):
+#   0 3 1 1,4,7,10 * /path/to/quarterly_maintenance.sh >> /var/log/cja_sdr/quarterly.log 2>&1
+#
+# Environment variables:
+#   REPORT_DIR      — output directory for reports (default: ./reports)
+#   SNAPSHOT_DIR    — snapshot directory (default: ./snapshots)
+#   KEEP_LAST       — number of snapshots to retain after pruning (default: 4)
+#   SLACK_WEBHOOK   — Slack incoming webhook URL (optional)
+#
+# Phases:
+#   1. Full SDR regeneration (all views, all formats)
+#   2. Cross-org governance review (clustering + similarity)
+#   3. Snapshot pruning and baseline rotation
+#   4. Compliance documentation export
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+REPORT_DIR="${REPORT_DIR:-$PROJECT_ROOT/reports}"
+SNAPSHOT_DIR="${SNAPSHOT_DIR:-$PROJECT_ROOT/snapshots}"
+KEEP_LAST="${KEEP_LAST:-4}"
+QUARTER="Q$(( ($(date +%-m) - 1) / 3 + 1 ))-$(date +%Y)"
+QUARTER_DIR="$REPORT_DIR/$QUARTER"
+LOG_PREFIX="[$(date '+%Y-%m-%d %H:%M:%S')]"
+
+# Load credentials
+if [[ -f "$PROJECT_ROOT/.env" ]]; then
+    set -a
+    # shellcheck source=/dev/null
+    source "$PROJECT_ROOT/.env"
+    set +a
+fi
+
+cd "$PROJECT_ROOT"
+
+echo "$LOG_PREFIX === Quarterly maintenance: $QUARTER ==="
+
+# Pre-flight check
+if ! uv run cja_auto_sdr --validate-config; then
+    echo "$LOG_PREFIX ERROR: Configuration validation failed" >&2
+    exit 1
+fi
+
+# Get data view list
+DATA_VIEWS=$(uv run cja_auto_sdr --list-dataviews --format json --output - | \
+    python3 -c "import sys,json; [print(dv['id']) for dv in json.load(sys.stdin)]" 2>/dev/null) || {
+    echo "$LOG_PREFIX ERROR: Failed to list data views" >&2
+    exit 1
+}
+
+mkdir -p "$QUARTER_DIR" "$SNAPSHOT_DIR"
+
+OVERALL_EXIT=0
+
+# --- Phase 1: Full SDR regeneration (all views, all formats) ---
+echo "$LOG_PREFIX Phase 1: Full SDR regeneration"
+
+for DV_ID in $DATA_VIEWS; do
+    echo "$LOG_PREFIX  Generating all formats for $DV_ID"
+    SDR_EXIT=0
+    uv run cja_auto_sdr "$DV_ID" --format all --output-dir "$QUARTER_DIR" || SDR_EXIT=$?
+
+    case $SDR_EXIT in
+        0) echo "$LOG_PREFIX  OK" ;;
+        2) echo "$LOG_PREFIX  WARNING: Quality threshold exceeded for $DV_ID"; OVERALL_EXIT=2 ;;
+        *) echo "$LOG_PREFIX  ERROR: SDR generation failed for $DV_ID (exit $SDR_EXIT)" >&2; OVERALL_EXIT=1 ;;
+    esac
+
+    # Update baseline snapshot
+    uv run cja_auto_sdr "$DV_ID" --snapshot "$SNAPSHOT_DIR/${DV_ID}_baseline.json"
+done
+
+# --- Phase 2: Cross-org governance review ---
+echo "$LOG_PREFIX Phase 2: Cross-org governance review"
+
+GOV_EXIT=0
+uv run cja_auto_sdr --org-report --cluster --force-similarity \
+    --format json --output - > "$QUARTER_DIR/org_governance.json" 2>/dev/null || GOV_EXIT=$?
+
+case $GOV_EXIT in
+    0) echo "$LOG_PREFIX  Governance review: PASS" ;;
+    2) echo "$LOG_PREFIX  Governance review: THRESHOLDS EXCEEDED — see org_governance.json" ;;
+    *) echo "$LOG_PREFIX  ERROR: Governance review failed (exit $GOV_EXIT)" >&2; OVERALL_EXIT=1 ;;
+esac
+
+# Also generate human-readable governance report
+uv run cja_auto_sdr --org-report --cluster --force-similarity \
+    --format markdown --output - > "$QUARTER_DIR/org_governance.md" 2>/dev/null || true
+
+# --- Phase 3: Snapshot pruning ---
+echo "$LOG_PREFIX Phase 3: Snapshot pruning (keeping last $KEEP_LAST)"
+
+uv run cja_auto_sdr --prune-snapshots --keep-last "$KEEP_LAST" --snapshot-dir "$SNAPSHOT_DIR" || true
+uv run cja_auto_sdr --prune-org-report-snapshots --org-report-keep-last "$KEEP_LAST" || true
+
+echo "$LOG_PREFIX  Snapshots pruned"
+
+# --- Phase 4: Compliance documentation export ---
+echo "$LOG_PREFIX Phase 4: Compliance documentation export"
+
+COMPLIANCE_DIR="$QUARTER_DIR/compliance"
+mkdir -p "$COMPLIANCE_DIR"
+
+for DV_ID in $DATA_VIEWS; do
+    # Excel + markdown for compliance binders
+    COMP_EXIT=0
+    uv run cja_auto_sdr "$DV_ID" --format reports --output-dir "$COMPLIANCE_DIR" || COMP_EXIT=$?
+    [[ $COMP_EXIT -ne 0 ]] && echo "$LOG_PREFIX  WARNING: Compliance export failed for $DV_ID" >&2
+done
+
+echo "$LOG_PREFIX  Compliance docs exported to $COMPLIANCE_DIR"
+
+# --- Summary ---
+echo "$LOG_PREFIX === Quarterly maintenance complete (exit: $OVERALL_EXIT) ==="
+
+# Notify on completion
+if [[ -n "${SLACK_WEBHOOK:-}" ]]; then
+    COLOR="good"
+    [[ $OVERALL_EXIT -ne 0 ]] && COLOR="warning"
+
+    curl -s -X POST "$SLACK_WEBHOOK" \
+        -H 'Content-Type: application/json' \
+        -d "{
+            \"attachments\": [{
+                \"color\": \"$COLOR\",
+                \"title\": \"$QUARTER Quarterly Maintenance Complete\",
+                \"text\": \"Exit code: $OVERALL_EXIT\nReports: $QUARTER_DIR\",
+                \"footer\": \"cja_auto_sdr quarterly maintenance\",
+                \"ts\": $(date +%s)
+            }]
+        }" > /dev/null
+    echo "$LOG_PREFIX Slack notification sent"
+fi
+
+exit $OVERALL_EXIT

--- a/examples/automation/quarterly_maintenance.sh
+++ b/examples/automation/quarterly_maintenance.sh
@@ -26,14 +26,80 @@ KEEP_LAST="${KEEP_LAST:-4}"
 QUARTER="Q$(( ($(date +%-m) - 1) / 3 + 1 ))-$(date +%Y)"
 QUARTER_DIR="$REPORT_DIR/$QUARTER"
 LOG_PREFIX="[$(date '+%Y-%m-%d %H:%M:%S')]"
+# Keep the example self-contained when copied as a single cron script.
+if [[ -f "$SCRIPT_DIR/_common.sh" ]]; then
+    # shellcheck source=/dev/null
+    source "$SCRIPT_DIR/_common.sh"
+else
+    is_signal_exit_code() {
+        local code="${1:-0}"
+
+        [[ "$code" =~ ^[0-9]+$ ]] || return 1
+        (( code > 128 && code <= 192 ))
+    }
+
+    capture_command_exit() {
+        local exit_var_name="$1"
+        shift
+
+        local exit_code=0
+        if "$@"; then
+            exit_code=0
+        else
+            exit_code=$?
+        fi
+
+        printf -v "$exit_var_name" '%s' "$exit_code"
+    }
+
+    capture_command_output() {
+        local exit_var_name="$1"
+        local output_var_name="$2"
+        shift 2
+
+        local exit_code=0
+        local output=""
+        if output="$("$@")"; then
+            exit_code=0
+        else
+            exit_code=$?
+        fi
+
+        printf -v "$exit_var_name" '%s' "$exit_code"
+        printf -v "$output_var_name" '%s' "$output"
+    }
+
+    exit_on_signal_exit() {
+        local code="${1:-0}"
+        shift
+
+        if is_signal_exit_code "$code"; then
+            if [[ $# -gt 0 ]]; then
+                echo "$* (exit $code)" >&2
+            fi
+            exit "$code"
+        fi
+    }
+fi
 
 update_overall_exit() {
     local code="${1:-0}"
 
+    if is_signal_exit_code "$OVERALL_EXIT"; then
+        return
+    fi
+
+    if is_signal_exit_code "$code"; then
+        OVERALL_EXIT="$code"
+        return
+    fi
+
     case "$code" in
+        0) ;;
         1) OVERALL_EXIT=1 ;;
         2) [[ $OVERALL_EXIT -ne 1 ]] && OVERALL_EXIT=2 ;;
         3) [[ $OVERALL_EXIT -eq 0 ]] && OVERALL_EXIT=3 ;;
+        *) OVERALL_EXIT=1 ;;
     esac
 }
 
@@ -74,25 +140,44 @@ echo "$LOG_PREFIX Phase 1: Full SDR regeneration"
 
 for DV_ID in $DATA_VIEWS; do
     echo "$LOG_PREFIX  Generating all formats for $DV_ID"
-    SDR_EXIT=0
-    uv run cja_auto_sdr "$DV_ID" --format all --output-dir "$QUARTER_DIR" || SDR_EXIT=$?
+    capture_command_exit SDR_EXIT uv run cja_auto_sdr "$DV_ID" --format all --output-dir "$QUARTER_DIR"
+    exit_on_signal_exit "$SDR_EXIT" "$LOG_PREFIX  ERROR: SDR generation interrupted for $DV_ID"
+    SHOULD_UPDATE_BASELINE=1
 
     case $SDR_EXIT in
         0) echo "$LOG_PREFIX  OK" ;;
         2) echo "$LOG_PREFIX  WARNING: Quality threshold exceeded for $DV_ID"; update_overall_exit 2 ;;
-        *) echo "$LOG_PREFIX  ERROR: SDR generation failed for $DV_ID (exit $SDR_EXIT)" >&2; update_overall_exit 1 ;;
+        *)
+            echo "$LOG_PREFIX  ERROR: SDR generation failed for $DV_ID (exit $SDR_EXIT)" >&2
+            update_overall_exit 1
+            SHOULD_UPDATE_BASELINE=0
+            ;;
     esac
 
-    # Update baseline snapshot
-    uv run cja_auto_sdr "$DV_ID" --snapshot "$SNAPSHOT_DIR/${DV_ID}_baseline.json"
+    if [[ $SHOULD_UPDATE_BASELINE -eq 1 ]]; then
+        capture_command_exit SNAPSHOT_EXIT uv run cja_auto_sdr "$DV_ID" --snapshot "$SNAPSHOT_DIR/${DV_ID}_baseline.json"
+        exit_on_signal_exit "$SNAPSHOT_EXIT" "$LOG_PREFIX  Baseline snapshot interrupted for $DV_ID"
+        case $SNAPSHOT_EXIT in
+            0) echo "$LOG_PREFIX  Baseline snapshot updated" ;;
+            *)
+                echo "$LOG_PREFIX  ERROR: Baseline snapshot failed for $DV_ID (exit $SNAPSHOT_EXIT)" >&2
+                update_overall_exit 1
+                ;;
+        esac
+    else
+        echo "$LOG_PREFIX  Baseline preserved due to SDR generation failure"
+    fi
 done
 
 # --- Phase 2: Cross-org governance review ---
 echo "$LOG_PREFIX Phase 2: Cross-org governance review"
 
-GOV_EXIT=0
-uv run cja_auto_sdr --org-report --cluster --force-similarity \
-    --format json --output - > "$QUARTER_DIR/org_governance.json" 2>/dev/null || GOV_EXIT=$?
+capture_command_exit GOV_EXIT uv run cja_auto_sdr --org-report --cluster --force-similarity \
+    --format json --output - > "$QUARTER_DIR/org_governance.json" 2>/dev/null
+if is_signal_exit_code "$GOV_EXIT"; then
+    echo "$LOG_PREFIX  ERROR: Governance review interrupted (exit $GOV_EXIT)" >&2
+    exit "$GOV_EXIT"
+fi
 
 case $GOV_EXIT in
     0) echo "$LOG_PREFIX  Governance review: PASS" ;;
@@ -101,10 +186,10 @@ case $GOV_EXIT in
 esac
 
 # Also generate human-readable governance report
-GOV_MD_EXIT=0
-uv run cja_auto_sdr --org-report --cluster --force-similarity \
-    --format markdown --output "$QUARTER_DIR/org_governance.md" || GOV_MD_EXIT=$?
+capture_command_exit GOV_MD_EXIT uv run cja_auto_sdr --org-report --cluster --force-similarity \
+    --format markdown --output "$QUARTER_DIR/org_governance.md"
 if [[ $GOV_MD_EXIT -ne 0 ]]; then
+    exit_on_signal_exit "$GOV_MD_EXIT" "$LOG_PREFIX  ERROR: Governance markdown export interrupted"
     echo "$LOG_PREFIX  ERROR: Governance markdown export failed (exit $GOV_MD_EXIT)" >&2
     update_overall_exit 1
 fi
@@ -112,8 +197,25 @@ fi
 # --- Phase 3: Snapshot pruning ---
 echo "$LOG_PREFIX Phase 3: Snapshot pruning (keeping last $KEEP_LAST)"
 
-uv run cja_auto_sdr --prune-snapshots --keep-last "$KEEP_LAST" --snapshot-dir "$SNAPSHOT_DIR" || true
-uv run cja_auto_sdr --prune-org-report-snapshots --org-report-keep-last "$KEEP_LAST" || true
+capture_command_exit PRUNE_EXIT uv run cja_auto_sdr --prune-snapshots --keep-last "$KEEP_LAST" --snapshot-dir "$SNAPSHOT_DIR"
+case $PRUNE_EXIT in
+    0) ;;
+    *)
+        exit_on_signal_exit "$PRUNE_EXIT" "$LOG_PREFIX  ERROR: Snapshot pruning interrupted"
+        echo "$LOG_PREFIX  ERROR: Snapshot pruning failed (exit $PRUNE_EXIT)" >&2
+        update_overall_exit 1
+        ;;
+esac
+
+capture_command_exit ORG_PRUNE_EXIT uv run cja_auto_sdr --prune-org-report-snapshots --org-report-keep-last "$KEEP_LAST"
+case $ORG_PRUNE_EXIT in
+    0) ;;
+    *)
+        exit_on_signal_exit "$ORG_PRUNE_EXIT" "$LOG_PREFIX  ERROR: Org-report snapshot pruning interrupted"
+        echo "$LOG_PREFIX  ERROR: Org-report snapshot pruning failed (exit $ORG_PRUNE_EXIT)" >&2
+        update_overall_exit 1
+        ;;
+esac
 
 echo "$LOG_PREFIX  Snapshots pruned"
 
@@ -125,9 +227,19 @@ mkdir -p "$COMPLIANCE_DIR"
 
 for DV_ID in $DATA_VIEWS; do
     # Excel + markdown for compliance binders
-    COMP_EXIT=0
-    uv run cja_auto_sdr "$DV_ID" --format reports --output-dir "$COMPLIANCE_DIR" || COMP_EXIT=$?
-    [[ $COMP_EXIT -ne 0 ]] && echo "$LOG_PREFIX  WARNING: Compliance export failed for $DV_ID" >&2
+    capture_command_exit COMP_EXIT uv run cja_auto_sdr "$DV_ID" --format reports --output-dir "$COMPLIANCE_DIR"
+    case $COMP_EXIT in
+        0) ;;
+        2)
+            echo "$LOG_PREFIX  WARNING: Compliance export exceeded quality threshold for $DV_ID" >&2
+            update_overall_exit 2
+            ;;
+        *)
+            exit_on_signal_exit "$COMP_EXIT" "$LOG_PREFIX  ERROR: Compliance export interrupted for $DV_ID"
+            echo "$LOG_PREFIX  WARNING: Compliance export failed for $DV_ID (exit $COMP_EXIT)" >&2
+            update_overall_exit 1
+            ;;
+    esac
 done
 
 echo "$LOG_PREFIX  Compliance docs exported to $COMPLIANCE_DIR"
@@ -150,10 +262,13 @@ if [[ -n "${SLACK_WEBHOOK:-}" ]]; then
             --arg footer "cja_auto_sdr quarterly maintenance" \
             --argjson ts "$(date +%s)" \
             '{attachments: [{color: $color, title: $title, text: $text, footer: $footer, ts: $ts}]}')
-        curl -s -X POST "$SLACK_WEBHOOK" \
+        if curl -fsS -X POST "$SLACK_WEBHOOK" \
             -H 'Content-Type: application/json' \
-            -d "$PAYLOAD" > /dev/null
-        echo "$LOG_PREFIX Slack notification sent"
+            -d "$PAYLOAD" > /dev/null; then
+            echo "$LOG_PREFIX Slack notification sent"
+        else
+            echo "$LOG_PREFIX WARNING: Slack notification failed" >&2
+        fi
     fi
 fi
 

--- a/examples/automation/weekly_sdr.sh
+++ b/examples/automation/weekly_sdr.sh
@@ -19,6 +19,16 @@ REPORT_DIR="${REPORT_DIR:-$PROJECT_ROOT/reports}"
 SNAPSHOT_DIR="${SNAPSHOT_DIR:-$PROJECT_ROOT/snapshots}"
 LOG_PREFIX="[$(date '+%Y-%m-%d %H:%M:%S')]"
 
+update_overall_exit() {
+    local code="${1:-0}"
+
+    case "$code" in
+        1) OVERALL_EXIT=1 ;;
+        2) [[ $OVERALL_EXIT -ne 1 ]] && OVERALL_EXIT=2 ;;
+        3) [[ $OVERALL_EXIT -eq 0 ]] && OVERALL_EXIT=3 ;;
+    esac
+}
+
 # Load credentials
 if [[ -f "$PROJECT_ROOT/.env" ]]; then
     set -a
@@ -41,7 +51,7 @@ echo "$LOG_PREFIX Configuration validated"
 
 # Get data view list
 DATA_VIEWS=$(uv run cja_auto_sdr --list-dataviews --format json --output - | \
-    python3 -c "import sys,json; [print(dv['id']) for dv in json.load(sys.stdin)]" 2>/dev/null) || {
+    python3 -c "import sys,json; data=json.load(sys.stdin); views=data if isinstance(data, list) else data.get('dataViews', []); [print(dv['id']) for dv in views if isinstance(dv, dict) and dv.get('id')]" 2>/dev/null) || {
     echo "$LOG_PREFIX ERROR: Failed to list data views" >&2
     exit 1
 }
@@ -59,9 +69,9 @@ for DV_ID in $DATA_VIEWS; do
 
     case $SDR_EXIT in
         0) echo "$LOG_PREFIX  SDR generated successfully" ;;
-        1) echo "$LOG_PREFIX  ERROR: SDR generation failed" >&2; OVERALL_EXIT=1; continue ;;
-        2) echo "$LOG_PREFIX  WARNING: Quality threshold exceeded"; OVERALL_EXIT=2 ;;
-        *) echo "$LOG_PREFIX  Unexpected exit code: $SDR_EXIT" >&2; OVERALL_EXIT=1; continue ;;
+        1) echo "$LOG_PREFIX  ERROR: SDR generation failed" >&2; update_overall_exit 1; continue ;;
+        2) echo "$LOG_PREFIX  WARNING: Quality threshold exceeded"; update_overall_exit 2 ;;
+        *) echo "$LOG_PREFIX  Unexpected exit code: $SDR_EXIT" >&2; update_overall_exit 1; continue ;;
     esac
 
     # Drift detection against baseline (if snapshot exists)
@@ -73,9 +83,9 @@ for DV_ID in $DATA_VIEWS; do
 
         case $DIFF_EXIT in
             0) echo "$LOG_PREFIX  No drift detected" ;;
-            2) echo "$LOG_PREFIX  DRIFT DETECTED — see ${DV_ID}_drift.json" ;;
-            3) echo "$LOG_PREFIX  Warning threshold exceeded" ;;
-            *) echo "$LOG_PREFIX  Diff failed (exit $DIFF_EXIT)" >&2 ;;
+            2) echo "$LOG_PREFIX  DRIFT DETECTED — see ${DV_ID}_drift.json"; update_overall_exit 2 ;;
+            3) echo "$LOG_PREFIX  Warning threshold exceeded"; update_overall_exit 3 ;;
+            *) echo "$LOG_PREFIX  Diff failed (exit $DIFF_EXIT)" >&2; update_overall_exit 1 ;;
         esac
     fi
 

--- a/examples/automation/weekly_sdr.sh
+++ b/examples/automation/weekly_sdr.sh
@@ -19,14 +19,80 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 REPORT_DIR="${REPORT_DIR:-$PROJECT_ROOT/reports}"
 SNAPSHOT_DIR="${SNAPSHOT_DIR:-$PROJECT_ROOT/snapshots}"
 LOG_PREFIX="[$(date '+%Y-%m-%d %H:%M:%S')]"
+# Keep the example self-contained when copied as a single cron script.
+if [[ -f "$SCRIPT_DIR/_common.sh" ]]; then
+    # shellcheck source=/dev/null
+    source "$SCRIPT_DIR/_common.sh"
+else
+    is_signal_exit_code() {
+        local code="${1:-0}"
+
+        [[ "$code" =~ ^[0-9]+$ ]] || return 1
+        (( code > 128 && code <= 192 ))
+    }
+
+    capture_command_exit() {
+        local exit_var_name="$1"
+        shift
+
+        local exit_code=0
+        if "$@"; then
+            exit_code=0
+        else
+            exit_code=$?
+        fi
+
+        printf -v "$exit_var_name" '%s' "$exit_code"
+    }
+
+    capture_command_output() {
+        local exit_var_name="$1"
+        local output_var_name="$2"
+        shift 2
+
+        local exit_code=0
+        local output=""
+        if output="$("$@")"; then
+            exit_code=0
+        else
+            exit_code=$?
+        fi
+
+        printf -v "$exit_var_name" '%s' "$exit_code"
+        printf -v "$output_var_name" '%s' "$output"
+    }
+
+    exit_on_signal_exit() {
+        local code="${1:-0}"
+        shift
+
+        if is_signal_exit_code "$code"; then
+            if [[ $# -gt 0 ]]; then
+                echo "$* (exit $code)" >&2
+            fi
+            exit "$code"
+        fi
+    }
+fi
 
 update_overall_exit() {
     local code="${1:-0}"
 
+    if is_signal_exit_code "$OVERALL_EXIT"; then
+        return
+    fi
+
+    if is_signal_exit_code "$code"; then
+        OVERALL_EXIT="$code"
+        return
+    fi
+
     case "$code" in
+        0) ;;
         1) OVERALL_EXIT=1 ;;
         2) [[ $OVERALL_EXIT -ne 1 ]] && OVERALL_EXIT=2 ;;
         3) [[ $OVERALL_EXIT -eq 0 ]] && OVERALL_EXIT=3 ;;
+        *) OVERALL_EXIT=1 ;;
     esac
 }
 
@@ -67,9 +133,9 @@ OVERALL_EXIT=0
 for DV_ID in $DATA_VIEWS; do
     echo "$LOG_PREFIX Processing data view: $DV_ID"
 
-    # Generate SDR (capture exit code — set -e would abort on non-zero)
-    SDR_EXIT=0
-    uv run cja_auto_sdr "$DV_ID" --format excel --output-dir "$REPORT_DIR" || SDR_EXIT=$?
+    # Capture non-zero exits without suppressing shell-style signal termination.
+    capture_command_exit SDR_EXIT uv run cja_auto_sdr "$DV_ID" --format excel --output-dir "$REPORT_DIR"
+    exit_on_signal_exit "$SDR_EXIT" "$LOG_PREFIX  ERROR: SDR generation interrupted"
 
     case $SDR_EXIT in
         0) echo "$LOG_PREFIX  SDR generated successfully" ;;
@@ -83,9 +149,14 @@ for DV_ID in $DATA_VIEWS; do
     DRIFT_REPORT="$REPORT_DIR/${DV_ID}_drift.json"
     SHOULD_UPDATE_BASELINE=1
     if [[ -f "$BASELINE" ]]; then
-        DIFF_EXIT=0
-        uv run cja_auto_sdr "$DV_ID" --diff-snapshot "$BASELINE" --format json --output - \
-            > "$DRIFT_REPORT" 2>/dev/null || DIFF_EXIT=$?
+        capture_command_exit DIFF_EXIT uv run cja_auto_sdr "$DV_ID" --diff-snapshot "$BASELINE" --format json --output - \
+            > "$DRIFT_REPORT" 2>/dev/null
+
+        if is_signal_exit_code "$DIFF_EXIT"; then
+            echo "$LOG_PREFIX  Diff interrupted (exit $DIFF_EXIT)" >&2
+            rm -f "$DRIFT_REPORT"
+            exit "$DIFF_EXIT"
+        fi
 
         case $DIFF_EXIT in
             0) echo "$LOG_PREFIX  No drift detected" ;;
@@ -102,8 +173,15 @@ for DV_ID in $DATA_VIEWS; do
 
     if [[ $SHOULD_UPDATE_BASELINE -eq 1 ]]; then
         # Update baseline snapshot (data view is positional, --snapshot takes FILE)
-        uv run cja_auto_sdr "$DV_ID" --snapshot "$SNAPSHOT_DIR/${DV_ID}_baseline.json"
-        echo "$LOG_PREFIX  Baseline snapshot updated"
+        capture_command_exit SNAPSHOT_EXIT uv run cja_auto_sdr "$DV_ID" --snapshot "$SNAPSHOT_DIR/${DV_ID}_baseline.json"
+        exit_on_signal_exit "$SNAPSHOT_EXIT" "$LOG_PREFIX  Baseline snapshot interrupted"
+        case $SNAPSHOT_EXIT in
+            0) echo "$LOG_PREFIX  Baseline snapshot updated" ;;
+            *)
+                echo "$LOG_PREFIX  Baseline snapshot failed (exit $SNAPSHOT_EXIT); baseline preserved" >&2
+                update_overall_exit 1
+                ;;
+        esac
     else
         echo "$LOG_PREFIX  Baseline preserved due to diff failure"
     fi

--- a/examples/automation/weekly_sdr.sh
+++ b/examples/automation/weekly_sdr.sh
@@ -5,7 +5,8 @@
 #   0 2 * * 0 /path/to/weekly_sdr.sh >> /var/log/cja_sdr/weekly.log 2>&1
 #
 # Prerequisites:
-#   - .env file with ORG_ID, CLIENT_ID, SECRET, SCOPES
+#   - Credentials injected via environment variables or secret manager
+#   - Optional local-only fallback: .env with ORG_ID, CLIENT_ID, SECRET, SCOPES
 #   - uv installed and cja_auto_sdr synced
 #
 # Exit codes follow cja_auto_sdr conventions:
@@ -29,12 +30,15 @@ update_overall_exit() {
     esac
 }
 
-# Load credentials
-if [[ -f "$PROJECT_ROOT/.env" ]]; then
-    set -a
-    # shellcheck source=/dev/null
-    source "$PROJECT_ROOT/.env"
-    set +a
+# Prefer credentials injected by the caller/CI. Fall back to a repo-local
+# .env only for workstation-style usage of this example script.
+if [[ -z "${ORG_ID:-}" || -z "${CLIENT_ID:-}" || -z "${SECRET:-}" || -z "${SCOPES:-}" ]]; then
+    if [[ -f "$PROJECT_ROOT/.env" ]]; then
+        set -a
+        # shellcheck source=/dev/null
+        source "$PROJECT_ROOT/.env"
+        set +a
+    fi
 fi
 
 cd "$PROJECT_ROOT"

--- a/examples/automation/weekly_sdr.sh
+++ b/examples/automation/weekly_sdr.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# weekly_sdr.sh — Weekly SDR generation with drift detection
+#
+# Cron entry (Sunday 2am):
+#   0 2 * * 0 /path/to/weekly_sdr.sh >> /var/log/cja_sdr/weekly.log 2>&1
+#
+# Prerequisites:
+#   - .env file with ORG_ID, CLIENT_ID, SECRET, SCOPES
+#   - uv installed and cja_auto_sdr synced
+#
+# Exit codes follow cja_auto_sdr conventions:
+#   0 = success, 1 = error, 2 = policy threshold exceeded, 3 = warning threshold
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+REPORT_DIR="${REPORT_DIR:-$PROJECT_ROOT/reports}"
+SNAPSHOT_DIR="${SNAPSHOT_DIR:-$PROJECT_ROOT/snapshots}"
+LOG_PREFIX="[$(date '+%Y-%m-%d %H:%M:%S')]"
+
+# Load credentials
+if [[ -f "$PROJECT_ROOT/.env" ]]; then
+    set -a
+    # shellcheck source=/dev/null
+    source "$PROJECT_ROOT/.env"
+    set +a
+fi
+
+cd "$PROJECT_ROOT"
+
+echo "$LOG_PREFIX Starting weekly SDR generation"
+
+# Pre-flight check
+if ! uv run cja_auto_sdr --validate-config; then
+    echo "$LOG_PREFIX ERROR: Configuration validation failed" >&2
+    exit 1
+fi
+
+echo "$LOG_PREFIX Configuration validated"
+
+# Get data view list
+DATA_VIEWS=$(uv run cja_auto_sdr --list-dataviews --format json --output - | \
+    python3 -c "import sys,json; [print(dv['id']) for dv in json.load(sys.stdin)]" 2>/dev/null) || {
+    echo "$LOG_PREFIX ERROR: Failed to list data views" >&2
+    exit 1
+}
+
+mkdir -p "$REPORT_DIR" "$SNAPSHOT_DIR"
+
+OVERALL_EXIT=0
+
+for DV_ID in $DATA_VIEWS; do
+    echo "$LOG_PREFIX Processing data view: $DV_ID"
+
+    # Generate SDR (capture exit code — set -e would abort on non-zero)
+    SDR_EXIT=0
+    uv run cja_auto_sdr "$DV_ID" --format excel --output-dir "$REPORT_DIR" || SDR_EXIT=$?
+
+    case $SDR_EXIT in
+        0) echo "$LOG_PREFIX  SDR generated successfully" ;;
+        1) echo "$LOG_PREFIX  ERROR: SDR generation failed" >&2; OVERALL_EXIT=1; continue ;;
+        2) echo "$LOG_PREFIX  WARNING: Quality threshold exceeded"; OVERALL_EXIT=2 ;;
+        *) echo "$LOG_PREFIX  Unexpected exit code: $SDR_EXIT" >&2; OVERALL_EXIT=1; continue ;;
+    esac
+
+    # Drift detection against baseline (if snapshot exists)
+    BASELINE="$SNAPSHOT_DIR/${DV_ID}_baseline.json"
+    if [[ -f "$BASELINE" ]]; then
+        DIFF_EXIT=0
+        uv run cja_auto_sdr "$DV_ID" --diff-snapshot "$BASELINE" --format json --output - \
+            > "$REPORT_DIR/${DV_ID}_drift.json" 2>/dev/null || DIFF_EXIT=$?
+
+        case $DIFF_EXIT in
+            0) echo "$LOG_PREFIX  No drift detected" ;;
+            2) echo "$LOG_PREFIX  DRIFT DETECTED — see ${DV_ID}_drift.json" ;;
+            3) echo "$LOG_PREFIX  Warning threshold exceeded" ;;
+            *) echo "$LOG_PREFIX  Diff failed (exit $DIFF_EXIT)" >&2 ;;
+        esac
+    fi
+
+    # Update baseline snapshot (data view is positional, --snapshot takes FILE)
+    uv run cja_auto_sdr "$DV_ID" --snapshot "$SNAPSHOT_DIR/${DV_ID}_baseline.json"
+    echo "$LOG_PREFIX  Baseline snapshot updated"
+done
+
+echo "$LOG_PREFIX Weekly SDR generation complete (exit: $OVERALL_EXIT)"
+exit $OVERALL_EXIT

--- a/examples/automation/weekly_sdr.sh
+++ b/examples/automation/weekly_sdr.sh
@@ -45,23 +45,6 @@ else
         printf -v "$exit_var_name" '%s' "$exit_code"
     }
 
-    capture_command_output() {
-        local exit_var_name="$1"
-        local output_var_name="$2"
-        shift 2
-
-        local exit_code=0
-        local output=""
-        if output="$("$@")"; then
-            exit_code=0
-        else
-            exit_code=$?
-        fi
-
-        printf -v "$exit_var_name" '%s' "$exit_code"
-        printf -v "$output_var_name" '%s' "$output"
-    }
-
     exit_on_signal_exit() {
         local code="${1:-0}"
         shift
@@ -188,4 +171,4 @@ for DV_ID in $DATA_VIEWS; do
 done
 
 echo "$LOG_PREFIX Weekly SDR generation complete (exit: $OVERALL_EXIT)"
-exit $OVERALL_EXIT
+exit "$OVERALL_EXIT"

--- a/examples/automation/weekly_sdr.sh
+++ b/examples/automation/weekly_sdr.sh
@@ -76,22 +76,33 @@ for DV_ID in $DATA_VIEWS; do
 
     # Drift detection against baseline (if snapshot exists)
     BASELINE="$SNAPSHOT_DIR/${DV_ID}_baseline.json"
+    DRIFT_REPORT="$REPORT_DIR/${DV_ID}_drift.json"
+    SHOULD_UPDATE_BASELINE=1
     if [[ -f "$BASELINE" ]]; then
         DIFF_EXIT=0
         uv run cja_auto_sdr "$DV_ID" --diff-snapshot "$BASELINE" --format json --output - \
-            > "$REPORT_DIR/${DV_ID}_drift.json" 2>/dev/null || DIFF_EXIT=$?
+            > "$DRIFT_REPORT" 2>/dev/null || DIFF_EXIT=$?
 
         case $DIFF_EXIT in
             0) echo "$LOG_PREFIX  No drift detected" ;;
             2) echo "$LOG_PREFIX  DRIFT DETECTED — see ${DV_ID}_drift.json"; update_overall_exit 2 ;;
             3) echo "$LOG_PREFIX  Warning threshold exceeded"; update_overall_exit 3 ;;
-            *) echo "$LOG_PREFIX  Diff failed (exit $DIFF_EXIT)" >&2; update_overall_exit 1 ;;
+            *)
+                echo "$LOG_PREFIX  Diff failed (exit $DIFF_EXIT)" >&2
+                update_overall_exit 1
+                SHOULD_UPDATE_BASELINE=0
+                rm -f "$DRIFT_REPORT"
+                ;;
         esac
     fi
 
-    # Update baseline snapshot (data view is positional, --snapshot takes FILE)
-    uv run cja_auto_sdr "$DV_ID" --snapshot "$SNAPSHOT_DIR/${DV_ID}_baseline.json"
-    echo "$LOG_PREFIX  Baseline snapshot updated"
+    if [[ $SHOULD_UPDATE_BASELINE -eq 1 ]]; then
+        # Update baseline snapshot (data view is positional, --snapshot takes FILE)
+        uv run cja_auto_sdr "$DV_ID" --snapshot "$SNAPSHOT_DIR/${DV_ID}_baseline.json"
+        echo "$LOG_PREFIX  Baseline snapshot updated"
+    else
+        echo "$LOG_PREFIX  Baseline preserved due to diff failure"
+    fi
 done
 
 echo "$LOG_PREFIX Weekly SDR generation complete (exit: $OVERALL_EXIT)"

--- a/examples/github-actions/cja-sdr-audit.yml
+++ b/examples/github-actions/cja-sdr-audit.yml
@@ -55,7 +55,7 @@ jobs:
             DATA_VIEWS="$DATA_VIEW_IDS"
           else
             DATA_VIEWS=$(uv run cja_auto_sdr --list-dataviews --format json --output - | \
-              python3 -c "import sys,json; print(','.join(dv['id'] for dv in json.load(sys.stdin)))")
+              python3 -c "import sys,json; data=json.load(sys.stdin); views=data if isinstance(data, list) else data.get('dataViews', []); print(','.join(dv['id'] for dv in views if isinstance(dv, dict) and dv.get('id')))")
           fi
 
           IFS=',' read -ra VIEWS <<< "$DATA_VIEWS"

--- a/examples/github-actions/cja-sdr-audit.yml
+++ b/examples/github-actions/cja-sdr-audit.yml
@@ -1,0 +1,92 @@
+# cja-sdr-audit.yml — GitHub Actions workflow for automated SDR auditing
+#
+# TEMPLATE: Copy this file to .github/workflows/ in your own repository.
+# This file lives in examples/ and does NOT execute on this repo's CI.
+#
+# Required secrets:
+#   ORG_ID, CLIENT_ID, SECRET, SCOPES
+#
+# Optional variables:
+#   DATA_VIEW_IDS — comma-separated list of data view IDs to process
+
+name: CJA SDR Audit
+
+on:
+  schedule:
+    - cron: '0 2 * * 1'  # Weekly Monday 2am UTC
+  workflow_dispatch:
+    inputs:
+      data_view:
+        description: 'Specific data view ID (leave empty for all)'
+        required: false
+        type: string
+
+env:
+  ORG_ID: ${{ secrets.ORG_ID }}
+  CLIENT_ID: ${{ secrets.CLIENT_ID }}
+  SECRET: ${{ secrets.SECRET }}
+  SCOPES: ${{ secrets.SCOPES }}
+
+jobs:
+  sdr-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: 'latest'
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Validate configuration
+        run: uv run cja_auto_sdr --validate-config
+
+      - name: Generate SDR reports
+        run: |
+          mkdir -p reports snapshots
+
+          if [[ -n "${{ inputs.data_view }}" ]]; then
+            DATA_VIEWS="${{ inputs.data_view }}"
+          elif [[ -n "${DATA_VIEW_IDS:-}" ]]; then
+            DATA_VIEWS="$DATA_VIEW_IDS"
+          else
+            DATA_VIEWS=$(uv run cja_auto_sdr --list-dataviews --format json --output - | \
+              python3 -c "import sys,json; print(','.join(dv['id'] for dv in json.load(sys.stdin)))")
+          fi
+
+          IFS=',' read -ra VIEWS <<< "$DATA_VIEWS"
+          for DV_ID in "${VIEWS[@]}"; do
+            echo "::group::Processing $DV_ID"
+
+            # Generate SDR
+            uv run cja_auto_sdr "$DV_ID" --format reports --output-dir ./reports/ || true
+
+            # Drift detection (if baseline exists)
+            BASELINE="snapshots/${DV_ID}_baseline.json"
+            if [[ -f "$BASELINE" ]]; then
+              uv run cja_auto_sdr "$DV_ID" --diff-snapshot "$BASELINE" \
+                --format json --output - > "reports/${DV_ID}_drift.json" 2>/dev/null || true
+            fi
+
+            # Update snapshot (data view is positional, --snapshot takes FILE)
+            uv run cja_auto_sdr "$DV_ID" --snapshot "snapshots/${DV_ID}_baseline.json"
+
+            echo "::endgroup::"
+          done
+
+      - name: Upload reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdr-reports-${{ github.run_number }}
+          path: reports/
+          retention-days: 90
+
+      - name: Commit updated snapshots
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add snapshots/
+          git diff --cached --quiet || git commit -m "Update SDR snapshots [skip ci]"
+          git push

--- a/examples/github-actions/cja-sdr-audit.yml
+++ b/examples/github-actions/cja-sdr-audit.yml
@@ -46,41 +46,18 @@ jobs:
         run: uv run cja_auto_sdr --validate-config
 
       - name: Generate SDR reports
+        id: audit
         env:
           INPUT_DATA_VIEW: ${{ inputs.data_view }}
         run: |
-          mkdir -p reports snapshots
-
-          if [[ -n "${INPUT_DATA_VIEW:-}" ]]; then
-            DATA_VIEWS="$INPUT_DATA_VIEW"
-          elif [[ -n "${DATA_VIEW_IDS:-}" ]]; then
-            DATA_VIEWS="$DATA_VIEW_IDS"
-          else
-            DATA_VIEWS=$(uv run cja_auto_sdr --list-dataviews --format json --output - | \
-              python3 -c "import sys,json; data=json.load(sys.stdin); views=data if isinstance(data, list) else data.get('dataViews', []); print(','.join(dv['id'] for dv in views if isinstance(dv, dict) and dv.get('id')))")
-          fi
-
-          IFS=',' read -ra VIEWS <<< "$DATA_VIEWS"
-          for DV_ID in "${VIEWS[@]}"; do
-            echo "::group::Processing $DV_ID"
-
-            # Generate SDR
-            uv run cja_auto_sdr "$DV_ID" --format reports --output-dir ./reports/ || true
-
-            # Drift detection (if baseline exists)
-            BASELINE="snapshots/${DV_ID}_baseline.json"
-            if [[ -f "$BASELINE" ]]; then
-              uv run cja_auto_sdr "$DV_ID" --diff-snapshot "$BASELINE" \
-                --format json --output - > "reports/${DV_ID}_drift.json" 2>/dev/null || true
-            fi
-
-            # Update snapshot (data view is positional, --snapshot takes FILE)
-            uv run cja_auto_sdr "$DV_ID" --snapshot "snapshots/${DV_ID}_baseline.json"
-
-            echo "::endgroup::"
-          done
+          uv run python scripts/github_actions_audit.py audit \
+            --input-data-view "${INPUT_DATA_VIEW:-}" \
+            --data-view-ids "${DATA_VIEW_IDS:-}" \
+            --reports-dir reports \
+            --snapshot-dir snapshots
 
       - name: Upload reports
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: sdr-reports-${{ github.run_number }}
@@ -93,10 +70,28 @@ jobs:
       #   1. Run this workflow on an unprotected branch, or
       #   2. Use a GitHub App token with bypass permissions, or
       #   3. Replace this step with a PR-based snapshot update.
+      # Publication is decoupled from the aggregate audit exit: successful
+      # baselines can still be published when later views fail, but only after
+      # manifest validation and only if earlier steps in the job all succeeded.
       - name: Commit updated snapshots
+        if: >-
+          success() &&
+          !cancelled() &&
+          steps.audit.outputs.publish_ready == 'true' &&
+          steps.audit.outputs.successful_snapshot_manifest != ''
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add snapshots/
-          git diff --cached --quiet || git commit -m "Update SDR snapshots [skip ci]"
+          uv run python scripts/github_actions_audit.py stage-manifest \
+            --manifest "${{ steps.audit.outputs.successful_snapshot_manifest }}"
+          if git diff --cached --quiet; then
+            exit 0
+          fi
+          git commit -m "Update SDR snapshots [skip ci]"
           git push
+
+      - name: Exit with audit status
+        if: always()
+        env:
+          AUDIT_EXIT_CODE: ${{ steps.audit.outputs.audit_exit_code }}
+        run: exit "${AUDIT_EXIT_CODE:-1}"

--- a/examples/github-actions/cja-sdr-audit.yml
+++ b/examples/github-actions/cja-sdr-audit.yml
@@ -85,6 +85,12 @@ jobs:
           path: reports/
           retention-days: 90
 
+      # NOTE: This step pushes directly to the checked-out branch.
+      # If branch protection rules are enabled (required reviews, status checks),
+      # the push will fail.  In that case, either:
+      #   1. Run this workflow on an unprotected branch, or
+      #   2. Use a GitHub App token with bypass permissions, or
+      #   3. Replace this step with a PR-based snapshot update.
       - name: Commit updated snapshots
         run: |
           git config user.name "github-actions[bot]"

--- a/examples/github-actions/cja-sdr-audit.yml
+++ b/examples/github-actions/cja-sdr-audit.yml
@@ -44,11 +44,13 @@ jobs:
         run: uv run cja_auto_sdr --validate-config
 
       - name: Generate SDR reports
+        env:
+          INPUT_DATA_VIEW: ${{ inputs.data_view }}
         run: |
           mkdir -p reports snapshots
 
-          if [[ -n "${{ inputs.data_view }}" ]]; then
-            DATA_VIEWS="${{ inputs.data_view }}"
+          if [[ -n "${INPUT_DATA_VIEW:-}" ]]; then
+            DATA_VIEWS="$INPUT_DATA_VIEW"
           elif [[ -n "${DATA_VIEW_IDS:-}" ]]; then
             DATA_VIEWS="$DATA_VIEW_IDS"
           else

--- a/examples/github-actions/cja-sdr-audit.yml
+++ b/examples/github-actions/cja-sdr-audit.yml
@@ -29,6 +29,8 @@ env:
 
 jobs:
   sdr-audit:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/examples/github-actions/cja-sdr-audit.yml
+++ b/examples/github-actions/cja-sdr-audit.yml
@@ -35,9 +35,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v5
         with:
-          version: 'latest'
+          python-version: "3.14"
 
       - name: Install dependencies
         run: uv sync

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,6 +160,8 @@ ignore = [
 "src/cja_auto_sdr/output/sdr/__init__.py" = ["F822", "ERA001", "RUF001", "RUF003"]  # F822: lazy forwarding; ERA001: section header comments; RUF001/3: intentional Unicode symbols
 "src/cja_auto_sdr/pipeline/*.py" = ["F822"]  # lazy forwarding modules
 "tests/**" = ["B", "SIM", "RUF012", "PERF", "DTZ", "S105", "S108", "S110", "S314", "PT017", "PT018", "PT019", "ARG", "T201", "ERA001", "PD011", "FLY002"]
+"scripts/orchestrator.py" = ["T201"]  # intentional CLI output in standalone script
+"examples/**" = ["INP001", "T201"]  # INP001: not a package; T201: example scripts use print
 
 [tool.ruff.lint.isort]
 known-first-party = ["cja_auto_sdr"]

--- a/scripts/github_actions_audit.py
+++ b/scripts/github_actions_audit.py
@@ -1,0 +1,421 @@
+"""Helpers for the example GitHub Actions SDR audit workflow."""
+
+# ruff: noqa: T201
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from cja_auto_sdr.core.json_io import write_json_atomic
+
+_BASE_CMD = ["uv", "run", "cja_auto_sdr"]
+_SIGNAL_EXIT_BASE = 128
+_MAX_SIGNAL_NUMBER = 64
+_INTERRUPT_EXIT_CODE = _SIGNAL_EXIT_BASE + 2
+_MANIFEST_KEY = "successful_snapshots"
+
+
+@dataclass
+class CommandResult:
+    exit_code: int
+    stdout: str = ""
+    stderr: str = ""
+    command: tuple[str, ...] = ()
+    interrupted: bool = False
+
+
+@dataclass
+class AuditOutcome:
+    audit_exit_code: int
+    publish_ready: bool
+    successful_snapshot_manifest: str
+    interrupted: bool
+    successful_snapshots: list[str]
+
+
+def _normalize_exit_code(code: int) -> int:
+    if code < 0:
+        return _SIGNAL_EXIT_BASE + abs(code)
+    return code
+
+
+def _is_signal_exit_code(code: int) -> bool:
+    return _SIGNAL_EXIT_BASE < code <= (_SIGNAL_EXIT_BASE + _MAX_SIGNAL_NUMBER)
+
+
+def _combine_exit_codes(current: int, new_code: int) -> int:
+    current = _normalize_exit_code(current)
+    new_code = _normalize_exit_code(new_code)
+
+    if _is_signal_exit_code(current):
+        return current
+    if _is_signal_exit_code(new_code):
+        return new_code
+
+    if new_code not in (0, 1, 2, 3):
+        new_code = 1
+
+    if current == 1 or new_code == 1:
+        return 1
+    if current == 2 or new_code == 2:
+        return 2
+    if current == 3 or new_code == 3:
+        return 3
+    return 0
+
+
+def _emit_annotation(level: str, title: str, message: str) -> None:
+    print(f"::{level} title={title}::{message}")
+
+
+def _write_github_output(name: str, value: str) -> None:
+    output_path = os.environ.get("GITHUB_OUTPUT", "").strip()
+    if not output_path:
+        return
+    with open(output_path, "a", encoding="utf-8") as f:
+        f.write(f"{name}={value}\n")
+
+
+def run_cja_command(
+    args: Sequence[str],
+    *,
+    forward_stdout: bool = True,
+    forward_stderr: bool = True,
+) -> CommandResult:
+    command = [*_BASE_CMD, *args]
+    try:
+        result = subprocess.run(command, capture_output=True, text=True, check=False)
+    except KeyboardInterrupt:
+        return CommandResult(
+            exit_code=_INTERRUPT_EXIT_CODE,
+            stderr="Command interrupted while waiting for subprocess completion",
+            command=tuple(command),
+            interrupted=True,
+        )
+
+    exit_code = _normalize_exit_code(result.returncode)
+    if forward_stdout and result.stdout:
+        sys.stdout.write(result.stdout)
+    if forward_stderr and result.stderr:
+        sys.stderr.write(result.stderr)
+    return CommandResult(
+        exit_code=exit_code,
+        stdout=result.stdout,
+        stderr=result.stderr,
+        command=tuple(command),
+        interrupted=_is_signal_exit_code(exit_code),
+    )
+
+
+def _parse_discovered_data_views(stdout: str) -> list[str]:
+    payload = json.loads(stdout)
+    if isinstance(payload, list):
+        views = payload
+    elif isinstance(payload, dict):
+        views = payload.get("dataViews", [])
+    else:
+        raise ValueError("Discovery returned an unexpected JSON payload")
+
+    return [str(view["id"]).strip() for view in views if isinstance(view, dict) and view.get("id")]
+
+
+def _write_manifest(manifest_path: Path, successful_snapshots: list[str]) -> Path:
+    write_json_atomic(
+        manifest_path,
+        {_MANIFEST_KEY: successful_snapshots},
+        indent=2,
+        ensure_ascii=False,
+    )
+    return manifest_path
+
+
+def run_audit(
+    *,
+    input_data_view: str = "",
+    data_view_ids: str = "",
+    reports_dir: str = "reports",
+    snapshot_dir: str = "snapshots",
+    manifest_path: str | None = None,
+    runner: Callable[..., CommandResult] = run_cja_command,
+) -> AuditOutcome:
+    reports_path = Path(reports_dir)
+    snapshot_path = Path(snapshot_dir)
+    reports_path.mkdir(parents=True, exist_ok=True)
+    snapshot_path.mkdir(parents=True, exist_ok=True)
+
+    successful_snapshots: list[str] = []
+    overall_exit = 0
+    interrupted = False
+    resolved_manifest_path = (
+        Path(manifest_path) if manifest_path else reports_path / "successful_snapshots_manifest.json"
+    )
+
+    stripped_input = input_data_view.strip()
+    stripped_data_view_ids = data_view_ids.strip()
+    if stripped_input:
+        data_views = [stripped_input]
+    elif stripped_data_view_ids:
+        data_views = [item.strip() for item in stripped_data_view_ids.split(",") if item.strip()]
+    else:
+        discovery = runner(
+            ["--list-dataviews", "--format", "json", "--output", "-"],
+            forward_stdout=False,
+        )
+        if discovery.exit_code != 0:
+            interrupted = _is_signal_exit_code(discovery.exit_code)
+            _emit_annotation(
+                "error",
+                "Data view discovery failed",
+                f"Unable to resolve data views automatically (exit {discovery.exit_code}).",
+            )
+            manifest = _write_manifest(resolved_manifest_path, successful_snapshots)
+            return AuditOutcome(
+                audit_exit_code=discovery.exit_code if interrupted else 1,
+                publish_ready=False,
+                successful_snapshot_manifest=str(manifest),
+                interrupted=interrupted,
+                successful_snapshots=successful_snapshots,
+            )
+        try:
+            data_views = _parse_discovered_data_views(discovery.stdout)
+        except (ValueError, json.JSONDecodeError) as exc:
+            _emit_annotation(
+                "error",
+                "Data view discovery failed",
+                f"Unable to parse discovered data views: {exc}",
+            )
+            manifest = _write_manifest(resolved_manifest_path, successful_snapshots)
+            return AuditOutcome(
+                audit_exit_code=1,
+                publish_ready=False,
+                successful_snapshot_manifest=str(manifest),
+                interrupted=False,
+                successful_snapshots=successful_snapshots,
+            )
+
+    for data_view_id in data_views:
+        print(f"::group::Processing {data_view_id}")
+        try:
+            sdr_result = runner(
+                [data_view_id, "--format", "reports", "--output-dir", str(reports_path)],
+            )
+            if sdr_result.exit_code == 2:
+                _emit_annotation(
+                    "warning",
+                    "Policy threshold exceeded",
+                    f"{data_view_id} returned exit code 2 while generating SDR output.",
+                )
+                overall_exit = _combine_exit_codes(overall_exit, 2)
+            elif sdr_result.exit_code == 3:
+                _emit_annotation(
+                    "warning",
+                    "Warning threshold exceeded",
+                    f"{data_view_id} returned exit code 3 while generating SDR output.",
+                )
+                overall_exit = _combine_exit_codes(overall_exit, 3)
+            elif sdr_result.exit_code != 0:
+                if _is_signal_exit_code(sdr_result.exit_code):
+                    interrupted = True
+                    overall_exit = _combine_exit_codes(overall_exit, sdr_result.exit_code)
+                    _emit_annotation(
+                        "error",
+                        "Processing interrupted",
+                        f"{data_view_id} generation was interrupted (exit {sdr_result.exit_code}).",
+                    )
+                    break
+                overall_exit = _combine_exit_codes(overall_exit, 1)
+                _emit_annotation(
+                    "error",
+                    "SDR generation failed",
+                    f"{data_view_id} generation failed with exit {sdr_result.exit_code}.",
+                )
+                continue
+
+            baseline_path = snapshot_path / f"{data_view_id}_baseline.json"
+            drift_report_path = reports_path / f"{data_view_id}_drift.json"
+            if baseline_path.exists():
+                diff_result = runner(
+                    [
+                        data_view_id,
+                        "--diff-snapshot",
+                        str(baseline_path),
+                        "--format",
+                        "json",
+                        "--output",
+                        "-",
+                    ],
+                    forward_stdout=False,
+                    forward_stderr=False,
+                )
+                if diff_result.exit_code in (0, 2, 3):
+                    drift_report_path.write_text(diff_result.stdout, encoding="utf-8")
+                    if diff_result.exit_code == 2:
+                        _emit_annotation(
+                            "warning",
+                            "Drift detected",
+                            f"{data_view_id} diff exited 2. See {drift_report_path.name}.",
+                        )
+                        overall_exit = _combine_exit_codes(overall_exit, 2)
+                    elif diff_result.exit_code == 3:
+                        _emit_annotation(
+                            "warning",
+                            "Drift warning",
+                            f"{data_view_id} diff exited 3. See {drift_report_path.name}.",
+                        )
+                        overall_exit = _combine_exit_codes(overall_exit, 3)
+                else:
+                    drift_report_path.unlink(missing_ok=True)
+                    if _is_signal_exit_code(diff_result.exit_code):
+                        interrupted = True
+                        overall_exit = _combine_exit_codes(overall_exit, diff_result.exit_code)
+                        _emit_annotation(
+                            "error",
+                            "Processing interrupted",
+                            f"{data_view_id} drift check was interrupted (exit {diff_result.exit_code}).",
+                        )
+                        break
+                    overall_exit = _combine_exit_codes(overall_exit, 1)
+                    _emit_annotation(
+                        "error",
+                        "Drift comparison failed",
+                        f"{data_view_id} drift check failed with exit {diff_result.exit_code}. Baseline preserved.",
+                    )
+                    continue
+
+            snapshot_result = runner([data_view_id, "--snapshot", str(baseline_path)])
+            if snapshot_result.exit_code == 0:
+                successful_snapshots.append(str(baseline_path))
+                continue
+            if _is_signal_exit_code(snapshot_result.exit_code):
+                interrupted = True
+                overall_exit = _combine_exit_codes(overall_exit, snapshot_result.exit_code)
+                _emit_annotation(
+                    "error",
+                    "Processing interrupted",
+                    f"{data_view_id} snapshot update was interrupted (exit {snapshot_result.exit_code}).",
+                )
+                break
+            overall_exit = _combine_exit_codes(overall_exit, 1)
+            _emit_annotation(
+                "error",
+                "Snapshot update failed",
+                f"{data_view_id} snapshot refresh failed with exit {snapshot_result.exit_code}.",
+            )
+        finally:
+            print("::endgroup::")
+
+    manifest = _write_manifest(resolved_manifest_path, successful_snapshots)
+    return AuditOutcome(
+        audit_exit_code=overall_exit,
+        publish_ready=bool(successful_snapshots) and not interrupted,
+        successful_snapshot_manifest=str(manifest),
+        interrupted=interrupted,
+        successful_snapshots=successful_snapshots,
+    )
+
+
+def _load_manifest(manifest_path: str | Path) -> list[str]:
+    with open(manifest_path, encoding="utf-8") as f:
+        payload = json.load(f)
+
+    if isinstance(payload, list):
+        candidates = payload
+    elif isinstance(payload, dict):
+        candidates = payload.get(_MANIFEST_KEY)
+    else:
+        raise ValueError(f"Manifest {manifest_path} has an unexpected JSON shape")
+
+    if not isinstance(candidates, list):
+        raise ValueError(f"Manifest {manifest_path} is missing a '{_MANIFEST_KEY}' list")
+    return [str(candidate) for candidate in candidates if str(candidate).strip()]
+
+
+def validate_manifest_snapshots(manifest_path: str | Path) -> list[str]:
+    manifest_entries = _load_manifest(manifest_path)
+    for entry in manifest_entries:
+        candidate = Path(entry)
+        if not candidate.is_file():
+            raise FileNotFoundError(f"Manifest entry does not exist: {entry}")
+        with open(candidate, encoding="utf-8") as f:
+            payload = json.load(f)
+        if not isinstance(payload, dict) or "snapshot_version" not in payload:
+            raise ValueError(f"Manifest entry is not a valid snapshot JSON file: {entry}")
+    return manifest_entries
+
+
+def stage_manifest_snapshots(
+    manifest_path: str | Path,
+    *,
+    git_runner: Callable[[Sequence[str]], subprocess.CompletedProcess[str] | Any] | None = None,
+) -> int:
+    snapshot_paths = validate_manifest_snapshots(manifest_path)
+    if not snapshot_paths:
+        return 0
+
+    runner = git_runner or (lambda command: subprocess.run(command, check=False))
+    result = runner(["git", "add", "--", *snapshot_paths])
+    return _normalize_exit_code(int(getattr(result, "returncode", result)))
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    audit_parser = subparsers.add_parser("audit", help="Run the example audit workflow logic")
+    audit_parser.add_argument("--input-data-view", default="")
+    audit_parser.add_argument("--data-view-ids", default=os.environ.get("DATA_VIEW_IDS", ""))
+    audit_parser.add_argument("--reports-dir", default="reports")
+    audit_parser.add_argument("--snapshot-dir", default="snapshots")
+    audit_parser.add_argument("--manifest-path", default="")
+
+    stage_parser = subparsers.add_parser("stage-manifest", help="Validate and stage snapshot files from a manifest")
+    stage_parser.add_argument("--manifest", required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+
+    if args.command == "audit":
+        outcome = run_audit(
+            input_data_view=args.input_data_view,
+            data_view_ids=args.data_view_ids,
+            reports_dir=args.reports_dir,
+            snapshot_dir=args.snapshot_dir,
+            manifest_path=args.manifest_path or None,
+        )
+        _write_github_output("audit_exit_code", str(outcome.audit_exit_code))
+        _write_github_output("publish_ready", str(outcome.publish_ready).lower())
+        _write_github_output("successful_snapshot_manifest", outcome.successful_snapshot_manifest)
+        _write_github_output("interrupted", str(outcome.interrupted).lower())
+        print(
+            json.dumps(
+                {
+                    "audit_exit_code": outcome.audit_exit_code,
+                    "publish_ready": outcome.publish_ready,
+                    "successful_snapshot_manifest": outcome.successful_snapshot_manifest,
+                    "interrupted": outcome.interrupted,
+                    "successful_snapshots": outcome.successful_snapshots,
+                },
+                indent=2,
+            )
+        )
+        return 0
+
+    try:
+        return stage_manifest_snapshots(args.manifest)
+    except (FileNotFoundError, ValueError, json.JSONDecodeError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/github_actions_audit.py
+++ b/scripts/github_actions_audit.py
@@ -14,12 +14,22 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from cja_auto_sdr.core.exit_codes import (
+    INTERRUPT_EXIT_CODE as _INTERRUPT_EXIT_CODE,
+)
+from cja_auto_sdr.core.exit_codes import (
+    combine_wrapper_exit_codes as _combine_exit_codes,
+)
+from cja_auto_sdr.core.exit_codes import (
+    is_signal_exit_code as _is_signal_exit_code,
+)
+from cja_auto_sdr.core.exit_codes import (
+    normalize_subprocess_exit_code as _normalize_exit_code,
+)
 from cja_auto_sdr.core.json_io import write_json_atomic
 
 _BASE_CMD = ["uv", "run", "cja_auto_sdr"]
-_SIGNAL_EXIT_BASE = 128
-_MAX_SIGNAL_NUMBER = 64
-_INTERRUPT_EXIT_CODE = _SIGNAL_EXIT_BASE + 2
+DEFAULT_TIMEOUT = 300
 _MANIFEST_KEY = "successful_snapshots"
 
 
@@ -41,37 +51,6 @@ class AuditOutcome:
     successful_snapshots: list[str]
 
 
-def _normalize_exit_code(code: int) -> int:
-    if code < 0:
-        return _SIGNAL_EXIT_BASE + abs(code)
-    return code
-
-
-def _is_signal_exit_code(code: int) -> bool:
-    return _SIGNAL_EXIT_BASE < code <= (_SIGNAL_EXIT_BASE + _MAX_SIGNAL_NUMBER)
-
-
-def _combine_exit_codes(current: int, new_code: int) -> int:
-    current = _normalize_exit_code(current)
-    new_code = _normalize_exit_code(new_code)
-
-    if _is_signal_exit_code(current):
-        return current
-    if _is_signal_exit_code(new_code):
-        return new_code
-
-    if new_code not in (0, 1, 2, 3):
-        new_code = 1
-
-    if current == 1 or new_code == 1:
-        return 1
-    if current == 2 or new_code == 2:
-        return 2
-    if current == 3 or new_code == 3:
-        return 3
-    return 0
-
-
 def _emit_annotation(level: str, title: str, message: str) -> None:
     print(f"::{level} title={title}::{message}")
 
@@ -89,10 +68,17 @@ def run_cja_command(
     *,
     forward_stdout: bool = True,
     forward_stderr: bool = True,
+    timeout: int = DEFAULT_TIMEOUT,
 ) -> CommandResult:
     command = [*_BASE_CMD, *args]
     try:
-        result = subprocess.run(command, capture_output=True, text=True, check=False)
+        result = subprocess.run(command, capture_output=True, text=True, check=False, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        return CommandResult(
+            exit_code=1,
+            stderr=f"Command timed out after {timeout}s",
+            command=tuple(command),
+        )
     except KeyboardInterrupt:
         return CommandResult(
             exit_code=_INTERRUPT_EXIT_CODE,

--- a/scripts/github_actions_audit.py
+++ b/scripts/github_actions_audit.py
@@ -66,6 +66,11 @@ def _write_github_output(name: str, value: str) -> None:
         f.write(f"{name}={value}\n")
 
 
+def _should_defer_audit_exit_to_github_outputs() -> bool:
+    """Keep the audit step green only when GitHub output plumbing is active."""
+    return bool(os.environ.get("GITHUB_OUTPUT", "").strip())
+
+
 def run_cja_command(
     args: Sequence[str],
     *,
@@ -397,7 +402,9 @@ def main(argv: list[str] | None = None) -> int:
                 indent=2,
             )
         )
-        return 0
+        if _should_defer_audit_exit_to_github_outputs():
+            return 0
+        return outcome.audit_exit_code
 
     try:
         return stage_manifest_snapshots(args.manifest)

--- a/scripts/github_actions_audit.py
+++ b/scripts/github_actions_audit.py
@@ -28,7 +28,10 @@ from cja_auto_sdr.core.exit_codes import (
 )
 from cja_auto_sdr.core.json_io import write_json_atomic
 
-_BASE_CMD = ["uv", "run", "cja_auto_sdr"]
+# Match the orchestrator's explicit project anchoring so this helper resolves
+# the checked-out package predictably even when invoked from another cwd.
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+_BASE_CMD = ["uv", "run", "--project", str(PROJECT_ROOT), "cja_auto_sdr"]
 DEFAULT_TIMEOUT = 300
 _MANIFEST_KEY = "successful_snapshots"
 

--- a/scripts/orchestrator.py
+++ b/scripts/orchestrator.py
@@ -11,6 +11,7 @@ Usage:
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -103,7 +104,7 @@ def run_diff(data_view: str, snapshot_path: str) -> dict:
         parse_json=True,
     )
     result["data_view"] = data_view
-    result["has_changes"] = result["exit_code"] == 2
+    result["has_changes"] = result["exit_code"] in (2, 3)
     result["threshold_exceeded"] = result["exit_code"] in (2, 3)
     return result
 
@@ -126,9 +127,7 @@ def run_snapshot(data_view: str, snapshot_path: str | None = None) -> dict:
 def main() -> int:
     """Standalone entry point: validate config, process data views, output JSON results."""
     # Get data views from args or environment
-    data_views = sys.argv[1:] or [
-        dv.strip() for dv in (__import__("os").environ.get("DATA_VIEWS", "")).split(",") if dv.strip()
-    ]
+    data_views = sys.argv[1:] or [dv.strip() for dv in os.environ.get("DATA_VIEWS", "").split(",") if dv.strip()]
 
     if not data_views:
         print(json.dumps({"error": "No data views specified. Pass as args or set DATA_VIEWS env var."}))

--- a/scripts/orchestrator.py
+++ b/scripts/orchestrator.py
@@ -18,18 +18,28 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Resolve the repository root once so every subprocess invocation can point uv
+# at the checked-out project, even when callers run this wrapper from elsewhere.
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
+# Anchor uv to this checkout so the wrapper can be invoked from any cwd
+# without changing how relative file paths are interpreted by the caller.
 BASE_CMD = ["uv", "run", "--project", str(PROJECT_ROOT), "cja_auto_sdr"]
 
 
+# Keep the default timeout conservative for CI and agent use, but allow callers
+# to override it for especially large organizations or slow API responses.
 DEFAULT_TIMEOUT = 300  # 5 minutes; override per-call for long-running commands
+_SIGNAL_EXIT_BASE = 128
+_MAX_SIGNAL_NUMBER = 64
+_INTERRUPT_EXIT_CODE = _SIGNAL_EXIT_BASE + 2
 
 
 class OrchestratorError(RuntimeError):
     """Raised when a wrapped cja_auto_sdr command fails unexpectedly."""
 
-    def __init__(self, message: str, *, result: dict | None = None):
+    def __init__(self, message: str, *, stage: str = "orchestrator", result: dict | None = None):
         super().__init__(message)
+        self.stage = stage
         self.result = result or {}
 
 
@@ -39,9 +49,38 @@ class OrchestratorArgumentError(ValueError):
 
 class _ArgumentParser(argparse.ArgumentParser):
     """ArgumentParser variant that raises instead of exiting on invalid input."""
+    # Raising keeps orchestration code in control of the JSON error envelope
+    # instead of letting argparse print directly to stderr and terminate.
 
     def error(self, message: str) -> None:
         raise OrchestratorArgumentError(message)
+
+
+def _normalize_exit_code(code: int) -> int:
+    """Translate subprocess signal return codes into shell-style exit codes."""
+    # subprocess reports signal exits as negative numbers. Converting to
+    # 128+signal keeps the wrapper aligned with the documented CLI contract.
+    if code < 0:
+        return _SIGNAL_EXIT_BASE + abs(code)
+    return code
+
+
+def _is_signal_exit_code(code: int) -> bool:
+    """Return True when an exit code represents signal termination."""
+    return _SIGNAL_EXIT_BASE < code <= (_SIGNAL_EXIT_BASE + _MAX_SIGNAL_NUMBER)
+
+
+def _interrupted_result(command: list[str], *, message: str) -> dict:
+    """Return a synthetic result for wrapper-side interruption paths."""
+    return {
+        "exit_code": _INTERRUPT_EXIT_CODE,
+        "success": False,
+        "stdout": "",
+        "stderr": message,
+        "command": command,
+        "error_type": "interrupted",
+        "interrupted": True,
+    }
 
 
 def _run(
@@ -52,9 +91,12 @@ def _run(
     shared_args: list[str] | None = None,
 ) -> dict:
     """Run a cja_auto_sdr command and return structured result."""
+    # Build one flat argv list so the returned payload can echo the exact child
+    # command back to CI logs or agent runtimes for debugging.
     command = [*BASE_CMD, *(shared_args or []), *args]
     try:
-        # check is intentionally omitted; exit codes are inspected by callers
+        # check is intentionally omitted; policy and warning exits are valid
+        # outcomes that callers need to inspect instead of treating as errors.
         result = subprocess.run(
             command,
             capture_output=True,
@@ -70,17 +112,31 @@ def _run(
             "timed_out": True,
             "command": command,
         }
+    except KeyboardInterrupt:
+        return _interrupted_result(
+            command,
+            message="Command interrupted while waiting for subprocess completion",
+        )
+
+    # Normalize the subprocess result into a single payload shape so every
+    # helper can enrich the same structure without special casing raw CompletedProcess.
+    exit_code = _normalize_exit_code(result.returncode)
     output: dict = {
-        "exit_code": result.returncode,
-        "success": result.returncode == 0,
+        "exit_code": exit_code,
+        "raw_exit_code": result.returncode,
+        "success": exit_code == 0,
         "stdout": result.stdout,
         "stderr": result.stderr,
         "command": command,
     }
     if parse_json and result.stdout.strip():
         try:
+            # Most automation paths expect machine-readable stdout, so decode it
+            # eagerly and attach the parsed payload alongside the raw text.
             output["data"] = json.loads(result.stdout)
         except json.JSONDecodeError:
+            # Keep the raw stdout so callers can surface a better error while
+            # still distinguishing "command failed" from "JSON contract broke".
             output["data"] = None
             output["parse_error"] = True
     return output
@@ -95,6 +151,8 @@ def _build_parser() -> _ArgumentParser:
         ),
         allow_abbrev=False,
     )
+    # Keep the CLI surface intentionally narrow: this wrapper exists to provide
+    # stable orchestration behavior, not to mirror every direct CLI flag.
     parser.add_argument(
         "data_views",
         nargs="*",
@@ -125,6 +183,8 @@ def _build_parser() -> _ArgumentParser:
 
 def _build_shared_args(args: argparse.Namespace) -> list[str]:
     """Translate wrapper options into cja_auto_sdr flags."""
+    # Only forward wrapper-supported auth/config flags here; this script is
+    # intentionally narrow and leaves broader CLI coverage to direct usage.
     shared_args: list[str] = []
     if args.profile:
         shared_args.extend(["--profile", args.profile])
@@ -135,6 +195,8 @@ def _build_shared_args(args: argparse.Namespace) -> list[str]:
 
 def _extract_error_text(result: dict) -> str:
     """Normalize stderr into a concise error message."""
+    # Timeouts do not necessarily produce stderr, so handle them before any
+    # stderr-based parsing and preserve the explicit timeout wording.
     if result.get("timed_out"):
         return result.get("stderr", "Command timed out")
 
@@ -143,6 +205,8 @@ def _extract_error_text(result: dict) -> str:
         return "Command failed without diagnostic output"
 
     try:
+        # The CLI emits JSON error envelopes on failure; unwrap them when
+        # possible so upstream tooling gets a stable, concise message.
         payload = json.loads(stderr)
     except json.JSONDecodeError:
         return stderr
@@ -154,6 +218,8 @@ def _extract_error_text(result: dict) -> str:
 
 def _unwrap_collection(data: object, key: str) -> list[dict] | None:
     """Normalize list-style CLI JSON payloads with optional metadata envelopes."""
+    # Some commands return a bare list while others wrap the list in a top-level
+    # object. This helper accepts either form and filters to dict rows only.
     if isinstance(data, list):
         return [item for item in data if isinstance(item, dict)]
     if isinstance(data, dict):
@@ -163,21 +229,25 @@ def _unwrap_collection(data: object, key: str) -> list[dict] | None:
     return None
 
 
-def _require_collection(result: dict, *, key: str, action: str) -> list[dict]:
+def _require_collection(result: dict, *, key: str, action: str, stage: str = "orchestrator") -> list[dict]:
     """Extract a collection payload or raise an orchestrator error."""
+    # Collection-style helpers share the same success criteria: the subprocess
+    # must complete cleanly, stdout must parse as JSON, and the payload shape
+    # must match the expected list-or-envelope contract.
     if not result["success"]:
         raise OrchestratorError(
             f"{action} failed with exit code {result.get('exit_code', 1)}: {_extract_error_text(result)}",
+            stage=stage,
             result=result,
         )
     if result.get("parse_error"):
-        raise OrchestratorError(f"{action} returned invalid JSON output", result=result)
+        raise OrchestratorError(f"{action} returned invalid JSON output", stage=stage, result=result)
     if "data" not in result:
-        raise OrchestratorError(f"{action} returned no JSON payload", result=result)
+        raise OrchestratorError(f"{action} returned no JSON payload", stage=stage, result=result)
 
     items = _unwrap_collection(result.get("data"), key)
     if items is None:
-        raise OrchestratorError(f"{action} returned unexpected JSON shape", result=result)
+        raise OrchestratorError(f"{action} returned unexpected JSON shape", stage=stage, result=result)
     return items
 
 
@@ -187,6 +257,8 @@ def _validate_config_result(
     timeout: int = DEFAULT_TIMEOUT,
 ) -> dict:
     """Run validation and preserve CLI diagnostics for callers that need them."""
+    # Keep validation as a thin wrapper so callers can either consume the raw
+    # diagnostics or collapse them into a simple bool with validate_config().
     return _run(["--validate-config"], shared_args=shared_args, timeout=timeout)
 
 
@@ -195,6 +267,8 @@ def _resolve_caller_path(path_str: str) -> str:
     if path_str == "-":
         return path_str
 
+    # The wrapped CLI runs with --project anchored to this repo, but file paths
+    # should still behave as if the caller invoked the CLI directly from cwd.
     path = Path(path_str).expanduser()
     if path.is_absolute():
         return str(path)
@@ -207,6 +281,9 @@ def _resolve_data_views(
     shared_args: list[str] | None = None,
 ) -> tuple[list[str], str]:
     """Resolve data view IDs from argv, environment, or discovery."""
+    # Resolution order is explicit IDs first, then active discovery, then the
+    # DATA_VIEWS environment fallback. Returning the source makes batch output
+    # easier for CI and agents to explain upstream.
     if args.data_views:
         return args.data_views, "argv"
 
@@ -214,12 +291,19 @@ def _resolve_data_views(
         discovered_rows = list_dataviews(shared_args=shared_args, timeout=args.timeout)
         data_views: list[str] = []
         for index, row in enumerate(discovered_rows, start=1):
+            # Discovery is only useful if every returned row has a concrete ID;
+            # fail fast so automation does not silently skip malformed entries.
             data_view_id = row.get("id")
             if not data_view_id:
-                raise OrchestratorError(f"Data view discovery row {index} did not include an 'id' field")
+                raise OrchestratorError(
+                    f"Data view discovery row {index} did not include an 'id' field",
+                    stage="data_view_resolution",
+                )
             data_views.append(str(data_view_id))
         return data_views, "discover"
 
+    # DATA_VIEWS is intentionally comma-delimited so it can be injected cleanly
+    # from CI systems without needing shell array support.
     env_data_views = [dv.strip() for dv in os.environ.get("DATA_VIEWS", "").split(",") if dv.strip()]
     if env_data_views:
         return env_data_views, "env"
@@ -229,6 +313,18 @@ def _resolve_data_views(
 
 def _combine_exit_codes(current: int, new_code: int) -> int:
     """Preserve policy/warn exit codes while failing closed on hard errors."""
+    current = _normalize_exit_code(current)
+    new_code = _normalize_exit_code(new_code)
+
+    # Signal-style exits should dominate the aggregate so cancellations are not
+    # rewritten into generic failures during batch runs.
+    if _is_signal_exit_code(current):
+        return current
+    if _is_signal_exit_code(new_code):
+        return new_code
+
+    # After cancellation handling, fail closed on anything outside the wrapper's
+    # documented contract and then preserve the highest-severity non-zero state.
     if new_code not in (0, 1, 2, 3):
         new_code = 1
 
@@ -243,12 +339,24 @@ def _combine_exit_codes(current: int, new_code: int) -> int:
 
 def _emit_error(message: str, *, stage: str, result: dict | None = None) -> None:
     """Emit machine-readable orchestrator failures."""
+    # Print a single JSON object to stdout so callers can redirect one stream
+    # and still treat failures as structured data instead of scraping text logs.
+    exit_code = result.get("exit_code") if result is not None else None
+    interrupted = (
+        stage == "interrupted"
+        or bool(result is not None and result.get("interrupted"))
+        or (isinstance(exit_code, int)
+        and _is_signal_exit_code(exit_code))
+    )
     payload: dict[str, object] = {
         "error": message,
         "stage": stage,
     }
-    if result is not None and "exit_code" in result:
-        payload["exit_code"] = result["exit_code"]
+    if exit_code is not None:
+        payload["exit_code"] = exit_code
+    if interrupted:
+        payload["error_type"] = "interrupted"
+        payload["interrupted"] = True
     print(json.dumps(payload))
 
 
@@ -269,13 +377,15 @@ def list_dataviews(
     timeout: int = DEFAULT_TIMEOUT,
 ) -> list[dict]:
     """Discover available data views as structured data."""
+    # Force JSON to stdout so discovery is deterministic and does not depend on
+    # whatever default output mode the CLI might use interactively.
     result = _run(
         ["--list-dataviews", "--format", "json", "--output", "-"],
         parse_json=True,
         shared_args=shared_args,
         timeout=timeout,
     )
-    return _require_collection(result, key="dataViews", action="Data view discovery")
+    return _require_collection(result, key="dataViews", action="Data view discovery", stage="data_view_resolution")
 
 
 def list_snapshots(
@@ -285,6 +395,8 @@ def list_snapshots(
     timeout: int = DEFAULT_TIMEOUT,
 ) -> list[dict]:
     """List existing snapshots for baseline management."""
+    # Resolve paths from the caller's cwd before invoking the CLI so the wrapper
+    # behaves like a normal command-line tool rather than like a repo-relative script.
     resolved_snapshot_dir = _resolve_caller_path(snapshot_dir)
     result = _run(
         ["--list-snapshots", "--snapshot-dir", resolved_snapshot_dir, "--format", "json", "--output", "-"],
@@ -292,7 +404,7 @@ def list_snapshots(
         shared_args=shared_args,
         timeout=timeout,
     )
-    return _require_collection(result, key="snapshots", action="Snapshot discovery")
+    return _require_collection(result, key="snapshots", action="Snapshot discovery", stage="snapshot_discovery")
 
 
 def run_sdr(
@@ -305,12 +417,18 @@ def run_sdr(
     timeout: int = DEFAULT_TIMEOUT,
 ) -> dict:
     """Generate SDR and return structured result."""
+    # Default to JSON because orchestrators and agent frameworks usually want
+    # the payload inline; filesystem-oriented formats remain opt-in.
     args = [data_view, "--format", fmt]
     if output_dir:
         args.extend(["--output-dir", _resolve_caller_path(output_dir)])
     if fmt in ("json", "csv"):
+        # Machine-readable formats are most useful when the wrapper captures the
+        # payload directly instead of forcing callers to inspect filesystem output.
         args.extend(["--output", "-"])
     if extra_args:
+        # Preserve caller ordering for extra flags so advanced automation can
+        # control downstream behavior without this wrapper needing new options.
         args.extend(extra_args)
     result = _run(args, parse_json=(fmt == "json"), shared_args=shared_args, timeout=timeout)
     result["data_view"] = data_view
@@ -332,6 +450,8 @@ def run_diff(
         2 = policy threshold exceeded (changes found)
         3 = warning threshold exceeded (--warn-threshold)
     """
+    # Snapshot paths are caller-facing inputs, so normalize them before passing
+    # them through the repo-anchored uv invocation.
     resolved_snapshot_path = _resolve_caller_path(snapshot_path)
     result = _run(
         [data_view, "--diff-snapshot", resolved_snapshot_path, "--format", "json", "--output", "-"],
@@ -362,6 +482,8 @@ def run_snapshot(
     if snapshot_path is None:
         snapshot_path = f"./snapshots/{data_view}_baseline.json"
     resolved_snapshot_path = _resolve_caller_path(snapshot_path)
+    # Match the example automation behavior by creating the parent folder before
+    # invoking the CLI; the CLI itself should not need to care how the path was prepared.
     Path(resolved_snapshot_path).parent.mkdir(parents=True, exist_ok=True)
     result = _run([data_view, "--snapshot", resolved_snapshot_path], shared_args=shared_args, timeout=timeout)
     result["data_view"] = data_view
@@ -372,6 +494,8 @@ def run_snapshot(
 def main(argv: list[str] | None = None) -> int:
     """Standalone entry point: validate config, process data views, output JSON results."""
     parser = _build_parser()
+    # Accept injected argv for tests while preserving normal CLI behavior when
+    # the module is executed directly.
     raw_argv = sys.argv[1:] if argv is None else argv
 
     try:
@@ -382,62 +506,81 @@ def main(argv: list[str] | None = None) -> int:
     except SystemExit as exc:
         return int(exc.code)
 
-    shared_args = _build_shared_args(args)
     try:
+        shared_args = _build_shared_args(args)
         data_views, source = _resolve_data_views(args, shared_args=shared_args)
-    except OrchestratorError as exc:
-        _emit_error(str(exc), stage="data_view_resolution", result=exc.result)
-        return int(exc.result.get("exit_code", 1))
 
-    if not data_views:
-        if source == "discover":
-            print(
-                json.dumps(
-                    {
-                        "data_views_source": source,
-                        "data_views_processed": 0,
-                        "overall_exit_code": 0,
-                        "results": [],
-                    },
-                    indent=2,
+        if not data_views:
+            if source == "discover":
+                # Treat "discover found nothing" as a successful no-op so scheduled
+                # automation can report emptiness without being marked as failed.
+                print(
+                    json.dumps(
+                        {
+                            "data_views_source": source,
+                            "data_views_processed": 0,
+                            "overall_exit_code": 0,
+                            "results": [],
+                        },
+                        indent=2,
+                    )
                 )
+                return 0
+            _emit_error(
+                "No data views specified. Pass IDs as args, set DATA_VIEWS, or use --discover.",
+                stage="arguments",
             )
-            return 0
+            return 1
+
+        # Validate once before batch work so auth/config problems fail fast and do
+        # not leave the wrapper mixing infrastructure errors with per-view results.
+        validation_result = _validate_config_result(shared_args=shared_args, timeout=args.timeout)
+        if not validation_result["success"]:
+            _emit_error(
+                f"Configuration validation failed: {_extract_error_text(validation_result)}",
+                stage="validation",
+                result=validation_result,
+            )
+            return _combine_exit_codes(0, int(validation_result.get("exit_code", 1)))
+
+        results = []
+        overall_exit = 0
+        for dv in data_views:
+            # Process each data view independently and preserve every child payload
+            # so callers can inspect mixed-success batches in a single JSON report.
+            result = run_sdr(dv, fmt="json", shared_args=shared_args, timeout=args.timeout)
+            results.append(result)
+            result_exit = int(result.get("exit_code", 1))
+            overall_exit = _combine_exit_codes(overall_exit, result_exit)
+            # Stop once a child reports interruption so the wrapper mirrors user or
+            # runner intent instead of continuing to start more work after cancel.
+            if _is_signal_exit_code(result_exit):
+                break
+
+        # Emit one final batch envelope regardless of mixed result quality so CI,
+        # scripts, and agent runtimes only need to parse a single JSON document.
+        print(
+            json.dumps(
+                {
+                    "data_views_source": source,
+                    "data_views_processed": len(results),
+                    "overall_exit_code": overall_exit,
+                    "results": results,
+                },
+                indent=2,
+            )
+        )
+        return overall_exit
+    except OrchestratorError as exc:
+        _emit_error(str(exc), stage=exc.stage, result=exc.result)
+        return _combine_exit_codes(0, int(exc.result.get("exit_code", 1)))
+    except KeyboardInterrupt:
         _emit_error(
-            "No data views specified. Pass IDs as args, set DATA_VIEWS, or use --discover.",
-            stage="arguments",
+            "Orchestration interrupted before batch completion",
+            stage="interrupted",
+            result={"exit_code": _INTERRUPT_EXIT_CODE, "interrupted": True},
         )
-        return 1
-
-    # Pre-flight check
-    validation_result = _validate_config_result(shared_args=shared_args, timeout=args.timeout)
-    if not validation_result["success"]:
-        _emit_error(
-            f"Configuration validation failed: {_extract_error_text(validation_result)}",
-            stage="validation",
-            result=validation_result,
-        )
-        return 1
-
-    results = []
-    overall_exit = 0
-    for dv in data_views:
-        result = run_sdr(dv, fmt="json", shared_args=shared_args, timeout=args.timeout)
-        results.append(result)
-        overall_exit = _combine_exit_codes(overall_exit, int(result.get("exit_code", 1)))
-
-    print(
-        json.dumps(
-            {
-                "data_views_source": source,
-                "data_views_processed": len(results),
-                "overall_exit_code": overall_exit,
-                "results": results,
-            },
-            indent=2,
-        )
-    )
-    return overall_exit
+        return _INTERRUPT_EXIT_CODE
 
 
 if __name__ == "__main__":

--- a/scripts/orchestrator.py
+++ b/scripts/orchestrator.py
@@ -19,13 +19,26 @@ from pathlib import Path
 BASE_CMD = ["uv", "run", "cja_auto_sdr"]
 
 
-def _run(args: list[str], *, parse_json: bool = False) -> dict:
+DEFAULT_TIMEOUT = 300  # 5 minutes; override per-call for long-running commands
+
+
+def _run(args: list[str], *, parse_json: bool = False, timeout: int = DEFAULT_TIMEOUT) -> dict:
     """Run a cja_auto_sdr command and return structured result."""
-    result = subprocess.run(
-        [*BASE_CMD, *args],
-        capture_output=True,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            [*BASE_CMD, *args],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return {
+            "exit_code": 1,
+            "success": False,
+            "stdout": "",
+            "stderr": f"Command timed out after {timeout}s",
+            "timed_out": True,
+        }
     output: dict = {
         "exit_code": result.returncode,
         "success": result.returncode == 0,
@@ -105,7 +118,7 @@ def run_diff(data_view: str, snapshot_path: str) -> dict:
     )
     result["data_view"] = data_view
     result["has_changes"] = result["exit_code"] in (2, 3)
-    result["threshold_exceeded"] = result["exit_code"] in (2, 3)
+    result["threshold_exceeded"] = result["exit_code"] == 2
     return result
 
 

--- a/scripts/orchestrator.py
+++ b/scripts/orchestrator.py
@@ -49,6 +49,7 @@ class OrchestratorArgumentError(ValueError):
 
 class _ArgumentParser(argparse.ArgumentParser):
     """ArgumentParser variant that raises instead of exiting on invalid input."""
+
     # Raising keeps orchestration code in control of the JSON error envelope
     # instead of letting argparse print directly to stderr and terminate.
 
@@ -345,8 +346,7 @@ def _emit_error(message: str, *, stage: str, result: dict | None = None) -> None
     interrupted = (
         stage == "interrupted"
         or bool(result is not None and result.get("interrupted"))
-        or (isinstance(exit_code, int)
-        and _is_signal_exit_code(exit_code))
+        or (isinstance(exit_code, int) and _is_signal_exit_code(exit_code))
     )
     payload: dict[str, object] = {
         "error": message,

--- a/scripts/orchestrator.py
+++ b/scripts/orchestrator.py
@@ -4,30 +4,59 @@ Wraps the CLI via subprocess for use in CI/CD pipelines,
 AI agent frameworks, and custom automation scripts.
 
 Usage:
+    python scripts/orchestrator.py --profile client-a dv_abc123
+    python scripts/orchestrator.py --profile client-a --discover
     python scripts/orchestrator.py              # Run with DATA_VIEWS env var
-    python scripts/orchestrator.py dv_abc123    # Run with explicit data view IDs
 """
 
 from __future__ import annotations
 
+import argparse
 import json
 import os
 import subprocess
 import sys
 from pathlib import Path
 
-BASE_CMD = ["uv", "run", "cja_auto_sdr"]
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+BASE_CMD = ["uv", "run", "--project", str(PROJECT_ROOT), "cja_auto_sdr"]
 
 
 DEFAULT_TIMEOUT = 300  # 5 minutes; override per-call for long-running commands
 
 
-def _run(args: list[str], *, parse_json: bool = False, timeout: int = DEFAULT_TIMEOUT) -> dict:
+class OrchestratorError(RuntimeError):
+    """Raised when a wrapped cja_auto_sdr command fails unexpectedly."""
+
+    def __init__(self, message: str, *, result: dict | None = None):
+        super().__init__(message)
+        self.result = result or {}
+
+
+class OrchestratorArgumentError(ValueError):
+    """Raised when the wrapper receives unsupported arguments."""
+
+
+class _ArgumentParser(argparse.ArgumentParser):
+    """ArgumentParser variant that raises instead of exiting on invalid input."""
+
+    def error(self, message: str) -> None:
+        raise OrchestratorArgumentError(message)
+
+
+def _run(
+    args: list[str],
+    *,
+    parse_json: bool = False,
+    timeout: int = DEFAULT_TIMEOUT,
+    shared_args: list[str] | None = None,
+) -> dict:
     """Run a cja_auto_sdr command and return structured result."""
+    command = [*BASE_CMD, *(shared_args or []), *args]
     try:
         # check is intentionally omitted; exit codes are inspected by callers
         result = subprocess.run(
-            [*BASE_CMD, *args],
+            command,
             capture_output=True,
             text=True,
             timeout=timeout,
@@ -39,12 +68,14 @@ def _run(args: list[str], *, parse_json: bool = False, timeout: int = DEFAULT_TI
             "stdout": "",
             "stderr": f"Command timed out after {timeout}s",
             "timed_out": True,
+            "command": command,
         }
     output: dict = {
         "exit_code": result.returncode,
         "success": result.returncode == 0,
         "stdout": result.stdout,
         "stderr": result.stderr,
+        "command": command,
     }
     if parse_json and result.stdout.strip():
         try:
@@ -55,18 +86,73 @@ def _run(args: list[str], *, parse_json: bool = False, timeout: int = DEFAULT_TI
     return output
 
 
-def validate_config() -> bool:
-    """Pre-flight credential and connectivity check.
+def _build_parser() -> _ArgumentParser:
+    """Create the standalone orchestrator CLI parser."""
+    parser = _ArgumentParser(
+        description=(
+            "Run cja_auto_sdr across one or more data views and emit a consolidated JSON report. "
+            "This wrapper forwards only auth/config options; use the direct CLI for broader flag coverage."
+        ),
+        allow_abbrev=False,
+    )
+    parser.add_argument(
+        "data_views",
+        nargs="*",
+        help="Data view IDs to process. If omitted, DATA_VIEWS is used or --discover can auto-discover.",
+    )
+    parser.add_argument(
+        "-p",
+        "--profile",
+        help="Named profile to forward to cja_auto_sdr for credentials.",
+    )
+    parser.add_argument(
+        "--config-file",
+        help="Configuration file to forward to cja_auto_sdr.",
+    )
+    parser.add_argument(
+        "--discover",
+        action="store_true",
+        help="Discover data views with --list-dataviews when no IDs are supplied.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=DEFAULT_TIMEOUT,
+        help=f"Per-command timeout in seconds (default: {DEFAULT_TIMEOUT}).",
+    )
+    return parser
 
-    Returns True if validation passes (exit code 0).
-    Note: --validate-config does not produce JSON output;
-    this function relies on exit code only.
-    """
-    result = _run(["--validate-config"])
-    return result["success"]
+
+def _build_shared_args(args: argparse.Namespace) -> list[str]:
+    """Translate wrapper options into cja_auto_sdr flags."""
+    shared_args: list[str] = []
+    if args.profile:
+        shared_args.extend(["--profile", args.profile])
+    if args.config_file:
+        shared_args.extend(["--config-file", _resolve_caller_path(args.config_file)])
+    return shared_args
 
 
-def _unwrap_collection(data: object, key: str) -> list[dict]:
+def _extract_error_text(result: dict) -> str:
+    """Normalize stderr into a concise error message."""
+    if result.get("timed_out"):
+        return result.get("stderr", "Command timed out")
+
+    stderr = (result.get("stderr") or "").strip()
+    if not stderr:
+        return "Command failed without diagnostic output"
+
+    try:
+        payload = json.loads(stderr)
+    except json.JSONDecodeError:
+        return stderr
+
+    if isinstance(payload, dict) and payload.get("error"):
+        return str(payload["error"])
+    return stderr
+
+
+def _unwrap_collection(data: object, key: str) -> list[dict] | None:
     """Normalize list-style CLI JSON payloads with optional metadata envelopes."""
     if isinstance(data, list):
         return [item for item in data if isinstance(item, dict)]
@@ -74,26 +160,139 @@ def _unwrap_collection(data: object, key: str) -> list[dict]:
         items = data.get(key)
         if isinstance(items, list):
             return [item for item in items if isinstance(item, dict)]
-    return []
+    return None
 
 
-def list_dataviews() -> list[dict]:
+def _require_collection(result: dict, *, key: str, action: str) -> list[dict]:
+    """Extract a collection payload or raise an orchestrator error."""
+    if not result["success"]:
+        raise OrchestratorError(
+            f"{action} failed with exit code {result.get('exit_code', 1)}: {_extract_error_text(result)}",
+            result=result,
+        )
+    if result.get("parse_error"):
+        raise OrchestratorError(f"{action} returned invalid JSON output", result=result)
+    if "data" not in result:
+        raise OrchestratorError(f"{action} returned no JSON payload", result=result)
+
+    items = _unwrap_collection(result.get("data"), key)
+    if items is None:
+        raise OrchestratorError(f"{action} returned unexpected JSON shape", result=result)
+    return items
+
+
+def _validate_config_result(
+    *,
+    shared_args: list[str] | None = None,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> dict:
+    """Run validation and preserve CLI diagnostics for callers that need them."""
+    return _run(["--validate-config"], shared_args=shared_args, timeout=timeout)
+
+
+def _resolve_caller_path(path_str: str) -> str:
+    """Resolve relative paths against the caller's working directory."""
+    if path_str == "-":
+        return path_str
+
+    path = Path(path_str).expanduser()
+    if path.is_absolute():
+        return str(path)
+    return str((Path.cwd() / path).resolve(strict=False))
+
+
+def _resolve_data_views(
+    args: argparse.Namespace,
+    *,
+    shared_args: list[str] | None = None,
+) -> tuple[list[str], str]:
+    """Resolve data view IDs from argv, environment, or discovery."""
+    if args.data_views:
+        return args.data_views, "argv"
+
+    if args.discover:
+        discovered_rows = list_dataviews(shared_args=shared_args, timeout=args.timeout)
+        data_views: list[str] = []
+        for index, row in enumerate(discovered_rows, start=1):
+            data_view_id = row.get("id")
+            if not data_view_id:
+                raise OrchestratorError(f"Data view discovery row {index} did not include an 'id' field")
+            data_views.append(str(data_view_id))
+        return data_views, "discover"
+
+    env_data_views = [dv.strip() for dv in os.environ.get("DATA_VIEWS", "").split(",") if dv.strip()]
+    if env_data_views:
+        return env_data_views, "env"
+
+    return [], "none"
+
+
+def _combine_exit_codes(current: int, new_code: int) -> int:
+    """Preserve policy/warn exit codes while failing closed on hard errors."""
+    if new_code not in (0, 1, 2, 3):
+        new_code = 1
+
+    if current == 1 or new_code == 1:
+        return 1
+    if current == 2 or new_code == 2:
+        return 2
+    if current == 3 or new_code == 3:
+        return 3
+    return 0
+
+
+def _emit_error(message: str, *, stage: str, result: dict | None = None) -> None:
+    """Emit machine-readable orchestrator failures."""
+    payload: dict[str, object] = {
+        "error": message,
+        "stage": stage,
+    }
+    if result is not None and "exit_code" in result:
+        payload["exit_code"] = result["exit_code"]
+    print(json.dumps(payload))
+
+
+def validate_config(*, shared_args: list[str] | None = None, timeout: int = DEFAULT_TIMEOUT) -> bool:
+    """Pre-flight credential and connectivity check.
+
+    Returns True if validation passes (exit code 0).
+    Note: --validate-config does not produce JSON output;
+    this function relies on exit code only.
+    """
+    result = _validate_config_result(shared_args=shared_args, timeout=timeout)
+    return result["success"]
+
+
+def list_dataviews(
+    *,
+    shared_args: list[str] | None = None,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> list[dict]:
     """Discover available data views as structured data."""
-    result = _run(["--list-dataviews", "--format", "json", "--output", "-"], parse_json=True)
-    if not result["success"]:
-        return []
-    return _unwrap_collection(result.get("data"), "dataViews")
-
-
-def list_snapshots(snapshot_dir: str = "./snapshots") -> list[dict]:
-    """List existing snapshots for baseline management."""
     result = _run(
-        ["--list-snapshots", "--snapshot-dir", snapshot_dir, "--format", "json", "--output", "-"],
+        ["--list-dataviews", "--format", "json", "--output", "-"],
         parse_json=True,
+        shared_args=shared_args,
+        timeout=timeout,
     )
-    if not result["success"]:
-        return []
-    return _unwrap_collection(result.get("data"), "snapshots")
+    return _require_collection(result, key="dataViews", action="Data view discovery")
+
+
+def list_snapshots(
+    snapshot_dir: str = "./snapshots",
+    *,
+    shared_args: list[str] | None = None,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> list[dict]:
+    """List existing snapshots for baseline management."""
+    resolved_snapshot_dir = _resolve_caller_path(snapshot_dir)
+    result = _run(
+        ["--list-snapshots", "--snapshot-dir", resolved_snapshot_dir, "--format", "json", "--output", "-"],
+        parse_json=True,
+        shared_args=shared_args,
+        timeout=timeout,
+    )
+    return _require_collection(result, key="snapshots", action="Snapshot discovery")
 
 
 def run_sdr(
@@ -101,21 +300,30 @@ def run_sdr(
     fmt: str = "json",
     output_dir: str | None = None,
     extra_args: list[str] | None = None,
+    *,
+    shared_args: list[str] | None = None,
+    timeout: int = DEFAULT_TIMEOUT,
 ) -> dict:
     """Generate SDR and return structured result."""
     args = [data_view, "--format", fmt]
     if output_dir:
-        args.extend(["--output-dir", output_dir])
+        args.extend(["--output-dir", _resolve_caller_path(output_dir)])
     if fmt in ("json", "csv"):
         args.extend(["--output", "-"])
     if extra_args:
         args.extend(extra_args)
-    result = _run(args, parse_json=(fmt == "json"))
+    result = _run(args, parse_json=(fmt == "json"), shared_args=shared_args, timeout=timeout)
     result["data_view"] = data_view
     return result
 
 
-def run_diff(data_view: str, snapshot_path: str) -> dict:
+def run_diff(
+    data_view: str,
+    snapshot_path: str,
+    *,
+    shared_args: list[str] | None = None,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> dict:
     """Drift detection against a baseline snapshot.
 
     Exit codes:
@@ -124,17 +332,27 @@ def run_diff(data_view: str, snapshot_path: str) -> dict:
         2 = policy threshold exceeded (changes found)
         3 = warning threshold exceeded (--warn-threshold)
     """
+    resolved_snapshot_path = _resolve_caller_path(snapshot_path)
     result = _run(
-        [data_view, "--diff-snapshot", snapshot_path, "--format", "json", "--output", "-"],
+        [data_view, "--diff-snapshot", resolved_snapshot_path, "--format", "json", "--output", "-"],
         parse_json=True,
+        shared_args=shared_args,
+        timeout=timeout,
     )
     result["data_view"] = data_view
+    result["snapshot_path"] = resolved_snapshot_path
     result["has_changes"] = result["exit_code"] in (2, 3)
     result["threshold_exceeded"] = result["exit_code"] == 2
     return result
 
 
-def run_snapshot(data_view: str, snapshot_path: str | None = None) -> dict:
+def run_snapshot(
+    data_view: str,
+    snapshot_path: str | None = None,
+    *,
+    shared_args: list[str] | None = None,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> dict:
     """Save a baseline snapshot.
 
     Args:
@@ -143,34 +361,83 @@ def run_snapshot(data_view: str, snapshot_path: str | None = None) -> dict:
     """
     if snapshot_path is None:
         snapshot_path = f"./snapshots/{data_view}_baseline.json"
-    Path(snapshot_path).parent.mkdir(parents=True, exist_ok=True)
-    result = _run([data_view, "--snapshot", snapshot_path])
+    resolved_snapshot_path = _resolve_caller_path(snapshot_path)
+    Path(resolved_snapshot_path).parent.mkdir(parents=True, exist_ok=True)
+    result = _run([data_view, "--snapshot", resolved_snapshot_path], shared_args=shared_args, timeout=timeout)
     result["data_view"] = data_view
+    result["snapshot_path"] = resolved_snapshot_path
     return result
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     """Standalone entry point: validate config, process data views, output JSON results."""
-    # Get data views from args or environment (positional only, no flags)
-    args = [a for a in sys.argv[1:] if not a.startswith("-")]
-    data_views = args or [dv.strip() for dv in os.environ.get("DATA_VIEWS", "").split(",") if dv.strip()]
+    parser = _build_parser()
+    raw_argv = sys.argv[1:] if argv is None else argv
+
+    try:
+        args = parser.parse_args(raw_argv)
+    except OrchestratorArgumentError as exc:
+        _emit_error(f"Invalid orchestrator arguments: {exc}", stage="arguments")
+        return 1
+    except SystemExit as exc:
+        return int(exc.code)
+
+    shared_args = _build_shared_args(args)
+    try:
+        data_views, source = _resolve_data_views(args, shared_args=shared_args)
+    except OrchestratorError as exc:
+        _emit_error(str(exc), stage="data_view_resolution", result=exc.result)
+        return int(exc.result.get("exit_code", 1))
 
     if not data_views:
-        print(json.dumps({"error": "No data views specified. Pass as args or set DATA_VIEWS env var."}))
+        if source == "discover":
+            print(
+                json.dumps(
+                    {
+                        "data_views_source": source,
+                        "data_views_processed": 0,
+                        "overall_exit_code": 0,
+                        "results": [],
+                    },
+                    indent=2,
+                )
+            )
+            return 0
+        _emit_error(
+            "No data views specified. Pass IDs as args, set DATA_VIEWS, or use --discover.",
+            stage="arguments",
+        )
         return 1
 
     # Pre-flight check
-    if not validate_config():
-        print(json.dumps({"error": "Configuration validation failed. Check credentials."}))
+    validation_result = _validate_config_result(shared_args=shared_args, timeout=args.timeout)
+    if not validation_result["success"]:
+        _emit_error(
+            f"Configuration validation failed: {_extract_error_text(validation_result)}",
+            stage="validation",
+            result=validation_result,
+        )
         return 1
 
     results = []
+    overall_exit = 0
     for dv in data_views:
-        result = run_sdr(dv, fmt="json")
+        result = run_sdr(dv, fmt="json", shared_args=shared_args, timeout=args.timeout)
         results.append(result)
+        overall_exit = _combine_exit_codes(overall_exit, int(result.get("exit_code", 1)))
 
-    print(json.dumps({"data_views_processed": len(results), "results": results}, indent=2))
-    return 0 if all(r["success"] for r in results) else 1
+    print(
+        json.dumps(
+            {
+                "data_views_source": source,
+                "data_views_processed": len(results),
+                "overall_exit_code": overall_exit,
+                "results": results,
+            },
+            indent=2,
+        )
+    )
+    return overall_exit
 
 
 if __name__ == "__main__":

--- a/scripts/orchestrator.py
+++ b/scripts/orchestrator.py
@@ -1,0 +1,152 @@
+"""Orchestrator for programmatic cja_auto_sdr automation.
+
+Wraps the CLI via subprocess for use in CI/CD pipelines,
+AI agent frameworks, and custom automation scripts.
+
+Usage:
+    python scripts/orchestrator.py              # Run with DATA_VIEWS env var
+    python scripts/orchestrator.py dv_abc123    # Run with explicit data view IDs
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+BASE_CMD = ["uv", "run", "cja_auto_sdr"]
+
+
+def _run(args: list[str], *, parse_json: bool = False) -> dict:
+    """Run a cja_auto_sdr command and return structured result."""
+    result = subprocess.run(
+        [*BASE_CMD, *args],
+        capture_output=True,
+        text=True,
+    )
+    output: dict = {
+        "exit_code": result.returncode,
+        "success": result.returncode == 0,
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+    }
+    if parse_json and result.stdout.strip():
+        try:
+            output["data"] = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            output["data"] = None
+            output["parse_error"] = True
+    return output
+
+
+def validate_config() -> bool:
+    """Pre-flight credential and connectivity check.
+
+    Returns True if validation passes (exit code 0).
+    Note: --validate-config does not produce JSON output;
+    this function relies on exit code only.
+    """
+    result = _run(["--validate-config"])
+    return result["success"]
+
+
+def list_dataviews() -> list[dict]:
+    """Discover available data views as structured data."""
+    result = _run(["--list-dataviews", "--format", "json", "--output", "-"], parse_json=True)
+    if result["success"] and result.get("data"):
+        return result["data"] if isinstance(result["data"], list) else [result["data"]]
+    return []
+
+
+def list_snapshots(snapshot_dir: str = "./snapshots") -> list[dict]:
+    """List existing snapshots for baseline management."""
+    result = _run(
+        ["--list-snapshots", "--snapshot-dir", snapshot_dir, "--format", "json", "--output", "-"],
+        parse_json=True,
+    )
+    if result["success"] and result.get("data"):
+        return result["data"] if isinstance(result["data"], list) else [result["data"]]
+    return []
+
+
+def run_sdr(
+    data_view: str,
+    fmt: str = "json",
+    output_dir: str | None = None,
+    extra_args: list[str] | None = None,
+) -> dict:
+    """Generate SDR and return structured result."""
+    args = [data_view, "--format", fmt]
+    if output_dir:
+        args.extend(["--output-dir", output_dir])
+    if fmt in ("json", "csv"):
+        args.extend(["--output", "-"])
+    if extra_args:
+        args.extend(extra_args)
+    result = _run(args, parse_json=(fmt == "json"))
+    result["data_view"] = data_view
+    return result
+
+
+def run_diff(data_view: str, snapshot_path: str) -> dict:
+    """Drift detection against a baseline snapshot.
+
+    Exit codes:
+        0 = no changes
+        1 = error
+        2 = policy threshold exceeded (changes found)
+        3 = warning threshold exceeded (--warn-threshold)
+    """
+    result = _run(
+        [data_view, "--diff-snapshot", snapshot_path, "--format", "json", "--output", "-"],
+        parse_json=True,
+    )
+    result["data_view"] = data_view
+    result["has_changes"] = result["exit_code"] == 2
+    result["threshold_exceeded"] = result["exit_code"] in (2, 3)
+    return result
+
+
+def run_snapshot(data_view: str, snapshot_path: str | None = None) -> dict:
+    """Save a baseline snapshot.
+
+    Args:
+        data_view: Data view ID.
+        snapshot_path: Output file path. Defaults to ./snapshots/<data_view>_baseline.json.
+    """
+    if snapshot_path is None:
+        snapshot_path = f"./snapshots/{data_view}_baseline.json"
+    Path(snapshot_path).parent.mkdir(parents=True, exist_ok=True)
+    result = _run([data_view, "--snapshot", snapshot_path])
+    result["data_view"] = data_view
+    return result
+
+
+def main() -> int:
+    """Standalone entry point: validate config, process data views, output JSON results."""
+    # Get data views from args or environment
+    data_views = sys.argv[1:] or [
+        dv.strip() for dv in (__import__("os").environ.get("DATA_VIEWS", "")).split(",") if dv.strip()
+    ]
+
+    if not data_views:
+        print(json.dumps({"error": "No data views specified. Pass as args or set DATA_VIEWS env var."}))
+        return 1
+
+    # Pre-flight check
+    if not validate_config():
+        print(json.dumps({"error": "Configuration validation failed. Check credentials."}))
+        return 1
+
+    results = []
+    for dv in data_views:
+        result = run_sdr(dv, fmt="json")
+        results.append(result)
+
+    print(json.dumps({"data_views_processed": len(results), "results": results}, indent=2))
+    return 0 if all(r["success"] for r in results) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/orchestrator.py
+++ b/scripts/orchestrator.py
@@ -25,6 +25,7 @@ DEFAULT_TIMEOUT = 300  # 5 minutes; override per-call for long-running commands
 def _run(args: list[str], *, parse_json: bool = False, timeout: int = DEFAULT_TIMEOUT) -> dict:
     """Run a cja_auto_sdr command and return structured result."""
     try:
+        # check is intentionally omitted; exit codes are inspected by callers
         result = subprocess.run(
             [*BASE_CMD, *args],
             capture_output=True,
@@ -139,8 +140,9 @@ def run_snapshot(data_view: str, snapshot_path: str | None = None) -> dict:
 
 def main() -> int:
     """Standalone entry point: validate config, process data views, output JSON results."""
-    # Get data views from args or environment
-    data_views = sys.argv[1:] or [dv.strip() for dv in os.environ.get("DATA_VIEWS", "").split(",") if dv.strip()]
+    # Get data views from args or environment (positional only, no flags)
+    args = [a for a in sys.argv[1:] if not a.startswith("-")]
+    data_views = args or [dv.strip() for dv in os.environ.get("DATA_VIEWS", "").split(",") if dv.strip()]
 
     if not data_views:
         print(json.dumps({"error": "No data views specified. Pass as args or set DATA_VIEWS env var."}))

--- a/scripts/orchestrator.py
+++ b/scripts/orchestrator.py
@@ -66,12 +66,23 @@ def validate_config() -> bool:
     return result["success"]
 
 
+def _unwrap_collection(data: object, key: str) -> list[dict]:
+    """Normalize list-style CLI JSON payloads with optional metadata envelopes."""
+    if isinstance(data, list):
+        return [item for item in data if isinstance(item, dict)]
+    if isinstance(data, dict):
+        items = data.get(key)
+        if isinstance(items, list):
+            return [item for item in items if isinstance(item, dict)]
+    return []
+
+
 def list_dataviews() -> list[dict]:
     """Discover available data views as structured data."""
     result = _run(["--list-dataviews", "--format", "json", "--output", "-"], parse_json=True)
-    if result["success"] and result.get("data"):
-        return result["data"] if isinstance(result["data"], list) else [result["data"]]
-    return []
+    if not result["success"]:
+        return []
+    return _unwrap_collection(result.get("data"), "dataViews")
 
 
 def list_snapshots(snapshot_dir: str = "./snapshots") -> list[dict]:
@@ -80,9 +91,9 @@ def list_snapshots(snapshot_dir: str = "./snapshots") -> list[dict]:
         ["--list-snapshots", "--snapshot-dir", snapshot_dir, "--format", "json", "--output", "-"],
         parse_json=True,
     )
-    if result["success"] and result.get("data"):
-        return result["data"] if isinstance(result["data"], list) else [result["data"]]
-    return []
+    if not result["success"]:
+        return []
+    return _unwrap_collection(result.get("data"), "snapshots")
 
 
 def run_sdr(

--- a/scripts/orchestrator.py
+++ b/scripts/orchestrator.py
@@ -18,6 +18,19 @@ import subprocess
 import sys
 from pathlib import Path
 
+from cja_auto_sdr.core.exit_codes import (
+    INTERRUPT_EXIT_CODE as _INTERRUPT_EXIT_CODE,
+)
+from cja_auto_sdr.core.exit_codes import (
+    combine_wrapper_exit_codes as _combine_exit_codes,
+)
+from cja_auto_sdr.core.exit_codes import (
+    is_signal_exit_code as _is_signal_exit_code,
+)
+from cja_auto_sdr.core.exit_codes import (
+    normalize_subprocess_exit_code as _normalize_exit_code,
+)
+
 # Resolve the repository root once so every subprocess invocation can point uv
 # at the checked-out project, even when callers run this wrapper from elsewhere.
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
@@ -29,9 +42,6 @@ BASE_CMD = ["uv", "run", "--project", str(PROJECT_ROOT), "cja_auto_sdr"]
 # Keep the default timeout conservative for CI and agent use, but allow callers
 # to override it for especially large organizations or slow API responses.
 DEFAULT_TIMEOUT = 300  # 5 minutes; override per-call for long-running commands
-_SIGNAL_EXIT_BASE = 128
-_MAX_SIGNAL_NUMBER = 64
-_INTERRUPT_EXIT_CODE = _SIGNAL_EXIT_BASE + 2
 
 
 class OrchestratorError(RuntimeError):
@@ -55,20 +65,6 @@ class _ArgumentParser(argparse.ArgumentParser):
 
     def error(self, message: str) -> None:
         raise OrchestratorArgumentError(message)
-
-
-def _normalize_exit_code(code: int) -> int:
-    """Translate subprocess signal return codes into shell-style exit codes."""
-    # subprocess reports signal exits as negative numbers. Converting to
-    # 128+signal keeps the wrapper aligned with the documented CLI contract.
-    if code < 0:
-        return _SIGNAL_EXIT_BASE + abs(code)
-    return code
-
-
-def _is_signal_exit_code(code: int) -> bool:
-    """Return True when an exit code represents signal termination."""
-    return _SIGNAL_EXIT_BASE < code <= (_SIGNAL_EXIT_BASE + _MAX_SIGNAL_NUMBER)
 
 
 def _interrupted_result(command: list[str], *, message: str) -> dict:
@@ -310,32 +306,6 @@ def _resolve_data_views(
         return env_data_views, "env"
 
     return [], "none"
-
-
-def _combine_exit_codes(current: int, new_code: int) -> int:
-    """Preserve policy/warn exit codes while failing closed on hard errors."""
-    current = _normalize_exit_code(current)
-    new_code = _normalize_exit_code(new_code)
-
-    # Signal-style exits should dominate the aggregate so cancellations are not
-    # rewritten into generic failures during batch runs.
-    if _is_signal_exit_code(current):
-        return current
-    if _is_signal_exit_code(new_code):
-        return new_code
-
-    # After cancellation handling, fail closed on anything outside the wrapper's
-    # documented contract and then preserve the highest-severity non-zero state.
-    if new_code not in (0, 1, 2, 3):
-        new_code = 1
-
-    if current == 1 or new_code == 1:
-        return 1
-    if current == 2 or new_code == 2:
-        return 2
-    if current == 3 or new_code == 3:
-        return 3
-    return 0
 
 
 def _emit_error(message: str, *, stage: str, result: dict | None = None) -> None:

--- a/src/cja_auto_sdr/core/exit_codes.py
+++ b/src/cja_auto_sdr/core/exit_codes.py
@@ -1,10 +1,48 @@
-"""Shared exit-code reference output.
+"""Shared exit-code helpers and reference output.
 
-Lightweight — safe to import from ``__main__.py`` without triggering
-heavyweight dependencies (pandas, cjapy, tqdm).
+Lightweight — safe to import from ``__main__.py`` or wrapper scripts without
+triggering heavyweight dependencies (pandas, cjapy, tqdm).
 """
 
 from __future__ import annotations
+
+SIGNAL_EXIT_BASE = 128
+MAX_SIGNAL_NUMBER = 64
+INTERRUPT_EXIT_CODE = SIGNAL_EXIT_BASE + 2
+
+
+def normalize_subprocess_exit_code(code: int) -> int:
+    """Convert negative subprocess signal exits into shell-style codes."""
+    if code < 0:
+        return SIGNAL_EXIT_BASE + abs(code)
+    return code
+
+
+def is_signal_exit_code(code: int) -> bool:
+    """Return True when a code represents shell-style signal termination."""
+    return SIGNAL_EXIT_BASE < code <= (SIGNAL_EXIT_BASE + MAX_SIGNAL_NUMBER)
+
+
+def combine_wrapper_exit_codes(current: int, new_code: int) -> int:
+    """Preserve policy/warn exits while failing closed on unexpected wrapper codes."""
+    current = normalize_subprocess_exit_code(current)
+    new_code = normalize_subprocess_exit_code(new_code)
+
+    if is_signal_exit_code(current):
+        return current
+    if is_signal_exit_code(new_code):
+        return new_code
+
+    if new_code not in (0, 1, 2, 3):
+        new_code = 1
+
+    if current == 1 or new_code == 1:
+        return 1
+    if current == 2 or new_code == 2:
+        return 2
+    if current == 3 or new_code == 3:
+        return 3
+    return 0
 
 
 def print_exit_codes(banner_width: int = 60) -> None:

--- a/src/cja_auto_sdr/core/exit_codes.py
+++ b/src/cja_auto_sdr/core/exit_codes.py
@@ -20,6 +20,7 @@ def normalize_subprocess_exit_code(code: int) -> int:
 
 def is_signal_exit_code(code: int) -> bool:
     """Return True when a code represents shell-style signal termination."""
+    # 128 is the shell's signal-exit base marker; actual signal exits start at 129.
     return SIGNAL_EXIT_BASE < code <= (SIGNAL_EXIT_BASE + MAX_SIGNAL_NUMBER)
 
 
@@ -33,6 +34,8 @@ def combine_wrapper_exit_codes(current: int, new_code: int) -> int:
     if is_signal_exit_code(new_code):
         return new_code
 
+    if current not in (0, 1, 2, 3):
+        current = 1
     if new_code not in (0, 1, 2, 3):
         new_code = 1
 

--- a/src/cja_auto_sdr/core/json_io.py
+++ b/src/cja_auto_sdr/core/json_io.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import contextlib
+import errno
+import json
+import os
+import uuid
+from pathlib import Path
+from typing import Any
+
+_DIRECTORY_FSYNC_BEST_EFFORT_ERRNOS = {
+    errno.EACCES,
+    errno.EBADF,
+    errno.EINVAL,
+    errno.EPERM,
+    getattr(errno, "ENOTSUP", errno.EINVAL),
+}
+
+
+def _reject_symlink_destination(target_path: Path) -> None:
+    """Disallow replacing an existing symlink with atomic rename semantics."""
+    if target_path.is_symlink():
+        raise OSError(errno.ELOOP, "Refusing to atomically replace symlink destination", str(target_path))
+
+
+def _fsync_directory(directory: Path) -> None:
+    """Best-effort directory fsync for rename durability after power loss."""
+    flags = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+
+    dir_fd: int | None = None
+    try:
+        dir_fd = os.open(directory, flags)
+        os.fsync(dir_fd)
+    except OSError as exc:
+        if exc.errno not in _DIRECTORY_FSYNC_BEST_EFFORT_ERRNOS:
+            raise
+    finally:
+        if dir_fd is not None:
+            os.close(dir_fd)
+
+
+def write_json_atomic(
+    path: str | Path,
+    payload: Any,
+    *,
+    indent: int | None = 2,
+    ensure_ascii: bool = True,
+    sort_keys: bool = False,
+    default: Any = None,
+    file_mode: int | None = None,
+    trailing_newline: bool = False,
+) -> Path:
+    """Persist JSON atomically, rejecting existing target symlinks and fsyncing the parent dir."""
+    target_path = Path(path)
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    _reject_symlink_destination(target_path)
+    tmp_path = target_path.with_name(f".{target_path.name}.{uuid.uuid4().hex}.tmp")
+    open_flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    create_mode = file_mode if file_mode is not None else 0o666
+
+    try:
+        fd = os.open(tmp_path, open_flags, create_mode)
+        try:
+            if file_mode is not None and hasattr(os, "fchmod"):
+                os.fchmod(fd, file_mode)
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                fd = -1
+                json.dump(
+                    payload,
+                    f,
+                    indent=indent,
+                    ensure_ascii=ensure_ascii,
+                    sort_keys=sort_keys,
+                    default=default,
+                )
+                if trailing_newline:
+                    f.write("\n")
+                f.flush()
+                os.fsync(f.fileno())
+        finally:
+            if fd != -1:
+                os.close(fd)
+
+        os.replace(tmp_path, target_path)
+        _fsync_directory(target_path.parent)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            tmp_path.unlink()
+        raise
+
+    return target_path

--- a/src/cja_auto_sdr/core/json_io.py
+++ b/src/cja_auto_sdr/core/json_io.py
@@ -5,6 +5,7 @@ import errno
 import json
 import os
 import uuid
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -48,7 +49,7 @@ def write_json_atomic(
     indent: int | None = 2,
     ensure_ascii: bool = True,
     sort_keys: bool = False,
-    default: Any = None,
+    default: Callable[[Any], Any] | None = None,
     file_mode: int | None = None,
     trailing_newline: bool = False,
 ) -> Path:

--- a/src/cja_auto_sdr/core/profiles.py
+++ b/src/cja_auto_sdr/core/profiles.py
@@ -17,6 +17,7 @@ from cja_auto_sdr.core.colors import ConsoleColors
 from cja_auto_sdr.core.constants import BANNER_WIDTH, CREDENTIAL_FIELDS, ENV_VAR_MAPPING
 from cja_auto_sdr.core.credentials import filter_credentials
 from cja_auto_sdr.core.exceptions import ProfileConfigError, ProfileNotFoundError
+from cja_auto_sdr.core.json_io import write_json_atomic
 
 __all__ = [
     "_normalize_import_credentials",
@@ -385,9 +386,7 @@ def add_profile_interactive(profile_name: str) -> bool:
 
     config_file = profile_path / "config.json"
     try:
-        fd = os.open(str(config_file), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-        with open(fd, "w", encoding="utf-8") as f:
-            json.dump(config, f, indent=2)
+        write_json_atomic(config_file, config, indent=2, file_mode=0o600)
     except OSError as e:
         print(ConsoleColors.error(f"Error writing config file: {e}"), file=sys.stderr)
         return False
@@ -543,10 +542,7 @@ def import_profile_non_interactive(profile_name: str, source_file: str | Path, o
     try:
         profile_path.mkdir(parents=True, exist_ok=True)
         config_path = profile_path / "config.json"
-        fd = os.open(str(config_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-        with open(fd, "w", encoding="utf-8") as f:
-            json.dump(config_payload, f, indent=2)
-            f.write("\n")
+        write_json_atomic(config_path, config_payload, indent=2, file_mode=0o600, trailing_newline=True)
     except OSError as e:
         print(ConsoleColors.error(f"Error writing profile config: {e}"), file=sys.stderr)
         return False

--- a/src/cja_auto_sdr/core/version.py
+++ b/src/cja_auto_sdr/core/version.py
@@ -1,3 +1,3 @@
 """Version information for CJA Auto SDR."""
 
-__version__ = "3.4.1"
+__version__ = "3.4.2"

--- a/src/cja_auto_sdr/diff/snapshot.py
+++ b/src/cja_auto_sdr/diff/snapshot.py
@@ -8,6 +8,7 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from cja_auto_sdr.core.colors import ConsoleColors
 from cja_auto_sdr.core.error_policies import RECOVERABLE_OPTIONAL_ENRICHMENT_EXCEPTIONS
+from cja_auto_sdr.core.json_io import write_json_atomic
 from cja_auto_sdr.diff.models import DataViewSnapshot
 
 
@@ -181,10 +182,7 @@ class SnapshotManager:
     def save_snapshot(self, snapshot: DataViewSnapshot, filepath: str) -> str:
         """Save a snapshot to a JSON file."""
         filepath = os.path.abspath(filepath)
-        os.makedirs(os.path.dirname(filepath) or ".", exist_ok=True)
-
-        with open(filepath, "w", encoding="utf-8") as f:
-            json.dump(snapshot.to_dict(), f, indent=2, ensure_ascii=False)
+        write_json_atomic(filepath, snapshot.to_dict(), indent=2, ensure_ascii=False)
 
         self.logger.info(f"Snapshot saved to: {filepath}")
         return filepath

--- a/src/cja_auto_sdr/org/cache.py
+++ b/src/cja_auto_sdr/org/cache.py
@@ -17,6 +17,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
+from cja_auto_sdr.core.json_io import write_json_atomic
 from cja_auto_sdr.core.locks.manager import LockManager
 from cja_auto_sdr.org.models import DataViewSummary
 from cja_auto_sdr.org.snapshot_utils import (
@@ -175,15 +176,10 @@ class OrgReportCache:
     def _save_cache(self) -> None:
         """Save cache to disk via atomic write-then-rename."""
         self.cache_dir.mkdir(parents=True, exist_ok=True)
-        tmp_path = self.cache_file.with_name(f".{self.cache_file.name}.{uuid.uuid4().hex}.tmp")
         try:
-            with open(tmp_path, "w", encoding="utf-8") as f:
-                json.dump(self._cache, f, indent=2, default=str)
-            os.replace(tmp_path, self.cache_file)
+            write_json_atomic(self.cache_file, self._cache, indent=2, default=str)
         except OSError as e:
             self.logger.warning(f"Failed to save org report cache to {self.cache_file}: {e}")
-            with contextlib.suppress(OSError):
-                tmp_path.unlink()
 
     @staticmethod
     def _sanitize_org_id(org_id: str | None) -> str:
@@ -225,14 +221,9 @@ class OrgReportCache:
         file_path = snapshot_dir / (
             f"org_report_{self._sanitize_org_id(resolved_org_id)}_{timestamp_slug}_{snapshot_id[:8]}.json"
         )
-        tmp_path = file_path.with_name(f".{file_path.name}.{uuid.uuid4().hex}.tmp")
         try:
-            with open(tmp_path, "w", encoding="utf-8") as f:
-                json.dump(payload, f, indent=2, ensure_ascii=False)
-            os.replace(tmp_path, file_path)
+            write_json_atomic(file_path, payload, indent=2, ensure_ascii=False)
         except OSError, TypeError, ValueError:
-            with contextlib.suppress(OSError):
-                tmp_path.unlink()
             raise
 
         return file_path

--- a/tests/README.md
+++ b/tests/README.md
@@ -118,7 +118,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 6,266 comprehensive tests**
+**Total: 6,269 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -230,8 +230,8 @@ tests/
 | `test_orchestrator.py` | 19 | Automation orchestrator wrapper CLI and exit-code handling |
 | `test_pipeline_single.py` | 1 | Modular single-dataview pipeline wrapper tests |
 | `test_processing_execution_policy.py` | 10 | Processing execution-policy derivation tests |
-| `test_github_actions_audit.py` | 4 | GitHub Actions audit workflow helper and manifest staging tests |
-| **Total** | **6,266** | **Collected via pytest --collect-only** |
+| `test_github_actions_audit.py` | 5 | GitHub Actions audit workflow helper and manifest staging tests |
+| **Total** | **6,269** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -635,7 +635,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (6,266 tests total)
+- [x] Comprehensive test coverage (6,269 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 175 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 77 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -111,12 +111,14 @@ tests/
 ├── test_discovery_exceptions.py     # Discovery exception classification contracts
 ├── test_lock_backend_edge_cases.py  # Lock backend metadata I/O, stale detection, legacy parsing
 ├── test_org_analyzer_coverage.py    # Org analyzer governance, naming audit, sampling, memory, drift, clustering
+├── test_orchestrator.py             # Automation orchestrator wrapper tests
 ├── test_pipeline_single.py          # Modular single-dataview pipeline wrapper tests
 ├── test_processing_execution_policy.py # Processing execution-policy derivation tests
+├── test_github_actions_audit.py     # GitHub Actions audit workflow helper tests
 └── README.md                        # This file
 ```
 
-**Total: 6,250 comprehensive tests**
+**Total: 6,266 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -168,7 +170,7 @@ tests/
 | `test_config_validation.py` | 55 | Configuration validation logic |
 | `test_credentials.py` | 70 | Credential resolution and source selection |
 | `test_perf.py` | 7 | Performance utilities (cache eviction, statistics) |
-| `test_snapshot.py` | 74 | Diff snapshot creation and comparison |
+| `test_snapshot.py` | 78 | Diff snapshot creation and comparison |
 | `test_colors.py` | 122 | Console color formatting, themes, TTY detection |
 | `test_exceptions.py` | 64 | Custom exception classes construction and formatting |
 | `test_logging_redaction.py` | 158 | Logging, sensitive data redaction, JSON formatter |
@@ -185,8 +187,8 @@ tests/
 | `test_small_module_coverage.py` | 113 | Logging, utils, calculated metrics, constants, lazy, tuning, locks, org cache |
 | `test_diff_inventory_output.py` | 88 | Inventory diff output across all formats (console, JSON, HTML, Excel, MD, CSV) |
 | `test_cli_command_handlers.py` | 146 | CLI dispatch for --stats, --org-report, --list-snapshots, discovery inspection, diff config unpacking |
-| `test_profile_management.py` | 46 | Interactive profile creation, import, test, show |
-| `test_snapshot_commands.py` | 58 | Snapshot creation, comparison, name resolution |
+| `test_profile_management.py` | 47 | Interactive profile creation, import, test, show |
+| `test_snapshot_commands.py` | 59 | Snapshot creation, comparison, name resolution |
 | `test_config_and_resolution.py` | 108 | Config status, validation, stats, name resolution |
 | `test_derived_fields_edge_cases.py` | 34 | Derived fields edge cases and coverage |
 | `test_diff_command_coverage.py` | 45 | Diff command edge cases and coverage |
@@ -225,9 +227,11 @@ tests/
 | `test_check_version_sync.py` | 18 | Version string sync validation across files |
 | `test_cli_color_policy_e2e.py` | 7 | End-to-end CLI color policy behavior tests |
 | `test_discovery_exceptions.py` | 6 | Discovery exception classification contracts |
+| `test_orchestrator.py` | 19 | Automation orchestrator wrapper CLI and exit-code handling |
 | `test_pipeline_single.py` | 1 | Modular single-dataview pipeline wrapper tests |
 | `test_processing_execution_policy.py` | 10 | Processing execution-policy derivation tests |
-| **Total** | **6,250** | **Collected via pytest --collect-only** |
+| `test_github_actions_audit.py` | 4 | GitHub Actions audit workflow helper and manifest staging tests |
+| **Total** | **6,266** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -631,7 +635,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (6,250 tests total)
+- [x] Comprehensive test coverage (6,266 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 175 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 77 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -118,7 +118,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 6,269 comprehensive tests**
+**Total: 6,286 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -230,8 +230,8 @@ tests/
 | `test_orchestrator.py` | 19 | Automation orchestrator wrapper CLI and exit-code handling |
 | `test_pipeline_single.py` | 1 | Modular single-dataview pipeline wrapper tests |
 | `test_processing_execution_policy.py` | 10 | Processing execution-policy derivation tests |
-| `test_github_actions_audit.py` | 5 | GitHub Actions audit workflow helper and manifest staging tests |
-| **Total** | **6,269** | **Collected via pytest --collect-only** |
+| `test_github_actions_audit.py` | 7 | GitHub Actions audit workflow helper and manifest staging tests |
+| **Total** | **6,286** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -635,7 +635,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (6,269 tests total)
+- [x] Comprehensive test coverage (6,286 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 175 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 77 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -116,7 +116,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 6,237 comprehensive tests**
+**Total: 6,250 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -227,7 +227,7 @@ tests/
 | `test_discovery_exceptions.py` | 6 | Discovery exception classification contracts |
 | `test_pipeline_single.py` | 1 | Modular single-dataview pipeline wrapper tests |
 | `test_processing_execution_policy.py` | 10 | Processing execution-policy derivation tests |
-| **Total** | **6,237** | **Collected via pytest --collect-only** |
+| **Total** | **6,250** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -631,7 +631,7 @@ Check for drift (CI-friendly):
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (6,237 tests total)
+- [x] Comprehensive test coverage (6,250 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 175 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 77 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -115,6 +115,9 @@ tests/
 ├── test_pipeline_single.py          # Modular single-dataview pipeline wrapper tests
 ├── test_processing_execution_policy.py # Processing execution-policy derivation tests
 ├── test_github_actions_audit.py     # GitHub Actions audit workflow helper tests
+├── test_example_automation_scripts.py # Automation shell script validation tests
+├── test_exit_codes.py               # Exit code helpers and signal detection tests
+├── test_json_io.py                  # JSON I/O atomic write and read tests
 └── README.md                        # This file
 ```
 
@@ -231,6 +234,9 @@ tests/
 | `test_pipeline_single.py` | 1 | Modular single-dataview pipeline wrapper tests |
 | `test_processing_execution_policy.py` | 10 | Processing execution-policy derivation tests |
 | `test_github_actions_audit.py` | 7 | GitHub Actions audit workflow helper and manifest staging tests |
+| `test_example_automation_scripts.py` | 4 | Automation shell script validation tests |
+| `test_exit_codes.py` | 11 | Exit code helpers and signal detection tests |
+| `test_json_io.py` | 2 | JSON I/O atomic write and read tests |
 | **Total** | **6,286** | **Collected via pytest --collect-only** |
 
 ## Running Tests

--- a/tests/test_example_automation_scripts.py
+++ b/tests/test_example_automation_scripts.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+AUTOMATION_DIR = PROJECT_ROOT / "examples" / "automation"
+
+
+def _install_fake_uv(tmp_path: Path) -> Path:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+
+    fake_uv = bin_dir / "uv"
+    fake_uv.write_text(
+        textwrap.dedent(
+            r"""\
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            args="$*"
+            printf '%s\n' "$args" >> "$FAKE_UV_LOG"
+
+            if [[ "$args" == "run cja_auto_sdr --validate-config" ]]; then
+                exit 0
+            fi
+
+            if [[ "$args" == "run cja_auto_sdr --list-dataviews --format json --output -" ]]; then
+                printf '%s\n' '[{"id":"dv_1"},{"id":"dv_2"}]'
+                exit 0
+            fi
+
+            if [[ "$args" == *"--org-report"* && "$args" == *"--format json --output -"* ]]; then
+                printf '%s\n' '{"status":"ok"}'
+                exit 0
+            fi
+
+            if [[ $args == run\ cja_auto_sdr\ dv_1\ * && $args == *\ --snapshot\ * ]]; then
+                exit "${FAKE_UV_DV1_SNAPSHOT_EXIT:-0}"
+            fi
+
+            exit 0
+            """,
+        ),
+        encoding="utf-8",
+    )
+    fake_uv.chmod(0o755)
+    return fake_uv
+
+
+def _base_env(tmp_path: Path) -> tuple[dict[str, str], Path]:
+    log_path = tmp_path / "uv_calls.log"
+    _install_fake_uv(tmp_path)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "ORG_ID": "test-org",
+            "CLIENT_ID": "test-client",
+            "SECRET": "test-secret",
+            "SCOPES": "test-scopes",
+            "REPORT_DIR": str(tmp_path / "reports"),
+            "SNAPSHOT_DIR": str(tmp_path / "snapshots"),
+            "FAKE_UV_LOG": str(log_path),
+            "FAKE_UV_DV1_SNAPSHOT_EXIT": "143",
+            "PATH": f"{tmp_path / 'bin'}{os.pathsep}{env['PATH']}",
+        },
+    )
+    return env, log_path
+
+
+def _copy_standalone_script(tmp_path: Path, script_name: str) -> Path:
+    standalone_dir = tmp_path / "standalone" / "examples" / "automation"
+    standalone_dir.mkdir(parents=True)
+
+    copied_script = standalone_dir / script_name
+    copied_script.write_text((AUTOMATION_DIR / script_name).read_text(encoding="utf-8"), encoding="utf-8")
+    copied_script.chmod(0o755)
+    return copied_script
+
+
+@pytest.mark.parametrize(
+    ("script_name", "blocked_commands"),
+    [
+        (
+            "weekly_sdr.sh",
+            [
+                "run cja_auto_sdr dv_2 --format excel",
+            ],
+        ),
+        (
+            "quarterly_maintenance.sh",
+            [
+                "run cja_auto_sdr dv_2 --format all",
+                "run cja_auto_sdr --org-report",
+                "run cja_auto_sdr --prune-snapshots",
+                "run cja_auto_sdr dv_1 --format reports",
+            ],
+        ),
+    ],
+)
+def test_snapshot_signal_exit_stops_automation_immediately(
+    tmp_path: Path,
+    script_name: str,
+    blocked_commands: list[str],
+) -> None:
+    env, log_path = _base_env(tmp_path)
+
+    result = subprocess.run(
+        ["bash", str(AUTOMATION_DIR / script_name)],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 143
+    assert "interrupted" in result.stderr
+    assert "exit 143" in result.stderr
+
+    calls = log_path.read_text(encoding="utf-8").splitlines()
+    assert any("run cja_auto_sdr dv_1 --snapshot" in call for call in calls)
+    for blocked_command in blocked_commands:
+        assert all(blocked_command not in call for call in calls)
+
+
+def test_weekly_script_remains_self_contained_without_common_helper(tmp_path: Path) -> None:
+    env, log_path = _base_env(tmp_path)
+    copied_script = _copy_standalone_script(tmp_path, "weekly_sdr.sh")
+
+    result = subprocess.run(
+        ["bash", str(copied_script)],
+        cwd=tmp_path / "standalone",
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 143
+    assert "_common.sh" not in result.stderr
+    assert "interrupted" in result.stderr
+
+    calls = log_path.read_text(encoding="utf-8").splitlines()
+    assert any("run cja_auto_sdr dv_1 --snapshot" in call for call in calls)
+
+
+def test_daily_drift_check_preserves_signal_exit_during_baseline_creation(tmp_path: Path) -> None:
+    env, log_path = _base_env(tmp_path)
+    env["DATA_VIEW_ID"] = "dv_1"
+
+    result = subprocess.run(
+        ["bash", str(AUTOMATION_DIR / "daily_drift_check.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 143
+    assert "Baseline creation interrupted" in result.stderr
+    assert "exit 143" in result.stderr
+
+    calls = log_path.read_text(encoding="utf-8").splitlines()
+    assert calls == [
+        f"run cja_auto_sdr dv_1 --snapshot {tmp_path / 'snapshots' / 'dv_1_baseline.json'}",
+    ]

--- a/tests/test_exit_codes.py
+++ b/tests/test_exit_codes.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import pytest
+
+from cja_auto_sdr.core.exit_codes import combine_wrapper_exit_codes, is_signal_exit_code, normalize_subprocess_exit_code
+
+
+@pytest.mark.parametrize(
+    ("current", "new_code", "expected"),
+    [
+        (0, 0, 0),
+        (0, 3, 3),
+        (3, 2, 2),
+        (2, 1, 1),
+        (99, 0, 1),
+        (0, 99, 1),
+        (-2, 0, 130),
+        (0, -15, 143),
+        (130, 0, 130),
+    ],
+)
+def test_combine_wrapper_exit_codes_preserves_priority_and_fails_closed(current, new_code, expected):
+    assert combine_wrapper_exit_codes(current, new_code) == expected
+
+
+def test_is_signal_exit_code_excludes_signal_base_marker():
+    assert is_signal_exit_code(128) is False
+    assert is_signal_exit_code(129) is True
+
+
+def test_normalize_subprocess_exit_code_converts_negative_signals():
+    assert normalize_subprocess_exit_code(-2) == 130
+    assert normalize_subprocess_exit_code(2) == 2

--- a/tests/test_github_actions_audit.py
+++ b/tests/test_github_actions_audit.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from types import SimpleNamespace
 
 import pytest
@@ -127,3 +128,21 @@ def test_stage_manifest_stages_only_manifest_entries(tmp_path):
 
     assert exit_code == 0
     assert git_calls == [["git", "add", "--", str(snapshot_a), str(snapshot_b)]]
+
+
+def test_run_cja_command_returns_bounded_timeout_error(monkeypatch):
+    calls = []
+
+    def _fake_run(command, **kwargs):
+        calls.append((command, kwargs["timeout"]))
+        raise subprocess.TimeoutExpired(command, kwargs["timeout"])
+
+    monkeypatch.setattr(github_actions_audit.subprocess, "run", _fake_run)
+
+    result = github_actions_audit.run_cja_command(["--validate-config"], timeout=12)
+
+    assert result.exit_code == 1
+    assert result.stderr == "Command timed out after 12s"
+    assert result.command == ("uv", "run", "cja_auto_sdr", "--validate-config")
+    assert result.interrupted is False
+    assert calls == [(["uv", "run", "cja_auto_sdr", "--validate-config"], 12)]

--- a/tests/test_github_actions_audit.py
+++ b/tests/test_github_actions_audit.py
@@ -165,3 +165,50 @@ def test_run_cja_command_returns_bounded_timeout_error(monkeypatch):
             12,
         )
     ]
+
+
+def test_main_returns_audit_exit_code_outside_github_actions(monkeypatch, capsys):
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    monkeypatch.setattr(
+        github_actions_audit,
+        "run_audit",
+        lambda **kwargs: github_actions_audit.AuditOutcome(
+            audit_exit_code=2,
+            publish_ready=False,
+            successful_snapshot_manifest="reports/manifest.json",
+            interrupted=False,
+            successful_snapshots=[],
+        ),
+    )
+
+    exit_code = github_actions_audit.main(["audit"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 2
+    assert payload["audit_exit_code"] == 2
+    assert payload["publish_ready"] is False
+
+
+def test_main_defers_audit_exit_code_when_github_output_is_present(monkeypatch, tmp_path, capsys):
+    github_output = tmp_path / "github_output.txt"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
+    monkeypatch.setattr(
+        github_actions_audit,
+        "run_audit",
+        lambda **kwargs: github_actions_audit.AuditOutcome(
+            audit_exit_code=3,
+            publish_ready=True,
+            successful_snapshot_manifest="reports/manifest.json",
+            interrupted=False,
+            successful_snapshots=["snapshots/dv_1_baseline.json"],
+        ),
+    )
+
+    exit_code = github_actions_audit.main(["audit"])
+    payload = json.loads(capsys.readouterr().out)
+    github_output_text = github_output.read_text(encoding="utf-8")
+
+    assert exit_code == 0
+    assert payload["audit_exit_code"] == 3
+    assert "audit_exit_code=3\n" in github_output_text
+    assert "publish_ready=true\n" in github_output_text

--- a/tests/test_github_actions_audit.py
+++ b/tests/test_github_actions_audit.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+from scripts import github_actions_audit
+
+
+def _command_result(exit_code: int, *, stdout: str = "", stderr: str = "") -> github_actions_audit.CommandResult:
+    return github_actions_audit.CommandResult(
+        exit_code=exit_code,
+        stdout=stdout,
+        stderr=stderr,
+        command=("uv", "run", "cja_auto_sdr"),
+        interrupted=github_actions_audit._is_signal_exit_code(exit_code),
+    )
+
+
+def _write_snapshot(path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "snapshot_version": "1.0",
+                "data_view_id": path.stem,
+                "data_view_name": path.stem,
+                "created_at": "2024-01-01T00:00:00+00:00",
+                "metrics": [],
+                "dimensions": [],
+            },
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_run_audit_sets_publish_ready_from_successful_manifest_even_after_later_failure(tmp_path):
+    reports_dir = tmp_path / "reports"
+    snapshot_dir = tmp_path / "snapshots"
+    runner_calls = []
+
+    def _runner(args, *, forward_stdout=True, forward_stderr=True):
+        runner_calls.append(tuple(args))
+        if args == ["dv_1", "--format", "reports", "--output-dir", str(reports_dir)]:
+            return _command_result(0)
+        if args == ["dv_1", "--snapshot", str(snapshot_dir / "dv_1_baseline.json")]:
+            return _command_result(0)
+        if args == ["dv_2", "--format", "reports", "--output-dir", str(reports_dir)]:
+            return _command_result(1)
+        raise AssertionError(f"Unexpected command: {args}")
+
+    outcome = github_actions_audit.run_audit(
+        data_view_ids="dv_1,dv_2",
+        reports_dir=str(reports_dir),
+        snapshot_dir=str(snapshot_dir),
+        runner=_runner,
+    )
+
+    assert outcome.audit_exit_code == 1
+    assert outcome.publish_ready is True
+    assert outcome.interrupted is False
+    manifest_payload = json.loads((reports_dir / "successful_snapshots_manifest.json").read_text(encoding="utf-8"))
+    assert manifest_payload["successful_snapshots"] == [str(snapshot_dir / "dv_1_baseline.json")]
+    assert runner_calls == [
+        ("dv_1", "--format", "reports", "--output-dir", str(reports_dir)),
+        ("dv_1", "--snapshot", str(snapshot_dir / "dv_1_baseline.json")),
+        ("dv_2", "--format", "reports", "--output-dir", str(reports_dir)),
+    ]
+
+
+def test_run_audit_clears_publish_ready_when_interrupted(tmp_path):
+    reports_dir = tmp_path / "reports"
+    snapshot_dir = tmp_path / "snapshots"
+
+    outcome = github_actions_audit.run_audit(
+        data_view_ids="dv_1",
+        reports_dir=str(reports_dir),
+        snapshot_dir=str(snapshot_dir),
+        runner=lambda args, *, forward_stdout=True, forward_stderr=True: _command_result(130),
+    )
+
+    assert outcome.audit_exit_code == 130
+    assert outcome.publish_ready is False
+    assert outcome.interrupted is True
+    manifest_payload = json.loads((reports_dir / "successful_snapshots_manifest.json").read_text(encoding="utf-8"))
+    assert manifest_payload["successful_snapshots"] == []
+
+
+def test_stage_manifest_rejects_invalid_json_before_git_add(tmp_path):
+    manifest_path = tmp_path / "manifest.json"
+    invalid_snapshot = tmp_path / "snapshots" / "broken.json"
+    invalid_snapshot.parent.mkdir(parents=True, exist_ok=True)
+    invalid_snapshot.write_text("{not-json", encoding="utf-8")
+    manifest_path.write_text(
+        json.dumps({"successful_snapshots": [str(invalid_snapshot)]}),
+        encoding="utf-8",
+    )
+
+    git_calls = []
+
+    with pytest.raises(json.JSONDecodeError):
+        github_actions_audit.stage_manifest_snapshots(
+            manifest_path,
+            git_runner=lambda command: git_calls.append(command) or SimpleNamespace(returncode=0),
+        )
+
+    assert git_calls == []
+
+
+def test_stage_manifest_stages_only_manifest_entries(tmp_path):
+    manifest_path = tmp_path / "manifest.json"
+    snapshot_a = tmp_path / "snapshots" / "a.json"
+    snapshot_b = tmp_path / "snapshots" / "b.json"
+    _write_snapshot(snapshot_a)
+    _write_snapshot(snapshot_b)
+    manifest_path.write_text(
+        json.dumps({"successful_snapshots": [str(snapshot_a), str(snapshot_b)]}),
+        encoding="utf-8",
+    )
+
+    git_calls = []
+
+    exit_code = github_actions_audit.stage_manifest_snapshots(
+        manifest_path,
+        git_runner=lambda command: git_calls.append(command) or SimpleNamespace(returncode=0),
+    )
+
+    assert exit_code == 0
+    assert git_calls == [["git", "add", "--", str(snapshot_a), str(snapshot_b)]]

--- a/tests/test_github_actions_audit.py
+++ b/tests/test_github_actions_audit.py
@@ -13,7 +13,7 @@ def _command_result(exit_code: int, *, stdout: str = "", stderr: str = "") -> gi
         exit_code=exit_code,
         stdout=stdout,
         stderr=stderr,
-        command=("uv", "run", "cja_auto_sdr"),
+        command=("uv", "run", "--project", str(github_actions_audit.PROJECT_ROOT), "cja_auto_sdr"),
         interrupted=github_actions_audit._is_signal_exit_code(exit_code),
     )
 
@@ -143,6 +143,25 @@ def test_run_cja_command_returns_bounded_timeout_error(monkeypatch):
 
     assert result.exit_code == 1
     assert result.stderr == "Command timed out after 12s"
-    assert result.command == ("uv", "run", "cja_auto_sdr", "--validate-config")
+    assert result.command == (
+        "uv",
+        "run",
+        "--project",
+        str(github_actions_audit.PROJECT_ROOT),
+        "cja_auto_sdr",
+        "--validate-config",
+    )
     assert result.interrupted is False
-    assert calls == [(["uv", "run", "cja_auto_sdr", "--validate-config"], 12)]
+    assert calls == [
+        (
+            [
+                "uv",
+                "run",
+                "--project",
+                str(github_actions_audit.PROJECT_ROOT),
+                "cja_auto_sdr",
+                "--validate-config",
+            ],
+            12,
+        )
+    ]

--- a/tests/test_json_io.py
+++ b/tests/test_json_io.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from cja_auto_sdr.core.json_io import write_json_atomic
+
+
+class _StringOnlyValue:
+    def __str__(self) -> str:
+        return "serialized-via-default"
+
+
+def test_write_json_atomic_supports_default_sort_keys_and_trailing_newline(tmp_path):
+    output_path = tmp_path / "payload.json"
+
+    write_json_atomic(
+        output_path,
+        {
+            "z_key": _StringOnlyValue(),
+            "a_key": 1,
+        },
+        sort_keys=True,
+        trailing_newline=True,
+        default=str,
+    )
+
+    raw_text = output_path.read_text(encoding="utf-8")
+
+    assert raw_text.endswith("\n")
+    assert raw_text.index('"a_key"') < raw_text.index('"z_key"')
+    assert json.loads(raw_text) == {
+        "a_key": 1,
+        "z_key": "serialized-via-default",
+    }
+
+
+@pytest.mark.skipif(not hasattr(os, "fchmod"), reason="requires os.fchmod support")
+def test_write_json_atomic_applies_explicit_file_mode(tmp_path):
+    output_path = tmp_path / "secret.json"
+
+    write_json_atomic(output_path, {"token": "value"}, file_mode=0o600)
+
+    assert Path(output_path).exists()
+    assert stat.S_IMODE(output_path.stat().st_mode) == 0o600

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -32,6 +32,34 @@ def test_run_targets_repo_project_without_overriding_caller_cwd(monkeypatch):
     ]
 
 
+def test_run_normalizes_signal_exit_codes(monkeypatch):
+    def _fake_run(*args, **kwargs):
+        return SimpleNamespace(returncode=-2, stdout="", stderr="")
+
+    monkeypatch.setattr(orchestrator.subprocess, "run", _fake_run)
+
+    result = orchestrator._run(["dv_123", "--format", "json", "--output", "-"])
+
+    assert result["success"] is False
+    assert result["raw_exit_code"] == -2
+    assert result["exit_code"] == 130
+
+
+def test_run_returns_structured_interrupt_result_when_wrapper_is_interrupted(monkeypatch):
+    def _fake_run(*args, **kwargs):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(orchestrator.subprocess, "run", _fake_run)
+
+    result = orchestrator._run(["dv_123", "--format", "json", "--output", "-"])
+
+    assert result["success"] is False
+    assert result["exit_code"] == 130
+    assert result["error_type"] == "interrupted"
+    assert result["interrupted"] is True
+    assert "interrupted" in result["stderr"].lower()
+
+
 def test_path_args_remain_caller_relative_when_subprocesses_run_from_project_root(monkeypatch, tmp_path):
     commands = []
 
@@ -283,6 +311,38 @@ def test_main_discovers_data_views_and_preserves_policy_exit_code(monkeypatch, c
     assert payload["data_views_processed"] == 2
 
 
+def test_main_stops_batch_and_preserves_interrupt_exit_code(monkeypatch, capsys):
+    monkeypatch.setattr(
+        orchestrator,
+        "_validate_config_result",
+        lambda *, shared_args=None, timeout=orchestrator.DEFAULT_TIMEOUT: {
+            "success": True,
+            "exit_code": 0,
+            "stderr": "",
+            "stdout": "",
+        },
+    )
+    run_calls = []
+    run_results = {
+        "dv_1": {"data_view": "dv_1", "exit_code": 0, "success": True},
+        "dv_2": {"data_view": "dv_2", "exit_code": 130, "success": False},
+    }
+
+    def _fake_run_sdr(data_view, fmt="json", output_dir=None, extra_args=None, *, shared_args=None, timeout=0):
+        run_calls.append(data_view)
+        return run_results[data_view]
+
+    monkeypatch.setattr(orchestrator, "run_sdr", _fake_run_sdr)
+
+    exit_code = orchestrator.main(["dv_1", "dv_2", "dv_3"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 130
+    assert payload["overall_exit_code"] == 130
+    assert payload["data_views_processed"] == 2
+    assert run_calls == ["dv_1", "dv_2"]
+
+
 def test_main_discover_overrides_data_views_environment(monkeypatch, capsys):
     monkeypatch.setenv("DATA_VIEWS", "stale_dv")
     monkeypatch.setattr(
@@ -317,6 +377,44 @@ def test_main_discover_overrides_data_views_environment(monkeypatch, capsys):
     assert run_calls == ["fresh_dv"]
 
 
+def test_main_validation_failure_preserves_interrupt_exit_code(monkeypatch, capsys):
+    monkeypatch.setattr(
+        orchestrator,
+        "_validate_config_result",
+        lambda *, shared_args=None, timeout=orchestrator.DEFAULT_TIMEOUT: {
+            "success": False,
+            "exit_code": 130,
+            "stderr": "Interrupted",
+            "stdout": "",
+        },
+    )
+
+    exit_code = orchestrator.main(["dv_123"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 130
+    assert payload["stage"] == "validation"
+    assert payload["exit_code"] == 130
+    assert payload["error_type"] == "interrupted"
+    assert payload["interrupted"] is True
+
+
+def test_main_emits_json_interrupt_when_keyboard_interrupt_escapes_run_path(monkeypatch, capsys):
+    def _raise_keyboard_interrupt(args):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(orchestrator, "_build_shared_args", _raise_keyboard_interrupt)
+
+    exit_code = orchestrator.main(["dv_123"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 130
+    assert payload["stage"] == "interrupted"
+    assert payload["exit_code"] == 130
+    assert payload["error_type"] == "interrupted"
+    assert payload["interrupted"] is True
+
+
 def test_main_discover_reports_empty_org_without_error(monkeypatch, capsys):
     monkeypatch.setattr(
         orchestrator,
@@ -340,6 +438,7 @@ def test_main_discover_emits_json_error_on_discovery_failure(monkeypatch, capsys
         lambda *, shared_args=None, timeout=orchestrator.DEFAULT_TIMEOUT: (_ for _ in ()).throw(
             orchestrator.OrchestratorError(
                 "Data view discovery failed with exit code 1: bad credentials",
+                stage="data_view_resolution",
                 result={"exit_code": 1},
             )
         ),
@@ -351,3 +450,24 @@ def test_main_discover_emits_json_error_on_discovery_failure(monkeypatch, capsys
     assert exit_code == 1
     assert payload["stage"] == "data_view_resolution"
     assert "bad credentials" in payload["error"]
+
+
+def test_main_preserves_orchestrator_error_stage(monkeypatch, capsys):
+    monkeypatch.setattr(
+        orchestrator,
+        "_build_shared_args",
+        lambda args: (_ for _ in ()).throw(
+            orchestrator.OrchestratorError(
+                "Synthetic staged failure",
+                stage="custom_stage",
+                result={"exit_code": 1},
+            )
+        ),
+    )
+
+    exit_code = orchestrator.main(["dv_123"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    assert payload["stage"] == "custom_stage"
+    assert payload["error"] == "Synthetic staged failure"

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,4 +1,145 @@
+import json
+from types import SimpleNamespace
+
+import pytest
 from scripts import orchestrator
+
+
+def test_run_targets_repo_project_without_overriding_caller_cwd(monkeypatch):
+    calls = []
+
+    def _fake_run(*args, **kwargs):
+        calls.append((args[0], kwargs.get("cwd")))
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(orchestrator.subprocess, "run", _fake_run)
+
+    result = orchestrator._run(["--validate-config"])
+
+    assert result["success"] is True
+    assert calls == [
+        (
+            [
+                "uv",
+                "run",
+                "--project",
+                str(orchestrator.PROJECT_ROOT),
+                "cja_auto_sdr",
+                "--validate-config",
+            ],
+            None,
+        )
+    ]
+
+
+def test_path_args_remain_caller_relative_when_subprocesses_run_from_project_root(monkeypatch, tmp_path):
+    commands = []
+
+    def _fake_run(*args, **kwargs):
+        commands.append((args[0], kwargs.get("cwd")))
+        return SimpleNamespace(returncode=0, stdout="{}", stderr="")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(orchestrator.subprocess, "run", _fake_run)
+
+    parser = orchestrator._build_parser()
+    parsed = parser.parse_args(["--config-file", "./config.json", "dv_123"])
+    shared_args = orchestrator._build_shared_args(parsed)
+
+    orchestrator.run_sdr("dv_123", output_dir="./reports", shared_args=shared_args)
+    orchestrator.run_diff("dv_123", "./snapshots/base.json", shared_args=shared_args)
+    orchestrator.run_snapshot("dv_123", "./snapshots/new.json", shared_args=shared_args)
+
+    expected_config = str((tmp_path / "config.json").resolve())
+    expected_output_dir = str((tmp_path / "reports").resolve())
+    expected_diff_snapshot = str((tmp_path / "snapshots" / "base.json").resolve())
+    expected_new_snapshot = str((tmp_path / "snapshots" / "new.json").resolve())
+
+    assert commands == [
+        (
+            [
+                "uv",
+                "run",
+                "--project",
+                str(orchestrator.PROJECT_ROOT),
+                "cja_auto_sdr",
+                "--config-file",
+                expected_config,
+                "dv_123",
+                "--format",
+                "json",
+                "--output-dir",
+                expected_output_dir,
+                "--output",
+                "-",
+            ],
+            None,
+        ),
+        (
+            [
+                "uv",
+                "run",
+                "--project",
+                str(orchestrator.PROJECT_ROOT),
+                "cja_auto_sdr",
+                "--config-file",
+                expected_config,
+                "dv_123",
+                "--diff-snapshot",
+                expected_diff_snapshot,
+                "--format",
+                "json",
+                "--output",
+                "-",
+            ],
+            None,
+        ),
+        (
+            [
+                "uv",
+                "run",
+                "--project",
+                str(orchestrator.PROJECT_ROOT),
+                "cja_auto_sdr",
+                "--config-file",
+                expected_config,
+                "dv_123",
+                "--snapshot",
+                expected_new_snapshot,
+            ],
+            None,
+        ),
+    ]
+
+
+def test_run_sdr_file_formats_keep_caller_default_output_directory(monkeypatch, tmp_path):
+    calls = []
+
+    def _fake_run(*args, **kwargs):
+        calls.append((args[0], kwargs.get("cwd")))
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(orchestrator.subprocess, "run", _fake_run)
+
+    result = orchestrator.run_sdr("dv_123", fmt="excel")
+
+    assert result["success"] is True
+    assert calls == [
+        (
+            [
+                "uv",
+                "run",
+                "--project",
+                str(orchestrator.PROJECT_ROOT),
+                "cja_auto_sdr",
+                "dv_123",
+                "--format",
+                "excel",
+            ],
+            None,
+        )
+    ]
 
 
 def test_list_dataviews_unwraps_data_views_envelope(monkeypatch):
@@ -34,3 +175,179 @@ def test_list_snapshots_unwraps_snapshots_envelope(monkeypatch):
         {"filepath": "/tmp/a.json"},
         {"filepath": "/tmp/b.json"},
     ]
+
+
+def test_list_dataviews_raises_on_cli_failure(monkeypatch):
+    monkeypatch.setattr(
+        orchestrator,
+        "_run",
+        lambda *args, **kwargs: {
+            "success": False,
+            "exit_code": 1,
+            "stderr": '{"error": "Configuration error: Missing credentials"}',
+        },
+    )
+
+    with pytest.raises(orchestrator.OrchestratorError, match="Missing credentials"):
+        orchestrator.list_dataviews()
+
+
+def test_list_snapshots_raises_on_cli_failure(monkeypatch):
+    monkeypatch.setattr(
+        orchestrator,
+        "_run",
+        lambda *args, **kwargs: {
+            "success": False,
+            "exit_code": 1,
+            "stderr": '{"error": "Snapshot listing failed"}',
+        },
+    )
+
+    with pytest.raises(orchestrator.OrchestratorError, match="Snapshot listing failed"):
+        orchestrator.list_snapshots()
+
+
+def test_main_forwards_profile_without_treating_it_as_data_view(monkeypatch, capsys):
+    validation_calls = []
+    run_calls = []
+
+    def _fake_validate(*, shared_args=None, timeout=orchestrator.DEFAULT_TIMEOUT):
+        validation_calls.append((shared_args, timeout))
+        return {"success": True, "exit_code": 0, "stderr": "", "stdout": ""}
+
+    def _fake_run_sdr(data_view, fmt="json", output_dir=None, extra_args=None, *, shared_args=None, timeout=0):
+        run_calls.append((data_view, fmt, shared_args, timeout))
+        return {"data_view": data_view, "exit_code": 0, "success": True}
+
+    monkeypatch.setattr(orchestrator, "_validate_config_result", _fake_validate)
+    monkeypatch.setattr(orchestrator, "run_sdr", _fake_run_sdr)
+
+    exit_code = orchestrator.main(["--profile", "client-a", "dv_123"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["data_views_processed"] == 1
+    assert payload["data_views_source"] == "argv"
+    assert validation_calls == [(["--profile", "client-a"], orchestrator.DEFAULT_TIMEOUT)]
+    assert run_calls == [("dv_123", "json", ["--profile", "client-a"], orchestrator.DEFAULT_TIMEOUT)]
+
+
+def test_main_rejects_unknown_wrapper_options(capsys):
+    exit_code = orchestrator.main(["--batch", "dv_123"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    assert payload["stage"] == "arguments"
+    assert "unrecognized arguments: --batch" in payload["error"]
+
+
+def test_main_discovers_data_views_and_preserves_policy_exit_code(monkeypatch, capsys):
+    monkeypatch.setattr(
+        orchestrator,
+        "_validate_config_result",
+        lambda *, shared_args=None, timeout=orchestrator.DEFAULT_TIMEOUT: {
+            "success": True,
+            "exit_code": 0,
+            "stderr": "",
+            "stdout": "",
+        },
+    )
+    monkeypatch.setattr(
+        orchestrator,
+        "list_dataviews",
+        lambda *, shared_args=None, timeout=orchestrator.DEFAULT_TIMEOUT: [
+            {"id": "dv_1"},
+            {"id": "dv_2"},
+        ],
+    )
+    run_results = iter(
+        [
+            {"data_view": "dv_1", "exit_code": 0, "success": True},
+            {"data_view": "dv_2", "exit_code": 2, "success": False},
+        ]
+    )
+    monkeypatch.setattr(
+        orchestrator,
+        "run_sdr",
+        lambda data_view, fmt="json", output_dir=None, extra_args=None, *, shared_args=None, timeout=0: next(
+            run_results
+        ),
+    )
+
+    exit_code = orchestrator.main(["--profile", "client-a", "--discover"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 2
+    assert payload["data_views_source"] == "discover"
+    assert payload["overall_exit_code"] == 2
+    assert payload["data_views_processed"] == 2
+
+
+def test_main_discover_overrides_data_views_environment(monkeypatch, capsys):
+    monkeypatch.setenv("DATA_VIEWS", "stale_dv")
+    monkeypatch.setattr(
+        orchestrator,
+        "_validate_config_result",
+        lambda *, shared_args=None, timeout=orchestrator.DEFAULT_TIMEOUT: {
+            "success": True,
+            "exit_code": 0,
+            "stderr": "",
+            "stdout": "",
+        },
+    )
+    monkeypatch.setattr(
+        orchestrator,
+        "list_dataviews",
+        lambda *, shared_args=None, timeout=orchestrator.DEFAULT_TIMEOUT: [{"id": "fresh_dv"}],
+    )
+    run_calls = []
+    monkeypatch.setattr(
+        orchestrator,
+        "run_sdr",
+        lambda data_view, fmt="json", output_dir=None, extra_args=None, *, shared_args=None, timeout=0: (
+            run_calls.append(data_view) or {"data_view": data_view, "exit_code": 0, "success": True}
+        ),
+    )
+
+    exit_code = orchestrator.main(["--discover"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["data_views_source"] == "discover"
+    assert run_calls == ["fresh_dv"]
+
+
+def test_main_discover_reports_empty_org_without_error(monkeypatch, capsys):
+    monkeypatch.setattr(
+        orchestrator,
+        "list_dataviews",
+        lambda *, shared_args=None, timeout=orchestrator.DEFAULT_TIMEOUT: [],
+    )
+
+    exit_code = orchestrator.main(["--discover"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["data_views_source"] == "discover"
+    assert payload["data_views_processed"] == 0
+    assert payload["overall_exit_code"] == 0
+
+
+def test_main_discover_emits_json_error_on_discovery_failure(monkeypatch, capsys):
+    monkeypatch.setattr(
+        orchestrator,
+        "list_dataviews",
+        lambda *, shared_args=None, timeout=orchestrator.DEFAULT_TIMEOUT: (_ for _ in ()).throw(
+            orchestrator.OrchestratorError(
+                "Data view discovery failed with exit code 1: bad credentials",
+                result={"exit_code": 1},
+            )
+        ),
+    )
+
+    exit_code = orchestrator.main(["--discover"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    assert payload["stage"] == "data_view_resolution"
+    assert "bad credentials" in payload["error"]

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,36 @@
+from scripts import orchestrator
+
+
+def test_list_dataviews_unwraps_data_views_envelope(monkeypatch):
+    monkeypatch.setattr(
+        orchestrator,
+        "_run",
+        lambda *args, **kwargs: {
+            "success": True,
+            "data": {
+                "dataViews": [{"id": "dv_1"}, {"id": "dv_2"}],
+                "count": 2,
+            },
+        },
+    )
+
+    assert orchestrator.list_dataviews() == [{"id": "dv_1"}, {"id": "dv_2"}]
+
+
+def test_list_snapshots_unwraps_snapshots_envelope(monkeypatch):
+    monkeypatch.setattr(
+        orchestrator,
+        "_run",
+        lambda *args, **kwargs: {
+            "success": True,
+            "data": {
+                "snapshots": [{"filepath": "/tmp/a.json"}, {"filepath": "/tmp/b.json"}],
+                "count": 2,
+            },
+        },
+    )
+
+    assert orchestrator.list_snapshots("/tmp/snapshots") == [
+        {"filepath": "/tmp/a.json"},
+        {"filepath": "/tmp/b.json"},
+    ]

--- a/tests/test_org_report.py
+++ b/tests/test_org_report.py
@@ -2129,7 +2129,7 @@ class TestOrgReportCache:
         with tempfile.TemporaryDirectory() as tmpdir:
             cache = OrgReportCache(cache_dir=Path(tmpdir), logger=logger)
 
-            with patch("builtins.open", side_effect=OSError("disk full")):
+            with patch("cja_auto_sdr.org.cache.write_json_atomic", side_effect=OSError("disk full")):
                 cache.put(DataViewSummary("dv_test", "Test DV"))
 
             logger.warning.assert_called()

--- a/tests/test_output_content_validation.py
+++ b/tests/test_output_content_validation.py
@@ -38,7 +38,7 @@ def rich_data_dict():
         "Metadata": pd.DataFrame(
             {
                 "Property": ["Generated At", "Data View ID", "Tool Version", "Total Metrics"],
-                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.4.1", 3],
+                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.4.2", 3],
             },
         ),
         "Data Quality": pd.DataFrame(
@@ -104,7 +104,7 @@ def rich_metadata_dict():
         "Generated At": "2025-01-15 10:30:00 PST",
         "Data View ID": "dv_content_test",
         "Data View Name": "Test DataView",
-        "Tool Version": "3.4.1",
+        "Tool Version": "3.4.2",
         "Metrics Count": "3",
         "Dimensions Count": "4",
     }
@@ -224,7 +224,7 @@ class TestJSONContentValidation:
             data = json.load(f)
 
         assert data["metadata"]["Data View ID"] == "dv_content_test"
-        assert data["metadata"]["Tool Version"] == "3.4.1"
+        assert data["metadata"]["Tool Version"] == "3.4.2"
 
     def test_json_metadata_preserves_partial_markers(self, tmp_path, rich_data_dict, rich_metadata_dict):
         logger = logging.getLogger("json_test")

--- a/tests/test_profile_management.py
+++ b/tests/test_profile_management.py
@@ -101,6 +101,7 @@ class TestAddProfileInteractive:
         assert config["client_id"] == "new_client_id"
         assert config["secret"] == "new_secret_value"
         assert config["scopes"] == "openid,AdobeID"
+        assert (profile_dir / "config.json").stat().st_mode & 0o777 == 0o600
 
     def test_successful_creation_new_profile(self, tmp_path, capsys):
         """Full happy-path creation of a brand new profile."""
@@ -123,6 +124,7 @@ class TestAddProfileInteractive:
 
         config = json.loads((profile_dir / "config.json").read_text())
         assert config["org_id"] == "MyOrg@AdobeOrg"
+        assert (profile_dir / "config.json").stat().st_mode & 0o777 == 0o600
 
     def test_empty_org_id_aborts(self, tmp_path, capsys):
         """Empty organization ID causes early exit."""
@@ -258,7 +260,7 @@ class TestAddProfileInteractive:
             patch("cja_auto_sdr.generator.get_profile_path", return_value=profile_dir),
             patch("builtins.input", side_effect=inputs),
             patch("getpass.getpass", return_value="my_secret"),
-            patch("os.open", side_effect=OSError("Disk full")),
+            patch("cja_auto_sdr.core.profiles.write_json_atomic", side_effect=OSError("Disk full")),
         ):
             result = add_profile_interactive("write-fail")
 
@@ -405,6 +407,7 @@ class TestImportProfileNonInteractiveExtended:
         assert result is True
         config = json.loads((profile_dir / "config.json").read_text())
         assert config["org_id"] == VALID_CREDENTIALS["org_id"]
+        assert (profile_dir / "config.json").stat().st_mode & 0o777 == 0o600
 
     def test_overwrite_warns_about_existing_dotenv(self, tmp_path, capsys):
         """Overwrite with existing .env should warn about potential conflicts."""
@@ -432,13 +435,33 @@ class TestImportProfileNonInteractiveExtended:
 
         with (
             patch("cja_auto_sdr.generator.get_profile_path", return_value=profile_dir),
-            patch("os.open", side_effect=OSError("Permission denied")),
+            patch("cja_auto_sdr.core.profiles.write_json_atomic", side_effect=OSError("Permission denied")),
         ):
             result = import_profile_non_interactive("bad-write", source)
 
         assert result is False
         captured = capsys.readouterr()
         assert "Error writing profile config" in captured.err
+
+    def test_overwrite_rejects_symlink_destination(self, tmp_path, capsys):
+        """Existing config.json symlinks are rejected instead of being replaced."""
+        source = tmp_path / "credentials.json"
+        source.write_text(json.dumps(VALID_CREDENTIALS))
+
+        profile_dir = tmp_path / "orgs" / "linked-profile"
+        profile_dir.mkdir(parents=True)
+        target_file = tmp_path / "real-config.json"
+        target_file.write_text(json.dumps({"org_id": "ORIGINAL@AdobeOrg"}))
+        (profile_dir / "config.json").symlink_to(target_file)
+
+        with patch("cja_auto_sdr.generator.get_profile_path", return_value=profile_dir):
+            result = import_profile_non_interactive("linked-profile", source, overwrite=True)
+
+        assert result is False
+        captured = capsys.readouterr()
+        assert "symlink" in captured.err.lower()
+        assert json.loads(target_file.read_text())["org_id"] == "ORIGINAL@AdobeOrg"
+        assert (profile_dir / "config.json").is_symlink()
 
     def test_validation_failure(self, tmp_path, capsys):
         """Credentials that fail strict validation should be rejected."""

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -9,10 +9,13 @@ import logging
 import os
 import sys
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 from zoneinfo import ZoneInfo
 
 import pytest
+
+import cja_auto_sdr.core.json_io as json_io
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -394,6 +397,81 @@ class TestCreateSnapshot:
             manager.create_snapshot(cja, "dv_test", quiet=True, include_segments=True)
             captured = capsys.readouterr()
             assert "quiet seg" not in captured.out
+
+
+# ==================== save_snapshot Tests ====================
+
+
+class TestSaveSnapshot:
+    """Tests for SnapshotManager.save_snapshot."""
+
+    def test_save_snapshot_writes_json(self, manager, sample_snapshot, tmp_path):
+        filepath = tmp_path / "snapshot.json"
+
+        saved = manager.save_snapshot(sample_snapshot, str(filepath))
+
+        assert saved == str(filepath.resolve())
+        with open(filepath, encoding="utf-8") as f:
+            data = json.load(f)
+        assert data["data_view_id"] == sample_snapshot.data_view_id
+        assert data["snapshot_version"] == sample_snapshot.snapshot_version
+
+    def test_save_snapshot_fsyncs_parent_directory(self, manager, sample_snapshot, tmp_path, monkeypatch):
+        filepath = tmp_path / "snapshot.json"
+        fsync_calls: list[Path] = []
+
+        monkeypatch.setattr(json_io, "_fsync_directory", lambda directory: fsync_calls.append(Path(directory)))
+
+        manager.save_snapshot(sample_snapshot, str(filepath))
+
+        assert fsync_calls == [tmp_path.resolve()]
+
+    def test_save_snapshot_rejects_symlink_destination(self, manager, sample_snapshot, tmp_path):
+        target_file = tmp_path / "real-snapshot.json"
+        target_file.write_text('{"snapshot_version": "1.0", "data_view_id": "dv_original"}', encoding="utf-8")
+        link_path = tmp_path / "snapshot.json"
+        link_path.symlink_to(target_file)
+
+        with pytest.raises(OSError, match="symlink"):
+            manager.save_snapshot(sample_snapshot, str(link_path))
+
+        assert link_path.is_symlink()
+        assert json.loads(target_file.read_text(encoding="utf-8"))["data_view_id"] == "dv_original"
+
+    def test_save_snapshot_failure_preserves_existing_file_and_cleans_temp(
+        self,
+        manager,
+        sample_snapshot,
+        tmp_path,
+        monkeypatch,
+    ):
+        filepath = tmp_path / "snapshot.json"
+        filepath.write_text(
+            json.dumps(
+                {
+                    "snapshot_version": "1.0",
+                    "data_view_id": "dv_original",
+                    "data_view_name": "Original",
+                    "created_at": "2024-01-01T00:00:00+00:00",
+                    "metrics": [],
+                    "dimensions": [],
+                },
+            ),
+            encoding="utf-8",
+        )
+        original_contents = filepath.read_text(encoding="utf-8")
+
+        def _failing_dump(payload, file_obj, *args, **kwargs):
+            file_obj.write('{"partial": ')
+            raise OSError("disk full")
+
+        monkeypatch.setattr(json_io.json, "dump", _failing_dump)
+
+        with pytest.raises(OSError, match="disk full"):
+            manager.save_snapshot(sample_snapshot, str(filepath))
+
+        assert filepath.read_text(encoding="utf-8") == original_contents
+        assert list(tmp_path.glob(f".{filepath.name}.*.tmp")) == []
 
 
 # ==================== list_snapshots edge cases ====================

--- a/tests/test_snapshot_commands.py
+++ b/tests/test_snapshot_commands.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+import cja_auto_sdr.core.json_io as json_io
 from cja_auto_sdr.diff.models import (
     DataViewSnapshot,
     DiffResult,
@@ -253,6 +254,49 @@ class TestHandleSnapshotCommand:
         mock_configure.assert_called_once_with(
             profile="staging", config_file="config.json", logger=mock_configure.call_args[1]["logger"]
         )
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_snapshot_write_failure_preserves_existing_file(self, mock_configure, mock_cjapy, tmp_path, monkeypatch):
+        """Atomic snapshot writes keep the prior baseline intact on write failure."""
+        mock_configure.return_value = (True, "config", None)
+        mock_cja = MagicMock()
+        mock_cjapy.CJA.return_value = mock_cja
+        mock_cja.getDataView.return_value = {"name": "DV", "owner": "o", "description": ""}
+        mock_cja.getMetrics.return_value = MagicMock(empty=False, to_dict=MagicMock(return_value=[]))
+        mock_cja.getDimensions.return_value = MagicMock(empty=False, to_dict=MagicMock(return_value=[]))
+
+        out_file = tmp_path / "snap.json"
+        out_file.write_text(
+            json.dumps(
+                {
+                    "snapshot_version": "1.0",
+                    "data_view_id": "dv_existing",
+                    "data_view_name": "Existing",
+                    "created_at": "2024-01-01T00:00:00+00:00",
+                    "metrics": [],
+                    "dimensions": [],
+                },
+            ),
+            encoding="utf-8",
+        )
+        original_contents = out_file.read_text(encoding="utf-8")
+
+        def _failing_dump(payload, file_obj, *args, **kwargs):
+            file_obj.write('{"partial": ')
+            raise OSError("disk full")
+
+        monkeypatch.setattr(json_io.json, "dump", _failing_dump)
+
+        result = handle_snapshot_command(
+            data_view_id="dv_123",
+            snapshot_file=str(out_file),
+            quiet=True,
+        )
+
+        assert result is False
+        assert out_file.read_text(encoding="utf-8") == original_contents
+        assert list(tmp_path.glob(f".{out_file.name}.*.tmp")) == []
 
 
 # ==================== handle_compare_snapshots_command ====================

--- a/tests/test_ux_features.py
+++ b/tests/test_ux_features.py
@@ -344,11 +344,11 @@ class TestCombinedFeatures:
 class TestVersionUpdated:
     """Test that version is correct"""
 
-    def test_version_is_3_4_1(self):
-        """Test that version is 3.4.1"""
+    def test_version_is_3_4_2(self):
+        """Test that version is 3.4.2"""
         from cja_auto_sdr.generator import __version__
 
-        assert __version__ == "3.4.1"
+        assert __version__ == "3.4.2"
 
 
 class TestFormatAutoDetection:


### PR DESCRIPTION
## Summary

**v3.4.2 adds first-class support for AI agent and CI/CD automation of the CJA SDR Generator.**

### Why this matters

Until now, `cja_auto_sdr` was a powerful CLI tool — but integrating it into automated workflows required users to reverse-engineer exit codes, guess at output conventions, parse human-readable banners out of stdout, and write fragile wrapper scripts from scratch. Every team building automation around the tool had to solve the same problems independently: credential injection, timeout handling, drift-detection semantics, notification wiring, and safe JSON output parsing.

v3.4.2 eliminates that friction by making the tool **automation-native**. It provides a formal machine-readable contract (`AGENTS.md`), a comprehensive human-readable guide (`docs/AGENT_AUTOMATION.md`), production-ready script templates, and a Python orchestrator — so teams can go from "we want to automate SDR governance" to a working pipeline in minutes instead of days.

### How this benefits users

- **AI agent integration becomes trivial.** `AGENTS.md` is a machine-parseable tool contract that any AI agent framework (Claude, LangChain, custom agents) can consume directly. It specifies auth requirements, every command and flag, exit code semantics with recommended agent actions, output format conventions, and file location defaults — everything an agent needs to invoke the tool correctly without human intervention.

- **CI/CD pipelines get first-class support.** The GitHub Actions workflow template (`cja-sdr-audit.yml`) provides a secure, injection-hardened starting point for scheduled SDR auditing. Env-var inputs prevent script injection. Artifact uploads capture generated reports. Snapshot commits maintain drift baselines automatically.

- **Exit codes have clear, documented semantics for automation.** Exit 0 = success, exit 1 = error (parse stderr JSON), exit 2 = policy threshold exceeded (flag for review, not a crash), exit 3 = warning threshold exceeded (notify, optionally escalate), exit 130 = interrupted. Wrapper scripts and agents can branch on these codes reliably instead of parsing text output.

- **Ready-to-use scheduling scripts cover the three most common patterns.** Weekly SDR generation with drift detection and baseline updates (`weekly_sdr.sh`), daily drift monitoring with Slack notifications (`daily_drift_check.sh`), and quarterly maintenance with baseline refresh, governance review, pruning, and compliance export (`quarterly_maintenance.sh`). All scripts use `jq` for safe JSON payloads (no shell injection), propagate exit codes correctly, and follow the credential injection patterns from the automation guide.

- **The Python orchestrator enables multi-org batch workflows.** `scripts/orchestrator.py` wraps the CLI via subprocess with a structured JSON envelope, 5-minute subprocess timeout with structured error on timeout, arg filtering to prevent shell injection via positional args, and separate `has_changes` vs `threshold_exceeded` semantics for drift detection. It supports profile-based auth, data view discovery via `--discover`, and consolidated exit code aggregation across multiple runs.

- **Security is hardened across the automation surface.** Shell scripts use `jq` for Slack JSON payloads instead of string interpolation. GitHub Actions workflows use env vars for `workflow_dispatch` inputs instead of `${{ }}` interpolation. The orchestrator filters positional arguments to prevent injection. The automation guide documents credential injection from AWS Secrets Manager, HashiCorp Vault, and GitHub Actions secrets — with explicit rules against hardcoding credentials, committing `config.json`, or passing secrets as positional arguments.

- **Core infrastructure improvements support the automation layer.** `core/json_io.py` extracts safe JSON read/write with atomic writes for concurrent access safety. `core/exit_codes.py` gains `normalize_subprocess_exit_code()`, `is_signal_exit_code()`, and `combine_wrapper_exit_codes()` — the building blocks that the orchestrator and shell scripts use for reliable exit code propagation. A new `github_actions_audit.py` script validates CI workflows for pinned actions, injection patterns, and permission scoping.

---

### What's included

#### Agent contract & documentation
- `AGENTS.md` — machine-parseable tool contract for AI agents (auth, commands, exit codes, output conventions)
- `docs/AGENT_AUTOMATION.md` — human-readable guide for CI/CD and agent automation patterns (scheduling, secrets management, notifications, security, troubleshooting)
- Agent automation cross-references in `docs/USE_CASES.md` and `README.md`

#### Python orchestrator (`scripts/orchestrator.py`)
- Subprocess wrapper with structured JSON envelope output
- 5-minute subprocess timeout with structured error on `TimeoutExpired`
- Arg filtering to prevent shell injection via positional args
- Separate `has_changes` (exit 2 or 3) vs `threshold_exceeded` (exit 2 only) semantics in `run_diff()`
- Profile/config-file forwarding, data view discovery, consolidated exit codes

#### Shell automation examples
- `weekly_sdr.sh` — weekly SDR generation with baseline update, drift report handling, and Slack notification
- `daily_drift_check.sh` — daily drift detection with Slack notification and baseline freeze on drift
- `quarterly_maintenance.sh` — baseline refresh, governance report, pruning, and compliance export

#### GitHub Actions
- `examples/github-actions/cja-sdr-audit.yml` — reusable workflow template with env-var inputs (no script injection), artifact uploads, snapshot commits, and branch protection caveat documented
- `scripts/github_actions_audit.py` — CI workflow validation script (pinned actions, injection patterns, permissions)
- Hardened existing CI workflows: actionlint pin, expanded lint targets, ruff per-file-ignores for new files

#### Core improvements
- `core/json_io.py` — safe JSON read/write with atomic writes
- `core/exit_codes.py` — automation-relevant helpers (`normalize_subprocess_exit_code`, `is_signal_exit_code`, `combine_wrapper_exit_codes`)
- Minor fixes in `core/profiles.py`, `diff/snapshot.py`, `org/cache.py`

#### Quality & testing
- 6,286 tests (up from 6,237), all passing, 95%+ coverage
- New test files: `test_orchestrator.py`, `test_github_actions_audit.py`, `test_json_io.py`, `test_snapshot.py`, `test_snapshot_commands.py`
- Expanded: `test_profile_management.py`, `test_snapshot.py`

#### Version bump
- Bumped to v3.4.2 across all 7 version-tracked files
- Added CHANGELOG.md entry

**40 files changed, 3,563 insertions, 50 deletions across 24 commits.**

## Test plan

- [x] Full test suite passes (6,286 tests, 0 failures)
- [x] `ruff check` and `ruff format` pass on all new files
- [x] Shell scripts use `jq` for Slack JSON payloads (no injection risk)
- [x] GHA workflow uses env vars for inputs (no script injection)
- [x] Verify AGENTS.md auth table lists SCOPES as required
- [x] Verify orchestrator arg order: data view positional before `--snapshot`/`--diff-snapshot`
- [x] Orchestrator has 5-minute subprocess timeout with structured error
- [x] Drift exit codes propagated correctly (exit 2 = threshold exceeded, exit 3 = warn)
- [x] `github_actions_audit.py` validates workflow pinning and injection patterns
- [x] `json_io.py` uses atomic writes for safe concurrent access
- [x] CI workflows hardened with actionlint pin
- [x] Shell scripts pass shellcheck (no warnings)
- [x] Automation example exit handling hardened