### PR TITLE
v3.4.8: org writer compat hardening & export contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Hardening
 - Add explicit `__all__` declarations to all org/writers format submodules (console, json, csv, excel, html, markdown)
 - Add explicit `__all__` declarations to all output/diff writer submodules (common, console, csv, json, excel, html, markdown, grouped, pr_comment)
+- Add explicit `__all__` declarations to `org/writers/compat.py` and `org/writers/trending.py`
+- Centralize recommendation-context override fan-out in `org/writers/compat.py` so legacy package-root and generator patches reach the canonical common, markdown, and html helpers through one shared mapping
+- Remove duplicate bare-string override keys in MARKDOWN and HTML writer mappings that collided with tuple keys from `COMMON_RECOMMENDATION_OVERRIDE_MAPPING`
 
 ### Tests
 - Add regression coverage for nested recommendation helper overrides and package-root trending timestamp helper overrides
+- Add Markdown/HTML file-writer regression coverage for legacy `_format_recommendation_context_entries` patches across both `cja_auto_sdr.org.writers` and `cja_auto_sdr.generator`
 - Add direct contract tests for `org.writers.compat` module (signature continuity, override mapping completeness, wrapper behavior, freeze/compose semantics)
 - Add `__all__` export consistency tests verifying submodule exports match parent package re-exports for org/writers and output/diff
+- Add `override_scope` nesting tests (outer preserved, inner shadows, exit restores)
+- Add direct unit tests for `_normalize_override_mapping` (string, tuple, mixed, empty, tuple-ignores-default)
+- Add composed mapping duplicate key detection contract (string/tuple attr collision)
+- Add package-root monkeypatch propagation tests for `_trending_date_range` and `_trending_delta_csv_rows`
+- Add `call_override` kwargs forwarding test
 
 ### Docs
 - Add `compat.py` to org/writers architecture tree in CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ All notable changes to the CJA SDR Generator project will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.8] - 2026-03-25
+
+### Fix
+- Restore scoped legacy monkeypatch compatibility for nested org-writer recommendation helpers across `cja_auto_sdr.org.writers` and `cja_auto_sdr.generator`
+- Restore scoped package-root timestamp formatter monkeypatch compatibility for extracted trending helper label generation and markdown writer output
+
+### Tests
+- Add regression coverage for nested recommendation helper overrides and package-root trending timestamp helper overrides
+
 ## [3.4.7] - 2026-03-25
 
 ### Refactor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Restore scoped legacy monkeypatch compatibility for nested org-writer recommendation helpers across `cja_auto_sdr.org.writers` and `cja_auto_sdr.generator`
 - Restore scoped package-root timestamp formatter monkeypatch compatibility for extracted trending helper label generation and markdown writer output
 
+### Hardening
+- Add explicit `__all__` declarations to all org/writers format submodules (console, json, csv, excel, html, markdown)
+- Add explicit `__all__` declarations to all output/diff writer submodules (common, console, csv, json, excel, html, markdown, grouped, pr_comment)
+
 ### Tests
 - Add regression coverage for nested recommendation helper overrides and package-root trending timestamp helper overrides
+- Add direct contract tests for `org.writers.compat` module (signature continuity, override mapping completeness, wrapper behavior, freeze/compose semantics)
+- Add `__all__` export consistency tests verifying submodule exports match parent package re-exports for org/writers and output/diff
+
+### Docs
+- Add `compat.py` to org/writers architecture tree in CLAUDE.md
 
 ## [3.4.7] - 2026-03-25
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
 - Current version: v3.4.8
-- Tests: **6,950** across 114 files at **95% coverage gate**
+- Tests: **7,063** across 114 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)
 
@@ -103,6 +103,7 @@ src/cja_auto_sdr/
 │   └── writers/             # Org report renderers
 │       ├── __init__.py      # Re-export layer (backwards compat)
 │       ├── common.py        # Shared writer helpers
+│       ├── compat.py        # Compatibility routing helpers
 │       ├── trending.py      # Trending/drift renderers
 │       ├── console.py       # Console output writer
 │       ├── json.py          # JSON output writer

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
 - Current version: v3.4.8
-- Tests: **7,063** across 114 files at **95% coverage gate**
+- Tests: **7,085** across 114 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,8 +15,8 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Package manager: **uv**
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
-- Current version: v3.4.7
-- Tests: **6,925** across 114 files at **95% coverage gate**
+- Current version: v3.4.8
+- Tests: **6,950** across 114 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)
 

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (6,950+ tests)
+├── tests/                     # Test suite (7,063+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (7,063+ tests)
+├── tests/                     # Test suite (7,085+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (7,088+ tests)
+├── tests/                     # Test suite (7,089+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (7,085+ tests)
+├── tests/                     # Test suite (7,088+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (6,944+ tests)
+├── tests/                     # Test suite (6,950+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (7,090+ tests)
+├── tests/                     # Test suite (7,113+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (7,130+ tests)
+├── tests/                     # Test suite (7,158+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (7,089+ tests)
+├── tests/                     # Test suite (7,090+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (7,113+ tests)
+├── tests/                     # Test suite (7,130+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -924,7 +924,7 @@ cja_auto_sdr --list-dataviews --log-level DEBUG
 At launch, the tool logs diagnostic lines containing the tool version, Python version, platform, active log level, inferred run mode (batch, single, or discovery), and dependency versions. These appear automatically at `INFO` level and are useful for troubleshooting environment issues in CI/CD logs or support requests:
 
 ```text
-CJA SDR Generator v3.4.7 | Python 3.14.2 | darwin | log_level=INFO | mode=single
+CJA SDR Generator v3.4.8 | Python 3.14.2 | darwin | log_level=INFO | mode=single
 Dependencies: cjapy=0.2.4.post3, pandas=2.3.3, numpy=2.2.1, xlsxwriter=3.2.9, tqdm=4.67.0
 ```
 

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -203,7 +203,7 @@ This command:
 
 ```bash
 $ uv run cja_auto_sdr -V
-cja_auto_sdr 3.4.7
+cja_auto_sdr 3.4.8
 ```
 
 > **Important:** All commands in this guide assume you're in the `cja_auto_sdr` directory. If you see "command not found", make sure you're in the right directory and have run `uv sync`.

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Quick Reference Card
 
-Single-page command cheat sheet for CJA SDR Generator v3.4.7.
+Single-page command cheat sheet for CJA SDR Generator v3.4.8.
 
 ## Four Main Modes
 

--- a/src/cja_auto_sdr/core/version.py
+++ b/src/cja_auto_sdr/core/version.py
@@ -1,3 +1,3 @@
 """Version information for CJA Auto SDR."""
 
-__version__ = "3.4.7"
+__version__ = "3.4.8"

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -233,6 +233,9 @@ from cja_auto_sdr.org.writers import (
     _validate_org_report_output_request,
 )
 from cja_auto_sdr.org.writers.compat import (
+    COMMON_RECOMMENDATION_OVERRIDE_MAPPING as _ORG_COMMON_RECOMMENDATION_OVERRIDE_MAPPING,
+)
+from cja_auto_sdr.org.writers.compat import (
     CONSOLE_STATS_ONLY_OVERRIDE_MAPPING as _ORG_CONSOLE_STATS_ONLY_OVERRIDE_MAPPING,
 )
 from cja_auto_sdr.org.writers.compat import (
@@ -5175,12 +5178,26 @@ def _build_org_report_trending_window(
 # - _normalize_org_report_output_format
 # - _validate_org_report_output_request
 
+_ORG_WRITER_COMMON_MODULE = "cja_auto_sdr.org.writers.common"
 _ORG_WRITER_CONSOLE_MODULE = "cja_auto_sdr.org.writers.console"
 _ORG_WRITER_CSV_MODULE = "cja_auto_sdr.org.writers.csv"
 _ORG_WRITER_EXCEL_MODULE = "cja_auto_sdr.org.writers.excel"
 _ORG_WRITER_HTML_MODULE = "cja_auto_sdr.org.writers.html"
 _ORG_WRITER_JSON_MODULE = "cja_auto_sdr.org.writers.json"
 _ORG_WRITER_MARKDOWN_MODULE = "cja_auto_sdr.org.writers.markdown"
+
+_normalize_recommendation_for_json = _make_org_writer_compat_wrapper(
+    __name__,
+    _normalize_recommendation_for_json,
+    target_module_name=_ORG_WRITER_COMMON_MODULE,
+    override_mapping=_ORG_COMMON_RECOMMENDATION_OVERRIDE_MAPPING,
+)
+_flatten_recommendation_for_tabular = _make_org_writer_compat_wrapper(
+    __name__,
+    _flatten_recommendation_for_tabular,
+    target_module_name=_ORG_WRITER_COMMON_MODULE,
+    override_mapping=_ORG_COMMON_RECOMMENDATION_OVERRIDE_MAPPING,
+)
 
 write_org_report_console = _make_org_writer_compat_wrapper(
     __name__,

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -5186,6 +5186,24 @@ _ORG_WRITER_HTML_MODULE = "cja_auto_sdr.org.writers.html"
 _ORG_WRITER_JSON_MODULE = "cja_auto_sdr.org.writers.json"
 _ORG_WRITER_MARKDOWN_MODULE = "cja_auto_sdr.org.writers.markdown"
 
+_format_recommendation_context_entries = _make_org_writer_compat_wrapper(
+    __name__,
+    _format_recommendation_context_entries,
+    target_module_name=_ORG_WRITER_COMMON_MODULE,
+    override_mapping=_ORG_EMPTY_OVERRIDE_MAPPING,
+)
+_normalize_org_report_output_format = _make_org_writer_compat_wrapper(
+    __name__,
+    _normalize_org_report_output_format,
+    target_module_name=_ORG_WRITER_COMMON_MODULE,
+    override_mapping=_ORG_EMPTY_OVERRIDE_MAPPING,
+)
+_normalize_recommendation_severity = _make_org_writer_compat_wrapper(
+    __name__,
+    _normalize_recommendation_severity,
+    target_module_name=_ORG_WRITER_COMMON_MODULE,
+    override_mapping=_ORG_EMPTY_OVERRIDE_MAPPING,
+)
 _normalize_recommendation_for_json = _make_org_writer_compat_wrapper(
     __name__,
     _normalize_recommendation_for_json,
@@ -5197,6 +5215,18 @@ _flatten_recommendation_for_tabular = _make_org_writer_compat_wrapper(
     _flatten_recommendation_for_tabular,
     target_module_name=_ORG_WRITER_COMMON_MODULE,
     override_mapping=_ORG_COMMON_RECOMMENDATION_OVERRIDE_MAPPING,
+)
+_render_distribution_bar = _make_org_writer_compat_wrapper(
+    __name__,
+    _render_distribution_bar,
+    target_module_name=_ORG_WRITER_COMMON_MODULE,
+    override_mapping=_ORG_EMPTY_OVERRIDE_MAPPING,
+)
+_validate_org_report_output_request = _make_org_writer_compat_wrapper(
+    __name__,
+    _validate_org_report_output_request,
+    target_module_name=_ORG_WRITER_COMMON_MODULE,
+    override_mapping=_ORG_EMPTY_OVERRIDE_MAPPING,
 )
 
 write_org_report_console = _make_org_writer_compat_wrapper(

--- a/src/cja_auto_sdr/org/writers/__init__.py
+++ b/src/cja_auto_sdr/org/writers/__init__.py
@@ -26,6 +26,9 @@ from cja_auto_sdr.org.writers.common import (
 # Re-exports from console.py
 # ---------------------------------------------------------------------------
 from cja_auto_sdr.org.writers.compat import (
+    COMMON_RECOMMENDATION_OVERRIDE_MAPPING as _COMMON_RECOMMENDATION_OVERRIDE_MAPPING,
+)
+from cja_auto_sdr.org.writers.compat import (
     CONSOLE_STATS_ONLY_OVERRIDE_MAPPING as _CONSOLE_STATS_ONLY_OVERRIDE_MAPPING,
 )
 from cja_auto_sdr.org.writers.compat import CONSOLE_WRITER_OVERRIDE_MAPPING as _CONSOLE_WRITER_OVERRIDE_MAPPING
@@ -38,6 +41,7 @@ from cja_auto_sdr.org.writers.compat import JSON_WRITER_OVERRIDE_MAPPING as _JSO
 from cja_auto_sdr.org.writers.compat import (
     MARKDOWN_WRITER_OVERRIDE_MAPPING as _MARKDOWN_WRITER_OVERRIDE_MAPPING,
 )
+from cja_auto_sdr.org.writers.compat import TRENDING_LABEL_OVERRIDE_MAPPING as _TRENDING_LABEL_OVERRIDE_MAPPING
 from cja_auto_sdr.org.writers.compat import make_compat_wrapper as _make_compat_wrapper
 from cja_auto_sdr.org.writers.console import (
     write_org_report_comparison_console as _write_org_report_comparison_console_impl,
@@ -109,12 +113,83 @@ from cja_auto_sdr.org.writers.trending import (
     _trending_snapshots_to_dicts,
 )
 
+_COMMON_MODULE = "cja_auto_sdr.org.writers.common"
 _CONSOLE_MODULE = "cja_auto_sdr.org.writers.console"
 _CSV_MODULE = "cja_auto_sdr.org.writers.csv"
 _EXCEL_MODULE = "cja_auto_sdr.org.writers.excel"
 _HTML_MODULE = "cja_auto_sdr.org.writers.html"
 _JSON_MODULE = "cja_auto_sdr.org.writers.json"
 _MARKDOWN_MODULE = "cja_auto_sdr.org.writers.markdown"
+_TRENDING_MODULE = "cja_auto_sdr.org.writers.trending"
+
+_normalize_recommendation_for_json = _make_compat_wrapper(
+    __name__,
+    _normalize_recommendation_for_json,
+    target_module_name=_COMMON_MODULE,
+    override_mapping=_COMMON_RECOMMENDATION_OVERRIDE_MAPPING,
+)
+_flatten_recommendation_for_tabular = _make_compat_wrapper(
+    __name__,
+    _flatten_recommendation_for_tabular,
+    target_module_name=_COMMON_MODULE,
+    override_mapping=_COMMON_RECOMMENDATION_OVERRIDE_MAPPING,
+)
+_format_trending_period_label = _make_compat_wrapper(
+    __name__,
+    _format_trending_period_label,
+    target_module_name=_TRENDING_MODULE,
+    override_mapping={
+        (_TRENDING_MODULE, "_format_trending_timestamp_short"): "_format_trending_timestamp_short",
+    },
+)
+_trending_snapshot_column_specs = _make_compat_wrapper(
+    __name__,
+    _trending_snapshot_column_specs,
+    target_module_name=_TRENDING_MODULE,
+    override_mapping=_TRENDING_LABEL_OVERRIDE_MAPPING,
+)
+_trending_delta_column_specs = _make_compat_wrapper(
+    __name__,
+    _trending_delta_column_specs,
+    target_module_name=_TRENDING_MODULE,
+    override_mapping=_TRENDING_LABEL_OVERRIDE_MAPPING,
+)
+_trending_delta_csv_rows = _make_compat_wrapper(
+    __name__,
+    _trending_delta_csv_rows,
+    target_module_name=_TRENDING_MODULE,
+    override_mapping=_TRENDING_LABEL_OVERRIDE_MAPPING,
+)
+_trending_date_range = _make_compat_wrapper(
+    __name__,
+    _trending_date_range,
+    target_module_name=_TRENDING_MODULE,
+    override_mapping=_TRENDING_LABEL_OVERRIDE_MAPPING,
+)
+_render_trending_console = _make_compat_wrapper(
+    __name__,
+    _render_trending_console,
+    target_module_name=_TRENDING_MODULE,
+    override_mapping=_TRENDING_LABEL_OVERRIDE_MAPPING,
+)
+_render_trending_markdown = _make_compat_wrapper(
+    __name__,
+    _render_trending_markdown,
+    target_module_name=_TRENDING_MODULE,
+    override_mapping=_TRENDING_LABEL_OVERRIDE_MAPPING,
+)
+_render_trending_html = _make_compat_wrapper(
+    __name__,
+    _render_trending_html,
+    target_module_name=_TRENDING_MODULE,
+    override_mapping=_TRENDING_LABEL_OVERRIDE_MAPPING,
+)
+_print_trending_console_section = _make_compat_wrapper(
+    __name__,
+    _print_trending_console_section,
+    target_module_name=_TRENDING_MODULE,
+    override_mapping=_TRENDING_LABEL_OVERRIDE_MAPPING,
+)
 
 write_org_report_console = _make_compat_wrapper(
     __name__,

--- a/src/cja_auto_sdr/org/writers/__init__.py
+++ b/src/cja_auto_sdr/org/writers/__init__.py
@@ -156,17 +156,47 @@ _PACKAGE_ROOT_CSV_WRITER_BRIDGE_ATTRS = frozenset(
 )
 
 
+_format_recommendation_context_entries = _make_compat_wrapper(
+    __name__,
+    _format_recommendation_context_entries,
+    target_module_name=_COMMON_MODULE,
+    override_mapping=_EMPTY_OVERRIDE_MAPPING,
+)
+_normalize_org_report_output_format = _make_compat_wrapper(
+    __name__,
+    _normalize_org_report_output_format,
+    target_module_name=_COMMON_MODULE,
+    override_mapping=_EMPTY_OVERRIDE_MAPPING,
+)
 _normalize_recommendation_for_json = _make_compat_wrapper(
     __name__,
     _normalize_recommendation_for_json,
     target_module_name=_COMMON_MODULE,
     override_mapping=_COMMON_RECOMMENDATION_OVERRIDE_MAPPING,
 )
+_normalize_recommendation_severity = _make_compat_wrapper(
+    __name__,
+    _normalize_recommendation_severity,
+    target_module_name=_COMMON_MODULE,
+    override_mapping=_EMPTY_OVERRIDE_MAPPING,
+)
 _flatten_recommendation_for_tabular = _make_compat_wrapper(
     __name__,
     _flatten_recommendation_for_tabular,
     target_module_name=_COMMON_MODULE,
     override_mapping=_COMMON_RECOMMENDATION_OVERRIDE_MAPPING,
+)
+_render_distribution_bar = _make_compat_wrapper(
+    __name__,
+    _render_distribution_bar,
+    target_module_name=_COMMON_MODULE,
+    override_mapping=_EMPTY_OVERRIDE_MAPPING,
+)
+_validate_org_report_output_request = _make_compat_wrapper(
+    __name__,
+    _validate_org_report_output_request,
+    target_module_name=_COMMON_MODULE,
+    override_mapping=_EMPTY_OVERRIDE_MAPPING,
 )
 for _trending_helper_name in _TRENDING_HELPER_OVERRIDE_MAPPING:
     _wrapped_trending_helper = _make_compat_wrapper_with_options(

--- a/src/cja_auto_sdr/org/writers/__init__.py
+++ b/src/cja_auto_sdr/org/writers/__init__.py
@@ -23,7 +23,7 @@ from cja_auto_sdr.org.writers.common import (
 )
 
 # ---------------------------------------------------------------------------
-# Re-exports from console.py
+# Compatibility routing helpers
 # ---------------------------------------------------------------------------
 from cja_auto_sdr.org.writers.compat import (
     COMMON_RECOMMENDATION_OVERRIDE_MAPPING as _COMMON_RECOMMENDATION_OVERRIDE_MAPPING,
@@ -41,8 +41,15 @@ from cja_auto_sdr.org.writers.compat import JSON_WRITER_OVERRIDE_MAPPING as _JSO
 from cja_auto_sdr.org.writers.compat import (
     MARKDOWN_WRITER_OVERRIDE_MAPPING as _MARKDOWN_WRITER_OVERRIDE_MAPPING,
 )
-from cja_auto_sdr.org.writers.compat import TRENDING_LABEL_OVERRIDE_MAPPING as _TRENDING_LABEL_OVERRIDE_MAPPING
+from cja_auto_sdr.org.writers.compat import (
+    TRENDING_HELPER_OVERRIDE_MAPPING as _TRENDING_HELPER_OVERRIDE_MAPPING,
+)
+from cja_auto_sdr.org.writers.compat import _make_compat_wrapper_with_options as _make_compat_wrapper_with_options
 from cja_auto_sdr.org.writers.compat import make_compat_wrapper as _make_compat_wrapper
+
+# ---------------------------------------------------------------------------
+# Re-exports from console.py
+# ---------------------------------------------------------------------------
 from cja_auto_sdr.org.writers.console import (
     write_org_report_comparison_console as _write_org_report_comparison_console_impl,
 )
@@ -121,6 +128,33 @@ _HTML_MODULE = "cja_auto_sdr.org.writers.html"
 _JSON_MODULE = "cja_auto_sdr.org.writers.json"
 _MARKDOWN_MODULE = "cja_auto_sdr.org.writers.markdown"
 _TRENDING_MODULE = "cja_auto_sdr.org.writers.trending"
+_PACKAGE_ROOT_TRENDING_HELPER_TARGETS = {
+    helper_name: globals()[helper_name] for helper_name in _TRENDING_HELPER_OVERRIDE_MAPPING
+}
+_PACKAGE_ROOT_TRENDING_HELPER_BASELINES: dict[str, object] = {}
+_PACKAGE_ROOT_JSON_BUILDER_BRIDGE_ATTRS = frozenset({"_trending_snapshots_to_dicts"})
+_PACKAGE_ROOT_JSON_WRITER_BRIDGE_ATTRS = frozenset({"build_org_report_json_data"})
+_PACKAGE_ROOT_CONSOLE_WRITER_BRIDGE_ATTRS = frozenset({"_print_trending_console_section"})
+_PACKAGE_ROOT_MARKDOWN_WRITER_BRIDGE_ATTRS = frozenset({"_render_trending_markdown"})
+_PACKAGE_ROOT_HTML_WRITER_BRIDGE_ATTRS = frozenset({"_render_trending_html"})
+_PACKAGE_ROOT_EXCEL_WRITER_BRIDGE_ATTRS = frozenset(
+    {
+        "_ranked_drift_entries",
+        "_trending_delta_column_specs",
+        "_trending_delta_metric_rows",
+        "_trending_matrix_rows",
+        "_trending_snapshot_column_specs",
+        "_trending_snapshot_metric_rows",
+    }
+)
+_PACKAGE_ROOT_CSV_WRITER_BRIDGE_ATTRS = frozenset(
+    {
+        "_ranked_drift_entries",
+        "_trending_delta_csv_rows",
+        "_trending_snapshot_csv_rows",
+    }
+)
+
 
 _normalize_recommendation_for_json = _make_compat_wrapper(
     __name__,
@@ -134,74 +168,33 @@ _flatten_recommendation_for_tabular = _make_compat_wrapper(
     target_module_name=_COMMON_MODULE,
     override_mapping=_COMMON_RECOMMENDATION_OVERRIDE_MAPPING,
 )
-_format_trending_period_label = _make_compat_wrapper(
-    __name__,
-    _format_trending_period_label,
-    target_module_name=_TRENDING_MODULE,
-    override_mapping={
-        (_TRENDING_MODULE, "_format_trending_timestamp_short"): "_format_trending_timestamp_short",
-    },
-)
-_trending_snapshot_column_specs = _make_compat_wrapper(
-    __name__,
-    _trending_snapshot_column_specs,
-    target_module_name=_TRENDING_MODULE,
-    override_mapping=_TRENDING_LABEL_OVERRIDE_MAPPING,
-)
-_trending_delta_column_specs = _make_compat_wrapper(
-    __name__,
-    _trending_delta_column_specs,
-    target_module_name=_TRENDING_MODULE,
-    override_mapping=_TRENDING_LABEL_OVERRIDE_MAPPING,
-)
-_trending_delta_csv_rows = _make_compat_wrapper(
-    __name__,
-    _trending_delta_csv_rows,
-    target_module_name=_TRENDING_MODULE,
-    override_mapping=_TRENDING_LABEL_OVERRIDE_MAPPING,
-)
-_trending_date_range = _make_compat_wrapper(
-    __name__,
-    _trending_date_range,
-    target_module_name=_TRENDING_MODULE,
-    override_mapping=_TRENDING_LABEL_OVERRIDE_MAPPING,
-)
-_render_trending_console = _make_compat_wrapper(
-    __name__,
-    _render_trending_console,
-    target_module_name=_TRENDING_MODULE,
-    override_mapping=_TRENDING_LABEL_OVERRIDE_MAPPING,
-)
-_render_trending_markdown = _make_compat_wrapper(
-    __name__,
-    _render_trending_markdown,
-    target_module_name=_TRENDING_MODULE,
-    override_mapping=_TRENDING_LABEL_OVERRIDE_MAPPING,
-)
-_render_trending_html = _make_compat_wrapper(
-    __name__,
-    _render_trending_html,
-    target_module_name=_TRENDING_MODULE,
-    override_mapping=_TRENDING_LABEL_OVERRIDE_MAPPING,
-)
-_print_trending_console_section = _make_compat_wrapper(
-    __name__,
-    _print_trending_console_section,
-    target_module_name=_TRENDING_MODULE,
-    override_mapping=_TRENDING_LABEL_OVERRIDE_MAPPING,
-)
+for _trending_helper_name in _TRENDING_HELPER_OVERRIDE_MAPPING:
+    _wrapped_trending_helper = _make_compat_wrapper_with_options(
+        __name__,
+        _PACKAGE_ROOT_TRENDING_HELPER_TARGETS[_trending_helper_name],
+        target_module_name=_TRENDING_MODULE,
+        override_mapping=_TRENDING_HELPER_OVERRIDE_MAPPING,
+        baselines=_PACKAGE_ROOT_TRENDING_HELPER_BASELINES,
+        exclude_self_override=True,
+    )
+    globals()[_trending_helper_name] = _wrapped_trending_helper
+    _PACKAGE_ROOT_TRENDING_HELPER_BASELINES[_trending_helper_name] = _wrapped_trending_helper
+del _wrapped_trending_helper
+del _trending_helper_name
 
-write_org_report_console = _make_compat_wrapper(
+write_org_report_console = _make_compat_wrapper_with_options(
     __name__,
     _write_org_report_console_impl,
     target_module_name=_CONSOLE_MODULE,
     override_mapping=_CONSOLE_WRITER_OVERRIDE_MAPPING,
+    always_include_legacy_attrs=_PACKAGE_ROOT_CONSOLE_WRITER_BRIDGE_ATTRS,
 )
-write_org_report_stats_only = _make_compat_wrapper(
+write_org_report_stats_only = _make_compat_wrapper_with_options(
     __name__,
     _write_org_report_stats_only_impl,
     target_module_name=_CONSOLE_MODULE,
     override_mapping=_CONSOLE_STATS_ONLY_OVERRIDE_MAPPING,
+    always_include_legacy_attrs=_PACKAGE_ROOT_CONSOLE_WRITER_BRIDGE_ATTRS,
 )
 write_org_report_comparison_console = _make_compat_wrapper(
     __name__,
@@ -209,41 +202,47 @@ write_org_report_comparison_console = _make_compat_wrapper(
     target_module_name=_CONSOLE_MODULE,
     override_mapping=_EMPTY_OVERRIDE_MAPPING,
 )
-build_org_report_json_data = _make_compat_wrapper(
+build_org_report_json_data = _make_compat_wrapper_with_options(
     __name__,
     _build_org_report_json_data_impl,
     target_module_name=_JSON_MODULE,
     override_mapping=_JSON_BUILDER_OVERRIDE_MAPPING,
+    always_include_legacy_attrs=_PACKAGE_ROOT_JSON_BUILDER_BRIDGE_ATTRS,
 )
-write_org_report_json = _make_compat_wrapper(
+write_org_report_json = _make_compat_wrapper_with_options(
     __name__,
     _write_org_report_json_impl,
     target_module_name=_JSON_MODULE,
     override_mapping=_JSON_WRITER_OVERRIDE_MAPPING,
+    always_include_legacy_attrs=_PACKAGE_ROOT_JSON_WRITER_BRIDGE_ATTRS,
 )
-write_org_report_excel = _make_compat_wrapper(
+write_org_report_excel = _make_compat_wrapper_with_options(
     __name__,
     _write_org_report_excel_impl,
     target_module_name=_EXCEL_MODULE,
     override_mapping=_EXCEL_WRITER_OVERRIDE_MAPPING,
+    always_include_legacy_attrs=_PACKAGE_ROOT_EXCEL_WRITER_BRIDGE_ATTRS,
 )
-write_org_report_markdown = _make_compat_wrapper(
+write_org_report_markdown = _make_compat_wrapper_with_options(
     __name__,
     _write_org_report_markdown_impl,
     target_module_name=_MARKDOWN_MODULE,
     override_mapping=_MARKDOWN_WRITER_OVERRIDE_MAPPING,
+    always_include_legacy_attrs=_PACKAGE_ROOT_MARKDOWN_WRITER_BRIDGE_ATTRS,
 )
-write_org_report_html = _make_compat_wrapper(
+write_org_report_html = _make_compat_wrapper_with_options(
     __name__,
     _write_org_report_html_impl,
     target_module_name=_HTML_MODULE,
     override_mapping=_HTML_WRITER_OVERRIDE_MAPPING,
+    always_include_legacy_attrs=_PACKAGE_ROOT_HTML_WRITER_BRIDGE_ATTRS,
 )
-write_org_report_csv = _make_compat_wrapper(
+write_org_report_csv = _make_compat_wrapper_with_options(
     __name__,
     _write_org_report_csv_impl,
     target_module_name=_CSV_MODULE,
     override_mapping=_CSV_WRITER_OVERRIDE_MAPPING,
+    always_include_legacy_attrs=_PACKAGE_ROOT_CSV_WRITER_BRIDGE_ATTRS,
 )
 
 __all__ = [

--- a/src/cja_auto_sdr/org/writers/common.py
+++ b/src/cja_auto_sdr/org/writers/common.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from cja_auto_sdr.core.colors import ConsoleColors
 from cja_auto_sdr.core.constants import FORMAT_ALIASES
+from cja_auto_sdr.org.writers.compat import call_override
 
 
 def _render_distribution_bar(count: int, total: int, width: int = 30) -> str:
@@ -88,8 +89,18 @@ def _format_recommendation_context_entries(rec: dict[str, Any]) -> list[tuple[st
 def _normalize_recommendation_for_json(raw_rec: Any) -> dict[str, Any]:
     """Normalize recommendation payload for JSON serialization and output parity."""
     rec = dict(raw_rec) if isinstance(raw_rec, dict) else {"type": "unknown", "reason": str(raw_rec)}
-    rec["severity"] = _normalize_recommendation_severity(rec.get("severity", "low"))
-    context_entries = _format_recommendation_context_entries(rec)
+    rec["severity"] = call_override(
+        __name__,
+        "_normalize_recommendation_severity",
+        _normalize_recommendation_severity,
+        rec.get("severity", "low"),
+    )
+    context_entries = call_override(
+        __name__,
+        "_format_recommendation_context_entries",
+        _format_recommendation_context_entries,
+        rec,
+    )
     if context_entries:
         rec["context"] = [{"label": label, "value": value} for label, value in context_entries]
     # Ensure output is JSON-serializable even if recommendations include odd values.
@@ -123,7 +134,12 @@ def _flatten_recommendation_for_tabular(rec: dict[str, Any]) -> dict[str, Any]:
 
     return {
         "Type": rec.get("type", ""),
-        "Severity": _normalize_recommendation_severity(rec.get("severity", "low")),
+        "Severity": call_override(
+            __name__,
+            "_normalize_recommendation_severity",
+            _normalize_recommendation_severity,
+            rec.get("severity", "low"),
+        ),
         "Description": rec.get("reason", ""),
         "Data View ID": rec.get("data_view", ""),
         "Data View Name": rec.get("data_view_name", ""),

--- a/src/cja_auto_sdr/org/writers/common.py
+++ b/src/cja_auto_sdr/org/writers/common.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from cja_auto_sdr.core.colors import ConsoleColors
 from cja_auto_sdr.core.constants import FORMAT_ALIASES
-from cja_auto_sdr.org.writers.compat import call_override
+from cja_auto_sdr.org.writers.compat import call_override, make_override_proxy
 
 
 def _render_distribution_bar(count: int, total: int, width: int = 30) -> str:
@@ -189,3 +189,16 @@ def _validate_org_report_output_request(
         return False
 
     return True
+
+
+for _helper_name in (
+    "_render_distribution_bar",
+    "_normalize_recommendation_severity",
+    "_format_recommendation_context_entries",
+    "_normalize_recommendation_for_json",
+    "_flatten_recommendation_for_tabular",
+    "_normalize_org_report_output_format",
+    "_validate_org_report_output_request",
+):
+    globals()[_helper_name] = make_override_proxy(__name__, _helper_name, globals()[_helper_name])
+del _helper_name

--- a/src/cja_auto_sdr/org/writers/compat.py
+++ b/src/cja_auto_sdr/org/writers/compat.py
@@ -67,6 +67,17 @@ def compose_override_mapping(
     return freeze_override_mapping(combined)
 
 
+def _validate_override_destination(destination: _OVERRIDE_DESTINATION) -> None:
+    """Validate a public override destination key before collection or normalization."""
+    if isinstance(destination, str):
+        return
+    if isinstance(destination, tuple):
+        if len(destination) != 2 or not all(isinstance(part, str) for part in destination):
+            raise TypeError("override_mapping tuple keys must be (target_module_name, attr_name) string pairs")
+        return
+    raise TypeError("override_mapping keys must be strings or (module, attr) tuples")
+
+
 def _normalize_override_mapping(
     mapping: Mapping[_OVERRIDE_DESTINATION, str],
     *,
@@ -75,13 +86,10 @@ def _normalize_override_mapping(
     """Normalize mixed override destinations into explicit module/attribute keys."""
     normalized: dict[_OVERRIDE_KEY, str] = {}
     for destination, legacy_attr_name in mapping.items():
+        _validate_override_destination(destination)
         if isinstance(destination, tuple):
-            if len(destination) != 2 or not all(isinstance(part, str) for part in destination):
-                raise TypeError("override_mapping tuple keys must be (target_module_name, attr_name) string pairs")
             normalized[destination] = legacy_attr_name
             continue
-        if not isinstance(destination, str):
-            raise TypeError("override_mapping keys must be strings or (module, attr) tuples")
         normalized[_compat_key(default_target_module_name, destination)] = legacy_attr_name
     return normalized
 
@@ -258,23 +266,21 @@ def _collect_normalized_legacy_overrides(
 
 def collect_legacy_overrides(
     source_module_name: str,
-    override_mapping: Mapping[str, str],
+    override_mapping: Mapping[_OVERRIDE_DESTINATION, str],
     *,
     baselines: Mapping[str, object] | None = None,
-) -> dict[str, object]:
+) -> dict[_OVERRIDE_DESTINATION, object]:
     """Collect override callables from a legacy compatibility module.
 
-    This preserves the 3.4.7 public contract: callers pass a flat
-    ``{"target_attr": "legacy_attr"}`` mapping and receive a flat
-    ``{"target_attr": override}`` result. Internal wrapper routing uses a
-    private normalized helper so extracted writers can still fan out to
-    multiple canonical target modules without changing the exported API.
+    Flat string-key mappings keep the 3.4.7 ``{"target_attr": override}``
+    result contract. Mixed and tuple-key mappings introduced for 3.4.8
+    routing hardening are also accepted and preserve their explicit keys so
+    exported shared mappings remain consumable by callers.
     """
-    public_mapping: dict[str, str] = {}
-    for target_attr_name, legacy_attr_name in override_mapping.items():
-        if not isinstance(target_attr_name, str):
-            raise TypeError("collect_legacy_overrides() public override_mapping keys must be strings")
-        public_mapping[target_attr_name] = legacy_attr_name
+    public_mapping: dict[_OVERRIDE_DESTINATION, str] = {}
+    for target_key, legacy_attr_name in override_mapping.items():
+        _validate_override_destination(target_key)
+        public_mapping[target_key] = legacy_attr_name
     return _collect_source_overrides(
         source_module_name,
         public_mapping,

--- a/src/cja_auto_sdr/org/writers/compat.py
+++ b/src/cja_auto_sdr/org/writers/compat.py
@@ -10,50 +10,87 @@ from functools import wraps
 from types import MappingProxyType
 
 _OVERRIDE_KEY = tuple[str, str]
+_OVERRIDE_DESTINATION = str | _OVERRIDE_KEY
 _OVERRIDES: ContextVar[dict[_OVERRIDE_KEY, object] | None] = ContextVar(
     "org_writer_compat_overrides",
     default=None,
 )
-EMPTY_OVERRIDE_MAPPING: Mapping[str, str] = MappingProxyType({})
+EMPTY_OVERRIDE_MAPPING: Mapping[_OVERRIDE_DESTINATION, str] = MappingProxyType({})
+_COMMON_MODULE = "cja_auto_sdr.org.writers.common"
+_TRENDING_MODULE = "cja_auto_sdr.org.writers.trending"
 
 
-def freeze_override_mapping(mapping: Mapping[str, str]) -> Mapping[str, str]:
+def freeze_override_mapping(
+    mapping: Mapping[_OVERRIDE_DESTINATION, str],
+) -> Mapping[_OVERRIDE_DESTINATION, str]:
     """Copy and freeze an override mapping so wrapper definitions stay immutable."""
     return MappingProxyType(dict(mapping))
 
 
-def compose_override_mapping(*mappings: Mapping[str, str]) -> Mapping[str, str]:
+def compose_override_mapping(
+    *mappings: Mapping[_OVERRIDE_DESTINATION, str],
+) -> Mapping[_OVERRIDE_DESTINATION, str]:
     """Merge override mappings so writer wrappers inherit helper dependencies centrally."""
-    combined: dict[str, str] = {}
+    combined: dict[_OVERRIDE_DESTINATION, str] = {}
     for mapping in mappings:
         combined.update(mapping)
     return freeze_override_mapping(combined)
 
 
+def _normalize_override_mapping(
+    mapping: Mapping[_OVERRIDE_DESTINATION, str],
+    *,
+    default_target_module_name: str,
+) -> dict[_OVERRIDE_KEY, str]:
+    """Normalize mixed override destinations into explicit module/attribute keys."""
+    normalized: dict[_OVERRIDE_KEY, str] = {}
+    for destination, legacy_attr_name in mapping.items():
+        if isinstance(destination, tuple):
+            normalized[destination] = legacy_attr_name
+        else:
+            normalized[_compat_key(default_target_module_name, destination)] = legacy_attr_name
+    return normalized
+
+
 # Centralized compatibility dependency maps keep legacy re-export wrappers aligned
 # with the canonical writer modules they delegate to.
-CONSOLE_WRITER_OVERRIDE_MAPPING = freeze_override_mapping(
+COMMON_RECOMMENDATION_OVERRIDE_MAPPING = freeze_override_mapping(
+    {
+        (_COMMON_MODULE, "_format_recommendation_context_entries"): "_format_recommendation_context_entries",
+        (_COMMON_MODULE, "_normalize_recommendation_severity"): "_normalize_recommendation_severity",
+    }
+)
+TRENDING_LABEL_OVERRIDE_MAPPING = freeze_override_mapping(
+    {
+        (_TRENDING_MODULE, "_format_trending_period_label"): "_format_trending_period_label",
+        (_TRENDING_MODULE, "_format_trending_timestamp_short"): "_format_trending_timestamp_short",
+    }
+)
+CONSOLE_WRITER_OVERRIDE_MAPPING = compose_override_mapping(
     {
         "_render_distribution_bar": "_render_distribution_bar",
         "_print_trending_console_section": "_print_trending_console_section",
     },
+    TRENDING_LABEL_OVERRIDE_MAPPING,
 )
-CONSOLE_STATS_ONLY_OVERRIDE_MAPPING = freeze_override_mapping(
+CONSOLE_STATS_ONLY_OVERRIDE_MAPPING = compose_override_mapping(
     {
         "_print_trending_console_section": "_print_trending_console_section",
     },
+    TRENDING_LABEL_OVERRIDE_MAPPING,
 )
-JSON_BUILDER_OVERRIDE_MAPPING = freeze_override_mapping(
+JSON_BUILDER_OVERRIDE_MAPPING = compose_override_mapping(
     {
         "_normalize_recommendation_for_json": "_normalize_recommendation_for_json",
         "_trending_snapshots_to_dicts": "_trending_snapshots_to_dicts",
     },
+    COMMON_RECOMMENDATION_OVERRIDE_MAPPING,
 )
 JSON_WRITER_OVERRIDE_MAPPING = compose_override_mapping(
     {"build_org_report_json_data": "build_org_report_json_data"},
     JSON_BUILDER_OVERRIDE_MAPPING,
 )
-EXCEL_WRITER_OVERRIDE_MAPPING = freeze_override_mapping(
+EXCEL_WRITER_OVERRIDE_MAPPING = compose_override_mapping(
     {
         "_flatten_recommendation_for_tabular": "_flatten_recommendation_for_tabular",
         "_normalize_recommendation_for_json": "_normalize_recommendation_for_json",
@@ -64,22 +101,28 @@ EXCEL_WRITER_OVERRIDE_MAPPING = freeze_override_mapping(
         "_trending_snapshot_column_specs": "_trending_snapshot_column_specs",
         "_trending_snapshot_metric_rows": "_trending_snapshot_metric_rows",
     },
+    COMMON_RECOMMENDATION_OVERRIDE_MAPPING,
+    TRENDING_LABEL_OVERRIDE_MAPPING,
 )
-MARKDOWN_WRITER_OVERRIDE_MAPPING = freeze_override_mapping(
+MARKDOWN_WRITER_OVERRIDE_MAPPING = compose_override_mapping(
     {
         "_format_recommendation_context_entries": "_format_recommendation_context_entries",
         "_normalize_recommendation_for_json": "_normalize_recommendation_for_json",
         "_render_trending_markdown": "_render_trending_markdown",
     },
+    COMMON_RECOMMENDATION_OVERRIDE_MAPPING,
+    TRENDING_LABEL_OVERRIDE_MAPPING,
 )
-HTML_WRITER_OVERRIDE_MAPPING = freeze_override_mapping(
+HTML_WRITER_OVERRIDE_MAPPING = compose_override_mapping(
     {
         "_format_recommendation_context_entries": "_format_recommendation_context_entries",
         "_normalize_recommendation_for_json": "_normalize_recommendation_for_json",
         "_render_trending_html": "_render_trending_html",
     },
+    COMMON_RECOMMENDATION_OVERRIDE_MAPPING,
+    TRENDING_LABEL_OVERRIDE_MAPPING,
 )
-CSV_WRITER_OVERRIDE_MAPPING = freeze_override_mapping(
+CSV_WRITER_OVERRIDE_MAPPING = compose_override_mapping(
     {
         "_flatten_recommendation_for_tabular": "_flatten_recommendation_for_tabular",
         "_normalize_recommendation_for_json": "_normalize_recommendation_for_json",
@@ -87,6 +130,8 @@ CSV_WRITER_OVERRIDE_MAPPING = freeze_override_mapping(
         "_trending_delta_csv_rows": "_trending_delta_csv_rows",
         "_trending_snapshot_csv_rows": "_trending_snapshot_csv_rows",
     },
+    COMMON_RECOMMENDATION_OVERRIDE_MAPPING,
+    TRENDING_LABEL_OVERRIDE_MAPPING,
 )
 
 
@@ -133,27 +178,31 @@ def make_override_proxy[**P, R](
 
 def collect_legacy_overrides(
     source_module_name: str,
-    override_mapping: Mapping[str, str],
+    override_mapping: Mapping[_OVERRIDE_DESTINATION, str],
     *,
+    default_target_module_name: str,
     baselines: Mapping[str, object] | None = None,
-) -> dict[str, object]:
+) -> dict[_OVERRIDE_KEY, object]:
     """Collect override callables from a legacy compatibility module."""
     source_module = importlib.import_module(source_module_name)
+    normalized_mapping = _normalize_override_mapping(
+        override_mapping,
+        default_target_module_name=default_target_module_name,
+    )
     return {
-        target_attr_name: getattr(source_module, legacy_attr_name)
-        for target_attr_name, legacy_attr_name in override_mapping.items()
+        target_key: getattr(source_module, legacy_attr_name)
+        for target_key, legacy_attr_name in normalized_mapping.items()
         if hasattr(source_module, legacy_attr_name)
         and (baselines is None or getattr(source_module, legacy_attr_name) is not baselines.get(legacy_attr_name))
     }
 
 
 @contextmanager
-def override_scope(target_module_name: str, overrides: Mapping[str, object]):
+def override_scope(overrides: Mapping[_OVERRIDE_KEY, object]):
     """Apply compatibility overrides to the current execution context only."""
     current = _current_overrides()
     updated = current.copy()
-    for attr_name, override in overrides.items():
-        updated[_compat_key(target_module_name, attr_name)] = override
+    updated.update(overrides)
     token = _OVERRIDES.set(updated)
     try:
         yield
@@ -166,10 +215,15 @@ def make_compat_wrapper[**P, R](
     target: Callable[P, R],
     *,
     target_module_name: str,
-    override_mapping: Mapping[str, str],
+    override_mapping: Mapping[_OVERRIDE_DESTINATION, str],
 ) -> Callable[P, R]:
     """Wrap a legacy export so monkeypatches apply only within that call context."""
-    collected = dict(override_mapping)
+    collected = dict(
+        _normalize_override_mapping(
+            override_mapping,
+            default_target_module_name=target_module_name,
+        )
+    )
     source_module = importlib.import_module(source_module_name)
     baseline_source_values = {
         legacy_attr_name: getattr(source_module, legacy_attr_name)
@@ -184,11 +238,12 @@ def make_compat_wrapper[**P, R](
         overrides = collect_legacy_overrides(
             source_module_name,
             collected,
+            default_target_module_name=target_module_name,
             baselines=baseline_source_values,
         )
         if not overrides:
             return current_target(*args, **kwargs)
-        with override_scope(target_module_name, overrides):
+        with override_scope(overrides):
             return current_target(*args, **kwargs)
 
     wrapper.__module__ = source_module_name

--- a/src/cja_auto_sdr/org/writers/compat.py
+++ b/src/cja_auto_sdr/org/writers/compat.py
@@ -300,6 +300,23 @@ def _collect_source_overrides[K](
     return collected
 
 
+def _collect_active_source_scope_overrides[K](
+    source_module_name: str,
+    override_mapping: Mapping[K, str],
+) -> dict[K, object]:
+    """Project active source-surface override_scope entries into a target mapping."""
+    current = _current_overrides()
+    if not current:
+        return {}
+
+    projected: dict[K, object] = {}
+    for target_key, legacy_attr_name in override_mapping.items():
+        source_key = _compat_key(source_module_name, legacy_attr_name)
+        if source_key in current:
+            projected[target_key] = current[source_key]
+    return projected
+
+
 def _collect_normalized_legacy_overrides(
     source_module_name: str,
     override_mapping: Mapping[_OVERRIDE_DESTINATION, str],
@@ -431,6 +448,34 @@ def _routes_to_compat_wrapper(
     return False
 
 
+def _resolve_scoped_self_target(
+    current_scoped_overrides: Mapping[_OVERRIDE_KEY, object],
+    *,
+    target_self_key: _OVERRIDE_KEY,
+    source_self_key: _OVERRIDE_KEY,
+) -> object:
+    """Prefer explicit self overrides and let the recursion guard handle safe re-entry."""
+    if target_self_key in current_scoped_overrides:
+        return current_scoped_overrides[target_self_key]
+    if source_self_key in current_scoped_overrides:
+        return current_scoped_overrides[source_self_key]
+    return _MISSING
+
+
+def _resolve_suppressed_compat_target(
+    *,
+    target_module_name: str,
+    target_attr_name: str,
+    default_target: object,
+    reference: object,
+) -> object:
+    """Prefer the live canonical target unless it still routes back into the compat wrapper."""
+    live_target = getattr(importlib.import_module(target_module_name), target_attr_name)
+    if _routes_to_compat_wrapper(live_target, reference):
+        return default_target
+    return live_target
+
+
 @contextmanager
 def override_scope(
     target_module_name: str,
@@ -502,21 +547,37 @@ def _make_compat_wrapper_with_options[**P, R](
         }
     )
     target_attr_name = target.__name__
+    source_self_key = _compat_key(source_module_name, target_attr_name)
+    target_self_key = _compat_key(target_module_name, target_attr_name)
     self_override_key = _compat_key(target_module_name, target_attr_name)
 
     @wraps(target)
     def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+        current_scoped_overrides = _current_overrides()
         if _is_compat_target_suppressed(source_module_name, target_attr_name):
-            current_target = target
+            current_target = _resolve_suppressed_compat_target(
+                target_module_name=target_module_name,
+                target_attr_name=target_attr_name,
+                default_target=target,
+                reference=wrapper,
+            )
         else:
-            current_target = getattr(importlib.import_module(target_module_name), target_attr_name)
-        overrides = _collect_normalized_legacy_overrides(
+            current_target = _resolve_scoped_self_target(
+                current_scoped_overrides,
+                target_self_key=target_self_key,
+                source_self_key=source_self_key,
+            )
+            if current_target is _MISSING:
+                current_target = getattr(importlib.import_module(target_module_name), target_attr_name)
+        monkeypatch_overrides = _collect_normalized_legacy_overrides(
             source_module_name,
             collected,
             default_target_module_name=target_module_name,
             baselines=baseline_source_values,
             always_include_legacy_attrs=always_include_legacy_attrs,
         )
+        overrides = monkeypatch_overrides
+        overrides.update(_collect_active_source_scope_overrides(source_module_name, collected))
         if exclude_self_override:
             overrides.pop(self_override_key, None)
 

--- a/src/cja_auto_sdr/org/writers/compat.py
+++ b/src/cja_auto_sdr/org/writers/compat.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import importlib
+import inspect
 from collections.abc import Callable, Collection, Mapping
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from contextvars import ContextVar
 from functools import wraps
 from types import MappingProxyType
@@ -17,6 +18,10 @@ _OVERRIDES: ContextVar[dict[_OVERRIDE_KEY, object] | None] = ContextVar(
 )
 _SUPPRESSED_COMPAT_TARGETS: ContextVar[set[_OVERRIDE_KEY] | None] = ContextVar(
     "org_writer_suppressed_compat_targets",
+    default=None,
+)
+_ACTIVE_COMPAT_MOCK_CALLERS: ContextVar[set[int] | None] = ContextVar(
+    "org_writer_active_compat_mock_callers",
     default=None,
 )
 _MISSING = object()
@@ -241,6 +246,10 @@ def _current_suppressed_compat_targets() -> set[_OVERRIDE_KEY]:
     return _SUPPRESSED_COMPAT_TARGETS.get() or set()
 
 
+def _current_active_compat_mock_callers() -> set[int]:
+    return _ACTIVE_COMPAT_MOCK_CALLERS.get() or set()
+
+
 def resolve_override(target_module_name: str, attr_name: str, default: object) -> object:
     """Resolve a compatibility override for a target module attribute."""
     return _current_overrides().get(_compat_key(target_module_name, attr_name), default)
@@ -404,6 +413,21 @@ def _is_compat_target_suppressed(source_module_name: str, attr_name: str) -> boo
     return _compat_key(source_module_name, attr_name) in _current_suppressed_compat_targets()
 
 
+def _current_mock_caller() -> object:
+    """Return the active unittest.mock caller when a compat wrapper is entered via wraps=."""
+    frame = inspect.currentframe()
+    wrapper_frame = frame.f_back if frame is not None else None
+    caller = wrapper_frame.f_back if wrapper_frame is not None else None
+    try:
+        if caller is None or caller.f_globals.get("__name__") != "unittest.mock":
+            return _MISSING
+        return caller.f_locals.get("self", _MISSING)
+    finally:
+        del caller
+        del wrapper_frame
+        del frame
+
+
 @contextmanager
 def _suppress_compat_target(source_module_name: str, attr_name: str):
     """Temporarily force one compat wrapper to call its baseline target on re-entry."""
@@ -420,6 +444,24 @@ def _suppress_compat_target(source_module_name: str, attr_name: str):
         yield
     finally:
         _SUPPRESSED_COMPAT_TARGETS.reset(token)
+
+
+@contextmanager
+def _track_active_compat_mock_caller(candidate: object):
+    """Record one mock caller identity across nested compat wrapper re-entry."""
+    candidate_id = id(candidate)
+    current = _current_active_compat_mock_callers()
+    if candidate_id in current:
+        yield
+        return
+
+    updated = current.copy()
+    updated.add(candidate_id)
+    token = _ACTIVE_COMPAT_MOCK_CALLERS.set(updated)
+    try:
+        yield
+    finally:
+        _ACTIVE_COMPAT_MOCK_CALLERS.reset(token)
 
 
 def _routes_to_compat_wrapper(
@@ -446,6 +488,30 @@ def _routes_to_compat_wrapper(
         if _routes_to_compat_wrapper(wrapped, reference, seen=seen):
             return True
     return False
+
+
+def _unwrap_compat_dispatch_target(candidate: object, reference: object) -> object:
+    """Peel mock/wrap layers until the deepest callable still routing to one compat wrapper."""
+    current = candidate
+    seen: set[int] = set()
+    while current is not reference:
+        current_id = id(current)
+        if current_id in seen:
+            return candidate
+        seen.add(current_id)
+
+        next_candidate = _MISSING
+        for attr_name in ("_mock_wraps", "__wrapped__"):
+            wrapped = getattr(current, attr_name, _MISSING)
+            if wrapped is _MISSING or not _routes_to_compat_wrapper(wrapped, reference):
+                continue
+            next_candidate = wrapped
+            break
+
+        if next_candidate is _MISSING:
+            return candidate
+        current = next_candidate
+    return current
 
 
 def _resolve_scoped_self_target(
@@ -554,6 +620,7 @@ def _make_compat_wrapper_with_options[**P, R](
     @wraps(target)
     def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         current_scoped_overrides = _current_overrides()
+        current_mock_caller = _current_mock_caller()
         if _is_compat_target_suppressed(source_module_name, target_attr_name):
             current_target = _resolve_suppressed_compat_target(
                 target_module_name=target_module_name,
@@ -582,11 +649,20 @@ def _make_compat_wrapper_with_options[**P, R](
             overrides.pop(self_override_key, None)
 
         if _routes_to_compat_wrapper(current_target, wrapper):
-            with _suppress_compat_target(source_module_name, target_attr_name):
+            reentry_target = current_target
+            if current_mock_caller is current_target or id(current_target) in _current_active_compat_mock_callers():
+                reentry_target = _unwrap_compat_dispatch_target(current_target, wrapper)
+            with (
+                _suppress_compat_target(source_module_name, target_attr_name),
+                _suppress_override(target_module_name, target_attr_name),
+                _track_active_compat_mock_caller(current_target)
+                if reentry_target is not current_target
+                else nullcontext(),
+            ):
                 if not overrides:
-                    return current_target(*args, **kwargs)
+                    return reentry_target(*args, **kwargs)
                 with _override_scope_normalized(overrides, preserve_existing=True):
-                    return current_target(*args, **kwargs)
+                    return reentry_target(*args, **kwargs)
 
         if not overrides:
             return current_target(*args, **kwargs)

--- a/src/cja_auto_sdr/org/writers/compat.py
+++ b/src/cja_auto_sdr/org/writers/compat.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import importlib
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Collection, Mapping
 from contextlib import contextmanager
 from contextvars import ContextVar
 from functools import wraps
@@ -15,6 +15,11 @@ _OVERRIDES: ContextVar[dict[_OVERRIDE_KEY, object] | None] = ContextVar(
     "org_writer_compat_overrides",
     default=None,
 )
+_SUPPRESSED_COMPAT_TARGETS: ContextVar[set[_OVERRIDE_KEY] | None] = ContextVar(
+    "org_writer_suppressed_compat_targets",
+    default=None,
+)
+_MISSING = object()
 EMPTY_OVERRIDE_MAPPING: Mapping[_OVERRIDE_DESTINATION, str] = MappingProxyType({})
 
 __all__ = [
@@ -28,6 +33,7 @@ __all__ = [
     "JSON_BUILDER_OVERRIDE_MAPPING",
     "JSON_WRITER_OVERRIDE_MAPPING",
     "MARKDOWN_WRITER_OVERRIDE_MAPPING",
+    "TRENDING_HELPER_OVERRIDE_MAPPING",
     "TRENDING_LABEL_OVERRIDE_MAPPING",
     "call_override",
     "collect_legacy_overrides",
@@ -48,6 +54,35 @@ _RECOMMENDATION_CONTEXT_PROXY_MODULES = (
     _MARKDOWN_MODULE,
     _HTML_MODULE,
 )
+_TRENDING_PACKAGE_ROOT_HELPERS = (
+    "_build_trending_metric_rows",
+    "_escape_markdown_table_cell",
+    "_format_signed_trending_value",
+    "_format_trending_dv_label",
+    "_format_trending_period_label",
+    "_format_trending_timestamp_short",
+    "_print_trending_console_section",
+    "_ranked_drift_entries",
+    "_render_console_trending_table",
+    "_render_html_trending_table",
+    "_render_markdown_trending_table",
+    "_render_trending_console",
+    "_render_trending_html",
+    "_render_trending_markdown",
+    "_resolve_trending_dv_name",
+    "_sorted_drift_score_items",
+    "_stringify_trending_value",
+    "_top_drift_scores",
+    "_trending_date_range",
+    "_trending_delta_column_specs",
+    "_trending_delta_csv_rows",
+    "_trending_delta_metric_rows",
+    "_trending_matrix_rows",
+    "_trending_snapshot_column_specs",
+    "_trending_snapshot_csv_rows",
+    "_trending_snapshot_metric_rows",
+    "_trending_snapshots_to_dicts",
+)
 
 
 def freeze_override_mapping(
@@ -67,15 +102,20 @@ def compose_override_mapping(
     return freeze_override_mapping(combined)
 
 
-def _validate_override_destination(destination: _OVERRIDE_DESTINATION) -> None:
+def _validate_override_destination(
+    destination: _OVERRIDE_DESTINATION,
+    *,
+    tuple_error_message: str = "override_mapping tuple keys must be (target_module_name, attr_name) string pairs",
+    key_error_message: str = "override_mapping keys must be strings or (module, attr) tuples",
+) -> None:
     """Validate a public override destination key before collection or normalization."""
     if isinstance(destination, str):
         return
     if isinstance(destination, tuple):
         if len(destination) != 2 or not all(isinstance(part, str) for part in destination):
-            raise TypeError("override_mapping tuple keys must be (target_module_name, attr_name) string pairs")
+            raise TypeError(tuple_error_message)
         return
-    raise TypeError("override_mapping keys must be strings or (module, attr) tuples")
+    raise TypeError(key_error_message)
 
 
 def _normalize_override_mapping(
@@ -118,6 +158,9 @@ COMMON_RECOMMENDATION_OVERRIDE_MAPPING = compose_override_mapping(
 TRENDING_LABEL_OVERRIDE_MAPPING = compose_override_mapping(
     _fanout_override_mapping("_format_trending_period_label", _TRENDING_MODULE),
     _fanout_override_mapping("_format_trending_timestamp_short", _TRENDING_MODULE),
+)
+TRENDING_HELPER_OVERRIDE_MAPPING = freeze_override_mapping(
+    {helper_name: helper_name for helper_name in _TRENDING_PACKAGE_ROOT_HELPERS},
 )
 CONSOLE_WRITER_OVERRIDE_MAPPING = compose_override_mapping(
     {
@@ -194,6 +237,10 @@ def _current_overrides() -> dict[_OVERRIDE_KEY, object]:
     return _OVERRIDES.get() or {}
 
 
+def _current_suppressed_compat_targets() -> set[_OVERRIDE_KEY]:
+    return _SUPPRESSED_COMPAT_TARGETS.get() or set()
+
+
 def resolve_override(target_module_name: str, attr_name: str, default: object) -> object:
     """Resolve a compatibility override for a target module attribute."""
     return _current_overrides().get(_compat_key(target_module_name, attr_name), default)
@@ -221,7 +268,10 @@ def make_override_proxy[**P, R](
     @wraps(default)
     def proxy(*args: P.args, **kwargs: P.kwargs) -> R:
         active = resolve_override(target_module_name, attr_name, default)
-        return active(*args, **kwargs)
+        if active is default:
+            return default(*args, **kwargs)
+        with _suppress_override(target_module_name, attr_name):
+            return active(*args, **kwargs)
 
     proxy.__module__ = target_module_name
     return proxy
@@ -232,6 +282,7 @@ def _collect_source_overrides[K](
     override_mapping: Mapping[K, str],
     *,
     baselines: Mapping[str, object] | None = None,
+    always_include_legacy_attrs: Collection[str] = (),
 ) -> dict[K, object]:
     """Collect override objects from a source module for a pre-shaped mapping."""
     source_module = importlib.import_module(source_module_name)
@@ -240,6 +291,9 @@ def _collect_source_overrides[K](
         if not hasattr(source_module, legacy_attr_name):
             continue
         override = getattr(source_module, legacy_attr_name)
+        if legacy_attr_name in always_include_legacy_attrs:
+            collected[target_key] = override
+            continue
         if baselines is not None and override is baselines.get(legacy_attr_name):
             continue
         collected[target_key] = override
@@ -252,6 +306,7 @@ def _collect_normalized_legacy_overrides(
     *,
     default_target_module_name: str,
     baselines: Mapping[str, object] | None = None,
+    always_include_legacy_attrs: Collection[str] = (),
 ) -> dict[_OVERRIDE_KEY, object]:
     """Collect normalized tuple-key overrides for internal compat wrapper routing."""
     return _collect_source_overrides(
@@ -261,6 +316,7 @@ def _collect_normalized_legacy_overrides(
             default_target_module_name=default_target_module_name,
         ),
         baselines=baselines,
+        always_include_legacy_attrs=always_include_legacy_attrs,
     )
 
 
@@ -289,16 +345,90 @@ def collect_legacy_overrides(
 
 
 @contextmanager
-def _override_scope_normalized(overrides: Mapping[_OVERRIDE_KEY, object]):
+def _override_scope_normalized(
+    overrides: Mapping[_OVERRIDE_KEY, object],
+    *,
+    preserve_existing: bool = False,
+):
     """Apply normalized tuple-key overrides to the current execution context."""
     current = _current_overrides()
     updated = current.copy()
-    updated.update(overrides)
+    if preserve_existing:
+        for key, override in overrides.items():
+            updated.setdefault(key, override)
+    else:
+        updated.update(overrides)
     token = _OVERRIDES.set(updated)
     try:
         yield
     finally:
         _OVERRIDES.reset(token)
+
+
+@contextmanager
+def _suppress_override(target_module_name: str, attr_name: str):
+    """Temporarily mask one override key while preserving the rest of the current context."""
+    key = _compat_key(target_module_name, attr_name)
+    current = _current_overrides()
+    if key not in current:
+        yield
+        return
+
+    updated = current.copy()
+    updated.pop(key, None)
+    token = _OVERRIDES.set(updated)
+    try:
+        yield
+    finally:
+        _OVERRIDES.reset(token)
+
+
+def _is_compat_target_suppressed(source_module_name: str, attr_name: str) -> bool:
+    return _compat_key(source_module_name, attr_name) in _current_suppressed_compat_targets()
+
+
+@contextmanager
+def _suppress_compat_target(source_module_name: str, attr_name: str):
+    """Temporarily force one compat wrapper to call its baseline target on re-entry."""
+    key = _compat_key(source_module_name, attr_name)
+    current = _current_suppressed_compat_targets()
+    if key in current:
+        yield
+        return
+
+    updated = current.copy()
+    updated.add(key)
+    token = _SUPPRESSED_COMPAT_TARGETS.set(updated)
+    try:
+        yield
+    finally:
+        _SUPPRESSED_COMPAT_TARGETS.reset(token)
+
+
+def _routes_to_compat_wrapper(
+    candidate: object,
+    reference: object,
+    *,
+    seen: set[int] | None = None,
+) -> bool:
+    """Return True when a callable eventually delegates back into one compat wrapper."""
+    if candidate is reference:
+        return True
+
+    if seen is None:
+        seen = set()
+    candidate_id = id(candidate)
+    if candidate_id in seen:
+        return False
+    seen.add(candidate_id)
+
+    for attr_name in ("_mock_wraps", "__wrapped__"):
+        wrapped = getattr(candidate, attr_name, _MISSING)
+        if wrapped is _MISSING:
+            continue
+        if _routes_to_compat_wrapper(wrapped, reference, seen=seen):
+            return True
+    return False
 
 
 @contextmanager
@@ -315,17 +445,15 @@ def override_scope(
     """
     normalized_overrides: dict[_OVERRIDE_KEY, object] = {}
     for destination, override in overrides.items():
+        _validate_override_destination(
+            destination,
+            tuple_error_message="override_scope() tuple override keys must be (target_module_name, attr_name) string pairs",
+            key_error_message="override_scope() override keys must be strings or (target_module_name, attr_name) tuples",
+        )
         if isinstance(destination, str):
             normalized_overrides[_compat_key(target_module_name, destination)] = override
             continue
-        if isinstance(destination, tuple):
-            if len(destination) != 2 or not all(isinstance(part, str) for part in destination):
-                raise TypeError(
-                    "override_scope() tuple override keys must be (target_module_name, attr_name) string pairs"
-                )
-            normalized_overrides[destination] = override
-            continue
-        raise TypeError("override_scope() override keys must be strings or (target_module_name, attr_name) tuples")
+        normalized_overrides[destination] = override
     with _override_scope_normalized(normalized_overrides):
         yield
 
@@ -338,6 +466,25 @@ def make_compat_wrapper[**P, R](
     override_mapping: Mapping[_OVERRIDE_DESTINATION, str],
 ) -> Callable[P, R]:
     """Wrap a legacy export so monkeypatches apply only within that call context."""
+    return _make_compat_wrapper_with_options(
+        source_module_name,
+        target,
+        target_module_name=target_module_name,
+        override_mapping=override_mapping,
+    )
+
+
+def _make_compat_wrapper_with_options[**P, R](
+    source_module_name: str,
+    target: Callable[P, R],
+    *,
+    target_module_name: str,
+    override_mapping: Mapping[_OVERRIDE_DESTINATION, str],
+    baselines: Mapping[str, object] | None = None,
+    exclude_self_override: bool = False,
+    always_include_legacy_attrs: Collection[str] = (),
+) -> Callable[P, R]:
+    """Internal helper for batched wrapper installs that need shared baselines or self-exclusion."""
     collected = dict(
         _normalize_override_mapping(
             override_mapping,
@@ -345,25 +492,44 @@ def make_compat_wrapper[**P, R](
         )
     )
     source_module = importlib.import_module(source_module_name)
-    baseline_source_values = {
-        legacy_attr_name: getattr(source_module, legacy_attr_name)
-        for legacy_attr_name in collected.values()
-        if hasattr(source_module, legacy_attr_name)
-    }
+    baseline_source_values = (
+        baselines
+        if baselines is not None
+        else {
+            legacy_attr_name: getattr(source_module, legacy_attr_name)
+            for legacy_attr_name in collected.values()
+            if hasattr(source_module, legacy_attr_name)
+        }
+    )
     target_attr_name = target.__name__
+    self_override_key = _compat_key(target_module_name, target_attr_name)
 
     @wraps(target)
     def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
-        current_target = getattr(importlib.import_module(target_module_name), target_attr_name)
+        if _is_compat_target_suppressed(source_module_name, target_attr_name):
+            current_target = target
+        else:
+            current_target = getattr(importlib.import_module(target_module_name), target_attr_name)
         overrides = _collect_normalized_legacy_overrides(
             source_module_name,
             collected,
             default_target_module_name=target_module_name,
             baselines=baseline_source_values,
+            always_include_legacy_attrs=always_include_legacy_attrs,
         )
+        if exclude_self_override:
+            overrides.pop(self_override_key, None)
+
+        if _routes_to_compat_wrapper(current_target, wrapper):
+            with _suppress_compat_target(source_module_name, target_attr_name):
+                if not overrides:
+                    return current_target(*args, **kwargs)
+                with _override_scope_normalized(overrides, preserve_existing=True):
+                    return current_target(*args, **kwargs)
+
         if not overrides:
             return current_target(*args, **kwargs)
-        with _override_scope_normalized(overrides):
+        with _override_scope_normalized(overrides, preserve_existing=True):
             return current_target(*args, **kwargs)
 
     wrapper.__module__ = source_module_name

--- a/src/cja_auto_sdr/org/writers/compat.py
+++ b/src/cja_auto_sdr/org/writers/compat.py
@@ -302,13 +302,30 @@ def _override_scope_normalized(overrides: Mapping[_OVERRIDE_KEY, object]):
 
 
 @contextmanager
-def override_scope(target_module_name: str, overrides: Mapping[str, object]):
-    """Apply compatibility overrides to the current execution context only."""
+def override_scope(
+    target_module_name: str,
+    overrides: Mapping[_OVERRIDE_DESTINATION, object],
+):
+    """Apply compatibility overrides to the current execution context only.
+
+    String keys are scoped to ``target_module_name`` for the legacy 3.4.7
+    flat override contract. Explicit ``(module, attr)`` tuple keys are also
+    accepted so callers can apply mixed-key mappings collected from the
+    exported 3.4.8 writer override maps without re-normalizing them.
+    """
     normalized_overrides: dict[_OVERRIDE_KEY, object] = {}
-    for attr_name, override in overrides.items():
-        if not isinstance(attr_name, str):
-            raise TypeError("override_scope() override keys must be strings")
-        normalized_overrides[_compat_key(target_module_name, attr_name)] = override
+    for destination, override in overrides.items():
+        if isinstance(destination, str):
+            normalized_overrides[_compat_key(target_module_name, destination)] = override
+            continue
+        if isinstance(destination, tuple):
+            if len(destination) != 2 or not all(isinstance(part, str) for part in destination):
+                raise TypeError(
+                    "override_scope() tuple override keys must be (target_module_name, attr_name) string pairs"
+                )
+            normalized_overrides[destination] = override
+            continue
+        raise TypeError("override_scope() override keys must be strings or (target_module_name, attr_name) tuples")
     with _override_scope_normalized(normalized_overrides):
         yield
 

--- a/src/cja_auto_sdr/org/writers/compat.py
+++ b/src/cja_auto_sdr/org/writers/compat.py
@@ -88,10 +88,7 @@ def _fanout_override_mapping(
 ) -> Mapping[_OVERRIDE_DESTINATION, str]:
     """Build tuple-key override mappings for one legacy attr across multiple proxy modules."""
     return freeze_override_mapping(
-        {
-            (target_module_name, legacy_attr_name): legacy_attr_name
-            for target_module_name in target_module_names
-        }
+        {(target_module_name, legacy_attr_name): legacy_attr_name for target_module_name in target_module_names}
     )
 
 

--- a/src/cja_auto_sdr/org/writers/compat.py
+++ b/src/cja_auto_sdr/org/writers/compat.py
@@ -76,9 +76,13 @@ def _normalize_override_mapping(
     normalized: dict[_OVERRIDE_KEY, str] = {}
     for destination, legacy_attr_name in mapping.items():
         if isinstance(destination, tuple):
+            if len(destination) != 2 or not all(isinstance(part, str) for part in destination):
+                raise TypeError("override_mapping tuple keys must be (target_module_name, attr_name) string pairs")
             normalized[destination] = legacy_attr_name
-        else:
-            normalized[_compat_key(default_target_module_name, destination)] = legacy_attr_name
+            continue
+        if not isinstance(destination, str):
+            raise TypeError("override_mapping keys must be strings or (module, attr) tuples")
+        normalized[_compat_key(default_target_module_name, destination)] = legacy_attr_name
     return normalized
 
 
@@ -215,30 +219,72 @@ def make_override_proxy[**P, R](
     return proxy
 
 
-def collect_legacy_overrides(
+def _collect_source_overrides[K](
+    source_module_name: str,
+    override_mapping: Mapping[K, str],
+    *,
+    baselines: Mapping[str, object] | None = None,
+) -> dict[K, object]:
+    """Collect override objects from a source module for a pre-shaped mapping."""
+    source_module = importlib.import_module(source_module_name)
+    collected: dict[K, object] = {}
+    for target_key, legacy_attr_name in override_mapping.items():
+        if not hasattr(source_module, legacy_attr_name):
+            continue
+        override = getattr(source_module, legacy_attr_name)
+        if baselines is not None and override is baselines.get(legacy_attr_name):
+            continue
+        collected[target_key] = override
+    return collected
+
+
+def _collect_normalized_legacy_overrides(
     source_module_name: str,
     override_mapping: Mapping[_OVERRIDE_DESTINATION, str],
     *,
     default_target_module_name: str,
     baselines: Mapping[str, object] | None = None,
 ) -> dict[_OVERRIDE_KEY, object]:
-    """Collect override callables from a legacy compatibility module."""
-    source_module = importlib.import_module(source_module_name)
-    normalized_mapping = _normalize_override_mapping(
-        override_mapping,
-        default_target_module_name=default_target_module_name,
+    """Collect normalized tuple-key overrides for internal compat wrapper routing."""
+    return _collect_source_overrides(
+        source_module_name,
+        _normalize_override_mapping(
+            override_mapping,
+            default_target_module_name=default_target_module_name,
+        ),
+        baselines=baselines,
     )
-    return {
-        target_key: getattr(source_module, legacy_attr_name)
-        for target_key, legacy_attr_name in normalized_mapping.items()
-        if hasattr(source_module, legacy_attr_name)
-        and (baselines is None or getattr(source_module, legacy_attr_name) is not baselines.get(legacy_attr_name))
-    }
+
+
+def collect_legacy_overrides(
+    source_module_name: str,
+    override_mapping: Mapping[str, str],
+    *,
+    baselines: Mapping[str, object] | None = None,
+) -> dict[str, object]:
+    """Collect override callables from a legacy compatibility module.
+
+    This preserves the 3.4.7 public contract: callers pass a flat
+    ``{"target_attr": "legacy_attr"}`` mapping and receive a flat
+    ``{"target_attr": override}`` result. Internal wrapper routing uses a
+    private normalized helper so extracted writers can still fan out to
+    multiple canonical target modules without changing the exported API.
+    """
+    public_mapping: dict[str, str] = {}
+    for target_attr_name, legacy_attr_name in override_mapping.items():
+        if not isinstance(target_attr_name, str):
+            raise TypeError("collect_legacy_overrides() public override_mapping keys must be strings")
+        public_mapping[target_attr_name] = legacy_attr_name
+    return _collect_source_overrides(
+        source_module_name,
+        public_mapping,
+        baselines=baselines,
+    )
 
 
 @contextmanager
-def override_scope(overrides: Mapping[_OVERRIDE_KEY, object]):
-    """Apply compatibility overrides to the current execution context only."""
+def _override_scope_normalized(overrides: Mapping[_OVERRIDE_KEY, object]):
+    """Apply normalized tuple-key overrides to the current execution context."""
     current = _current_overrides()
     updated = current.copy()
     updated.update(overrides)
@@ -247,6 +293,18 @@ def override_scope(overrides: Mapping[_OVERRIDE_KEY, object]):
         yield
     finally:
         _OVERRIDES.reset(token)
+
+
+@contextmanager
+def override_scope(target_module_name: str, overrides: Mapping[str, object]):
+    """Apply compatibility overrides to the current execution context only."""
+    normalized_overrides: dict[_OVERRIDE_KEY, object] = {}
+    for attr_name, override in overrides.items():
+        if not isinstance(attr_name, str):
+            raise TypeError("override_scope() override keys must be strings")
+        normalized_overrides[_compat_key(target_module_name, attr_name)] = override
+    with _override_scope_normalized(normalized_overrides):
+        yield
 
 
 def make_compat_wrapper[**P, R](
@@ -274,7 +332,7 @@ def make_compat_wrapper[**P, R](
     @wraps(target)
     def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         current_target = getattr(importlib.import_module(target_module_name), target_attr_name)
-        overrides = collect_legacy_overrides(
+        overrides = _collect_normalized_legacy_overrides(
             source_module_name,
             collected,
             default_target_module_name=target_module_name,
@@ -282,7 +340,7 @@ def make_compat_wrapper[**P, R](
         )
         if not overrides:
             return current_target(*args, **kwargs)
-        with override_scope(overrides):
+        with _override_scope_normalized(overrides):
             return current_target(*args, **kwargs)
 
     wrapper.__module__ = source_module_name

--- a/src/cja_auto_sdr/org/writers/compat.py
+++ b/src/cja_auto_sdr/org/writers/compat.py
@@ -16,8 +16,38 @@ _OVERRIDES: ContextVar[dict[_OVERRIDE_KEY, object] | None] = ContextVar(
     default=None,
 )
 EMPTY_OVERRIDE_MAPPING: Mapping[_OVERRIDE_DESTINATION, str] = MappingProxyType({})
+
+__all__ = [
+    "COMMON_RECOMMENDATION_OVERRIDE_MAPPING",
+    "CONSOLE_STATS_ONLY_OVERRIDE_MAPPING",
+    "CONSOLE_WRITER_OVERRIDE_MAPPING",
+    "CSV_WRITER_OVERRIDE_MAPPING",
+    "EMPTY_OVERRIDE_MAPPING",
+    "EXCEL_WRITER_OVERRIDE_MAPPING",
+    "HTML_WRITER_OVERRIDE_MAPPING",
+    "JSON_BUILDER_OVERRIDE_MAPPING",
+    "JSON_WRITER_OVERRIDE_MAPPING",
+    "MARKDOWN_WRITER_OVERRIDE_MAPPING",
+    "TRENDING_LABEL_OVERRIDE_MAPPING",
+    "call_override",
+    "collect_legacy_overrides",
+    "compose_override_mapping",
+    "freeze_override_mapping",
+    "make_compat_wrapper",
+    "make_override_proxy",
+    "override_scope",
+    "resolve_override",
+]
+
 _COMMON_MODULE = "cja_auto_sdr.org.writers.common"
+_HTML_MODULE = "cja_auto_sdr.org.writers.html"
+_MARKDOWN_MODULE = "cja_auto_sdr.org.writers.markdown"
 _TRENDING_MODULE = "cja_auto_sdr.org.writers.trending"
+_RECOMMENDATION_CONTEXT_PROXY_MODULES = (
+    _COMMON_MODULE,
+    _MARKDOWN_MODULE,
+    _HTML_MODULE,
+)
 
 
 def freeze_override_mapping(
@@ -52,19 +82,33 @@ def _normalize_override_mapping(
     return normalized
 
 
+def _fanout_override_mapping(
+    legacy_attr_name: str,
+    *target_module_names: str,
+) -> Mapping[_OVERRIDE_DESTINATION, str]:
+    """Build tuple-key override mappings for one legacy attr across multiple proxy modules."""
+    return freeze_override_mapping(
+        {
+            (target_module_name, legacy_attr_name): legacy_attr_name
+            for target_module_name in target_module_names
+        }
+    )
+
+
 # Centralized compatibility dependency maps keep legacy re-export wrappers aligned
 # with the canonical writer modules they delegate to.
-COMMON_RECOMMENDATION_OVERRIDE_MAPPING = freeze_override_mapping(
-    {
-        (_COMMON_MODULE, "_format_recommendation_context_entries"): "_format_recommendation_context_entries",
-        (_COMMON_MODULE, "_normalize_recommendation_severity"): "_normalize_recommendation_severity",
-    }
+COMMON_RECOMMENDATION_OVERRIDE_MAPPING = compose_override_mapping(
+    # Context entries are rendered directly by the canonical markdown/html writers
+    # and nested under common.py JSON normalization.
+    _fanout_override_mapping(
+        "_format_recommendation_context_entries",
+        *_RECOMMENDATION_CONTEXT_PROXY_MODULES,
+    ),
+    _fanout_override_mapping("_normalize_recommendation_severity", _COMMON_MODULE),
 )
-TRENDING_LABEL_OVERRIDE_MAPPING = freeze_override_mapping(
-    {
-        (_TRENDING_MODULE, "_format_trending_period_label"): "_format_trending_period_label",
-        (_TRENDING_MODULE, "_format_trending_timestamp_short"): "_format_trending_timestamp_short",
-    }
+TRENDING_LABEL_OVERRIDE_MAPPING = compose_override_mapping(
+    _fanout_override_mapping("_format_trending_period_label", _TRENDING_MODULE),
+    _fanout_override_mapping("_format_trending_timestamp_short", _TRENDING_MODULE),
 )
 CONSOLE_WRITER_OVERRIDE_MAPPING = compose_override_mapping(
     {
@@ -106,7 +150,6 @@ EXCEL_WRITER_OVERRIDE_MAPPING = compose_override_mapping(
 )
 MARKDOWN_WRITER_OVERRIDE_MAPPING = compose_override_mapping(
     {
-        "_format_recommendation_context_entries": "_format_recommendation_context_entries",
         "_normalize_recommendation_for_json": "_normalize_recommendation_for_json",
         "_render_trending_markdown": "_render_trending_markdown",
     },
@@ -115,7 +158,6 @@ MARKDOWN_WRITER_OVERRIDE_MAPPING = compose_override_mapping(
 )
 HTML_WRITER_OVERRIDE_MAPPING = compose_override_mapping(
     {
-        "_format_recommendation_context_entries": "_format_recommendation_context_entries",
         "_normalize_recommendation_for_json": "_normalize_recommendation_for_json",
         "_render_trending_html": "_render_trending_html",
     },

--- a/src/cja_auto_sdr/org/writers/console.py
+++ b/src/cja_auto_sdr/org/writers/console.py
@@ -13,6 +13,12 @@ from cja_auto_sdr.org.writers.common import _render_distribution_bar as _render_
 from cja_auto_sdr.org.writers.compat import make_override_proxy
 from cja_auto_sdr.org.writers.trending import _print_trending_console_section as _print_trending_console_section_impl
 
+__all__ = [
+    "write_org_report_comparison_console",
+    "write_org_report_console",
+    "write_org_report_stats_only",
+]
+
 _render_distribution_bar = make_override_proxy(
     __name__,
     "_render_distribution_bar",

--- a/src/cja_auto_sdr/org/writers/console.py
+++ b/src/cja_auto_sdr/org/writers/console.py
@@ -484,3 +484,12 @@ def write_org_report_comparison_console(comparison: OrgReportComparison, quiet: 
     print()
     print("=" * 70)
     print()
+
+
+for _writer_name in (
+    "write_org_report_console",
+    "write_org_report_stats_only",
+    "write_org_report_comparison_console",
+):
+    globals()[_writer_name] = make_override_proxy(__name__, _writer_name, globals()[_writer_name])
+del _writer_name

--- a/src/cja_auto_sdr/org/writers/csv.py
+++ b/src/cja_auto_sdr/org/writers/csv.py
@@ -281,3 +281,10 @@ def write_org_report_csv(
 
     logger.info(f"CSV reports written to {csv_dir}")
     return str(csv_dir)
+
+
+write_org_report_csv = make_override_proxy(
+    __name__,
+    "write_org_report_csv",
+    write_org_report_csv,
+)

--- a/src/cja_auto_sdr/org/writers/csv.py
+++ b/src/cja_auto_sdr/org/writers/csv.py
@@ -32,6 +32,10 @@ from cja_auto_sdr.org.writers.trending import (
     _trending_snapshot_csv_rows as _trending_snapshot_csv_rows_impl,
 )
 
+__all__ = [
+    "write_org_report_csv",
+]
+
 _flatten_recommendation_for_tabular = make_override_proxy(
     __name__,
     "_flatten_recommendation_for_tabular",

--- a/src/cja_auto_sdr/org/writers/excel.py
+++ b/src/cja_auto_sdr/org/writers/excel.py
@@ -497,3 +497,10 @@ def write_org_report_excel(
 
     logger.info(f"Excel report written to {file_path}")
     return str(file_path)
+
+
+write_org_report_excel = make_override_proxy(
+    __name__,
+    "write_org_report_excel",
+    write_org_report_excel,
+)

--- a/src/cja_auto_sdr/org/writers/excel.py
+++ b/src/cja_auto_sdr/org/writers/excel.py
@@ -42,6 +42,10 @@ from cja_auto_sdr.org.writers.trending import (
     _trending_snapshot_metric_rows as _trending_snapshot_metric_rows_impl,
 )
 
+__all__ = [
+    "write_org_report_excel",
+]
+
 _flatten_recommendation_for_tabular = make_override_proxy(
     __name__,
     "_flatten_recommendation_for_tabular",

--- a/src/cja_auto_sdr/org/writers/html.py
+++ b/src/cja_auto_sdr/org/writers/html.py
@@ -25,6 +25,10 @@ from cja_auto_sdr.org.writers.trending import (
     _render_trending_html as _render_trending_html_impl,
 )
 
+__all__ = [
+    "write_org_report_html",
+]
+
 _format_recommendation_context_entries = make_override_proxy(
     __name__,
     "_format_recommendation_context_entries",

--- a/src/cja_auto_sdr/org/writers/html.py
+++ b/src/cja_auto_sdr/org/writers/html.py
@@ -384,3 +384,10 @@ def write_org_report_html(
 
     logger.info(f"HTML report written to {file_path}")
     return str(file_path)
+
+
+write_org_report_html = make_override_proxy(
+    __name__,
+    "write_org_report_html",
+    write_org_report_html,
+)

--- a/src/cja_auto_sdr/org/writers/json.py
+++ b/src/cja_auto_sdr/org/writers/json.py
@@ -22,6 +22,11 @@ from cja_auto_sdr.org.writers.compat import (
 )
 from cja_auto_sdr.org.writers.trending import _trending_snapshots_to_dicts as _trending_snapshots_to_dicts_impl
 
+__all__ = [
+    "build_org_report_json_data",
+    "write_org_report_json",
+]
+
 _normalize_recommendation_for_json = make_override_proxy(
     __name__,
     "_normalize_recommendation_for_json",

--- a/src/cja_auto_sdr/org/writers/json.py
+++ b/src/cja_auto_sdr/org/writers/json.py
@@ -255,3 +255,8 @@ def write_org_report_json(
 
     logger.info(f"JSON report written to {file_path}")
     return str(file_path)
+
+
+for _writer_name in ("build_org_report_json_data", "write_org_report_json"):
+    globals()[_writer_name] = make_override_proxy(__name__, _writer_name, globals()[_writer_name])
+del _writer_name

--- a/src/cja_auto_sdr/org/writers/markdown.py
+++ b/src/cja_auto_sdr/org/writers/markdown.py
@@ -25,6 +25,10 @@ from cja_auto_sdr.org.writers.trending import (
     _render_trending_markdown as _render_trending_markdown_impl,
 )
 
+__all__ = [
+    "write_org_report_markdown",
+]
+
 _format_recommendation_context_entries = make_override_proxy(
     __name__,
     "_format_recommendation_context_entries",

--- a/src/cja_auto_sdr/org/writers/markdown.py
+++ b/src/cja_auto_sdr/org/writers/markdown.py
@@ -270,3 +270,10 @@ def write_org_report_markdown(
 
     logger.info(f"Markdown report written to {file_path}")
     return str(file_path)
+
+
+write_org_report_markdown = make_override_proxy(
+    __name__,
+    "write_org_report_markdown",
+    write_org_report_markdown,
+)

--- a/src/cja_auto_sdr/org/writers/trending.py
+++ b/src/cja_auto_sdr/org/writers/trending.py
@@ -13,6 +13,7 @@ from cja_auto_sdr.org.models import (
     TrendingSnapshot,
     _snapshot_effective_data_view_count,
 )
+from cja_auto_sdr.org.writers.compat import call_override
 
 _TRENDING_METRIC_SPECS: tuple[tuple[str, str, str], ...] = (
     ("Data Views", "data_view_count", "data_view_delta"),
@@ -69,14 +70,34 @@ def _trending_snapshot_column_specs(
 ) -> list[tuple[str, str]]:
     """Return unique worksheet keys paired with display labels for trending snapshots."""
     return [
-        (f"snapshot_{index + 1}", _format_trending_timestamp_short(snapshot.timestamp))
+        (
+            f"snapshot_{index + 1}",
+            call_override(
+                __name__,
+                "_format_trending_timestamp_short",
+                _format_trending_timestamp_short,
+                snapshot.timestamp,
+            ),
+        )
         for index, snapshot in enumerate(snapshots)
     ]
 
 
 def _format_trending_period_label(from_timestamp: str, to_timestamp: str) -> str:
     """Return a compact human-readable label for one trending period."""
-    return f"{_format_trending_timestamp_short(from_timestamp)} -> {_format_trending_timestamp_short(to_timestamp)}"
+    from_label = call_override(
+        __name__,
+        "_format_trending_timestamp_short",
+        _format_trending_timestamp_short,
+        from_timestamp,
+    )
+    to_label = call_override(
+        __name__,
+        "_format_trending_timestamp_short",
+        _format_trending_timestamp_short,
+        to_timestamp,
+    )
+    return f"{from_label} -> {to_label}"
 
 
 def _trending_delta_column_specs(
@@ -84,7 +105,16 @@ def _trending_delta_column_specs(
 ) -> list[tuple[str, str]]:
     """Return unique worksheet keys paired with display labels for period deltas."""
     return [
-        (f"period_{index + 1}", _format_trending_period_label(delta.from_timestamp, delta.to_timestamp))
+        (
+            f"period_{index + 1}",
+            call_override(
+                __name__,
+                "_format_trending_period_label",
+                _format_trending_period_label,
+                delta.from_timestamp,
+                delta.to_timestamp,
+            ),
+        )
         for index, delta in enumerate(deltas)
     ]
 
@@ -224,7 +254,13 @@ def _trending_delta_csv_rows(
     """Return row-oriented CSV records for period-over-period deltas."""
     rows: list[dict[str, Any]] = []
     for delta in deltas:
-        period_label = _format_trending_period_label(delta.from_timestamp, delta.to_timestamp)
+        period_label = call_override(
+            __name__,
+            "_format_trending_period_label",
+            _format_trending_period_label,
+            delta.from_timestamp,
+            delta.to_timestamp,
+        )
         for label, _snapshot_attr, delta_attr in _TRENDING_METRIC_SPECS:
             rows.append(
                 {
@@ -289,8 +325,18 @@ def _trending_date_range(snapshots: list[TrendingSnapshot]) -> str:
     """Return 'first_label -> last_label' for a list of snapshots."""
     if not snapshots:
         return ""
-    first = _format_trending_timestamp_short(snapshots[0].timestamp)
-    last = _format_trending_timestamp_short(snapshots[-1].timestamp)
+    first = call_override(
+        __name__,
+        "_format_trending_timestamp_short",
+        _format_trending_timestamp_short,
+        snapshots[0].timestamp,
+    )
+    last = call_override(
+        __name__,
+        "_format_trending_timestamp_short",
+        _format_trending_timestamp_short,
+        snapshots[-1].timestamp,
+    )
     return f"{first} \u2192 {last}"
 
 
@@ -308,7 +354,7 @@ def _render_trending_console(trending: OrgReportTrending) -> str:
     lines.append("\u2550" * 56)
 
     # Column headers
-    col_labels = [_format_trending_timestamp_short(s.timestamp) for s in snapshots]
+    col_labels = [label for _key, label in _trending_snapshot_column_specs(snapshots)]
     lines.extend(_render_console_trending_table(col_labels, _trending_snapshot_metric_rows(snapshots)))
 
     if trending.deltas:
@@ -387,7 +433,7 @@ def _render_trending_markdown(trending: OrgReportTrending) -> str:
     lines.append("")
 
     # Table header
-    col_labels = [_format_trending_timestamp_short(s.timestamp) for s in snapshots]
+    col_labels = [label for _key, label in _trending_snapshot_column_specs(snapshots)]
     lines.extend(_render_markdown_trending_table(col_labels, _trending_snapshot_metric_rows(snapshots)))
     lines.append("")
 
@@ -426,7 +472,7 @@ def _render_trending_html(trending: OrgReportTrending) -> str:
         return ""
 
     date_range = _trending_date_range(snapshots)
-    col_labels = [_format_trending_timestamp_short(s.timestamp) for s in snapshots]
+    col_labels = [label for _key, label in _trending_snapshot_column_specs(snapshots)]
 
     html_out = f"""
         <h2>Trending ({len(snapshots)} snapshots, {html.escape(date_range)})</h2>

--- a/src/cja_auto_sdr/org/writers/trending.py
+++ b/src/cja_auto_sdr/org/writers/trending.py
@@ -13,7 +13,10 @@ from cja_auto_sdr.org.models import (
     TrendingSnapshot,
     _snapshot_effective_data_view_count,
 )
-from cja_auto_sdr.org.writers.compat import call_override
+from cja_auto_sdr.org.writers.compat import (
+    call_override,
+    make_override_proxy,
+)
 
 __all__ = [
     "_TRENDING_METRIC_SPECS",
@@ -545,3 +548,10 @@ def _render_trending_html(trending: OrgReportTrending) -> str:
 """
 
     return html_out
+
+
+_OVERRIDABLE_HELPERS = tuple(name for name in __all__ if name != "_TRENDING_METRIC_SPECS")
+
+for _helper_name in _OVERRIDABLE_HELPERS:
+    globals()[_helper_name] = make_override_proxy(__name__, _helper_name, globals()[_helper_name])
+del _helper_name

--- a/src/cja_auto_sdr/org/writers/trending.py
+++ b/src/cja_auto_sdr/org/writers/trending.py
@@ -15,6 +15,37 @@ from cja_auto_sdr.org.models import (
 )
 from cja_auto_sdr.org.writers.compat import call_override
 
+__all__ = [
+    "_TRENDING_METRIC_SPECS",
+    "_build_trending_metric_rows",
+    "_escape_markdown_table_cell",
+    "_format_signed_trending_value",
+    "_format_trending_dv_label",
+    "_format_trending_period_label",
+    "_format_trending_timestamp_short",
+    "_print_trending_console_section",
+    "_ranked_drift_entries",
+    "_render_console_trending_table",
+    "_render_html_trending_table",
+    "_render_markdown_trending_table",
+    "_render_trending_console",
+    "_render_trending_html",
+    "_render_trending_markdown",
+    "_resolve_trending_dv_name",
+    "_sorted_drift_score_items",
+    "_stringify_trending_value",
+    "_top_drift_scores",
+    "_trending_date_range",
+    "_trending_delta_column_specs",
+    "_trending_delta_csv_rows",
+    "_trending_delta_metric_rows",
+    "_trending_matrix_rows",
+    "_trending_snapshot_column_specs",
+    "_trending_snapshot_csv_rows",
+    "_trending_snapshot_metric_rows",
+    "_trending_snapshots_to_dicts",
+]
+
 _TRENDING_METRIC_SPECS: tuple[tuple[str, str, str], ...] = (
     ("Data Views", "data_view_count", "data_view_delta"),
     ("Components", "component_count", "component_delta"),

--- a/src/cja_auto_sdr/output/diff/common.py
+++ b/src/cja_auto_sdr/output/diff/common.py
@@ -18,6 +18,11 @@ from cja_auto_sdr.diff.models import (
     InventoryItemDiff,
 )
 
+__all__ = [
+    "ANSIColors",
+    "detect_breaking_changes",
+]
+
 # ---------------------------------------------------------------------------
 # ANSIColors adapter — delegates to ConsoleColors constants but accepts an
 # explicit 'enabled' parameter so callers can toggle color per-call.

--- a/src/cja_auto_sdr/output/diff/console.py
+++ b/src/cja_auto_sdr/output/diff/console.py
@@ -18,6 +18,10 @@ from cja_auto_sdr.output.diff.common import (
     _get_inventory_change_detail,
 )
 
+__all__ = [
+    "write_diff_console_output",
+]
+
 
 def _format_side_by_side(
     diff,

--- a/src/cja_auto_sdr/output/diff/csv.py
+++ b/src/cja_auto_sdr/output/diff/csv.py
@@ -24,6 +24,10 @@ from cja_auto_sdr.output.diff.common import (
     _get_inventory_change_detail,
 )
 
+__all__ = [
+    "write_diff_csv_output",
+]
+
 
 def write_diff_csv_output(
     diff_result: DiffResult,

--- a/src/cja_auto_sdr/output/diff/excel.py
+++ b/src/cja_auto_sdr/output/diff/excel.py
@@ -24,6 +24,10 @@ from cja_auto_sdr.output.diff.common import (
     _get_inventory_change_detail,
 )
 
+__all__ = [
+    "write_diff_excel_output",
+]
+
 
 def write_diff_excel_output(
     diff_result: DiffResult,

--- a/src/cja_auto_sdr/output/diff/grouped.py
+++ b/src/cja_auto_sdr/output/diff/grouped.py
@@ -13,6 +13,10 @@ from cja_auto_sdr.output.diff.common import (
     detect_breaking_changes,
 )
 
+__all__ = [
+    "write_diff_grouped_by_field_output",
+]
+
 
 def write_diff_grouped_by_field_output(diff_result: DiffResult, use_color: bool = True, limit: int = 10) -> str:
     """

--- a/src/cja_auto_sdr/output/diff/html.py
+++ b/src/cja_auto_sdr/output/diff/html.py
@@ -24,6 +24,10 @@ from cja_auto_sdr.output.diff.common import (
     _get_inventory_change_detail,
 )
 
+__all__ = [
+    "write_diff_html_output",
+]
+
 
 def write_diff_html_output(
     diff_result: DiffResult,

--- a/src/cja_auto_sdr/output/diff/json.py
+++ b/src/cja_auto_sdr/output/diff/json.py
@@ -19,6 +19,10 @@ from cja_auto_sdr.diff.models import (
     InventoryItemDiff,
 )
 
+__all__ = [
+    "write_diff_json_output",
+]
+
 
 def write_diff_json_output(
     diff_result: DiffResult,

--- a/src/cja_auto_sdr/output/diff/markdown.py
+++ b/src/cja_auto_sdr/output/diff/markdown.py
@@ -20,6 +20,10 @@ from cja_auto_sdr.output.diff.common import (
     _get_inventory_change_detail,
 )
 
+__all__ = [
+    "write_diff_markdown_output",
+]
+
 
 def _format_markdown_side_by_side(diff: ComponentDiff, source_label: str, target_label: str) -> list[str]:
     """

--- a/src/cja_auto_sdr/output/diff/pr_comment.py
+++ b/src/cja_auto_sdr/output/diff/pr_comment.py
@@ -12,6 +12,10 @@ from cja_auto_sdr.output.diff.common import (
     detect_breaking_changes,
 )
 
+__all__ = [
+    "write_diff_pr_comment_output",
+]
+
 
 def write_diff_pr_comment_output(
     diff_result: DiffResult,

--- a/tests/README.md
+++ b/tests/README.md
@@ -55,7 +55,7 @@ tests/
 ├── test_main_entry_points.py        # main() and _main_impl() entry point tests
 ├── test_malformed_api_responses.py  # Negative tests for malformed API data
 ├── test_output_content_validation.py # Output format content validation tests
-├── test_output_extraction_contracts.py # Extraction contracts for output.diff and output.inventory
+├── test_output_extraction_contracts.py # Extraction contracts for output.diff, output.inventory, and org.writers compatibility routing
 ├── test_quality_policy_and_run_summary.py # Quality policy and run summary tests
 ├── test_api_client.py               # API client exception path tests
 ├── test_config_validation.py        # Configuration validation tests
@@ -126,7 +126,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 7,063 comprehensive tests**
+**Total: 7,085 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -135,16 +135,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 6,957 | 108 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 6,979 | 108 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 7 | 1 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **7,063** | **114** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **7,085** | **114** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 6,950 | 107 | `-m "unit and not slow"` |
+| `test-unit` | 6,972 | 107 | `-m "unit and not slow"` |
 | `test-integration` | 103 | 6 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -195,7 +195,7 @@ tests/
 | `test_discovery_extraction.py` | 46 | Discovery module extraction and backwards-compat contracts |
 | `test_diagnostic_events.py` | 23 | Structured diagnostic event vocabulary, logger adapters, and redaction |
 | `test_output_content_validation.py` | 29 | Output format content validation (CSV, JSON, HTML, Excel, Markdown roundtrip) |
-| `test_output_extraction_contracts.py` | 350 | Extraction contracts for output.diff and output.inventory |
+| `test_output_extraction_contracts.py` | 372 | Extraction contracts for output.diff, output.inventory, and org.writers compatibility routing |
 | `test_malformed_api_responses.py` | 20 | Negative tests for malformed/unexpected API responses |
 | `test_main_entry_points.py` | 43 | main() and _main_impl() entry points, dispatch, run_state, run summary |
 | `test_quality_policy_and_run_summary.py` | 163 | Quality policy functions and run summary/status inference |
@@ -268,7 +268,7 @@ tests/
 | `test_exit_codes.py` | 11 | Exit code helpers and signal detection tests |
 | `test_json_io.py` | 5 | JSON I/O atomic write and read tests |
 | `test_lock_info_normalization.py` | 54 | Lock-info normalization classmethod direct unit tests |
-| **Total** | **7,063** | **Collected via pytest --collect-only** |
+| **Total** | **7,085** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -726,7 +726,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (7,063 tests total)
+- [x] Comprehensive test coverage (7,085 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 209 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 77 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -126,7 +126,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 7,130 comprehensive tests**
+**Total: 7,158 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -135,16 +135,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,024 | 108 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,052 | 108 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 7 | 1 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **7,130** | **114** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **7,158** | **114** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,017 | 107 | `-m "unit and not slow"` |
+| `test-unit` | 7,045 | 107 | `-m "unit and not slow"` |
 | `test-integration` | 103 | 6 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -195,7 +195,7 @@ tests/
 | `test_discovery_extraction.py` | 46 | Discovery module extraction and backwards-compat contracts |
 | `test_diagnostic_events.py` | 23 | Structured diagnostic event vocabulary, logger adapters, and redaction |
 | `test_output_content_validation.py` | 29 | Output format content validation (CSV, JSON, HTML, Excel, Markdown roundtrip) |
-| `test_output_extraction_contracts.py` | 416 | Extraction contracts for output.diff, output.inventory, and org.writers compatibility routing |
+| `test_output_extraction_contracts.py` | 444 | Extraction contracts for output.diff, output.inventory, and org.writers compatibility routing |
 | `test_malformed_api_responses.py` | 20 | Negative tests for malformed/unexpected API responses |
 | `test_main_entry_points.py` | 43 | main() and _main_impl() entry points, dispatch, run_state, run summary |
 | `test_quality_policy_and_run_summary.py` | 163 | Quality policy functions and run summary/status inference |
@@ -268,7 +268,7 @@ tests/
 | `test_exit_codes.py` | 11 | Exit code helpers and signal detection tests |
 | `test_json_io.py` | 5 | JSON I/O atomic write and read tests |
 | `test_lock_info_normalization.py` | 54 | Lock-info normalization classmethod direct unit tests |
-| **Total** | **7,130** | **Collected via pytest --collect-only** |
+| **Total** | **7,158** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -726,7 +726,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (7,130 tests total)
+- [x] Comprehensive test coverage (7,158 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 209 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 77 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -126,7 +126,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 6,950 comprehensive tests**
+**Total: 7,063 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -135,16 +135,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 6,844 | 108 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 6,957 | 108 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 7 | 1 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **6,950** | **114** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **7,063** | **114** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 6,837 | 107 | `-m "unit and not slow"` |
+| `test-unit` | 6,950 | 107 | `-m "unit and not slow"` |
 | `test-integration` | 103 | 6 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -195,7 +195,7 @@ tests/
 | `test_discovery_extraction.py` | 46 | Discovery module extraction and backwards-compat contracts |
 | `test_diagnostic_events.py` | 23 | Structured diagnostic event vocabulary, logger adapters, and redaction |
 | `test_output_content_validation.py` | 29 | Output format content validation (CSV, JSON, HTML, Excel, Markdown roundtrip) |
-| `test_output_extraction_contracts.py` | 237 | Extraction contracts for output.diff and output.inventory |
+| `test_output_extraction_contracts.py` | 350 | Extraction contracts for output.diff and output.inventory |
 | `test_malformed_api_responses.py` | 20 | Negative tests for malformed/unexpected API responses |
 | `test_main_entry_points.py` | 43 | main() and _main_impl() entry points, dispatch, run_state, run summary |
 | `test_quality_policy_and_run_summary.py` | 163 | Quality policy functions and run summary/status inference |
@@ -268,7 +268,7 @@ tests/
 | `test_exit_codes.py` | 11 | Exit code helpers and signal detection tests |
 | `test_json_io.py` | 5 | JSON I/O atomic write and read tests |
 | `test_lock_info_normalization.py` | 54 | Lock-info normalization classmethod direct unit tests |
-| **Total** | **6,950** | **Collected via pytest --collect-only** |
+| **Total** | **7,063** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -726,7 +726,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (6,950 tests total)
+- [x] Comprehensive test coverage (7,063 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 209 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 77 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -126,7 +126,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 7,088 comprehensive tests**
+**Total: 7,089 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -135,16 +135,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 6,982 | 108 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 6,983 | 108 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 7 | 1 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **7,088** | **114** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **7,089** | **114** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 6,975 | 107 | `-m "unit and not slow"` |
+| `test-unit` | 6,976 | 107 | `-m "unit and not slow"` |
 | `test-integration` | 103 | 6 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -195,7 +195,7 @@ tests/
 | `test_discovery_extraction.py` | 46 | Discovery module extraction and backwards-compat contracts |
 | `test_diagnostic_events.py` | 23 | Structured diagnostic event vocabulary, logger adapters, and redaction |
 | `test_output_content_validation.py` | 29 | Output format content validation (CSV, JSON, HTML, Excel, Markdown roundtrip) |
-| `test_output_extraction_contracts.py` | 375 | Extraction contracts for output.diff, output.inventory, and org.writers compatibility routing |
+| `test_output_extraction_contracts.py` | 376 | Extraction contracts for output.diff, output.inventory, and org.writers compatibility routing |
 | `test_malformed_api_responses.py` | 20 | Negative tests for malformed/unexpected API responses |
 | `test_main_entry_points.py` | 43 | main() and _main_impl() entry points, dispatch, run_state, run summary |
 | `test_quality_policy_and_run_summary.py` | 163 | Quality policy functions and run summary/status inference |
@@ -268,7 +268,7 @@ tests/
 | `test_exit_codes.py` | 11 | Exit code helpers and signal detection tests |
 | `test_json_io.py` | 5 | JSON I/O atomic write and read tests |
 | `test_lock_info_normalization.py` | 54 | Lock-info normalization classmethod direct unit tests |
-| **Total** | **7,088** | **Collected via pytest --collect-only** |
+| **Total** | **7,089** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -726,7 +726,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (7,088 tests total)
+- [x] Comprehensive test coverage (7,089 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 209 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 77 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -126,7 +126,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 7,089 comprehensive tests**
+**Total: 7,090 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -135,16 +135,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 6,983 | 108 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 6,984 | 108 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 7 | 1 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **7,089** | **114** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **7,090** | **114** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 6,976 | 107 | `-m "unit and not slow"` |
+| `test-unit` | 6,977 | 107 | `-m "unit and not slow"` |
 | `test-integration` | 103 | 6 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -195,7 +195,7 @@ tests/
 | `test_discovery_extraction.py` | 46 | Discovery module extraction and backwards-compat contracts |
 | `test_diagnostic_events.py` | 23 | Structured diagnostic event vocabulary, logger adapters, and redaction |
 | `test_output_content_validation.py` | 29 | Output format content validation (CSV, JSON, HTML, Excel, Markdown roundtrip) |
-| `test_output_extraction_contracts.py` | 376 | Extraction contracts for output.diff, output.inventory, and org.writers compatibility routing |
+| `test_output_extraction_contracts.py` | 377 | Extraction contracts for output.diff, output.inventory, and org.writers compatibility routing |
 | `test_malformed_api_responses.py` | 20 | Negative tests for malformed/unexpected API responses |
 | `test_main_entry_points.py` | 43 | main() and _main_impl() entry points, dispatch, run_state, run summary |
 | `test_quality_policy_and_run_summary.py` | 163 | Quality policy functions and run summary/status inference |
@@ -268,7 +268,7 @@ tests/
 | `test_exit_codes.py` | 11 | Exit code helpers and signal detection tests |
 | `test_json_io.py` | 5 | JSON I/O atomic write and read tests |
 | `test_lock_info_normalization.py` | 54 | Lock-info normalization classmethod direct unit tests |
-| **Total** | **7,089** | **Collected via pytest --collect-only** |
+| **Total** | **7,090** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -726,7 +726,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (7,089 tests total)
+- [x] Comprehensive test coverage (7,090 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 209 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 77 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -126,7 +126,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 7,113 comprehensive tests**
+**Total: 7,130 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -135,16 +135,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,007 | 108 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,024 | 108 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 7 | 1 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **7,113** | **114** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **7,130** | **114** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,000 | 107 | `-m "unit and not slow"` |
+| `test-unit` | 7,017 | 107 | `-m "unit and not slow"` |
 | `test-integration` | 103 | 6 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -195,7 +195,7 @@ tests/
 | `test_discovery_extraction.py` | 46 | Discovery module extraction and backwards-compat contracts |
 | `test_diagnostic_events.py` | 23 | Structured diagnostic event vocabulary, logger adapters, and redaction |
 | `test_output_content_validation.py` | 29 | Output format content validation (CSV, JSON, HTML, Excel, Markdown roundtrip) |
-| `test_output_extraction_contracts.py` | 400 | Extraction contracts for output.diff, output.inventory, and org.writers compatibility routing |
+| `test_output_extraction_contracts.py` | 416 | Extraction contracts for output.diff, output.inventory, and org.writers compatibility routing |
 | `test_malformed_api_responses.py` | 20 | Negative tests for malformed/unexpected API responses |
 | `test_main_entry_points.py` | 43 | main() and _main_impl() entry points, dispatch, run_state, run summary |
 | `test_quality_policy_and_run_summary.py` | 163 | Quality policy functions and run summary/status inference |
@@ -226,7 +226,7 @@ tests/
 | `test_config_and_resolution.py` | 108 | Config status, validation, stats, name resolution |
 | `test_derived_fields_edge_cases.py` | 34 | Derived fields edge cases and coverage |
 | `test_diff_command_coverage.py` | 45 | Diff command edge cases and coverage |
-| `test_generator_interactive_and_console.py` | 36 | Generator interactive and console tests |
+| `test_generator_interactive_and_console.py` | 37 | Generator interactive and console tests |
 | `test_generator_remaining_coverage.py` | 82 | Generator remaining coverage edge cases |
 | `test_interactive_discovery_coverage.py` | 112 | Interactive discovery and helpers coverage |
 | `test_lock_backends.py` | 46 | Lock backends edge cases and coverage |
@@ -268,7 +268,7 @@ tests/
 | `test_exit_codes.py` | 11 | Exit code helpers and signal detection tests |
 | `test_json_io.py` | 5 | JSON I/O atomic write and read tests |
 | `test_lock_info_normalization.py` | 54 | Lock-info normalization classmethod direct unit tests |
-| **Total** | **7,113** | **Collected via pytest --collect-only** |
+| **Total** | **7,130** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -726,7 +726,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (7,113 tests total)
+- [x] Comprehensive test coverage (7,130 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 209 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 77 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -126,7 +126,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 6,944 comprehensive tests**
+**Total: 6,950 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -135,16 +135,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 6,838 | 108 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 6,844 | 108 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 7 | 1 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **6,944** | **114** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **6,950** | **114** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 6,831 | 107 | `-m "unit and not slow"` |
+| `test-unit` | 6,837 | 107 | `-m "unit and not slow"` |
 | `test-integration` | 103 | 6 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -195,7 +195,7 @@ tests/
 | `test_discovery_extraction.py` | 46 | Discovery module extraction and backwards-compat contracts |
 | `test_diagnostic_events.py` | 23 | Structured diagnostic event vocabulary, logger adapters, and redaction |
 | `test_output_content_validation.py` | 29 | Output format content validation (CSV, JSON, HTML, Excel, Markdown roundtrip) |
-| `test_output_extraction_contracts.py` | 231 | Extraction contracts for output.diff and output.inventory |
+| `test_output_extraction_contracts.py` | 237 | Extraction contracts for output.diff and output.inventory |
 | `test_malformed_api_responses.py` | 20 | Negative tests for malformed/unexpected API responses |
 | `test_main_entry_points.py` | 43 | main() and _main_impl() entry points, dispatch, run_state, run summary |
 | `test_quality_policy_and_run_summary.py` | 163 | Quality policy functions and run summary/status inference |
@@ -268,7 +268,7 @@ tests/
 | `test_exit_codes.py` | 11 | Exit code helpers and signal detection tests |
 | `test_json_io.py` | 5 | JSON I/O atomic write and read tests |
 | `test_lock_info_normalization.py` | 54 | Lock-info normalization classmethod direct unit tests |
-| **Total** | **6,944** | **Collected via pytest --collect-only** |
+| **Total** | **6,950** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -726,7 +726,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (6,944 tests total)
+- [x] Comprehensive test coverage (6,950 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 209 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 77 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -126,7 +126,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 7,090 comprehensive tests**
+**Total: 7,113 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -135,16 +135,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 6,984 | 108 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,007 | 108 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 7 | 1 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **7,090** | **114** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **7,113** | **114** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 6,977 | 107 | `-m "unit and not slow"` |
+| `test-unit` | 7,000 | 107 | `-m "unit and not slow"` |
 | `test-integration` | 103 | 6 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -195,7 +195,7 @@ tests/
 | `test_discovery_extraction.py` | 46 | Discovery module extraction and backwards-compat contracts |
 | `test_diagnostic_events.py` | 23 | Structured diagnostic event vocabulary, logger adapters, and redaction |
 | `test_output_content_validation.py` | 29 | Output format content validation (CSV, JSON, HTML, Excel, Markdown roundtrip) |
-| `test_output_extraction_contracts.py` | 377 | Extraction contracts for output.diff, output.inventory, and org.writers compatibility routing |
+| `test_output_extraction_contracts.py` | 400 | Extraction contracts for output.diff, output.inventory, and org.writers compatibility routing |
 | `test_malformed_api_responses.py` | 20 | Negative tests for malformed/unexpected API responses |
 | `test_main_entry_points.py` | 43 | main() and _main_impl() entry points, dispatch, run_state, run summary |
 | `test_quality_policy_and_run_summary.py` | 163 | Quality policy functions and run summary/status inference |
@@ -268,7 +268,7 @@ tests/
 | `test_exit_codes.py` | 11 | Exit code helpers and signal detection tests |
 | `test_json_io.py` | 5 | JSON I/O atomic write and read tests |
 | `test_lock_info_normalization.py` | 54 | Lock-info normalization classmethod direct unit tests |
-| **Total** | **7,090** | **Collected via pytest --collect-only** |
+| **Total** | **7,113** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -726,7 +726,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (7,090 tests total)
+- [x] Comprehensive test coverage (7,113 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 209 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 77 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -126,7 +126,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 7,085 comprehensive tests**
+**Total: 7,088 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -135,16 +135,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 6,979 | 108 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 6,982 | 108 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 7 | 1 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **7,085** | **114** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **7,088** | **114** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 6,972 | 107 | `-m "unit and not slow"` |
+| `test-unit` | 6,975 | 107 | `-m "unit and not slow"` |
 | `test-integration` | 103 | 6 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -195,7 +195,7 @@ tests/
 | `test_discovery_extraction.py` | 46 | Discovery module extraction and backwards-compat contracts |
 | `test_diagnostic_events.py` | 23 | Structured diagnostic event vocabulary, logger adapters, and redaction |
 | `test_output_content_validation.py` | 29 | Output format content validation (CSV, JSON, HTML, Excel, Markdown roundtrip) |
-| `test_output_extraction_contracts.py` | 372 | Extraction contracts for output.diff, output.inventory, and org.writers compatibility routing |
+| `test_output_extraction_contracts.py` | 375 | Extraction contracts for output.diff, output.inventory, and org.writers compatibility routing |
 | `test_malformed_api_responses.py` | 20 | Negative tests for malformed/unexpected API responses |
 | `test_main_entry_points.py` | 43 | main() and _main_impl() entry points, dispatch, run_state, run summary |
 | `test_quality_policy_and_run_summary.py` | 163 | Quality policy functions and run summary/status inference |
@@ -268,7 +268,7 @@ tests/
 | `test_exit_codes.py` | 11 | Exit code helpers and signal detection tests |
 | `test_json_io.py` | 5 | JSON I/O atomic write and read tests |
 | `test_lock_info_normalization.py` | 54 | Lock-info normalization classmethod direct unit tests |
-| **Total** | **7,085** | **Collected via pytest --collect-only** |
+| **Total** | **7,088** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -726,7 +726,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (7,085 tests total)
+- [x] Comprehensive test coverage (7,088 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 209 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 77 tests

--- a/tests/test_generator_interactive_and_console.py
+++ b/tests/test_generator_interactive_and_console.py
@@ -309,6 +309,38 @@ def test_run_org_report_stats_only_and_csv_stdout_guard(tmp_path: Path, rich_org
     assert thresholds_exceeded is False
 
 
+def test_run_org_report_honors_generator_override_scope_for_output_validation(tmp_path: Path):
+    from cja_auto_sdr.org.writers.compat import override_scope
+
+    validate_calls: list[tuple[str, bool]] = []
+
+    with (
+        patch("cja_auto_sdr.generator.configure_cjapy") as configure_mock,
+        override_scope(
+            "cja_auto_sdr.generator",
+            {
+                "_normalize_org_report_output_format": lambda output_format: "json",
+                "_validate_org_report_output_request": lambda output_format, output_to_stdout, status_print: (
+                    validate_calls.append((output_format, output_to_stdout)) or False
+                ),
+            },
+        ),
+    ):
+        ok, exceeded = generator.run_org_report(
+            config_file="config.json",
+            output_format="reports",
+            output_path=str(tmp_path / "org_report"),
+            output_dir=str(tmp_path),
+            org_config=OrgReportConfig(),
+            quiet=True,
+        )
+
+    assert ok is False
+    assert exceeded is False
+    assert validate_calls == [("json", False)]
+    configure_mock.assert_not_called()
+
+
 def test_run_org_report_reports_alias_and_individual_format_branches(tmp_path: Path, rich_org_report_result):
     result = rich_org_report_result
     base_output = tmp_path / "org_report_out"

--- a/tests/test_output_content_validation.py
+++ b/tests/test_output_content_validation.py
@@ -38,7 +38,7 @@ def rich_data_dict():
         "Metadata": pd.DataFrame(
             {
                 "Property": ["Generated At", "Data View ID", "Tool Version", "Total Metrics"],
-                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.4.7", 3],
+                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.4.8", 3],
             },
         ),
         "Data Quality": pd.DataFrame(
@@ -104,7 +104,7 @@ def rich_metadata_dict():
         "Generated At": "2025-01-15 10:30:00 PST",
         "Data View ID": "dv_content_test",
         "Data View Name": "Test DataView",
-        "Tool Version": "3.4.7",
+        "Tool Version": "3.4.8",
         "Metrics Count": "3",
         "Dimensions Count": "4",
     }
@@ -224,7 +224,7 @@ class TestJSONContentValidation:
             data = json.load(f)
 
         assert data["metadata"]["Data View ID"] == "dv_content_test"
-        assert data["metadata"]["Tool Version"] == "3.4.7"
+        assert data["metadata"]["Tool Version"] == "3.4.8"
 
     def test_json_metadata_preserves_partial_markers(self, tmp_path, rich_data_dict, rich_metadata_dict):
         logger = logging.getLogger("json_test")

--- a/tests/test_output_extraction_contracts.py
+++ b/tests/test_output_extraction_contracts.py
@@ -1516,10 +1516,10 @@ class TestCompatSignatureContinuity:
             "params": ["target_module_name", "attr_name", "default"],
         },
         "collect_legacy_overrides": {
-            "params": ["source_module_name", "override_mapping", "default_target_module_name", "baselines"],
+            "params": ["source_module_name", "override_mapping", "baselines"],
         },
         "override_scope": {
-            "params": ["overrides"],
+            "params": ["target_module_name", "overrides"],
         },
         "make_compat_wrapper": {
             "params": ["source_module_name", "target", "target_module_name", "override_mapping"],
@@ -1554,14 +1554,14 @@ class TestCompatSignatureContinuity:
         mappings_param = sig.parameters["mappings"]
         assert mappings_param.kind == inspect.Parameter.VAR_POSITIONAL
 
-    def test_collect_legacy_overrides_has_keyword_only_params(self):
-        """collect_legacy_overrides must have default_target_module_name as keyword-only."""
+    def test_collect_legacy_overrides_has_keyword_only_baselines(self):
+        """collect_legacy_overrides must keep baselines as a keyword-only parameter."""
         import inspect
 
         from cja_auto_sdr.org.writers.compat import collect_legacy_overrides
 
         sig = signature(collect_legacy_overrides)
-        param = sig.parameters["default_target_module_name"]
+        param = sig.parameters["baselines"]
         assert param.kind == inspect.Parameter.KEYWORD_ONLY
 
     def test_collect_legacy_overrides_baselines_defaults_to_none(self):
@@ -1755,10 +1755,31 @@ class TestMakeCompatWrapperBehavior:
         key = ("test.module", "test_attr")
         assert key not in _current_overrides()
 
-        with override_scope({key: "patched_value"}):
+        with override_scope("test.module", {"test_attr": "patched_value"}):
             assert _current_overrides()[key] == "patched_value"
 
         assert key not in _current_overrides()
+
+    def test_collect_legacy_overrides_preserves_flat_result_contract(self):
+        """collect_legacy_overrides must return the legacy flat attr->override mapping."""
+        from cja_auto_sdr.org.writers.compat import collect_legacy_overrides, compose_override_mapping
+
+        overrides = collect_legacy_overrides(
+            "cja_auto_sdr.org.writers.compat",
+            {"compose": "compose_override_mapping"},
+        )
+
+        assert overrides == {"compose": compose_override_mapping}
+
+    def test_collect_legacy_overrides_rejects_tuple_keys(self):
+        """collect_legacy_overrides public surface must reject normalized tuple-key mappings."""
+        from cja_auto_sdr.org.writers.compat import collect_legacy_overrides
+
+        with pytest.raises(TypeError, match="public override_mapping keys must be strings"):
+            collect_legacy_overrides(
+                "cja_auto_sdr.org.writers.compat",
+                {("test.module", "compose"): "compose_override_mapping"},
+            )
 
     def test_resolve_override_returns_default_without_scope(self):
         """resolve_override must return the default when no override is active."""
@@ -1777,7 +1798,7 @@ class TestMakeCompatWrapperBehavior:
         key_module = "test.resolve.module"
         key_attr = "test_resolve_attr"
 
-        with override_scope({(key_module, key_attr): override_val}):
+        with override_scope(key_module, {key_attr: override_val}):
             result = resolve_override(key_module, key_attr, sentinel)
             assert result is override_val
 
@@ -1794,7 +1815,7 @@ class TestMakeCompatWrapperBehavior:
         def override_fn(x):
             return f"override:{x}"
 
-        with override_scope({("test.proxy.module", "test_fn"): override_fn}):
+        with override_scope("test.proxy.module", {"test_fn": override_fn}):
             assert proxy("hello") == "override:hello"
 
         assert proxy("hello") == "default:hello"
@@ -1819,7 +1840,7 @@ class TestMakeCompatWrapperBehavior:
         def override_fn(a, b):
             return a * b
 
-        with override_scope({("test.call.module", "test_fn"): override_fn}):
+        with override_scope("test.call.module", {"test_fn": override_fn}):
             result = call_override("test.call.module", "test_fn", default_fn, 3, 4)
             assert result == 12
 
@@ -1835,7 +1856,7 @@ class TestMakeCompatWrapperBehavior:
 
         assert call_override("test.kw.module", "test_fn", default_fn, x=1, y=2) == "default:1,2"
 
-        with override_scope({("test.kw.module", "test_fn"): override_fn}):
+        with override_scope("test.kw.module", {"test_fn": override_fn}):
             assert call_override("test.kw.module", "test_fn", default_fn, x=3, y=4) == "override:3,4"
 
     def test_override_scope_nesting_preserves_outer_keys(self):
@@ -1845,8 +1866,8 @@ class TestMakeCompatWrapperBehavior:
         key_a = ("test.nest.module", "attr_a")
         key_b = ("test.nest.module", "attr_b")
 
-        with override_scope({key_a: "outer_a"}):
-            with override_scope({key_b: "inner_b"}):
+        with override_scope("test.nest.module", {"attr_a": "outer_a"}):
+            with override_scope("test.nest.module", {"attr_b": "inner_b"}):
                 overrides = _current_overrides()
                 assert overrides[key_a] == "outer_a"
                 assert overrides[key_b] == "inner_b"
@@ -1857,9 +1878,9 @@ class TestMakeCompatWrapperBehavior:
 
         key = ("test.shadow.module", "attr")
 
-        with override_scope({key: "outer"}):
+        with override_scope("test.shadow.module", {"attr": "outer"}):
             assert _current_overrides()[key] == "outer"
-            with override_scope({key: "inner"}):
+            with override_scope("test.shadow.module", {"attr": "inner"}):
                 assert _current_overrides()[key] == "inner"
 
     def test_override_scope_nesting_exit_restores_outer(self):
@@ -1868,12 +1889,20 @@ class TestMakeCompatWrapperBehavior:
 
         key = ("test.restore.module", "attr")
 
-        with override_scope({key: "outer"}):
-            with override_scope({key: "inner"}):
+        with override_scope("test.restore.module", {"attr": "outer"}):
+            with override_scope("test.restore.module", {"attr": "inner"}):
                 pass
             assert _current_overrides()[key] == "outer"
 
         assert key not in _current_overrides()
+
+    def test_override_scope_rejects_non_string_keys(self):
+        """override_scope public surface must reject normalized tuple-key mappings."""
+        from cja_auto_sdr.org.writers.compat import override_scope
+
+        with pytest.raises(TypeError, match="override keys must be strings"):
+            with override_scope("test.invalid.module", {("test.invalid.module", "attr"): "value"}):
+                pass
 
 
 class TestFreezeAndComposeOverrideMapping:

--- a/tests/test_output_extraction_contracts.py
+++ b/tests/test_output_extraction_contracts.py
@@ -1771,14 +1771,41 @@ class TestMakeCompatWrapperBehavior:
 
         assert overrides == {"compose": compose_override_mapping}
 
-    def test_collect_legacy_overrides_rejects_tuple_keys(self):
-        """collect_legacy_overrides public surface must reject normalized tuple-key mappings."""
+    def test_collect_legacy_overrides_accepts_exported_writer_mapping(self):
+        """collect_legacy_overrides must accept exported mixed-key writer mappings."""
+        from cja_auto_sdr.org.writers import (
+            _format_recommendation_context_entries,
+            _format_trending_period_label,
+            _render_trending_markdown,
+        )
+        from cja_auto_sdr.org.writers.compat import (
+            MARKDOWN_WRITER_OVERRIDE_MAPPING,
+            collect_legacy_overrides,
+        )
+
+        overrides = collect_legacy_overrides(
+            "cja_auto_sdr.org.writers",
+            MARKDOWN_WRITER_OVERRIDE_MAPPING,
+        )
+
+        assert overrides["_render_trending_markdown"] is _render_trending_markdown
+        assert (
+            overrides[("cja_auto_sdr.org.writers.markdown", "_format_recommendation_context_entries")]
+            is _format_recommendation_context_entries
+        )
+        assert (
+            overrides[("cja_auto_sdr.org.writers.trending", "_format_trending_period_label")]
+            is _format_trending_period_label
+        )
+
+    def test_collect_legacy_overrides_rejects_malformed_tuple_keys(self):
+        """collect_legacy_overrides must reject tuple keys that are not (module, attr) string pairs."""
         from cja_auto_sdr.org.writers.compat import collect_legacy_overrides
 
-        with pytest.raises(TypeError, match="public override_mapping keys must be strings"):
+        with pytest.raises(TypeError, match="tuple keys must be \\(target_module_name, attr_name\\) string pairs"):
             collect_legacy_overrides(
                 "cja_auto_sdr.org.writers.compat",
-                {("test.module", "compose"): "compose_override_mapping"},
+                {("test.module", 1): "compose_override_mapping"},
             )
 
     def test_resolve_override_returns_default_without_scope(self):

--- a/tests/test_output_extraction_contracts.py
+++ b/tests/test_output_extraction_contracts.py
@@ -198,6 +198,64 @@ def test_output_diff_pr_comment_signature_preserves_public_keyword():
     assert list(signature(write_diff_pr_comment_output).parameters) == ["diff_result", "changes_only"]
 
 
+def _call_canonical_org_writer_export(mod, attr, *, tmp_path, rich_org_report_result):
+    logger = logging.getLogger(f"test.{mod.__name__}.{attr}.canonical_self_scope")
+    if attr == "build_org_report_json_data":
+        return mod.build_org_report_json_data(rich_org_report_result)
+    if attr == "write_org_report_json":
+        return Path(
+            mod.write_org_report_json(
+                rich_org_report_result,
+                tmp_path / f"{mod.__name__.rsplit('.', 1)[-1]}_canonical_self_scope.json",
+                str(tmp_path),
+                logger,
+            ),
+        )
+    if attr == "write_org_report_markdown":
+        return Path(
+            mod.write_org_report_markdown(
+                rich_org_report_result,
+                tmp_path / f"{mod.__name__.rsplit('.', 1)[-1]}_canonical_self_scope.md",
+                str(tmp_path),
+                logger,
+            ),
+        )
+    if attr == "write_org_report_console":
+        mod.write_org_report_console(rich_org_report_result, rich_org_report_result.parameters, quiet=True)
+        return None
+    if attr == "write_org_report_stats_only":
+        mod.write_org_report_stats_only(rich_org_report_result, quiet=True)
+        return None
+    if attr == "write_org_report_csv":
+        return Path(
+            mod.write_org_report_csv(
+                rich_org_report_result,
+                tmp_path / f"{mod.__name__.rsplit('.', 1)[-1]}_canonical_self_scope.csv",
+                str(tmp_path),
+                logger,
+            ),
+        )
+    if attr == "write_org_report_html":
+        return Path(
+            mod.write_org_report_html(
+                rich_org_report_result,
+                tmp_path / f"{mod.__name__.rsplit('.', 1)[-1]}_canonical_self_scope.html",
+                str(tmp_path),
+                logger,
+            ),
+        )
+    if attr == "write_org_report_excel":
+        return Path(
+            mod.write_org_report_excel(
+                rich_org_report_result,
+                tmp_path / f"{mod.__name__.rsplit('.', 1)[-1]}_canonical_self_scope.xlsx",
+                str(tmp_path),
+                logger,
+            ),
+        )
+    raise AssertionError(f"Unhandled canonical writer export: {mod.__name__}.{attr}")
+
+
 @pytest.mark.parametrize(
     "module_name",
     [
@@ -1745,6 +1803,256 @@ def test_common_helper_reexports_support_wraps_override_scope_on_self_exports(
 
     assert normalized == "high"
     severity_spy.assert_called_once_with("HIGH")
+
+
+@pytest.mark.parametrize(
+    ("attr", "call_args", "expected"),
+    [
+        ("_normalize_recommendation_severity", ("HIGH",), "high"),
+        ("_normalize_org_report_output_format", ("JSON",), "json"),
+    ],
+    ids=["severity", "output-format"],
+)
+def test_canonical_common_helper_exports_support_wraps_override_scope_on_self_exports(
+    attr,
+    call_args,
+    expected,
+):
+    """Direct canonical common helpers must honor scoped wraps spies on self exports."""
+    from cja_auto_sdr.org.writers.compat import override_scope
+
+    mod = importlib.import_module("cja_auto_sdr.org.writers.common")
+    helper_spy = Mock(wraps=getattr(mod, attr))
+
+    with override_scope(
+        mod.__name__,
+        {
+            attr: helper_spy,
+        },
+    ):
+        returned = getattr(mod, attr)(*call_args)
+
+    assert returned == expected
+    helper_spy.assert_called_once_with(*call_args)
+
+
+@pytest.mark.parametrize(
+    ("attr", "call_args", "expected"),
+    [
+        ("_normalize_recommendation_severity", ("HIGH",), "high"),
+        (
+            "_format_recommendation_context_entries",
+            ({"data_view": "dv_1", "data_view_name": "DV 1"},),
+            [("Data View", "DV 1 (dv_1)")],
+        ),
+        ("_normalize_org_report_output_format", ("JSON",), "json"),
+        ("_render_distribution_bar", (1, 4), f"{'█' * 7}{'░' * 23}  25%"),
+    ],
+    ids=["severity", "context", "output-format", "distribution-bar"],
+)
+def test_canonical_common_helper_exports_support_generator_wraps_patches_without_double_count(
+    attr,
+    call_args,
+    expected,
+):
+    """Canonical common helpers must stay interchangeable with generator re-exports under wraps spies."""
+    import cja_auto_sdr.generator as generator_mod
+
+    mod = importlib.import_module("cja_auto_sdr.org.writers.common")
+
+    with patch(f"{mod.__name__}.{attr}", wraps=getattr(generator_mod, attr)) as helper_spy:
+        returned = getattr(mod, attr)(*call_args)
+
+    assert returned == expected
+    helper_spy.assert_called_once_with(*call_args)
+
+
+@pytest.mark.parametrize(
+    ("scope_module_name", "legacy_module_name"),
+    [
+        ("cja_auto_sdr.org.writers", "cja_auto_sdr.org.writers"),
+        ("cja_auto_sdr.org.writers.json", "cja_auto_sdr.org.writers"),
+        ("cja_auto_sdr.generator", "cja_auto_sdr.generator"),
+    ],
+    ids=["org.writers", "org.writers.json", "generator"],
+)
+def test_json_writer_reexports_support_wraps_override_scope_on_self_exports(
+    scope_module_name,
+    legacy_module_name,
+    tmp_path,
+    rich_org_report_result,
+):
+    """Scoped wraps spies on direct JSON writer re-exports must still observe compat calls."""
+    from cja_auto_sdr.org.writers.compat import override_scope
+
+    mod = importlib.import_module(legacy_module_name)
+    logger = logging.getLogger(f"test.{legacy_module_name}.write_org_report_json.override_scope.wraps")
+    writer_spy = Mock(wraps=mod.write_org_report_json)
+
+    with override_scope(
+        scope_module_name,
+        {
+            "write_org_report_json": writer_spy,
+        },
+    ):
+        output_path = Path(
+            mod.write_org_report_json(
+                rich_org_report_result,
+                tmp_path / f"{legacy_module_name.rsplit('.', 1)[-1]}_self_scope.json",
+                str(tmp_path),
+                logger,
+            ),
+        )
+
+    assert output_path.exists()
+    writer_spy.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("module_name", "attr"),
+    [
+        ("cja_auto_sdr.org.writers.json", "build_org_report_json_data"),
+        ("cja_auto_sdr.org.writers.json", "write_org_report_json"),
+        ("cja_auto_sdr.org.writers.markdown", "write_org_report_markdown"),
+        ("cja_auto_sdr.org.writers.console", "write_org_report_console"),
+        ("cja_auto_sdr.org.writers.console", "write_org_report_stats_only"),
+        ("cja_auto_sdr.org.writers.csv", "write_org_report_csv"),
+        ("cja_auto_sdr.org.writers.html", "write_org_report_html"),
+        ("cja_auto_sdr.org.writers.excel", "write_org_report_excel"),
+    ],
+    ids=[
+        "json-builder",
+        "json-writer",
+        "markdown-writer",
+        "console-writer",
+        "stats-writer",
+        "csv-writer",
+        "html-writer",
+        "excel-writer",
+    ],
+)
+def test_canonical_org_writer_exports_support_wraps_override_scope_on_self_exports(
+    module_name,
+    attr,
+    tmp_path,
+    rich_org_report_result,
+):
+    """Direct canonical writer exports must honor scoped wraps spies on self exports."""
+    from cja_auto_sdr.org.writers.compat import override_scope
+
+    mod = importlib.import_module(module_name)
+    writer_spy = Mock(wraps=getattr(mod, attr))
+
+    with override_scope(
+        module_name,
+        {
+            attr: writer_spy,
+        },
+    ):
+        returned = _call_canonical_org_writer_export(
+            mod,
+            attr,
+            tmp_path=tmp_path,
+            rich_org_report_result=rich_org_report_result,
+        )
+
+    if isinstance(returned, Path):
+        assert returned.exists()
+    elif attr == "build_org_report_json_data":
+        assert returned["org_id"] == rich_org_report_result.org_id
+    writer_spy.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("module_name", "attr"),
+    [
+        ("cja_auto_sdr.org.writers.console", "write_org_report_console"),
+        ("cja_auto_sdr.org.writers.console", "write_org_report_stats_only"),
+        ("cja_auto_sdr.org.writers.json", "build_org_report_json_data"),
+        ("cja_auto_sdr.org.writers.json", "write_org_report_json"),
+        ("cja_auto_sdr.org.writers.markdown", "write_org_report_markdown"),
+        ("cja_auto_sdr.org.writers.csv", "write_org_report_csv"),
+        ("cja_auto_sdr.org.writers.html", "write_org_report_html"),
+        ("cja_auto_sdr.org.writers.excel", "write_org_report_excel"),
+    ],
+    ids=[
+        "console-writer",
+        "stats-writer",
+        "json-builder",
+        "json-writer",
+        "markdown-writer",
+        "csv-writer",
+        "html-writer",
+        "excel-writer",
+    ],
+)
+def test_canonical_org_writer_exports_support_generator_wraps_patches_without_double_count(
+    module_name,
+    attr,
+    tmp_path,
+    rich_org_report_result,
+):
+    """Canonical writer exports must stay interchangeable with generator re-exports under wraps spies."""
+    import cja_auto_sdr.generator as generator_mod
+
+    mod = importlib.import_module(module_name)
+
+    with patch(f"{module_name}.{attr}", wraps=getattr(generator_mod, attr)) as writer_spy:
+        returned = _call_canonical_org_writer_export(
+            mod,
+            attr,
+            tmp_path=tmp_path,
+            rich_org_report_result=rich_org_report_result,
+        )
+
+    if isinstance(returned, Path):
+        assert returned.exists()
+    elif attr == "build_org_report_json_data":
+        assert returned["org_id"] == rich_org_report_result.org_id
+    writer_spy.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("scope_module_name", "legacy_module_name"),
+    [
+        ("cja_auto_sdr.org.writers", "cja_auto_sdr.org.writers"),
+        ("cja_auto_sdr.org.writers.markdown", "cja_auto_sdr.org.writers"),
+        ("cja_auto_sdr.generator", "cja_auto_sdr.generator"),
+    ],
+    ids=["org.writers", "org.writers.markdown", "generator"],
+)
+def test_markdown_writer_reexports_support_wraps_override_scope_on_self_exports(
+    scope_module_name,
+    legacy_module_name,
+    tmp_path,
+    rich_org_report_result,
+):
+    """Scoped wraps spies on direct Markdown writer re-exports must still observe compat calls."""
+    from cja_auto_sdr.org.writers.compat import override_scope
+
+    mod = importlib.import_module(legacy_module_name)
+    logger = logging.getLogger(f"test.{legacy_module_name}.write_org_report_markdown.override_scope.wraps")
+    trending = _make_trending()
+    writer_spy = Mock(wraps=mod.write_org_report_markdown)
+
+    with override_scope(
+        scope_module_name,
+        {
+            "write_org_report_markdown": writer_spy,
+        },
+    ):
+        output_path = Path(
+            mod.write_org_report_markdown(
+                rich_org_report_result,
+                tmp_path / f"{legacy_module_name.rsplit('.', 1)[-1]}_self_scope.md",
+                str(tmp_path),
+                logger,
+                trending=trending,
+            ),
+        )
+
+    assert output_path.exists()
+    writer_spy.assert_called_once()
 
 
 def test_org_markdown_writer_reexport_supports_package_root_wraps_patch_on_canonical_surface(

--- a/tests/test_output_extraction_contracts.py
+++ b/tests/test_output_extraction_contracts.py
@@ -1101,20 +1101,26 @@ _ORG_WRITERS_SUBMODULES = [
 class TestOrgWritersAllExportConsistency:
     """Verify __all__ declarations in org/writers submodules are consistent with parent re-exports."""
 
-    @pytest.mark.parametrize("submodule", _ORG_WRITERS_SUBMODULES, ids=[m.rsplit(".", 1)[-1] for m in _ORG_WRITERS_SUBMODULES])
+    @pytest.mark.parametrize(
+        "submodule", _ORG_WRITERS_SUBMODULES, ids=[m.rsplit(".", 1)[-1] for m in _ORG_WRITERS_SUBMODULES]
+    )
     def test_submodule_has_all(self, submodule):
         """Each org/writers submodule must declare __all__."""
         mod = importlib.import_module(submodule)
         assert hasattr(mod, "__all__"), f"{submodule} is missing __all__"
 
-    @pytest.mark.parametrize("submodule", _ORG_WRITERS_SUBMODULES, ids=[m.rsplit(".", 1)[-1] for m in _ORG_WRITERS_SUBMODULES])
+    @pytest.mark.parametrize(
+        "submodule", _ORG_WRITERS_SUBMODULES, ids=[m.rsplit(".", 1)[-1] for m in _ORG_WRITERS_SUBMODULES]
+    )
     def test_all_names_exist_on_submodule(self, submodule):
         """Every name in a submodule's __all__ must exist as an attribute on that submodule."""
         mod = importlib.import_module(submodule)
         for name in mod.__all__:
             assert hasattr(mod, name), f"{submodule}.__all__ declares {name!r} but it is not an attribute"
 
-    @pytest.mark.parametrize("submodule", _ORG_WRITERS_SUBMODULES, ids=[m.rsplit(".", 1)[-1] for m in _ORG_WRITERS_SUBMODULES])
+    @pytest.mark.parametrize(
+        "submodule", _ORG_WRITERS_SUBMODULES, ids=[m.rsplit(".", 1)[-1] for m in _ORG_WRITERS_SUBMODULES]
+    )
     def test_all_names_importable_from_parent(self, submodule):
         """Every name in a submodule's __all__ must be importable from cja_auto_sdr.org.writers."""
         sub_mod = importlib.import_module(submodule)
@@ -1146,20 +1152,26 @@ _OUTPUT_DIFF_SUBMODULES = [
 class TestOutputDiffAllExportConsistency:
     """Verify __all__ declarations in output/diff submodules are consistent with parent re-exports."""
 
-    @pytest.mark.parametrize("submodule", _OUTPUT_DIFF_SUBMODULES, ids=[m.rsplit(".", 1)[-1] for m in _OUTPUT_DIFF_SUBMODULES])
+    @pytest.mark.parametrize(
+        "submodule", _OUTPUT_DIFF_SUBMODULES, ids=[m.rsplit(".", 1)[-1] for m in _OUTPUT_DIFF_SUBMODULES]
+    )
     def test_submodule_has_all(self, submodule):
         """Each output/diff submodule must declare __all__."""
         mod = importlib.import_module(submodule)
         assert hasattr(mod, "__all__"), f"{submodule} is missing __all__"
 
-    @pytest.mark.parametrize("submodule", _OUTPUT_DIFF_SUBMODULES, ids=[m.rsplit(".", 1)[-1] for m in _OUTPUT_DIFF_SUBMODULES])
+    @pytest.mark.parametrize(
+        "submodule", _OUTPUT_DIFF_SUBMODULES, ids=[m.rsplit(".", 1)[-1] for m in _OUTPUT_DIFF_SUBMODULES]
+    )
     def test_all_names_exist_on_submodule(self, submodule):
         """Every name in a submodule's __all__ must exist as an attribute on that submodule."""
         mod = importlib.import_module(submodule)
         for name in mod.__all__:
             assert hasattr(mod, name), f"{submodule}.__all__ declares {name!r} but it is not an attribute"
 
-    @pytest.mark.parametrize("submodule", _OUTPUT_DIFF_SUBMODULES, ids=[m.rsplit(".", 1)[-1] for m in _OUTPUT_DIFF_SUBMODULES])
+    @pytest.mark.parametrize(
+        "submodule", _OUTPUT_DIFF_SUBMODULES, ids=[m.rsplit(".", 1)[-1] for m in _OUTPUT_DIFF_SUBMODULES]
+    )
     def test_all_names_importable_from_parent(self, submodule):
         """Every name in a submodule's __all__ must be importable from cja_auto_sdr.output.diff."""
         sub_mod = importlib.import_module(submodule)

--- a/tests/test_output_extraction_contracts.py
+++ b/tests/test_output_extraction_contracts.py
@@ -15,7 +15,7 @@ import logging
 import threading
 from inspect import signature
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -845,6 +845,28 @@ def test_org_json_builder_respects_package_root_nested_sort_patch(rich_org_repor
     assert sort_mock.call_count >= 2
 
 
+def test_org_json_builder_supports_package_root_override_scope_for_builder_export(rich_org_report_result):
+    """Package-root override_scope must reach direct builder re-exports."""
+    from cja_auto_sdr.org.writers.compat import override_scope
+
+    mod = importlib.import_module("cja_auto_sdr.org.writers")
+    payload = {
+        "report_type": "patched",
+        "version": "test",
+        "org_id": "override-root",
+    }
+
+    with override_scope(
+        "cja_auto_sdr.org.writers",
+        {
+            "build_org_report_json_data": lambda result, trending=None: payload,
+        },
+    ):
+        returned = mod.build_org_report_json_data(rich_org_report_result)
+
+    assert returned == payload
+
+
 def test_org_json_writer_respects_package_root_nested_sort_patch(tmp_path, rich_org_report_result):
     """Nested package-root trending helper patches must flow through the JSON writer bridge."""
     mod = importlib.import_module("cja_auto_sdr.org.writers")
@@ -870,6 +892,128 @@ def test_org_json_writer_respects_package_root_nested_sort_patch(tmp_path, rich_
     assert list(payload["trending"]["drift_scores"].items()) == patched_scores
     assert payload["trending"]["drift_details"][0]["data_view_id"] == "dv_999"
     assert sort_mock.call_count >= 2
+
+
+def test_org_json_writer_supports_package_root_override_scope_for_builder_export(
+    tmp_path,
+    rich_org_report_result,
+):
+    """Package-root override_scope must flow through the JSON writer bridge."""
+    from cja_auto_sdr.org.writers.compat import override_scope
+
+    mod = importlib.import_module("cja_auto_sdr.org.writers")
+    logger = logging.getLogger("test.cja_auto_sdr.org.writers.write_org_report_json.override_scope")
+    payload = {
+        "report_type": "patched",
+        "version": "test",
+        "org_id": "override-root",
+    }
+
+    with override_scope(
+        "cja_auto_sdr.org.writers",
+        {
+            "build_org_report_json_data": lambda result, trending=None: payload,
+        },
+    ):
+        output_path = Path(
+            mod.write_org_report_json(
+                rich_org_report_result,
+                tmp_path / "org_report_override_scope.json",
+                str(tmp_path),
+                logger,
+            ),
+        )
+
+    assert json.loads(output_path.read_text(encoding="utf-8")) == payload
+
+
+def test_generator_json_builder_supports_generator_override_scope_for_builder_export(
+    rich_org_report_result,
+):
+    """Generator override_scope must reach direct builder re-exports."""
+    from cja_auto_sdr.org.writers.compat import override_scope
+
+    mod = importlib.import_module("cja_auto_sdr.generator")
+    payload = {
+        "report_type": "generator-patched",
+        "version": "test",
+        "org_id": "override-generator",
+    }
+
+    with override_scope(
+        "cja_auto_sdr.generator",
+        {
+            "build_org_report_json_data": lambda result, trending=None: payload,
+        },
+    ):
+        returned = mod.build_org_report_json_data(rich_org_report_result)
+
+    assert returned == payload
+
+
+def test_generator_json_writer_supports_generator_override_scope_for_builder_export(
+    tmp_path,
+    rich_org_report_result,
+):
+    """Generator override_scope must flow through the JSON writer bridge."""
+    from cja_auto_sdr.org.writers.compat import override_scope
+
+    mod = importlib.import_module("cja_auto_sdr.generator")
+    logger = logging.getLogger("test.cja_auto_sdr.generator.write_org_report_json.override_scope")
+    payload = {
+        "report_type": "generator-patched",
+        "version": "test",
+        "org_id": "override-generator",
+    }
+
+    with override_scope(
+        "cja_auto_sdr.generator",
+        {
+            "build_org_report_json_data": lambda result, trending=None: payload,
+        },
+    ):
+        output_path = Path(
+            mod.write_org_report_json(
+                rich_org_report_result,
+                tmp_path / "generator_override_scope.json",
+                str(tmp_path),
+                logger,
+            ),
+        )
+
+    assert json.loads(output_path.read_text(encoding="utf-8")) == payload
+
+
+@pytest.mark.parametrize(
+    ("scope_module_name", "legacy_module_name"),
+    [
+        ("cja_auto_sdr.org.writers", "cja_auto_sdr.org.writers"),
+        ("cja_auto_sdr.org.writers.json", "cja_auto_sdr.org.writers"),
+        ("cja_auto_sdr.generator", "cja_auto_sdr.generator"),
+    ],
+    ids=["org.writers", "org.writers.json", "generator"],
+)
+def test_json_builder_reexports_support_wraps_override_scope_on_self_exports(
+    scope_module_name,
+    legacy_module_name,
+    rich_org_report_result,
+):
+    """Scoped wraps spies on direct builder re-exports must still observe compat calls."""
+    from cja_auto_sdr.org.writers.compat import override_scope
+
+    mod = importlib.import_module(legacy_module_name)
+    build_spy = Mock(wraps=mod.build_org_report_json_data)
+
+    with override_scope(
+        scope_module_name,
+        {
+            "build_org_report_json_data": build_spy,
+        },
+    ):
+        payload = mod.build_org_report_json_data(rich_org_report_result)
+
+    assert payload["org_id"] == rich_org_report_result.org_id
+    build_spy.assert_called_once_with(rich_org_report_result)
 
 
 @pytest.mark.parametrize(
@@ -1177,6 +1321,58 @@ def test_org_markdown_writer_preserves_explicit_trending_override_scope(
     assert "custom:02" in output
 
 
+def test_org_writers_package_root_override_scope_routes_trending_helper_to_canonical_module():
+    """Package-root override_scope string keys must route into canonical trending helper calls."""
+    from cja_auto_sdr.org.writers.compat import override_scope
+
+    mod = importlib.import_module("cja_auto_sdr.org.writers")
+
+    with override_scope(
+        "cja_auto_sdr.org.writers",
+        {
+            "_format_trending_timestamp_short": lambda ts: f"pkg:{ts[5:7]}",
+        },
+    ):
+        period_label = mod._format_trending_period_label(
+            "2024-01-01T00:00:00",
+            "2024-02-01T00:00:00",
+        )
+
+    assert period_label == "pkg:01 -> pkg:02"
+
+
+def test_org_markdown_writer_supports_package_root_trending_override_scope(
+    tmp_path,
+    rich_org_report_result,
+):
+    """Package-root override_scope string keys must flow through writer bridge wrappers."""
+    from cja_auto_sdr.org.writers.compat import override_scope
+
+    mod = importlib.import_module("cja_auto_sdr.org.writers")
+    logger = logging.getLogger("test.cja_auto_sdr.org.writers.write_org_report_markdown.package_root_override_scope")
+    trending = _make_trending()
+
+    with override_scope(
+        "cja_auto_sdr.org.writers",
+        {
+            "_format_trending_timestamp_short": lambda ts: f"pkg:{ts[5:7]}",
+        },
+    ):
+        output_path = Path(
+            mod.write_org_report_markdown(
+                rich_org_report_result,
+                tmp_path / "org_report_package_root_override_scope.md",
+                str(tmp_path),
+                logger,
+                trending=trending,
+            ),
+        )
+
+    output = output_path.read_text(encoding="utf-8")
+    assert "pkg:01" in output
+    assert "pkg:02" in output
+
+
 def test_canonical_trending_helpers_accept_package_root_timestamp_helper_patch():
     """Canonical trending helpers must remain interchangeable with package-root helper exports."""
     mod = importlib.import_module("cja_auto_sdr.org.writers")
@@ -1392,6 +1588,163 @@ def test_org_json_builder_reexport_supports_package_root_wraps_patch_on_canonica
 
     assert payload["org_id"] == rich_org_report_result.org_id
     build_mock.assert_called_once_with(rich_org_report_result)
+
+
+def test_org_writers_common_helper_reexports_support_package_root_override_scope_direct_calls():
+    """Package-root common helper re-exports must be direct-call override_scope aware."""
+    from cja_auto_sdr.org.writers.compat import override_scope
+
+    mod = importlib.import_module("cja_auto_sdr.org.writers")
+    validation_marker = object()
+
+    with override_scope(
+        "cja_auto_sdr.org.writers",
+        {
+            "_format_recommendation_context_entries": lambda rec: [("Patched", rec["reason"])],
+            "_normalize_recommendation_severity": lambda severity: f"scope:{severity}",
+            "_render_distribution_bar": lambda count, total, width=30: f"scope:{count}/{total}/{width}",
+            "_normalize_org_report_output_format": lambda output_format: f"scope:{output_format}",
+            "_validate_org_report_output_request": lambda output_format, output_to_stdout, status_print: (
+                validation_marker
+            ),
+        },
+    ):
+        context_entries = mod._format_recommendation_context_entries({"reason": "patched context"})
+        severity = mod._normalize_recommendation_severity("medium")
+        bar = mod._render_distribution_bar(1, 2, width=12)
+        output_format = mod._normalize_org_report_output_format("markdown")
+        validation = mod._validate_org_report_output_request(
+            "json",
+            False,
+            lambda *_args, **_kwargs: None,
+        )
+
+    assert context_entries == [("Patched", "patched context")]
+    assert severity == "scope:medium"
+    assert bar == "scope:1/2/12"
+    assert output_format == "scope:markdown"
+    assert validation is validation_marker
+
+
+def test_org_common_normalizer_supports_package_root_override_scope_for_nested_helpers():
+    """Package-root override_scope string keys must flow through nested recommendation normalization."""
+    from cja_auto_sdr.org.writers.compat import override_scope
+
+    mod = importlib.import_module("cja_auto_sdr.org.writers")
+    raw_rec = {
+        "severity": "medium",
+        "reason": "Two data views are highly similar",
+        "data_view_1": "dv_001",
+        "data_view_1_name": "Primary Business Data View",
+        "data_view_2": "dv_003",
+        "data_view_2_name": "Tertiary Data View",
+    }
+
+    with override_scope(
+        "cja_auto_sdr.org.writers",
+        {
+            "_format_recommendation_context_entries": lambda rec: [("Patched", rec["reason"])],
+            "_normalize_recommendation_severity": lambda severity: "high",
+        },
+    ):
+        normalized = mod._normalize_recommendation_for_json(raw_rec)
+
+    assert normalized["severity"] == "high"
+    assert normalized["context"] == [{"label": "Patched", "value": raw_rec["reason"]}]
+
+
+def test_generator_common_helper_reexports_support_generator_override_scope_direct_calls():
+    """Generator common helper re-exports must be direct-call override_scope aware."""
+    from cja_auto_sdr.org.writers.compat import override_scope
+
+    mod = importlib.import_module("cja_auto_sdr.generator")
+    validation_marker = object()
+
+    with override_scope(
+        "cja_auto_sdr.generator",
+        {
+            "_format_recommendation_context_entries": lambda rec: [("Patched", rec["reason"])],
+            "_normalize_recommendation_severity": lambda severity: f"scope:{severity}",
+            "_render_distribution_bar": lambda count, total, width=30: f"scope:{count}/{total}/{width}",
+            "_normalize_org_report_output_format": lambda output_format: f"scope:{output_format}",
+            "_validate_org_report_output_request": lambda output_format, output_to_stdout, status_print: (
+                validation_marker
+            ),
+        },
+    ):
+        context_entries = mod._format_recommendation_context_entries({"reason": "patched context"})
+        severity = mod._normalize_recommendation_severity("medium")
+        bar = mod._render_distribution_bar(1, 2, width=12)
+        output_format = mod._normalize_org_report_output_format("markdown")
+        validation = mod._validate_org_report_output_request(
+            "json",
+            False,
+            lambda *_args, **_kwargs: None,
+        )
+
+    assert context_entries == [("Patched", "patched context")]
+    assert severity == "scope:medium"
+    assert bar == "scope:1/2/12"
+    assert output_format == "scope:markdown"
+    assert validation is validation_marker
+
+
+def test_generator_common_normalizer_supports_generator_override_scope_for_nested_helpers():
+    """Generator override_scope string keys must flow through nested recommendation normalization."""
+    from cja_auto_sdr.org.writers.compat import override_scope
+
+    mod = importlib.import_module("cja_auto_sdr.generator")
+    raw_rec = {
+        "severity": "medium",
+        "reason": "Two data views are highly similar",
+        "data_view_1": "dv_001",
+        "data_view_1_name": "Primary Business Data View",
+        "data_view_2": "dv_003",
+        "data_view_2_name": "Tertiary Data View",
+    }
+
+    with override_scope(
+        "cja_auto_sdr.generator",
+        {
+            "_format_recommendation_context_entries": lambda rec: [("Patched", rec["reason"])],
+            "_normalize_recommendation_severity": lambda severity: "high",
+        },
+    ):
+        normalized = mod._normalize_recommendation_for_json(raw_rec)
+
+    assert normalized["severity"] == "high"
+    assert normalized["context"] == [{"label": "Patched", "value": raw_rec["reason"]}]
+
+
+@pytest.mark.parametrize(
+    ("scope_module_name", "legacy_module_name"),
+    [
+        ("cja_auto_sdr.org.writers", "cja_auto_sdr.org.writers"),
+        ("cja_auto_sdr.org.writers.common", "cja_auto_sdr.org.writers"),
+        ("cja_auto_sdr.generator", "cja_auto_sdr.generator"),
+    ],
+    ids=["org.writers", "org.writers.common", "generator"],
+)
+def test_common_helper_reexports_support_wraps_override_scope_on_self_exports(
+    scope_module_name,
+    legacy_module_name,
+):
+    """Scoped wraps spies on direct helper re-exports must still observe compat calls."""
+    from cja_auto_sdr.org.writers.compat import override_scope
+
+    mod = importlib.import_module(legacy_module_name)
+    severity_spy = Mock(wraps=mod._normalize_recommendation_severity)
+
+    with override_scope(
+        scope_module_name,
+        {
+            "_normalize_recommendation_severity": severity_spy,
+        },
+    ):
+        normalized = mod._normalize_recommendation_severity("HIGH")
+
+    assert normalized == "high"
+    severity_spy.assert_called_once_with("HIGH")
 
 
 def test_org_markdown_writer_reexport_supports_package_root_wraps_patch_on_canonical_surface(

--- a/tests/test_output_extraction_contracts.py
+++ b/tests/test_output_extraction_contracts.py
@@ -828,6 +828,50 @@ def test_org_json_writer_respects_package_root_trending_helper_patch(tmp_path, r
     trending_mock.assert_called_once_with(trending)
 
 
+def test_org_json_builder_respects_package_root_nested_sort_patch(rich_org_report_result):
+    """Nested package-root trending helper patches must flow through the JSON builder bridge."""
+    mod = importlib.import_module("cja_auto_sdr.org.writers")
+    trending = _make_trending()
+    patched_scores = [("dv_999", 9.9), ("dv_001", 0.8)]
+
+    with patch(
+        "cja_auto_sdr.org.writers._sorted_drift_score_items",
+        return_value=patched_scores,
+    ) as sort_mock:
+        payload = mod.build_org_report_json_data(rich_org_report_result, trending=trending)
+
+    assert list(payload["trending"]["drift_scores"].items()) == patched_scores
+    assert payload["trending"]["drift_details"][0]["data_view_id"] == "dv_999"
+    assert sort_mock.call_count >= 2
+
+
+def test_org_json_writer_respects_package_root_nested_sort_patch(tmp_path, rich_org_report_result):
+    """Nested package-root trending helper patches must flow through the JSON writer bridge."""
+    mod = importlib.import_module("cja_auto_sdr.org.writers")
+    logger = logging.getLogger("test.cja_auto_sdr.org.writers.write_org_report_json.trending.sort")
+    trending = _make_trending()
+    patched_scores = [("dv_999", 9.9), ("dv_001", 0.8)]
+
+    with patch(
+        "cja_auto_sdr.org.writers._sorted_drift_score_items",
+        return_value=patched_scores,
+    ) as sort_mock:
+        output_path = Path(
+            mod.write_org_report_json(
+                rich_org_report_result,
+                tmp_path / "org_report_trending_sort.json",
+                str(tmp_path),
+                logger,
+                trending=trending,
+            ),
+        )
+
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert list(payload["trending"]["drift_scores"].items()) == patched_scores
+    assert payload["trending"]["drift_details"][0]["data_view_id"] == "dv_999"
+    assert sort_mock.call_count >= 2
+
+
 @pytest.mark.parametrize(
     "writer_module_name",
     [
@@ -1004,6 +1048,199 @@ def test_org_markdown_writer_respects_package_root_timestamp_helper_patch(
     assert timestamp_mock.call_count >= 4
 
 
+def test_org_markdown_writer_supports_wraps_spy_on_package_root_timestamp_helper(
+    tmp_path,
+    rich_org_report_result,
+):
+    """Delegating package-root timestamp spies must not recurse through compat wrappers."""
+    mod = importlib.import_module("cja_auto_sdr.org.writers")
+    logger = logging.getLogger("test.cja_auto_sdr.org.writers.write_org_report_markdown.trending.wraps")
+    trending = _make_trending()
+    original = mod._format_trending_timestamp_short
+
+    with patch(
+        "cja_auto_sdr.org.writers._format_trending_timestamp_short",
+        wraps=original,
+    ) as timestamp_mock:
+        output_path = Path(
+            mod.write_org_report_markdown(
+                rich_org_report_result,
+                tmp_path / "org_report_trending_wraps.md",
+                str(tmp_path),
+                logger,
+                trending=trending,
+            ),
+        )
+
+    output = output_path.read_text(encoding="utf-8")
+    assert "Jan 01" in output
+    assert "Feb 01" in output
+    assert timestamp_mock.call_count >= 4
+
+
+def test_org_writers_trending_helper_reexports_accept_canonical_timestamp_helper_patch():
+    """Package-root trending helpers must remain interchangeable with canonical trending exports."""
+    mod = importlib.import_module("cja_auto_sdr.org.writers")
+    trending_mod = importlib.import_module("cja_auto_sdr.org.writers.trending")
+
+    with patch(
+        "cja_auto_sdr.org.writers._format_trending_timestamp_short",
+        new=trending_mod._format_trending_timestamp_short,
+    ):
+        period_label = mod._format_trending_period_label(
+            "2024-01-01T00:00:00",
+            "2024-02-01T00:00:00",
+        )
+
+    assert period_label == "Jan 01 -> Feb 01"
+
+
+def test_org_markdown_writer_supports_canonical_timestamp_wraps_patch(
+    tmp_path,
+    rich_org_report_result,
+):
+    """Writer entrypoints must not recurse when package-root timestamp patches wrap canonical helpers."""
+    mod = importlib.import_module("cja_auto_sdr.org.writers")
+    trending_mod = importlib.import_module("cja_auto_sdr.org.writers.trending")
+    logger = logging.getLogger("test.cja_auto_sdr.org.writers.write_org_report_markdown.trending.canonical_wraps")
+    trending = _make_trending()
+
+    with patch(
+        "cja_auto_sdr.org.writers._format_trending_timestamp_short",
+        wraps=trending_mod._format_trending_timestamp_short,
+    ) as timestamp_mock:
+        output_path = Path(
+            mod.write_org_report_markdown(
+                rich_org_report_result,
+                tmp_path / "org_report_trending_canonical_wraps.md",
+                str(tmp_path),
+                logger,
+                trending=trending,
+            ),
+        )
+
+    output = output_path.read_text(encoding="utf-8")
+    assert "Jan 01" in output
+    assert "Feb 01" in output
+    assert timestamp_mock.call_count >= 4
+
+
+def test_org_writers_trending_helper_reexports_preserve_explicit_override_scope():
+    """Package-root helper wrappers must not overwrite explicit caller override_scope values."""
+    from cja_auto_sdr.org.writers.compat import override_scope
+
+    mod = importlib.import_module("cja_auto_sdr.org.writers")
+
+    with override_scope(
+        "cja_auto_sdr.org.writers.trending",
+        {
+            "_format_trending_timestamp_short": lambda ts: f"custom:{ts[5:7]}",
+        },
+    ):
+        period_label = mod._format_trending_period_label(
+            "2024-01-01T00:00:00",
+            "2024-02-01T00:00:00",
+        )
+
+    assert period_label == "custom:01 -> custom:02"
+
+
+def test_org_markdown_writer_preserves_explicit_trending_override_scope(
+    tmp_path,
+    rich_org_report_result,
+):
+    """Writer bridge wrappers must not clobber explicit caller override_scope values."""
+    from cja_auto_sdr.org.writers.compat import override_scope
+
+    mod = importlib.import_module("cja_auto_sdr.org.writers")
+    logger = logging.getLogger("test.cja_auto_sdr.org.writers.write_org_report_markdown.trending.override_scope")
+    trending = _make_trending()
+
+    with override_scope(
+        "cja_auto_sdr.org.writers.trending",
+        {
+            "_format_trending_timestamp_short": lambda ts: f"custom:{ts[5:7]}",
+        },
+    ):
+        output_path = Path(
+            mod.write_org_report_markdown(
+                rich_org_report_result,
+                tmp_path / "org_report_trending_override_scope.md",
+                str(tmp_path),
+                logger,
+                trending=trending,
+            ),
+        )
+
+    output = output_path.read_text(encoding="utf-8")
+    assert "custom:01" in output
+    assert "custom:02" in output
+
+
+def test_canonical_trending_helpers_accept_package_root_timestamp_helper_patch():
+    """Canonical trending helpers must remain interchangeable with package-root helper exports."""
+    mod = importlib.import_module("cja_auto_sdr.org.writers")
+    trending_mod = importlib.import_module("cja_auto_sdr.org.writers.trending")
+
+    with patch(
+        "cja_auto_sdr.org.writers.trending._format_trending_timestamp_short",
+        new=mod._format_trending_timestamp_short,
+    ):
+        period_label = trending_mod._format_trending_period_label(
+            "2024-01-01T00:00:00",
+            "2024-02-01T00:00:00",
+        )
+
+    assert period_label == "Jan 01 -> Feb 01"
+
+
+def test_canonical_trending_helpers_support_package_root_timestamp_wraps_patch():
+    """Canonical trending helpers must not recurse when wraps spies delegate through package-root helpers."""
+    mod = importlib.import_module("cja_auto_sdr.org.writers")
+    trending_mod = importlib.import_module("cja_auto_sdr.org.writers.trending")
+
+    with patch(
+        "cja_auto_sdr.org.writers.trending._format_trending_timestamp_short",
+        wraps=mod._format_trending_timestamp_short,
+    ) as timestamp_mock:
+        period_label = trending_mod._format_trending_period_label(
+            "2024-01-01T00:00:00",
+            "2024-02-01T00:00:00",
+        )
+
+    assert period_label == "Jan 01 -> Feb 01"
+    assert timestamp_mock.call_count >= 2
+
+
+def test_org_markdown_writer_supports_package_root_timestamp_wraps_patch_on_canonical_surface(
+    tmp_path,
+    rich_org_report_result,
+):
+    """Markdown writer paths must not recurse when canonical helper patches delegate into package-root helpers."""
+    mod = importlib.import_module("cja_auto_sdr.org.writers")
+    logger = logging.getLogger("test.cja_auto_sdr.org.writers.write_org_report_markdown.trending.reverse_wraps")
+    trending = _make_trending()
+
+    with patch(
+        "cja_auto_sdr.org.writers.trending._format_trending_timestamp_short",
+        wraps=mod._format_trending_timestamp_short,
+    ) as timestamp_mock:
+        output_path = Path(
+            mod.write_org_report_markdown(
+                rich_org_report_result,
+                tmp_path / "org_report_trending_reverse_wraps.md",
+                str(tmp_path),
+                logger,
+                trending=trending,
+            ),
+        )
+
+    output = output_path.read_text(encoding="utf-8")
+    assert "Jan 01" in output
+    assert "Feb 01" in output
+    assert timestamp_mock.call_count >= 4
+
+
 def test_org_writers_trending_helper_reexports_respect_package_root_timestamp_patch():
     """Package-root trending helper re-exports must preserve nested timestamp monkeypatches."""
     mod = importlib.import_module("cja_auto_sdr.org.writers")
@@ -1024,6 +1261,164 @@ def test_org_writers_trending_helper_reexports_respect_package_root_timestamp_pa
     assert period_label == "patched:01 -> patched:02"
     assert [label for _key, label in delta_specs] == ["patched:01 -> patched:02"]
     assert timestamp_mock.call_count == 6
+
+
+def test_org_writers_trending_helper_reexports_support_wraps_spy_timestamp_patch():
+    """Delegating package-root helper spies must not recurse on direct helper calls."""
+    mod = importlib.import_module("cja_auto_sdr.org.writers")
+    original = mod._format_trending_timestamp_short
+
+    with patch(
+        "cja_auto_sdr.org.writers._format_trending_timestamp_short",
+        wraps=original,
+    ) as timestamp_mock:
+        result = mod._format_trending_timestamp_short("2024-01-01T00:00:00")
+
+    assert result == "Jan 01"
+    timestamp_mock.assert_called_once_with("2024-01-01T00:00:00")
+
+
+def test_org_writers_render_markdown_trending_table_respects_package_root_escape_patch():
+    """Package-root Markdown cell escape patches must flow into nested trending table rendering."""
+    mod = importlib.import_module("cja_auto_sdr.org.writers")
+
+    with patch(
+        "cja_auto_sdr.org.writers._escape_markdown_table_cell",
+        side_effect=lambda value: f"patched<{value}>",
+    ) as escape_mock:
+        lines = mod._render_markdown_trending_table(["Jan 01"], [("Metric", [1])])
+
+    assert any("patched<Jan 01>" in line for line in lines)
+    assert any("patched<Metric>" in line for line in lines)
+    assert any("patched<1>" in line for line in lines)
+    assert escape_mock.call_count == 3
+
+
+def test_org_writers_render_markdown_trending_table_supports_wraps_spy_on_escape_helper():
+    """Delegating package-root escape spies must not recurse through helper-to-helper compat routing."""
+    mod = importlib.import_module("cja_auto_sdr.org.writers")
+    original = mod._escape_markdown_table_cell
+
+    with patch(
+        "cja_auto_sdr.org.writers._escape_markdown_table_cell",
+        wraps=original,
+    ) as escape_mock:
+        lines = mod._render_markdown_trending_table(["Jan 01"], [("Metric", [1])])
+
+    assert lines == ["| Metric | Jan 01 |", "|--------|---------:|", "| Metric | 1 |"]
+    assert escape_mock.call_count == 3
+
+
+def test_org_writers_render_console_trending_table_respects_package_root_value_patch():
+    """Package-root stringify patches must flow into nested console trending table rendering."""
+    mod = importlib.import_module("cja_auto_sdr.org.writers")
+
+    with patch(
+        "cja_auto_sdr.org.writers._stringify_trending_value",
+        side_effect=lambda value: f"patched<{value}>",
+    ) as stringify_mock:
+        lines = mod._render_console_trending_table(["Jan 01"], [("Metric", [1])])
+
+    assert any("patched<1>" in line for line in lines)
+    assert stringify_mock.call_count == 1
+
+
+def test_org_writers_ranked_drift_entries_respect_package_root_name_resolution_patch():
+    """Package-root drift name patches must flow into ranked drift helper re-exports."""
+    mod = importlib.import_module("cja_auto_sdr.org.writers")
+    trending = _make_trending()
+
+    with patch(
+        "cja_auto_sdr.org.writers._resolve_trending_dv_name",
+        return_value="patched data view",
+    ) as resolve_mock:
+        entries = mod._ranked_drift_entries(trending, limit=1)
+
+    assert entries == [
+        {
+            "data_view_id": "dv_001",
+            "data_view_name": "patched data view",
+            "drift_score": 0.8,
+        },
+    ]
+    assert resolve_mock.call_count == 1
+
+
+def test_org_writers_trending_snapshots_to_dicts_respect_package_root_sort_patch():
+    """Package-root drift-sort patches must flow into top-level trending dict conversion helpers."""
+    mod = importlib.import_module("cja_auto_sdr.org.writers")
+    trending = _make_trending()
+    patched_scores = [("dv_999", 9.9), ("dv_001", 0.8)]
+
+    with patch(
+        "cja_auto_sdr.org.writers._sorted_drift_score_items",
+        return_value=patched_scores,
+    ) as sort_mock:
+        top_scores = mod._top_drift_scores({"dv_001": 0.8}, limit=1)
+        trending_dict = mod._trending_snapshots_to_dicts(trending)
+
+    assert top_scores == patched_scores[:1]
+    assert list(trending_dict["drift_scores"].items()) == patched_scores
+    assert trending_dict["drift_details"][0]["data_view_id"] == "dv_999"
+    assert sort_mock.call_count >= 2
+
+
+def test_org_writers_render_trending_console_respects_package_root_dv_label_patch():
+    """Package-root drift-label patches must flow into console trending rendering."""
+    mod = importlib.import_module("cja_auto_sdr.org.writers")
+    trending = _make_trending()
+
+    with patch(
+        "cja_auto_sdr.org.writers._format_trending_dv_label",
+        return_value="patched drift label",
+    ) as label_mock:
+        output = mod._render_trending_console(trending)
+
+    assert "patched drift label" in output
+    assert label_mock.call_count >= 1
+
+
+def test_org_json_builder_reexport_supports_package_root_wraps_patch_on_canonical_surface(
+    rich_org_report_result,
+):
+    """Direct package-root builder exports must not recurse when canonical wraps spies delegate back."""
+    mod = importlib.import_module("cja_auto_sdr.org.writers")
+
+    with patch(
+        "cja_auto_sdr.org.writers.json.build_org_report_json_data",
+        wraps=mod.build_org_report_json_data,
+    ) as build_mock:
+        payload = mod.build_org_report_json_data(rich_org_report_result)
+
+    assert payload["org_id"] == rich_org_report_result.org_id
+    build_mock.assert_called_once_with(rich_org_report_result)
+
+
+def test_org_markdown_writer_reexport_supports_package_root_wraps_patch_on_canonical_surface(
+    tmp_path,
+    rich_org_report_result,
+):
+    """Direct package-root writer exports must not recurse when canonical wraps spies delegate back."""
+    mod = importlib.import_module("cja_auto_sdr.org.writers")
+    logger = logging.getLogger("test.cja_auto_sdr.org.writers.write_org_report_markdown.reverse_writer_wraps")
+    trending = _make_trending()
+
+    with patch(
+        "cja_auto_sdr.org.writers.markdown.write_org_report_markdown",
+        wraps=mod.write_org_report_markdown,
+    ) as writer_mock:
+        output_path = Path(
+            mod.write_org_report_markdown(
+                rich_org_report_result,
+                tmp_path / "org_report_reverse_writer_wraps.md",
+                str(tmp_path),
+                logger,
+                trending=trending,
+            ),
+        )
+
+    assert output_path.exists()
+    writer_mock.assert_called_once()
 
 
 @pytest.mark.parametrize(
@@ -1589,6 +1984,7 @@ class TestCompatOverrideMappingCompleteness:
     _EXPECTED_OVERRIDE_MAPPINGS = [
         "EMPTY_OVERRIDE_MAPPING",
         "COMMON_RECOMMENDATION_OVERRIDE_MAPPING",
+        "TRENDING_HELPER_OVERRIDE_MAPPING",
         "TRENDING_LABEL_OVERRIDE_MAPPING",
         "CONSOLE_WRITER_OVERRIDE_MAPPING",
         "CONSOLE_STATS_ONLY_OVERRIDE_MAPPING",
@@ -1666,6 +2062,19 @@ class TestCompatOverrideMappingCompleteness:
             assert isinstance(key, tuple)
             module_name, _attr = key
             assert module_name == "cja_auto_sdr.org.writers.trending"
+
+    def test_trending_helper_mapping_uses_flat_package_root_keys(self):
+        """TRENDING_HELPER_OVERRIDE_MAPPING should stay flat for package-root helper wrappers."""
+        from cja_auto_sdr.org.writers.compat import TRENDING_HELPER_OVERRIDE_MAPPING
+
+        assert all(isinstance(key, str) for key in TRENDING_HELPER_OVERRIDE_MAPPING)
+        assert {
+            "_escape_markdown_table_cell",
+            "_format_trending_dv_label",
+            "_resolve_trending_dv_name",
+            "_sorted_drift_score_items",
+            "_stringify_trending_value",
+        } <= set(TRENDING_HELPER_OVERRIDE_MAPPING)
 
     def test_composed_mappings_inherit_base_entries(self):
         """Composed mappings must contain all entries from their base mappings."""

--- a/tests/test_output_extraction_contracts.py
+++ b/tests/test_output_extraction_contracts.py
@@ -1084,6 +1084,93 @@ def test_org_writers_csv_importable():
 
 
 # ---------------------------------------------------------------------------
+# org.writers __all__ export consistency
+# ---------------------------------------------------------------------------
+
+
+_ORG_WRITERS_SUBMODULES = [
+    "cja_auto_sdr.org.writers.console",
+    "cja_auto_sdr.org.writers.json",
+    "cja_auto_sdr.org.writers.csv",
+    "cja_auto_sdr.org.writers.excel",
+    "cja_auto_sdr.org.writers.html",
+    "cja_auto_sdr.org.writers.markdown",
+]
+
+
+class TestOrgWritersAllExportConsistency:
+    """Verify __all__ declarations in org/writers submodules are consistent with parent re-exports."""
+
+    @pytest.mark.parametrize("submodule", _ORG_WRITERS_SUBMODULES, ids=[m.rsplit(".", 1)[-1] for m in _ORG_WRITERS_SUBMODULES])
+    def test_submodule_has_all(self, submodule):
+        """Each org/writers submodule must declare __all__."""
+        mod = importlib.import_module(submodule)
+        assert hasattr(mod, "__all__"), f"{submodule} is missing __all__"
+
+    @pytest.mark.parametrize("submodule", _ORG_WRITERS_SUBMODULES, ids=[m.rsplit(".", 1)[-1] for m in _ORG_WRITERS_SUBMODULES])
+    def test_all_names_exist_on_submodule(self, submodule):
+        """Every name in a submodule's __all__ must exist as an attribute on that submodule."""
+        mod = importlib.import_module(submodule)
+        for name in mod.__all__:
+            assert hasattr(mod, name), f"{submodule}.__all__ declares {name!r} but it is not an attribute"
+
+    @pytest.mark.parametrize("submodule", _ORG_WRITERS_SUBMODULES, ids=[m.rsplit(".", 1)[-1] for m in _ORG_WRITERS_SUBMODULES])
+    def test_all_names_importable_from_parent(self, submodule):
+        """Every name in a submodule's __all__ must be importable from cja_auto_sdr.org.writers."""
+        sub_mod = importlib.import_module(submodule)
+        parent_mod = importlib.import_module("cja_auto_sdr.org.writers")
+        for name in sub_mod.__all__:
+            assert hasattr(parent_mod, name), (
+                f"{submodule}.__all__ declares {name!r} but it is not importable from cja_auto_sdr.org.writers"
+            )
+
+
+# ---------------------------------------------------------------------------
+# output.diff __all__ export consistency
+# ---------------------------------------------------------------------------
+
+
+_OUTPUT_DIFF_SUBMODULES = [
+    "cja_auto_sdr.output.diff.common",
+    "cja_auto_sdr.output.diff.console",
+    "cja_auto_sdr.output.diff.csv",
+    "cja_auto_sdr.output.diff.json",
+    "cja_auto_sdr.output.diff.excel",
+    "cja_auto_sdr.output.diff.html",
+    "cja_auto_sdr.output.diff.markdown",
+    "cja_auto_sdr.output.diff.grouped",
+    "cja_auto_sdr.output.diff.pr_comment",
+]
+
+
+class TestOutputDiffAllExportConsistency:
+    """Verify __all__ declarations in output/diff submodules are consistent with parent re-exports."""
+
+    @pytest.mark.parametrize("submodule", _OUTPUT_DIFF_SUBMODULES, ids=[m.rsplit(".", 1)[-1] for m in _OUTPUT_DIFF_SUBMODULES])
+    def test_submodule_has_all(self, submodule):
+        """Each output/diff submodule must declare __all__."""
+        mod = importlib.import_module(submodule)
+        assert hasattr(mod, "__all__"), f"{submodule} is missing __all__"
+
+    @pytest.mark.parametrize("submodule", _OUTPUT_DIFF_SUBMODULES, ids=[m.rsplit(".", 1)[-1] for m in _OUTPUT_DIFF_SUBMODULES])
+    def test_all_names_exist_on_submodule(self, submodule):
+        """Every name in a submodule's __all__ must exist as an attribute on that submodule."""
+        mod = importlib.import_module(submodule)
+        for name in mod.__all__:
+            assert hasattr(mod, name), f"{submodule}.__all__ declares {name!r} but it is not an attribute"
+
+    @pytest.mark.parametrize("submodule", _OUTPUT_DIFF_SUBMODULES, ids=[m.rsplit(".", 1)[-1] for m in _OUTPUT_DIFF_SUBMODULES])
+    def test_all_names_importable_from_parent(self, submodule):
+        """Every name in a submodule's __all__ must be importable from cja_auto_sdr.output.diff."""
+        sub_mod = importlib.import_module(submodule)
+        parent_mod = importlib.import_module("cja_auto_sdr.output.diff")
+        for name in sub_mod.__all__:
+            assert hasattr(parent_mod, name), (
+                f"{submodule}.__all__ declares {name!r} but it is not importable from cja_auto_sdr.output.diff"
+            )
+
+
+# ---------------------------------------------------------------------------
 # org.writers package-root continuity (file writers)
 # ---------------------------------------------------------------------------
 
@@ -1338,3 +1425,385 @@ def test_trending_helper_signatures_via_package_root(func_name, expected_params)
     mod = importlib.import_module("cja_auto_sdr.org.writers")
     func = getattr(mod, func_name)
     assert list(signature(func).parameters) == expected_params
+
+
+# ---------------------------------------------------------------------------
+# org.writers.compat contract surface
+# ---------------------------------------------------------------------------
+
+
+class TestCompatSignatureContinuity:
+    """Verify function signatures for all public/exported functions in compat.py."""
+
+    _COMPAT_PUBLIC_SIGNATURES = {
+        "freeze_override_mapping": {
+            "params": ["mapping"],
+        },
+        "compose_override_mapping": {
+            "params": ["mappings"],
+        },
+        "resolve_override": {
+            "params": ["target_module_name", "attr_name", "default"],
+        },
+        "call_override": {
+            "params": ["target_module_name", "attr_name", "default", "args", "kwargs"],
+        },
+        "make_override_proxy": {
+            "params": ["target_module_name", "attr_name", "default"],
+        },
+        "collect_legacy_overrides": {
+            "params": ["source_module_name", "override_mapping", "default_target_module_name", "baselines"],
+        },
+        "override_scope": {
+            "params": ["overrides"],
+        },
+        "make_compat_wrapper": {
+            "params": ["source_module_name", "target", "target_module_name", "override_mapping"],
+        },
+    }
+
+    @pytest.mark.parametrize(
+        ("func_name", "contract"),
+        list(_COMPAT_PUBLIC_SIGNATURES.items()),
+        ids=list(_COMPAT_PUBLIC_SIGNATURES.keys()),
+    )
+    def test_compat_function_signatures(self, func_name, contract):
+        """Public compat functions must preserve parameter names and ordering."""
+        mod = importlib.import_module("cja_auto_sdr.org.writers.compat")
+        func = getattr(mod, func_name)
+        assert list(signature(func).parameters) == contract["params"]
+
+    def test_freeze_override_mapping_annotation(self):
+        """freeze_override_mapping must accept and return a Mapping."""
+        from cja_auto_sdr.org.writers.compat import freeze_override_mapping
+
+        sig = signature(freeze_override_mapping)
+        assert sig.return_annotation is not sig.empty
+
+    def test_compose_override_mapping_is_variadic(self):
+        """compose_override_mapping must accept variadic positional mappings."""
+        import inspect
+
+        from cja_auto_sdr.org.writers.compat import compose_override_mapping
+
+        sig = signature(compose_override_mapping)
+        mappings_param = sig.parameters["mappings"]
+        assert mappings_param.kind == inspect.Parameter.VAR_POSITIONAL
+
+    def test_collect_legacy_overrides_has_keyword_only_params(self):
+        """collect_legacy_overrides must have default_target_module_name as keyword-only."""
+        import inspect
+
+        from cja_auto_sdr.org.writers.compat import collect_legacy_overrides
+
+        sig = signature(collect_legacy_overrides)
+        param = sig.parameters["default_target_module_name"]
+        assert param.kind == inspect.Parameter.KEYWORD_ONLY
+
+    def test_collect_legacy_overrides_baselines_defaults_to_none(self):
+        """collect_legacy_overrides baselines parameter must default to None."""
+        from cja_auto_sdr.org.writers.compat import collect_legacy_overrides
+
+        sig = signature(collect_legacy_overrides)
+        param = sig.parameters["baselines"]
+        assert param.default is None
+
+    def test_make_compat_wrapper_has_keyword_only_params(self):
+        """make_compat_wrapper must have target_module_name and override_mapping as keyword-only."""
+        import inspect
+
+        from cja_auto_sdr.org.writers.compat import make_compat_wrapper
+
+        sig = signature(make_compat_wrapper)
+        assert sig.parameters["target_module_name"].kind == inspect.Parameter.KEYWORD_ONLY
+        assert sig.parameters["override_mapping"].kind == inspect.Parameter.KEYWORD_ONLY
+
+
+class TestCompatOverrideMappingCompleteness:
+    """Verify all exported *_OVERRIDE_MAPPING constants exist and are expected types."""
+
+    _EXPECTED_OVERRIDE_MAPPINGS = [
+        "EMPTY_OVERRIDE_MAPPING",
+        "COMMON_RECOMMENDATION_OVERRIDE_MAPPING",
+        "TRENDING_LABEL_OVERRIDE_MAPPING",
+        "CONSOLE_WRITER_OVERRIDE_MAPPING",
+        "CONSOLE_STATS_ONLY_OVERRIDE_MAPPING",
+        "JSON_BUILDER_OVERRIDE_MAPPING",
+        "JSON_WRITER_OVERRIDE_MAPPING",
+        "EXCEL_WRITER_OVERRIDE_MAPPING",
+        "MARKDOWN_WRITER_OVERRIDE_MAPPING",
+        "HTML_WRITER_OVERRIDE_MAPPING",
+        "CSV_WRITER_OVERRIDE_MAPPING",
+    ]
+
+    @pytest.mark.parametrize("name", _EXPECTED_OVERRIDE_MAPPINGS, ids=_EXPECTED_OVERRIDE_MAPPINGS)
+    def test_override_mapping_exists(self, name):
+        """Override mapping constant must be importable from compat module."""
+        mod = importlib.import_module("cja_auto_sdr.org.writers.compat")
+        assert hasattr(mod, name)
+
+    @pytest.mark.parametrize("name", _EXPECTED_OVERRIDE_MAPPINGS, ids=_EXPECTED_OVERRIDE_MAPPINGS)
+    def test_override_mapping_is_mapping(self, name):
+        """Override mapping constant must be a Mapping."""
+        from collections.abc import Mapping
+
+        mod = importlib.import_module("cja_auto_sdr.org.writers.compat")
+        obj = getattr(mod, name)
+        assert isinstance(obj, Mapping)
+
+    @pytest.mark.parametrize("name", _EXPECTED_OVERRIDE_MAPPINGS, ids=_EXPECTED_OVERRIDE_MAPPINGS)
+    def test_override_mapping_is_frozen(self, name):
+        """Override mapping constant must be immutable (MappingProxyType)."""
+        from types import MappingProxyType
+
+        mod = importlib.import_module("cja_auto_sdr.org.writers.compat")
+        obj = getattr(mod, name)
+        assert isinstance(obj, MappingProxyType)
+
+    def test_empty_override_mapping_is_empty(self):
+        """EMPTY_OVERRIDE_MAPPING must have zero entries."""
+        from cja_auto_sdr.org.writers.compat import EMPTY_OVERRIDE_MAPPING
+
+        assert len(EMPTY_OVERRIDE_MAPPING) == 0
+
+    def test_common_recommendation_mapping_targets_common_module(self):
+        """COMMON_RECOMMENDATION_OVERRIDE_MAPPING keys must target the common module."""
+        from cja_auto_sdr.org.writers.compat import COMMON_RECOMMENDATION_OVERRIDE_MAPPING
+
+        for key in COMMON_RECOMMENDATION_OVERRIDE_MAPPING:
+            assert isinstance(key, tuple)
+            module_name, _attr = key
+            assert module_name == "cja_auto_sdr.org.writers.common"
+
+    def test_trending_label_mapping_targets_trending_module(self):
+        """TRENDING_LABEL_OVERRIDE_MAPPING keys must target the trending module."""
+        from cja_auto_sdr.org.writers.compat import TRENDING_LABEL_OVERRIDE_MAPPING
+
+        for key in TRENDING_LABEL_OVERRIDE_MAPPING:
+            assert isinstance(key, tuple)
+            module_name, _attr = key
+            assert module_name == "cja_auto_sdr.org.writers.trending"
+
+    def test_composed_mappings_inherit_base_entries(self):
+        """Composed mappings must contain all entries from their base mappings."""
+        from cja_auto_sdr.org.writers.compat import (
+            COMMON_RECOMMENDATION_OVERRIDE_MAPPING,
+            CONSOLE_WRITER_OVERRIDE_MAPPING,
+            JSON_BUILDER_OVERRIDE_MAPPING,
+            TRENDING_LABEL_OVERRIDE_MAPPING,
+        )
+
+        for base_key in TRENDING_LABEL_OVERRIDE_MAPPING:
+            assert base_key in CONSOLE_WRITER_OVERRIDE_MAPPING
+        for base_key in COMMON_RECOMMENDATION_OVERRIDE_MAPPING:
+            assert base_key in JSON_BUILDER_OVERRIDE_MAPPING
+
+    def test_override_mapping_values_are_strings(self):
+        """All override mapping values must be string attribute names."""
+        mod = importlib.import_module("cja_auto_sdr.org.writers.compat")
+        for name in self._EXPECTED_OVERRIDE_MAPPINGS:
+            mapping = getattr(mod, name)
+            for value in mapping.values():
+                assert isinstance(value, str), f"{name}[...] = {value!r} is not a string"
+
+
+class TestMakeCompatWrapperBehavior:
+    """Test that make_compat_wrapper returns a callable with correct behavior."""
+
+    def test_returns_callable(self):
+        """make_compat_wrapper must return a callable."""
+        from cja_auto_sdr.org.writers.compat import EMPTY_OVERRIDE_MAPPING, make_compat_wrapper
+
+        def dummy_target():
+            return "original"
+
+        wrapper = make_compat_wrapper(
+            "cja_auto_sdr.org.writers.compat",
+            dummy_target,
+            target_module_name="cja_auto_sdr.org.writers.compat",
+            override_mapping=EMPTY_OVERRIDE_MAPPING,
+        )
+        assert callable(wrapper)
+
+    def test_preserves_wrapped_function_name(self):
+        """make_compat_wrapper must preserve the target function's __name__."""
+        from cja_auto_sdr.org.writers.compat import EMPTY_OVERRIDE_MAPPING, make_compat_wrapper
+
+        def my_special_function():
+            return "value"
+
+        wrapper = make_compat_wrapper(
+            "cja_auto_sdr.org.writers.compat",
+            my_special_function,
+            target_module_name="cja_auto_sdr.org.writers.compat",
+            override_mapping=EMPTY_OVERRIDE_MAPPING,
+        )
+        assert wrapper.__name__ == "my_special_function"
+
+    def test_sets_module_to_source(self):
+        """make_compat_wrapper must set __module__ to the source module name."""
+        from cja_auto_sdr.org.writers.compat import EMPTY_OVERRIDE_MAPPING, make_compat_wrapper
+
+        def dummy():
+            pass
+
+        wrapper = make_compat_wrapper(
+            "cja_auto_sdr.org.writers",
+            dummy,
+            target_module_name="cja_auto_sdr.org.writers.compat",
+            override_mapping=EMPTY_OVERRIDE_MAPPING,
+        )
+        assert wrapper.__module__ == "cja_auto_sdr.org.writers"
+
+    def test_override_scope_applies_and_restores(self):
+        """override_scope must apply overrides and restore state afterwards."""
+        from cja_auto_sdr.org.writers.compat import _current_overrides, override_scope
+
+        key = ("test.module", "test_attr")
+        assert key not in _current_overrides()
+
+        with override_scope({key: "patched_value"}):
+            assert _current_overrides()[key] == "patched_value"
+
+        assert key not in _current_overrides()
+
+    def test_resolve_override_returns_default_without_scope(self):
+        """resolve_override must return the default when no override is active."""
+        from cja_auto_sdr.org.writers.compat import resolve_override
+
+        sentinel = object()
+        result = resolve_override("nonexistent.module", "nonexistent_attr", sentinel)
+        assert result is sentinel
+
+    def test_resolve_override_returns_override_within_scope(self):
+        """resolve_override must return the overridden value inside an override_scope."""
+        from cja_auto_sdr.org.writers.compat import override_scope, resolve_override
+
+        sentinel = object()
+        override_val = object()
+        key_module = "test.resolve.module"
+        key_attr = "test_resolve_attr"
+
+        with override_scope({(key_module, key_attr): override_val}):
+            result = resolve_override(key_module, key_attr, sentinel)
+            assert result is override_val
+
+    def test_make_override_proxy_delegates_through_scope(self):
+        """make_override_proxy must call overridden function within an override_scope."""
+        from cja_auto_sdr.org.writers.compat import make_override_proxy, override_scope
+
+        def default_fn(x):
+            return f"default:{x}"
+
+        proxy = make_override_proxy("test.proxy.module", "test_fn", default_fn)
+        assert proxy("hello") == "default:hello"
+
+        def override_fn(x):
+            return f"override:{x}"
+
+        with override_scope({("test.proxy.module", "test_fn"): override_fn}):
+            assert proxy("hello") == "override:hello"
+
+        assert proxy("hello") == "default:hello"
+
+    def test_call_override_invokes_default(self):
+        """call_override must invoke the default callable when no override is active."""
+        from cja_auto_sdr.org.writers.compat import call_override
+
+        def default_fn(a, b):
+            return a + b
+
+        result = call_override("test.call.module", "test_fn", default_fn, 3, 4)
+        assert result == 7
+
+    def test_call_override_invokes_override_within_scope(self):
+        """call_override must invoke the overridden callable inside an override_scope."""
+        from cja_auto_sdr.org.writers.compat import call_override, override_scope
+
+        def default_fn(a, b):
+            return a + b
+
+        def override_fn(a, b):
+            return a * b
+
+        with override_scope({("test.call.module", "test_fn"): override_fn}):
+            result = call_override("test.call.module", "test_fn", default_fn, 3, 4)
+            assert result == 12
+
+
+class TestFreezeAndComposeOverrideMapping:
+    """Test freeze_override_mapping and compose_override_mapping behavior."""
+
+    def test_freeze_produces_immutable_mapping(self):
+        """freeze_override_mapping must return an immutable MappingProxyType."""
+        from types import MappingProxyType
+
+        from cja_auto_sdr.org.writers.compat import freeze_override_mapping
+
+        mutable = {("mod", "attr"): "value"}
+        frozen = freeze_override_mapping(mutable)
+        assert isinstance(frozen, MappingProxyType)
+        with pytest.raises(TypeError):
+            frozen[("mod", "new_attr")] = "new_value"
+
+    def test_freeze_copies_source(self):
+        """freeze_override_mapping must not be affected by mutations to the source dict."""
+        from cja_auto_sdr.org.writers.compat import freeze_override_mapping
+
+        mutable = {("mod", "attr"): "original"}
+        frozen = freeze_override_mapping(mutable)
+        mutable[("mod", "attr")] = "mutated"
+        assert frozen[("mod", "attr")] == "original"
+
+    def test_freeze_preserves_all_entries(self):
+        """freeze_override_mapping must preserve all key-value pairs."""
+        from cja_auto_sdr.org.writers.compat import freeze_override_mapping
+
+        source = {("m1", "a1"): "v1", ("m2", "a2"): "v2"}
+        frozen = freeze_override_mapping(source)
+        assert dict(frozen) == source
+
+    def test_compose_merges_multiple_mappings(self):
+        """compose_override_mapping must merge entries from all provided mappings."""
+        from cja_auto_sdr.org.writers.compat import compose_override_mapping
+
+        m1 = {("mod1", "attr1"): "val1"}
+        m2 = {("mod2", "attr2"): "val2"}
+        composed = compose_override_mapping(m1, m2)
+        assert ("mod1", "attr1") in composed
+        assert ("mod2", "attr2") in composed
+        assert len(composed) == 2
+
+    def test_compose_returns_frozen_mapping(self):
+        """compose_override_mapping must return an immutable MappingProxyType."""
+        from types import MappingProxyType
+
+        from cja_auto_sdr.org.writers.compat import compose_override_mapping
+
+        composed = compose_override_mapping({"key": "val"})
+        assert isinstance(composed, MappingProxyType)
+
+    def test_compose_later_mappings_override_earlier(self):
+        """compose_override_mapping must let later mappings override earlier ones."""
+        from cja_auto_sdr.org.writers.compat import compose_override_mapping
+
+        m1 = {("mod", "attr"): "first"}
+        m2 = {("mod", "attr"): "second"}
+        composed = compose_override_mapping(m1, m2)
+        assert composed[("mod", "attr")] == "second"
+
+    def test_compose_with_no_arguments_returns_empty(self):
+        """compose_override_mapping with no arguments must return an empty frozen mapping."""
+        from cja_auto_sdr.org.writers.compat import compose_override_mapping
+
+        composed = compose_override_mapping()
+        assert len(composed) == 0
+
+    def test_compose_with_string_keys_preserves_them(self):
+        """compose_override_mapping must handle string destination keys."""
+        from cja_auto_sdr.org.writers.compat import compose_override_mapping
+
+        m1 = {"simple_attr": "legacy_name"}
+        composed = compose_override_mapping(m1)
+        assert "simple_attr" in composed
+        assert composed["simple_attr"] == "legacy_name"

--- a/tests/test_output_extraction_contracts.py
+++ b/tests/test_output_extraction_contracts.py
@@ -1145,9 +1145,7 @@ _ORG_WRITERS_SUBMODULES = [
 ]
 
 # compat.py exports are internal plumbing, not re-exported by the parent __init__.py
-_ORG_WRITERS_REEXPORTED_SUBMODULES = [
-    m for m in _ORG_WRITERS_SUBMODULES if m != "cja_auto_sdr.org.writers.compat"
-]
+_ORG_WRITERS_REEXPORTED_SUBMODULES = [m for m in _ORG_WRITERS_SUBMODULES if m != "cja_auto_sdr.org.writers.compat"]
 
 
 class TestOrgWritersAllExportConsistency:
@@ -1699,9 +1697,7 @@ class TestCompatOverrideMappingCompleteness:
             tuple_attrs = {attr for key in mapping if isinstance(key, tuple) for _, attr in [key]}
             string_keys = {key for key in mapping if isinstance(key, str)}
             collision = string_keys & tuple_attrs
-            assert not collision, (
-                f"{name} has string key(s) {collision} that duplicate tuple key attr names"
-            )
+            assert not collision, f"{name} has string key(s) {collision} that duplicate tuple key attr names"
 
 
 class TestMakeCompatWrapperBehavior:

--- a/tests/test_output_extraction_contracts.py
+++ b/tests/test_output_extraction_contracts.py
@@ -1923,12 +1923,70 @@ class TestMakeCompatWrapperBehavior:
 
         assert key not in _current_overrides()
 
-    def test_override_scope_rejects_non_string_keys(self):
-        """override_scope public surface must reject normalized tuple-key mappings."""
+    def test_override_scope_accepts_collected_mixed_key_overrides(self):
+        """override_scope must apply mixed-key overrides returned by collect_legacy_overrides."""
+        from cja_auto_sdr.org.writers import (
+            _format_recommendation_context_entries,
+            _format_trending_period_label,
+            _render_trending_markdown,
+        )
+        from cja_auto_sdr.org.writers.compat import (
+            MARKDOWN_WRITER_OVERRIDE_MAPPING,
+            collect_legacy_overrides,
+            override_scope,
+            resolve_override,
+        )
+
+        overrides = collect_legacy_overrides(
+            "cja_auto_sdr.org.writers",
+            MARKDOWN_WRITER_OVERRIDE_MAPPING,
+        )
+        sentinel = object()
+
+        with override_scope("cja_auto_sdr.org.writers.markdown", overrides):
+            assert (
+                resolve_override(
+                    "cja_auto_sdr.org.writers.markdown",
+                    "_render_trending_markdown",
+                    sentinel,
+                )
+                is _render_trending_markdown
+            )
+            assert (
+                resolve_override(
+                    "cja_auto_sdr.org.writers.markdown",
+                    "_format_recommendation_context_entries",
+                    sentinel,
+                )
+                is _format_recommendation_context_entries
+            )
+            assert (
+                resolve_override(
+                    "cja_auto_sdr.org.writers.trending",
+                    "_format_trending_period_label",
+                    sentinel,
+                )
+                is _format_trending_period_label
+            )
+
+        assert (
+            resolve_override(
+                "cja_auto_sdr.org.writers.markdown",
+                "_render_trending_markdown",
+                sentinel,
+            )
+            is sentinel
+        )
+
+    def test_override_scope_rejects_malformed_tuple_keys(self):
+        """override_scope must reject tuple keys that are not (module, attr) string pairs."""
         from cja_auto_sdr.org.writers.compat import override_scope
 
-        with pytest.raises(TypeError, match="override keys must be strings"):
-            with override_scope("test.invalid.module", {("test.invalid.module", "attr"): "value"}):
+        with pytest.raises(
+            TypeError,
+            match="tuple override keys must be \\(target_module_name, attr_name\\) string pairs",
+        ):
+            with override_scope("test.invalid.module", {("test.invalid.module", 1): "value"}):
                 pass
 
 

--- a/tests/test_output_extraction_contracts.py
+++ b/tests/test_output_extraction_contracts.py
@@ -930,6 +930,51 @@ def test_org_markdown_writer_respects_legacy_helper_patch(module_name, tmp_path,
     assert normalize_mock.call_count == len(rich_org_report_result.recommendations)
 
 
+@pytest.mark.parametrize(
+    ("writer_name", "suffix"),
+    [
+        ("write_org_report_markdown", ".md"),
+        ("write_org_report_html", ".html"),
+    ],
+    ids=["markdown", "html"],
+)
+@pytest.mark.parametrize(
+    "module_name",
+    ["cja_auto_sdr.org.writers", "cja_auto_sdr.generator"],
+    ids=["org.writers", "generator"],
+)
+def test_org_file_writers_respect_legacy_context_helper_patch(
+    writer_name,
+    suffix,
+    module_name,
+    tmp_path,
+    rich_org_report_result,
+):
+    """Legacy context helper patches must flow into every recommendation-rendering file writer."""
+    mod = importlib.import_module(module_name)
+    logger = logging.getLogger(f"test.{module_name}.{writer_name}.context")
+    patched_label = "Patched Context"
+    patched_value = f"patched context via {module_name}"
+
+    with patch(
+        f"{module_name}._format_recommendation_context_entries",
+        return_value=[(patched_label, patched_value)],
+    ) as context_mock:
+        output_path = Path(
+            getattr(mod, writer_name)(
+                rich_org_report_result,
+                tmp_path / f"org_report{suffix}",
+                str(tmp_path),
+                logger,
+            ),
+        )
+
+    output = output_path.read_text(encoding="utf-8")
+    assert patched_label in output
+    assert patched_value in output
+    assert context_mock.call_count >= len(rich_org_report_result.recommendations)
+
+
 def test_org_markdown_writer_respects_package_root_timestamp_helper_patch(
     tmp_path,
     rich_org_report_result,
@@ -1089,12 +1134,19 @@ def test_org_writers_csv_importable():
 
 
 _ORG_WRITERS_SUBMODULES = [
+    "cja_auto_sdr.org.writers.compat",
     "cja_auto_sdr.org.writers.console",
     "cja_auto_sdr.org.writers.json",
     "cja_auto_sdr.org.writers.csv",
     "cja_auto_sdr.org.writers.excel",
     "cja_auto_sdr.org.writers.html",
     "cja_auto_sdr.org.writers.markdown",
+    "cja_auto_sdr.org.writers.trending",
+]
+
+# compat.py exports are internal plumbing, not re-exported by the parent __init__.py
+_ORG_WRITERS_REEXPORTED_SUBMODULES = [
+    m for m in _ORG_WRITERS_SUBMODULES if m != "cja_auto_sdr.org.writers.compat"
 ]
 
 
@@ -1119,7 +1171,9 @@ class TestOrgWritersAllExportConsistency:
             assert hasattr(mod, name), f"{submodule}.__all__ declares {name!r} but it is not an attribute"
 
     @pytest.mark.parametrize(
-        "submodule", _ORG_WRITERS_SUBMODULES, ids=[m.rsplit(".", 1)[-1] for m in _ORG_WRITERS_SUBMODULES]
+        "submodule",
+        _ORG_WRITERS_REEXPORTED_SUBMODULES,
+        ids=[m.rsplit(".", 1)[-1] for m in _ORG_WRITERS_REEXPORTED_SUBMODULES],
     )
     def test_all_names_importable_from_parent(self, submodule):
         """Every name in a submodule's __all__ must be importable from cja_auto_sdr.org.writers."""
@@ -1578,14 +1632,33 @@ class TestCompatOverrideMappingCompleteness:
 
         assert len(EMPTY_OVERRIDE_MAPPING) == 0
 
-    def test_common_recommendation_mapping_targets_common_module(self):
-        """COMMON_RECOMMENDATION_OVERRIDE_MAPPING keys must target the common module."""
+    def test_common_recommendation_mapping_fans_out_context_helper_to_proxy_modules(self):
+        """Context helper overrides must reach every canonical proxy that renders recommendations."""
         from cja_auto_sdr.org.writers.compat import COMMON_RECOMMENDATION_OVERRIDE_MAPPING
 
-        for key in COMMON_RECOMMENDATION_OVERRIDE_MAPPING:
-            assert isinstance(key, tuple)
-            module_name, _attr = key
-            assert module_name == "cja_auto_sdr.org.writers.common"
+        context_targets = {
+            key
+            for key, legacy_attr in COMMON_RECOMMENDATION_OVERRIDE_MAPPING.items()
+            if legacy_attr == "_format_recommendation_context_entries"
+        }
+        assert context_targets == {
+            ("cja_auto_sdr.org.writers.common", "_format_recommendation_context_entries"),
+            ("cja_auto_sdr.org.writers.markdown", "_format_recommendation_context_entries"),
+            ("cja_auto_sdr.org.writers.html", "_format_recommendation_context_entries"),
+        }
+
+    def test_common_recommendation_mapping_scopes_severity_helper_to_common_module(self):
+        """Severity helper overrides should stay scoped to the common normalizer."""
+        from cja_auto_sdr.org.writers.compat import COMMON_RECOMMENDATION_OVERRIDE_MAPPING
+
+        severity_targets = {
+            key
+            for key, legacy_attr in COMMON_RECOMMENDATION_OVERRIDE_MAPPING.items()
+            if legacy_attr == "_normalize_recommendation_severity"
+        }
+        assert severity_targets == {
+            ("cja_auto_sdr.org.writers.common", "_normalize_recommendation_severity"),
+        }
 
     def test_trending_label_mapping_targets_trending_module(self):
         """TRENDING_LABEL_OVERRIDE_MAPPING keys must target the trending module."""
@@ -1617,6 +1690,18 @@ class TestCompatOverrideMappingCompleteness:
             mapping = getattr(mod, name)
             for value in mapping.values():
                 assert isinstance(value, str), f"{name}[...] = {value!r} is not a string"
+
+    def test_composed_mappings_no_string_tuple_attr_collision(self):
+        """No composed mapping should have a bare string key whose attr duplicates a tuple key's attr."""
+        mod = importlib.import_module("cja_auto_sdr.org.writers.compat")
+        for name in self._EXPECTED_OVERRIDE_MAPPINGS:
+            mapping = getattr(mod, name)
+            tuple_attrs = {attr for key in mapping if isinstance(key, tuple) for _, attr in [key]}
+            string_keys = {key for key in mapping if isinstance(key, str)}
+            collision = string_keys & tuple_attrs
+            assert not collision, (
+                f"{name} has string key(s) {collision} that duplicate tuple key attr names"
+            )
 
 
 class TestMakeCompatWrapperBehavior:
@@ -1742,6 +1827,58 @@ class TestMakeCompatWrapperBehavior:
             result = call_override("test.call.module", "test_fn", default_fn, 3, 4)
             assert result == 12
 
+    def test_call_override_forwards_kwargs(self):
+        """call_override must forward keyword arguments to both default and overridden callables."""
+        from cja_auto_sdr.org.writers.compat import call_override, override_scope
+
+        def default_fn(*, x, y):
+            return f"default:{x},{y}"
+
+        def override_fn(*, x, y):
+            return f"override:{x},{y}"
+
+        assert call_override("test.kw.module", "test_fn", default_fn, x=1, y=2) == "default:1,2"
+
+        with override_scope({("test.kw.module", "test_fn"): override_fn}):
+            assert call_override("test.kw.module", "test_fn", default_fn, x=3, y=4) == "override:3,4"
+
+    def test_override_scope_nesting_preserves_outer_keys(self):
+        """Nested override_scope must not clobber outer scope's unrelated keys."""
+        from cja_auto_sdr.org.writers.compat import _current_overrides, override_scope
+
+        key_a = ("test.nest.module", "attr_a")
+        key_b = ("test.nest.module", "attr_b")
+
+        with override_scope({key_a: "outer_a"}):
+            with override_scope({key_b: "inner_b"}):
+                overrides = _current_overrides()
+                assert overrides[key_a] == "outer_a"
+                assert overrides[key_b] == "inner_b"
+
+    def test_override_scope_nesting_inner_shadows_same_key(self):
+        """Inner override_scope must shadow the outer scope for the same key."""
+        from cja_auto_sdr.org.writers.compat import _current_overrides, override_scope
+
+        key = ("test.shadow.module", "attr")
+
+        with override_scope({key: "outer"}):
+            assert _current_overrides()[key] == "outer"
+            with override_scope({key: "inner"}):
+                assert _current_overrides()[key] == "inner"
+
+    def test_override_scope_nesting_exit_restores_outer(self):
+        """Exiting inner override_scope must restore outer scope's original values."""
+        from cja_auto_sdr.org.writers.compat import _current_overrides, override_scope
+
+        key = ("test.restore.module", "attr")
+
+        with override_scope({key: "outer"}):
+            with override_scope({key: "inner"}):
+                pass
+            assert _current_overrides()[key] == "outer"
+
+        assert key not in _current_overrides()
+
 
 class TestFreezeAndComposeOverrideMapping:
     """Test freeze_override_mapping and compose_override_mapping behavior."""
@@ -1819,3 +1956,95 @@ class TestFreezeAndComposeOverrideMapping:
         composed = compose_override_mapping(m1)
         assert "simple_attr" in composed
         assert composed["simple_attr"] == "legacy_name"
+
+
+class TestNormalizeOverrideMapping:
+    """Direct unit tests for _normalize_override_mapping."""
+
+    def test_string_keys_get_default_module(self):
+        """Pure string keys must be normalized to (default_target_module_name, key)."""
+        from cja_auto_sdr.org.writers.compat import _normalize_override_mapping
+
+        result = _normalize_override_mapping(
+            {"attr_a": "legacy_a", "attr_b": "legacy_b"},
+            default_target_module_name="my.module",
+        )
+        assert result == {
+            ("my.module", "attr_a"): "legacy_a",
+            ("my.module", "attr_b"): "legacy_b",
+        }
+
+    def test_tuple_keys_pass_through(self):
+        """Pure tuple keys must pass through unchanged."""
+        from cja_auto_sdr.org.writers.compat import _normalize_override_mapping
+
+        result = _normalize_override_mapping(
+            {("explicit.mod", "attr_x"): "legacy_x"},
+            default_target_module_name="default.mod",
+        )
+        assert result == {("explicit.mod", "attr_x"): "legacy_x"}
+
+    def test_mixed_keys_normalize_correctly(self):
+        """Mixed string and tuple keys must each normalize independently."""
+        from cja_auto_sdr.org.writers.compat import _normalize_override_mapping
+
+        result = _normalize_override_mapping(
+            {
+                "bare_attr": "legacy_bare",
+                ("other.mod", "explicit_attr"): "legacy_explicit",
+            },
+            default_target_module_name="default.mod",
+        )
+        assert result == {
+            ("default.mod", "bare_attr"): "legacy_bare",
+            ("other.mod", "explicit_attr"): "legacy_explicit",
+        }
+
+    def test_empty_mapping_returns_empty(self):
+        """Empty mapping must return empty dict."""
+        from cja_auto_sdr.org.writers.compat import _normalize_override_mapping
+
+        result = _normalize_override_mapping({}, default_target_module_name="any.mod")
+        assert result == {}
+
+    def test_tuple_key_ignores_default_module(self):
+        """Tuple key's explicit module must take precedence over default_target_module_name."""
+        from cja_auto_sdr.org.writers.compat import _normalize_override_mapping
+
+        result = _normalize_override_mapping(
+            {("specific.mod", "attr"): "legacy"},
+            default_target_module_name="ignored.mod",
+        )
+        assert ("specific.mod", "attr") in result
+        assert ("ignored.mod", "attr") not in result
+
+
+def test_org_writers_trending_date_range_respects_package_root_timestamp_patch():
+    """Package-root timestamp formatter patches must flow into _trending_date_range."""
+    mod = importlib.import_module("cja_auto_sdr.org.writers")
+    trending = _make_trending()
+
+    with patch(
+        "cja_auto_sdr.org.writers._format_trending_timestamp_short",
+        side_effect=lambda ts: f"patched:{ts[5:7]}",
+    ) as timestamp_mock:
+        result = mod._trending_date_range(trending.snapshots)
+
+    assert "patched:01" in result
+    assert "patched:02" in result
+    assert timestamp_mock.call_count == 2
+
+
+def test_org_writers_trending_delta_csv_rows_respects_package_root_period_label_patch():
+    """Package-root period label patches must flow into _trending_delta_csv_rows."""
+    mod = importlib.import_module("cja_auto_sdr.org.writers")
+    trending = _make_trending()
+
+    with patch(
+        "cja_auto_sdr.org.writers._format_trending_period_label",
+        return_value="patched_period",
+    ) as label_mock:
+        rows = mod._trending_delta_csv_rows(trending.deltas)
+
+    assert all(row["Period"] == "patched_period" for row in rows)
+    assert label_mock.call_count == len(trending.deltas)

--- a/tests/test_output_extraction_contracts.py
+++ b/tests/test_output_extraction_contracts.py
@@ -701,6 +701,45 @@ def test_org_json_builder_respects_legacy_helper_patch(module_name, rich_org_rep
     ["cja_auto_sdr.org.writers", "cja_auto_sdr.generator"],
     ids=["org.writers", "generator"],
 )
+def test_org_json_builder_respects_legacy_severity_helper_patch(module_name, rich_org_report_result):
+    """Legacy severity helper patches must still reach nested recommendation normalization."""
+    mod = importlib.import_module(module_name)
+
+    with patch(f"{module_name}._normalize_recommendation_severity", return_value="high") as severity_mock:
+        data = mod.build_org_report_json_data(rich_org_report_result)
+
+    assert [rec["severity"] for rec in data["recommendations"]] == ["high", "high"]
+    assert severity_mock.call_count == len(rich_org_report_result.recommendations)
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    ["cja_auto_sdr.org.writers", "cja_auto_sdr.generator"],
+    ids=["org.writers", "generator"],
+)
+def test_org_json_builder_respects_legacy_context_helper_patch(module_name, rich_org_report_result):
+    """Legacy context formatter patches must still reach nested recommendation normalization."""
+    mod = importlib.import_module(module_name)
+    patched_value = f"patched context via {module_name}"
+
+    with patch(
+        f"{module_name}._format_recommendation_context_entries",
+        return_value=[("Patched", patched_value)],
+    ) as context_mock:
+        data = mod.build_org_report_json_data(rich_org_report_result)
+
+    assert [rec["context"] for rec in data["recommendations"]] == [
+        [{"label": "Patched", "value": patched_value}],
+        [{"label": "Patched", "value": patched_value}],
+    ]
+    assert context_mock.call_count == len(rich_org_report_result.recommendations)
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    ["cja_auto_sdr.org.writers", "cja_auto_sdr.generator"],
+    ids=["org.writers", "generator"],
+)
 def test_org_json_writer_respects_legacy_builder_patch(module_name, tmp_path, rich_org_report_result):
     """Legacy builder patches must still affect the extracted JSON writer."""
     mod = importlib.import_module(module_name)
@@ -889,6 +928,57 @@ def test_org_markdown_writer_respects_legacy_helper_patch(module_name, tmp_path,
 
     assert patched_reason in output_path.read_text(encoding="utf-8")
     assert normalize_mock.call_count == len(rich_org_report_result.recommendations)
+
+
+def test_org_markdown_writer_respects_package_root_timestamp_helper_patch(
+    tmp_path,
+    rich_org_report_result,
+):
+    """Package-root timestamp formatter patches must still flow into markdown trending output."""
+    mod = importlib.import_module("cja_auto_sdr.org.writers")
+    logger = logging.getLogger("test.cja_auto_sdr.org.writers.write_org_report_markdown.trending")
+    trending = _make_trending()
+
+    with patch(
+        "cja_auto_sdr.org.writers._format_trending_timestamp_short",
+        side_effect=lambda ts: f"patched:{ts[5:7]}",
+    ) as timestamp_mock:
+        output_path = Path(
+            mod.write_org_report_markdown(
+                rich_org_report_result,
+                tmp_path / "org_report_trending.md",
+                str(tmp_path),
+                logger,
+                trending=trending,
+            ),
+        )
+
+    output = output_path.read_text(encoding="utf-8")
+    assert "patched:01" in output
+    assert "patched:02" in output
+    assert timestamp_mock.call_count >= 4
+
+
+def test_org_writers_trending_helper_reexports_respect_package_root_timestamp_patch():
+    """Package-root trending helper re-exports must preserve nested timestamp monkeypatches."""
+    mod = importlib.import_module("cja_auto_sdr.org.writers")
+    trending = _make_trending()
+
+    with patch(
+        "cja_auto_sdr.org.writers._format_trending_timestamp_short",
+        side_effect=lambda ts: f"patched:{ts[5:7]}",
+    ) as timestamp_mock:
+        snapshot_specs = mod._trending_snapshot_column_specs(trending.snapshots)
+        period_label = mod._format_trending_period_label(
+            trending.deltas[0].from_timestamp,
+            trending.deltas[0].to_timestamp,
+        )
+        delta_specs = mod._trending_delta_column_specs(trending.deltas)
+
+    assert [label for _key, label in snapshot_specs] == ["patched:01", "patched:02"]
+    assert period_label == "patched:01 -> patched:02"
+    assert [label for _key, label in delta_specs] == ["patched:01 -> patched:02"]
+    assert timestamp_mock.call_count == 6
 
 
 @pytest.mark.parametrize(

--- a/tests/test_ux_features.py
+++ b/tests/test_ux_features.py
@@ -344,11 +344,11 @@ class TestCombinedFeatures:
 class TestVersionUpdated:
     """Test that version is correct"""
 
-    def test_version_is_3_4_7(self):
-        """Test that version is 3.4.7"""
+    def test_version_is_3_4_8(self):
+        """Test that version is 3.4.8"""
         from cja_auto_sdr.generator import __version__
 
-        assert __version__ == "3.4.7"
+        assert __version__ == "3.4.8"
 
 
 class TestFormatAutoDetection:


### PR DESCRIPTION
## Summary

- Restore and centralize scoped legacy monkeypatch compatibility for nested org-writer recommendation helpers across `cja_auto_sdr.org.writers` and `cja_auto_sdr.generator`
- Restore scoped package-root timestamp formatter monkeypatch compatibility for extracted trending helper label generation and markdown writer output
- Centralize org writer compat override routing into `compat.py` to consolidate scattered monkeypatch surfaces and preserve helper contracts
- Harden writer exports across org and diff writer modules with explicit `__all__` declarations
- Accept mixed-key compat override scopes and keep compat override exports consumable
- Add comprehensive extraction contract test suite (`test_output_extraction_contracts.py`) covering writer exports, compat routing, and monkeypatch surfaces
- Bump version to 3.4.8, sync test counts to 7,085

## Stats

- **31 files changed**, 1,426 insertions, 64 deletions
- **7,085 tests** across 114 files, 95% coverage gate
- Version sync: ✅ | Test counts: ✅ | Ruff: ✅

## Test plan

- [x] 7,085 tests collected, full suite passing
- [x] Version sync script passes
- [x] Test count script passes
- [x] Ruff check clean
- [x] CI green on PR