### PR TITLE
v3.5.0 — agent integration, advisories, manifests, playbooks, workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,7 +48,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y shellcheck
       - name: Lint shell scripts
-        run: shellcheck examples/automation/*.sh
+        run: shellcheck examples/automation/*.sh examples/agent-workflows/*.sh
 
   lockfile:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,11 +47,11 @@ Supports `--filter PATTERN`, `--exclude PATTERN`, `--limit N`, `--sort FIELD`.
 ### Inspection (per data view)
 
 ```bash
-uv run cja_auto_sdr <dv_id> --describe-dataview
-uv run cja_auto_sdr <dv_id> --list-metrics    [--format json|csv] [--output -]
-uv run cja_auto_sdr <dv_id> --list-dimensions [--format json|csv] [--output -]
-uv run cja_auto_sdr <dv_id> --list-segments   [--format json|csv] [--output -]
-uv run cja_auto_sdr <dv_id> --list-calculated-metrics [--format json|csv] [--output -]
+uv run cja_auto_sdr --describe-dataview <DATA_VIEW_ID_OR_NAME>
+uv run cja_auto_sdr --list-metrics <DATA_VIEW_ID_OR_NAME>    [--format json|csv] [--output -]
+uv run cja_auto_sdr --list-dimensions <DATA_VIEW_ID_OR_NAME> [--format json|csv] [--output -]
+uv run cja_auto_sdr --list-segments <DATA_VIEW_ID_OR_NAME>   [--format json|csv] [--output -]
+uv run cja_auto_sdr --list-calculated-metrics <DATA_VIEW_ID_OR_NAME> [--format json|csv] [--output -]
 uv run cja_auto_sdr <dv_id> --stats
 ```
 
@@ -207,6 +207,64 @@ Use `--explain-exit-code CODE` to get a human-readable explanation of any exit c
 | Profiles          | `~/.cja/orgs/<name>/`             | `--profile`, `CJA_PROFILE`, `CJA_HOME` |
 
 Log levels: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`. Log formats: `text` (default), `json`.
+
+---
+
+## Agent Integration
+
+### `--agent-mode` Preset
+
+`--agent-mode` is a convenience preset that expands to:
+
+```
+--format json --output - --log-format json
+```
+
+It produces machine-readable JSON on stdout and structured log output on stderr, with no banner or progress output. Use it for unattended automation where you want a single predictable output stream.
+
+```bash
+# Equivalent forms:
+uv run cja_auto_sdr <dv_id> --agent-mode
+uv run cja_auto_sdr <dv_id> --format json --output - --log-format json
+```
+
+Config preflight before running unattended:
+
+```bash
+uv run cja_auto_sdr --validate-config          # verify credentials + API connectivity
+uv run cja_auto_sdr --config-status --config-json  # machine-readable config state
+```
+
+### Command-Family Applicability
+
+| Command Family | `--agent-mode` | Notes |
+|---|---|---|
+| Single SDR | ✅ | JSON on stdout |
+| Discovery | ✅ | JSON on stdout |
+| Org Report | ✅ | JSON on stdout |
+| Diff | ✅ | JSON on stdout |
+| Batch | ✅ | JSON on stdout |
+| Config/Stats | ❌ | Use `--config-status --config-json` |
+
+### JSON `advisories` Block
+
+Org-report and diff commands include an `advisories` array in their JSON output when issues requiring attention are detected (e.g. duplicate components, stale segments, governance threshold violations). Parse this field to drive downstream alerting or CI gate decisions.
+
+Run-summary advisory rollups are available via `--run-summary-json <file>` — the summary includes aggregated advisory counts across all processed data views.
+
+### Exact-ID Guidance
+
+Prefer exact data view IDs (`dv_...`) over names for unattended automation. Name resolution requires an extra API call and is subject to naming ambiguity. Use `--list-dataviews --format json --output -` to resolve names to IDs in a preflight step.
+
+### `scripts/orchestrator.py` Scope
+
+`scripts/orchestrator.py` is a higher-level JSON wrapper that is currently strongest for batched SDR generation and discovery. It is not the primary wrapper for org-report and diff-family flows — invoke those directly via the CLI with `--agent-mode` or explicit `--format json --output -`.
+
+### Tools Manifests and Playbooks
+
+- [`tools/`](tools/) — OpenAI-compatible function call manifests for each command family (`cja_sdr_generate.json`, `cja_sdr_discover.json`, `cja_sdr_governance.json`, `cja_sdr_diff.json`, `cja_sdr_config.json`)
+- [`docs/agent-playbooks/`](docs/agent-playbooks/) — task-oriented playbooks (onboarding, quality monitor, diff reviewer, SDR auditor, snapshot manager)
+- [`examples/agent-workflows/`](examples/agent-workflows/) — end-to-end workflow examples for common agent automation patterns
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,8 +75,8 @@ uv run cja_auto_sdr <dv_id> --stats
 # Generate default Excel SDR
 uv run cja_auto_sdr <dv_id>
 
-# Machine-readable JSON to stdout
-uv run cja_auto_sdr <dv_id> --format json --output -
+# JSON SDR artifact
+uv run cja_auto_sdr <dv_id> --format json --output-dir /reports
 
 # Write to specific directory
 uv run cja_auto_sdr <dv_id> --format excel --output-dir /reports
@@ -182,9 +182,10 @@ Use `--explain-exit-code CODE` to get a human-readable explanation of any exit c
 
 ## Output Conventions
 
-- Use `--format json --output -` for machine-parseable stdout.
+- Use `--format json --output -` for machine-parseable stdout on command families that support direct stdout emission.
 - Only `json` and `csv` formats are valid with `--output -` (stdout).
 - `--output -` implies `--quiet` (suppresses banner/progress to stderr).
+- Single-SDR generation currently writes auto-named artifacts under `--output-dir`; use `--run-summary-json` for stable machine-readable completion metadata.
 - For scheduled/agent runs, prefer retry settings such as `--max-retries 5 --retry-max-delay 60` to absorb transient Adobe API rate limits.
 - On failure, stderr receives a JSON error envelope:
   ```json
@@ -220,12 +221,15 @@ Log levels: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`. Log formats: `text`
 --format json --output - --log-format json
 ```
 
-It produces machine-readable JSON on stdout and structured log output on stderr, with no banner or progress output. Use it for unattended automation where you want a single predictable output stream.
+It applies machine-friendly defaults. Discovery, diff, and org-report flows emit machine-readable JSON on stdout with structured logs on stderr. Single-SDR and batch generation currently still write auto-named artifacts under `--output-dir`.
 
 ```bash
-# Equivalent forms:
-uv run cja_auto_sdr <dv_id> --agent-mode
-uv run cja_auto_sdr <dv_id> --format json --output - --log-format json
+# Direct stdout command families:
+uv run cja_auto_sdr --list-dataviews --agent-mode
+uv run cja_auto_sdr --org-report --agent-mode
+
+# Single SDR keeps the preset but still writes auto-named artifacts
+uv run cja_auto_sdr <dv_id> --agent-mode --output-dir /reports
 ```
 
 Config preflight before running unattended:
@@ -239,12 +243,12 @@ uv run cja_auto_sdr --config-status --config-json  # machine-readable config sta
 
 | Command Family | `--agent-mode` | Notes |
 |---|---|---|
-| Single SDR | ✅ | JSON on stdout |
+| Single SDR | Limited | Preset applies, but current generation writes auto-named artifacts under `--output-dir` |
 | Discovery | ✅ | JSON on stdout |
 | Org Report | ✅ | JSON on stdout |
 | Diff | ✅ | JSON on stdout |
-| Batch | ✅ | JSON on stdout |
-| Config/Stats | ❌ | Use `--config-status --config-json` |
+| Batch | Limited | Preset applies, but generated artifacts still land under `--output-dir` per data view |
+| Config/Stats | Partial | Use `--config-status --config-json`; stats supports `--format json --output -` |
 
 ### JSON `advisories` Block
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,9 +252,9 @@ uv run cja_auto_sdr --config-status --config-json  # machine-readable config sta
 
 ### JSON `advisories` Block
 
-Org-report and diff commands include an `advisories` array in their JSON output when issues requiring attention are detected (e.g. duplicate components, stale segments, governance threshold violations). Parse this field to drive downstream alerting or CI gate decisions.
+Org-report and diff commands include an `advisories` block in their JSON output. Parse `advisories.findings` and `advisories.recommended_actions` to drive downstream alerting or CI gate decisions. In v3.5.0, an empty advisories block with `findings: []` is still a valid machine-readable payload.
 
-Run-summary advisory rollups are available via `--run-summary-json <file>` — the summary includes aggregated advisory counts across all processed data views.
+Run-summary advisory rollups are available via `--run-summary-json <file>` under `details.advisories`. The compact rollup includes severity, summary counts, `types`, and `recommended_actions` for org-report and diff runs.
 
 ### Exact-ID Guidance
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,7 +183,7 @@ Use `--explain-exit-code CODE` to get a human-readable explanation of any exit c
 ## Output Conventions
 
 - Use `--format json --output -` for machine-parseable stdout on command families that support direct stdout emission.
-- Only `json` and `csv` formats are valid with `--output -` (stdout).
+- Machine-readable stdout uses `json` or `csv`; org-report also supports `console` on stdout for human-readable output.
 - `--output -` implies `--quiet` (suppresses banner/progress to stderr).
 - Single-SDR generation currently writes auto-named artifacts under `--output-dir`; use `--run-summary-json` for stable machine-readable completion metadata.
 - For scheduled/agent runs, prefer retry settings such as `--max-retries 5 --retry-max-delay 60` to absorb transient Adobe API rate limits.
@@ -244,11 +244,13 @@ uv run cja_auto_sdr --config-status --config-json  # machine-readable config sta
 | Command Family | `--agent-mode` | Notes |
 |---|---|---|
 | Single SDR | Limited | Preset applies, but current generation writes auto-named artifacts under `--output-dir` |
-| Discovery | ✅ | JSON on stdout |
-| Org Report | ✅ | JSON on stdout |
-| Diff | ✅ | JSON on stdout |
-| Batch | Limited | Preset applies, but generated artifacts still land under `--output-dir` per data view |
-| Config/Stats | Partial | Use `--config-status --config-json`; stats supports `--format json --output -` |
+| Batch SDR | Limited | Preset applies, but generated artifacts still land under `--output-dir` per data view |
+| Discovery / Inspection | ✅ | JSON on stdout for machine-readable flows; prefer exact IDs for unattended inspection |
+| Org Report | ✅ | JSON on stdout; `--format console --output -` is also supported for human-readable stdout |
+| Diff Family | ✅ | JSON on stdout for `--diff`, `--diff-snapshot`, `--compare-with-prev`, and `--compare-snapshots` |
+| Validation / Preflight | Partial | Use `--config-status --config-json` for JSON state; `--validate-config` remains exit-code driven |
+| Stats | Partial | Supports `--format json --output -` |
+| Fast-Path Flags | Partial | `--version` and `--completion` tolerate `--agent-mode`, but the preset is not applied before early exit |
 
 ### JSON `advisories` Block
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ All notable changes to the CJA SDR Generator project will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.0] — 2026-03-28
+
+### Added
+- `--agent-mode` CLI preset: defaults to `--format json --output - --log-format json` for agent-friendly invocation
+- JSON `advisories` block in org-report and diff output — derived convenience layer with versioned schema
+- Compact advisory rollups in `--run-summary-json` for org-report and diff modes
+- `tools/` directory with OpenAI-style JSON tool manifests for agent framework integration
+- `docs/agent-playbooks/` cross-agent task playbooks (sdr-auditor, diff-reviewer, onboarding-guide, quality-monitor, snapshot-manager)
+- `examples/agent-workflows/` behavior-tested shell workflows (audit_and_report, onboard_dataview, quarterly_governance)
+- `sample_outputs/agent/` contract fixtures for representative machine-readable payloads
+- Agent Integration section in root `AGENTS.md`
+
+### Changed
+- Extracted `build_diff_json_data()` as shared public diff JSON builder
+- Expanded `docs/AGENT_AUTOMATION.md` with `--agent-mode` guidance, advisories registry, and machine-interface decision matrix
+- Expanded shell lint coverage to include `examples/agent-workflows/*.sh`
+
+### Fixed
+- Corrected inspection command examples in `AGENTS.md` to use current `--flag <VALUE>` form
+
 ## [3.4.9] - 2026-03-27
 
 ### Internal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the CJA SDR Generator project will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.5.0] — 2026-03-28
+## [3.5.0] — 2026-03-30
 
 ### Added
 - `--agent-mode` CLI preset: defaults to `--format json --output - --log-format json` for agent-friendly invocation
@@ -26,6 +26,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Corrected inspection command examples in `AGENTS.md` to use current `--flag <VALUE>` form
+- Align agent-mode defaults and contract docs with v3.5.0 spec
+- Honor diff stdout alias (`--output -`) and advisory action registry in agent-mode
+- Restore org-report console stdout output path
+- Recompute org-report quiet flag after output resolution
+- Align diff agent-mode contracts for consistent JSON output
+
+### Tests
+- 7,590 tests across 127 files at 95% coverage gate (up from 7,294)
+- 553+ new agent workflow contract tests
+- 57 agent-mode tests, 109 playbook/workflow tests, 44 manifest tests
 
 ## [3.4.9] - 2026-03-27
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
 - Current version: v3.5.0
-- Tests: **7,509** across 127 files at **95% coverage gate**
+- Tests: **7,566** across 127 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,8 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Package manager: **uv**
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
-- Current version: v3.4.9
-- Tests: **7,294** across 120 files at **95% coverage gate**
+- Current version: v3.5.0
+- Tests: **7,509** across 127 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # Project Notes for Claude
 
+> For agent and automation tool contracts, see [AGENTS.md](AGENTS.md).
+
 ## Python Version
 
 This project requires **Python 3.14+**. This is intentional and correct — Python 3.14 exists and is the minimum supported version for this project.
@@ -255,6 +257,10 @@ When adding new CLI flags, update these docs:
 - `README.md` — common use cases table
 - Feature-specific docs (e.g. `DATA_QUALITY.md`, `DIFF_COMPARISON.md`, `CONFIGURATION.md`)
 - `tests/README.md` — tree listing and test count table (if new test files added)
+- `tools/*.json` — tool manifests for agent frameworks
+- `docs/agent-playbooks/*.md` — cross-agent task playbooks
+- `examples/agent-workflows/*.sh` — shell workflow examples
+- `docs/AGENT_AUTOMATION.md` — agent automation guide
 
 ### Documentation Inventory (`docs/`)
 

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (7,566+ tests)
+├── tests/                     # Test suite (7,578+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (7,543+ tests)
+├── tests/                     # Test suite (7,566+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (7,578+ tests)
+├── tests/                     # Test suite (7,580+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (7,521+ tests)
+├── tests/                     # Test suite (7,527+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (7,580+ tests)
+├── tests/                     # Test suite (7,583+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (7,509+ tests)
+├── tests/                     # Test suite (7,521+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (7,583+ tests)
+├── tests/                     # Test suite (7,590+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (7,527+ tests)
+├── tests/                     # Test suite (7,543+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (7,294+ tests)
+├── tests/                     # Test suite (7,509+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/docs/AGENT_AUTOMATION.md
+++ b/docs/AGENT_AUTOMATION.md
@@ -138,15 +138,16 @@ uv run cja_auto_sdr --config-status --config-json --agent-mode
 
 ### --agent-mode command-family applicability
 
-| Command family                       | `--agent-mode` supported | Notes                                              |
-|--------------------------------------|--------------------------|----------------------------------------------------|
-| SDR generation (single / batch)      | Limited                  | Preset applies, but current generation still writes auto-named artifacts under `--output-dir` |
-| Org-report (`--org-report`)          | Yes                      | JSON to stdout; advisories block included          |
-| Diff (`--diff`, `--diff-snapshot`)   | Yes                      | JSON to stdout; advisories block included          |
-| Discovery (`--list-*`)               | Yes                      | JSON to stdout                                     |
-| Config status (`--config-status`)    | Yes                      | Use with `--config-json` for full JSON payload     |
-| Fast-path flags (`--version`, etc.)  | Partial                  | Informational fast paths such as `--version` and `--completion` tolerate `--agent-mode`, but the preset itself is not applied before exit |
-| Interactive commands (`--show-config`) | No                     | Interactive; not suitable for agent use            |
+| Command family                                      | `--agent-mode` supported | Notes |
+|-----------------------------------------------------|--------------------------|-------|
+| SDR generation (single)                             | Limited                  | Preset applies, but current generation still writes auto-named artifacts under `--output-dir` |
+| Batch SDR generation                                | Limited                  | Preset applies, but per-data-view artifacts still land under `--output-dir` |
+| Discovery / inspection (`--list-*`, `--describe-dataview`) | Yes             | JSON to stdout for machine-readable flows; prefer exact IDs for unattended inspection |
+| Org-report (`--org-report`)                         | Yes                      | JSON to stdout; advisories block included; `--format console --output -` is also valid for human-readable stdout |
+| Diff family (`--diff`, `--diff-snapshot`, `--compare-with-prev`, `--compare-snapshots`) | Yes | JSON to stdout; advisories block included |
+| Validation / preflight (`--validate-config`, `--config-status`) | Partial        | Use `--config-status --config-json` for JSON state; `--validate-config` is primarily exit-code driven |
+| Fast-path flags (`--version`, `--completion`)       | Partial                  | Informational fast paths tolerate `--agent-mode`, but the preset itself is not applied before exit |
+| Interactive mode (`--interactive`)                  | No                       | Interactive prompts are not suitable for unattended pipelines |
 
 ---
 
@@ -170,7 +171,7 @@ Starting in v3.5.0, JSON output for org-report and diff commands includes an `ad
         "type": "governance_threshold_breach",
         "severity": "critical",
         "message": "One or more governance thresholds have been exceeded.",
-        "details": { "violation_count": 3, "violations": [...] },
+        "details": { "count": 3, "violations": [...] },
         "recommended_actions": ["review_governance_thresholds", "remediate_threshold_breach"]
       }
     ],
@@ -187,14 +188,16 @@ The top-level `recommended_actions` list is a deduplicated union of all finding-
 |---------------------------------|------------------------------------|--------------------------------------------------------------|
 | `review_overlap_pairs`          | `high_overlap`                     | Inspect the flagged data view pairs for intentional overlap  |
 | `verify_intentional_duplicates` | `high_overlap`                     | Confirm duplicates are deliberate (e.g. regional variants)   |
-| `review_isolated_views`         | (future finding type)              | Examine data views with no shared components                 |
-| `add_descriptions`              | (future finding type)              | Add missing descriptions to flagged components               |
-| `review_stale_views`            | (future finding type)              | Review data views with no recent activity                    |
+| `review_isolated_views`         | `isolated_review`                  | Examine data views with many isolated components             |
+| `add_descriptions`              | `metadata_hygiene`                 | Add missing descriptions to flagged data views               |
+| `review_stale_views`            | `metadata_hygiene`                 | Review stale data views and confirm they are still needed    |
 | `review_governance_thresholds`  | `governance_threshold_breach`      | Review which thresholds are configured and why they fired    |
 | `remediate_threshold_breach`    | `governance_threshold_breach`      | Take corrective action on breached governance thresholds     |
 | `investigate_fetch_failures`    | `fetch_failures`                   | Diagnose why specific data views could not be fetched        |
 | `review_drift_activity`         | `drift_activity`                   | Inspect which data views are drifting and by how much        |
 | `compare_recent_reports`        | `drift_activity`                   | Run `--compare-org-report` against a recent baseline         |
+
+`metadata_hygiene` can emit one or both of `add_descriptions` and `review_stale_views`, depending on which underlying recommendations are present.
 
 ### Diff recommended_actions registry
 
@@ -476,7 +479,7 @@ fi
 | Stale snapshot comparison misses changes | Snapshot file is too old or wrong data view    | Re-run `uv run cja_auto_sdr <dv_id> --snapshot <file>` to refresh; check `--snapshot-dir` path  |
 | Git commit step fails in CI              | Missing git identity on runner                 | Set `git config user.email` and `git config user.name` in the workflow before any git steps      |
 | Rate limiting (429 errors)               | Too many concurrent requests                   | Reduce `--workers` count; increase `--retry-base-delay`; use `--org-report --use-cache`          |
-| JSON parse error on `--output -`         | Banner or progress text mixed into stdout      | Ensure `--output -` is used (it implies `--quiet`); do not use `--format console` with stdout    |
+| JSON parse error on `--output -`         | Banner or progress text mixed into stdout      | Ensure `--format json --output -` is used for machine-readable stdout. Org-report `--format console --output -` is valid, but it is human-readable rather than JSON |
 | `--validate-config` passes but SDR fails | Data view ID not accessible to service account | Confirm data view ID exists and the service account has the correct CJA product profile access   |
 | Exit 2 on governance run without alert   | `--fail-on-threshold` not set                  | Add `--fail-on-threshold` to enable exit code 2 on threshold breach                             |
 | `advisories` block absent from JSON output | Command family or format does not emit advisories | Advisories are emitted for org-report and diff commands with `--format json`; use `--agent-mode` |

--- a/docs/AGENT_AUTOMATION.md
+++ b/docs/AGENT_AUTOMATION.md
@@ -52,17 +52,18 @@ This guide covers how to automate `cja_auto_sdr` in CI/CD pipelines, scheduled j
 ### Machine-readable output
 
 ```bash
-# JSON to stdout — parse with jq, Python json.loads(), etc.
-uv run cja_auto_sdr <dv_id> --format json --output -
-
-# Discovery as JSON
+# Discovery JSON to stdout — parse with jq, Python json.loads(), etc.
 uv run cja_auto_sdr --list-dataviews --format json --output -
+
+# Org-report JSON to stdout
+uv run cja_auto_sdr --org-report --format json --output -
 
 # Structured run summary (includes per-DV status, failure codes, output paths)
 uv run cja_auto_sdr <dv_id> --format json --run-summary-json -
 ```
 
 `--output -` implies `--quiet`, so stdout contains only the payload and stderr contains any log output.
+Single-SDR generation currently writes auto-named artifacts under `--output-dir` rather than streaming the SDR payload to stdout.
 
 ### Exit codes
 
@@ -110,17 +111,17 @@ If you explicitly pass any of these options, your explicit value takes precedenc
 ### Examples by command family
 
 ```bash
-# SDR generation — JSON to stdout, structured logs to stderr
-uv run cja_auto_sdr dv_abc123 --agent-mode
+# SDR generation — preset/logging apply, artifact still lands under output_dir
+uv run cja_auto_sdr dv_abc123 --agent-mode --output-dir ./reports
 
-# Batch generation — JSON for each data view, structured error envelopes
-uv run cja_auto_sdr dv_abc123 dv_def456 --agent-mode --continue-on-error
+# Batch generation — preset/logging apply, artifacts still land under output_dir
+uv run cja_auto_sdr dv_abc123 dv_def456 --agent-mode --continue-on-error --output-dir ./reports
 
 # Org-wide governance report
 uv run cja_auto_sdr --org-report --agent-mode
 
 # Org-report with governance gate
-uv run cja_auto_sdr --org-report --agent-mode --duplicate-threshold 0.8 --fail-on-threshold
+uv run cja_auto_sdr --org-report --agent-mode --duplicate-threshold 5 --fail-on-threshold
 
 # Diff — compare two data views
 uv run cja_auto_sdr --diff dv_abc123 dv_def456 --agent-mode
@@ -139,12 +140,12 @@ uv run cja_auto_sdr --config-status --config-json --agent-mode
 
 | Command family                       | `--agent-mode` supported | Notes                                              |
 |--------------------------------------|--------------------------|----------------------------------------------------|
-| SDR generation (single / batch)      | Yes                      | JSON to stdout; `--output -` applies               |
+| SDR generation (single / batch)      | Limited                  | Preset applies, but current generation still writes auto-named artifacts under `--output-dir` |
 | Org-report (`--org-report`)          | Yes                      | JSON to stdout; advisories block included          |
 | Diff (`--diff`, `--diff-snapshot`)   | Yes                      | JSON to stdout; advisories block included          |
 | Discovery (`--list-*`)               | Yes                      | JSON to stdout                                     |
 | Config status (`--config-status`)    | Yes                      | Use with `--config-json` for full JSON payload     |
-| Fast-path flags (`--version`, etc.)  | No                       | Fast-path exits before `--agent-mode` is resolved  |
+| Fast-path flags (`--version`, etc.)  | Partial                  | Informational fast paths such as `--version` and `--completion` tolerate `--agent-mode`, but the preset itself is not applied before exit |
 | Interactive commands (`--show-config`) | No                     | Interactive; not suitable for agent use            |
 
 ---
@@ -401,10 +402,10 @@ For any new agent integration, the recommended reading order is:
 
 ### Structured run summary
 
-`--run-summary-json` writes a JSON file after each command that includes exit code, duration, component counts, and advisory rollup. Use `-` to receive it on stdout alongside the main payload:
+`--run-summary-json` writes a JSON file after each command that includes exit code, duration, component counts, and advisory rollup. For single-SDR generation under `--agent-mode`, use a file path because the preset already routes primary output to stdout. Use `-` only when the command is not already emitting its main payload on stdout.
 
 ```bash
-uv run cja_auto_sdr dv_abc123 --agent-mode --run-summary-json -
+uv run cja_auto_sdr dv_abc123 --agent-mode --run-summary-json run_summary.json
 ```
 
 The run summary includes an `advisories` rollup key when advisories are present (org-report and diff commands).

--- a/docs/AGENT_AUTOMATION.md
+++ b/docs/AGENT_AUTOMATION.md
@@ -7,12 +7,18 @@ This guide covers how to automate `cja_auto_sdr` in CI/CD pipelines, scheduled j
 1. [Why Automate](#why-automate)
 2. [Prerequisites](#prerequisites)
 3. [Agent-Friendly CLI Features](#agent-friendly-cli-features)
-4. [Configuration for Automation](#configuration-for-automation)
-5. [Scheduling Patterns](#scheduling-patterns)
-6. [Agent Framework Integration](#agent-framework-integration)
-7. [Notification Integration](#notification-integration)
-8. [Security Considerations](#security-considerations)
-9. [Troubleshooting](#troubleshooting)
+4. [--agent-mode Flag](#--agent-mode-flag)
+5. [Advisories Block](#advisories-block)
+6. [Machine-Interface Decision Matrix](#machine-interface-decision-matrix)
+7. [Tool Manifests](#tool-manifests)
+8. [Configuration for Automation](#configuration-for-automation)
+9. [Config Preflight Surfaces](#config-preflight-surfaces)
+10. [Exact-ID Guidance](#exact-id-guidance)
+11. [Scheduling Patterns](#scheduling-patterns)
+12. [Agent Framework Integration](#agent-framework-integration)
+13. [Notification Integration](#notification-integration)
+14. [Security Considerations](#security-considerations)
+15. [Troubleshooting](#troubleshooting)
 
 ---
 
@@ -85,6 +91,161 @@ uv run cja_auto_sdr <dv_id> --dry-run
 
 ---
 
+## --agent-mode Flag
+
+`--agent-mode` is a convenience preset that configures the CLI for unattended, machine-readable operation.
+
+### What it expands to
+
+`--agent-mode` sets the following defaults when those options are not explicitly provided on the command line:
+
+| Option         | Default applied |
+|----------------|-----------------|
+| `--format`     | `json`          |
+| `--output`     | `-` (stdout)    |
+| `--log-format` | `json`          |
+
+If you explicitly pass any of these options, your explicit value takes precedence — `--agent-mode` only fills in options you did not supply.
+
+### Examples by command family
+
+```bash
+# SDR generation — JSON to stdout, structured logs to stderr
+uv run cja_auto_sdr dv_abc123 --agent-mode
+
+# Batch generation — JSON for each data view, structured error envelopes
+uv run cja_auto_sdr dv_abc123 dv_def456 --agent-mode --continue-on-error
+
+# Org-wide governance report
+uv run cja_auto_sdr --org-report --agent-mode
+
+# Org-report with governance gate
+uv run cja_auto_sdr --org-report --agent-mode --duplicate-threshold 0.8 --fail-on-threshold
+
+# Diff — compare two data views
+uv run cja_auto_sdr --diff dv_abc123 dv_def456 --agent-mode
+
+# Diff against snapshot
+uv run cja_auto_sdr dv_abc123 --diff-snapshot ./snapshots/dv_abc123.json --agent-mode
+
+# Discovery
+uv run cja_auto_sdr --list-dataviews --agent-mode
+
+# Config status (machine-readable)
+uv run cja_auto_sdr --config-status --config-json --agent-mode
+```
+
+### --agent-mode command-family applicability
+
+| Command family                       | `--agent-mode` supported | Notes                                              |
+|--------------------------------------|--------------------------|----------------------------------------------------|
+| SDR generation (single / batch)      | Yes                      | JSON to stdout; `--output -` applies               |
+| Org-report (`--org-report`)          | Yes                      | JSON to stdout; advisories block included          |
+| Diff (`--diff`, `--diff-snapshot`)   | Yes                      | JSON to stdout; advisories block included          |
+| Discovery (`--list-*`)               | Yes                      | JSON to stdout                                     |
+| Config status (`--config-status`)    | Yes                      | Use with `--config-json` for full JSON payload     |
+| Fast-path flags (`--version`, etc.)  | No                       | Fast-path exits before `--agent-mode` is resolved  |
+| Interactive commands (`--show-config`) | No                     | Interactive; not suitable for agent use            |
+
+---
+
+## Advisories Block
+
+Starting in v3.5.0, JSON output for org-report and diff commands includes an `advisories` block with structured findings and a `recommended_actions` registry. Agents should read `advisories.recommended_actions` to determine follow-up steps.
+
+### Advisories block structure
+
+```json
+{
+  "advisories": {
+    "advisories_version": "1.0",
+    "severity": "critical",
+    "summary": {
+      "total_findings": 2,
+      "by_severity": {"critical": 1, "warning": 1}
+    },
+    "findings": [
+      {
+        "type": "governance_threshold_breach",
+        "severity": "critical",
+        "message": "One or more governance thresholds have been exceeded.",
+        "details": { "violation_count": 3, "violations": [...] },
+        "recommended_actions": ["review_governance_thresholds", "remediate_threshold_breach"]
+      }
+    ],
+    "recommended_actions": ["review_governance_thresholds", "remediate_threshold_breach"]
+  }
+}
+```
+
+The top-level `recommended_actions` list is a deduplicated union of all finding-level actions, ordered by first appearance.
+
+### Org-report recommended_actions registry
+
+| Action token                    | Triggered by finding type          | Meaning                                                      |
+|---------------------------------|------------------------------------|--------------------------------------------------------------|
+| `review_overlap_pairs`          | `high_overlap`                     | Inspect the flagged data view pairs for intentional overlap  |
+| `verify_intentional_duplicates` | `high_overlap`                     | Confirm duplicates are deliberate (e.g. regional variants)   |
+| `review_isolated_views`         | (future finding type)              | Examine data views with no shared components                 |
+| `add_descriptions`              | (future finding type)              | Add missing descriptions to flagged components               |
+| `review_stale_views`            | (future finding type)              | Review data views with no recent activity                    |
+| `review_governance_thresholds`  | `governance_threshold_breach`      | Review which thresholds are configured and why they fired    |
+| `remediate_threshold_breach`    | `governance_threshold_breach`      | Take corrective action on breached governance thresholds     |
+| `investigate_fetch_failures`    | `fetch_failures`                   | Diagnose why specific data views could not be fetched        |
+| `review_drift_activity`         | `drift_activity`                   | Inspect which data views are drifting and by how much        |
+| `compare_recent_reports`        | `drift_activity`                   | Run `--compare-org-report` against a recent baseline         |
+
+### Diff recommended_actions registry
+
+| Action token                    | Triggered by finding type | Meaning                                                         |
+|---------------------------------|---------------------------|-----------------------------------------------------------------|
+| `review_breaking_changes`       | `breaking_changes`        | Inspect removed components before merging or deploying          |
+| `update_downstream_dependencies`| `breaking_changes`        | Update any analytics or BI tools that reference removed fields  |
+| `review_schema_changes`         | `schema_changes`          | Review modified component definitions for unintended changes    |
+| `validate_mappings`             | `schema_changes`          | Re-validate field mappings in downstream consumers              |
+| `acknowledge_additive_change`   | `additions_only`          | Confirm additions are expected; no breaking changes detected    |
+
+### Severity levels
+
+| Severity   | Meaning                                             |
+|------------|-----------------------------------------------------|
+| `critical` | Immediate action required; may block CI gates       |
+| `warning`  | Review recommended; does not fail unless gated      |
+| `info`     | Informational; no action strictly required          |
+
+---
+
+## Machine-Interface Decision Matrix
+
+| Need                                              | Use                                                 |
+|---------------------------------------------------|-----------------------------------------------------|
+| Direct JSON payload from CLI                      | `--agent-mode` or `--format json --output -`        |
+| Structured run metadata (exit code, counts, paths)| `--run-summary-json <file>` (use `-` for stdout)    |
+| Batched SDR/discovery from Python                 | `scripts/orchestrator.py`                           |
+| LLM agent tool calling                            | `tools/*.json` manifests                            |
+| Config validation before pipeline step            | `--validate-config` or `--config-status --config-json` |
+| Structured advisories on org / diff results       | `advisories` block in JSON output (`--agent-mode`)  |
+
+---
+
+## Tool Manifests
+
+`tools/` contains OpenAI-style JSON function definitions (tool manifests) for integrating `cja_auto_sdr` into agent frameworks (OpenAI function calling, Anthropic tool use, LangChain, etc.). These manifests are the **authoritative tool-schema surface** for agent integration.
+
+| File                      | Tool name             | Purpose                                      |
+|---------------------------|-----------------------|----------------------------------------------|
+| `tools/cja_sdr_generate.json`   | `cja_sdr_generate`  | Single data view SDR generation            |
+| `tools/cja_sdr_discover.json`   | `cja_sdr_discover`  | Discovery and resource inspection          |
+| `tools/cja_sdr_config.json`     | `cja_sdr_config`    | Config preflight and status checks         |
+| `tools/cja_sdr_diff.json`       | `cja_sdr_diff`      | Snapshot comparison and drift detection    |
+| `tools/cja_sdr_governance.json` | `cja_sdr_governance`| Org-wide governance reporting              |
+
+See `tools/README.md` for full parameter documentation, command-family applicability notes, and example tool-calling sequences.
+
+> **Note:** Any inline tool JSON shown elsewhere in this documentation is illustrative only. Always use the manifests in `tools/` as the authoritative schema source.
+
+---
+
 ## Configuration for Automation
 
 ### Environment variable setup
@@ -119,6 +280,68 @@ export SECRET=$(vault kv get -field=secret secret/cja/prod)
 
 ---
 
+## Config Preflight Surfaces
+
+Two CLI surfaces support pre-flight validation in automated pipelines:
+
+### --validate-config
+
+Performs a lightweight credential resolution and API ping without generating any SDR output. Use this as the first step in any pipeline to catch auth and connectivity issues early.
+
+```bash
+uv run cja_auto_sdr --validate-config
+# Exit 0 → credentials resolved and API reachable
+# Exit 1 → configuration or connectivity error (parse stderr JSON)
+```
+
+### --config-status --config-json
+
+Emits the effective resolved configuration as a JSON object. Useful for audit logging and pipeline diagnostics. Credentials are masked in the output.
+
+```bash
+uv run cja_auto_sdr --config-status --config-json
+# stdout: JSON object with resolved profile, org_id (masked), workers, cache settings, etc.
+```
+
+Combine with `--agent-mode` for consistent JSON log output:
+
+```bash
+uv run cja_auto_sdr --config-status --config-json --agent-mode
+```
+
+Recommended preflight sequence for automated pipelines:
+
+```bash
+# 1. Validate credentials and connectivity
+uv run cja_auto_sdr --validate-config || { echo "Config validation failed"; exit 1; }
+
+# 2. Log effective config for audit trail
+uv run cja_auto_sdr --config-status --config-json >> pipeline_audit.jsonl
+
+# 3. Proceed with primary command
+uv run cja_auto_sdr dv_abc123 --agent-mode --run-summary-json run_summary.json
+```
+
+---
+
+## Exact-ID Guidance
+
+Always use **exact data view IDs** (e.g. `dv_abc123xyz`) in unattended automation, never display names.
+
+- Display names are not guaranteed to be unique across an org. Two data views can share the same name in different connections.
+- Name-based resolution requires an extra list API call and may match the wrong data view silently.
+- IDs beginning with `dv_` are stable CJA identifiers that do not change when a data view is renamed.
+
+To enumerate available data view IDs before an automated run:
+
+```bash
+uv run cja_auto_sdr --list-dataviews --format json --output - | jq '[.[] | {id, name}]'
+```
+
+Or use the `cja_sdr_discover` tool manifest with `command: "list_dataviews"` in agent frameworks.
+
+---
+
 ## Scheduling Patterns
 
 ### Shell script (cron / systemd timer)
@@ -150,58 +373,41 @@ See `scripts/orchestrator.py` for a Python orchestration script that:
 
 ## Agent Framework Integration
 
-Agents should use `AGENTS.md` (repo root) as the primary tool contract. It provides:
-- Complete command syntax
-- Exit code table with agent actions
-- Output format guidance
-- File convention defaults
+### Tool manifests vs. orchestrator
 
-### Inline JSON tool definition
+The repo exposes two distinct automation surfaces:
 
-If your agent framework requires a tool schema, use this minimal definition:
+| Surface | Best for |
+|---------|----------|
+| `tools/*.json` manifests | LLM agent frameworks (OpenAI function calling, Anthropic tool use, LangChain) |
+| `scripts/orchestrator.py` | Python-native batch pipelines, CI scripts, subprocess orchestration |
 
-```json
-{
-  "name": "cja_auto_sdr",
-  "description": "Generate SDR documentation from Adobe CJA data views. Use --format json --output - for machine output.",
-  "parameters": {
-    "type": "object",
-    "properties": {
-      "data_view_id": {
-        "type": "string",
-        "description": "Data view ID (e.g. dv_12345) or exact name"
-      },
-      "format": {
-        "type": "string",
-        "enum": ["excel", "csv", "json", "html", "markdown", "all", "reports", "data", "ci"],
-        "default": "json"
-      },
-      "output": {
-        "type": "string",
-        "description": "Output path. Use '-' for stdout (json/csv only).",
-        "default": "-"
-      },
-      "extra_flags": {
-        "type": "array",
-        "items": {"type": "string"},
-        "description": "Additional CLI flags, e.g. ['--dry-run', '--quiet']"
-      }
-    },
-    "required": ["data_view_id"]
-  }
-}
-```
+`scripts/orchestrator.py` is currently strongest for batched SDR generation and discovery workflows. It is not the primary integration point for org-report and diff-family flows in agent frameworks — use the `tools/cja_sdr_governance.json` and `tools/cja_sdr_diff.json` manifests for those.
 
-### Orchestrator
+### Root AGENTS.md / CLAUDE.md vs. docs/agent-playbooks/
 
-`scripts/orchestrator.py` is the recommended starting point for agent-driven batch workflows when you want a thin JSON-emitting wrapper around repeated CLI runs.
+| Document | Purpose |
+|----------|---------|
+| `AGENTS.md` (repo root) | Primary tool contract: complete command syntax, exit codes, output format guidance, file conventions. Start here for any agent integration. |
+| `CLAUDE.md` (repo root) | Developer instructions for Claude Code: project architecture, test conventions, version bump checklist. Not an agent tool contract. |
+| `docs/agent-playbooks/` | Scenario-specific playbooks (SDR auditor, diff reviewer, quality monitor, snapshot manager, onboarding guide). Use these for task-scoped agent configuration. |
+| `docs/AGENT_AUTOMATION.md` | Scheduling patterns, agent framework integration, advisories, security. The document you are reading. |
+
+For any new agent integration, the recommended reading order is:
+1. `AGENTS.md` — command contract and exit codes
+2. `tools/README.md` — tool manifests and parameter reference
+3. `docs/agent-playbooks/<scenario>.md` — task-specific guidance
+4. `docs/AGENT_AUTOMATION.md` — scheduling, security, advisories
+
+### Structured run summary
+
+`--run-summary-json` writes a JSON file after each command that includes exit code, duration, component counts, and advisory rollup. Use `-` to receive it on stdout alongside the main payload:
 
 ```bash
-# Discover data views, allow 15 minutes per wrapped CLI command
-uv run python scripts/orchestrator.py --discover --timeout 900
+uv run cja_auto_sdr dv_abc123 --agent-mode --run-summary-json -
 ```
 
-Unlike the direct CLI, the orchestrator writes both success payloads and its own machine-readable error envelopes to stdout so callers can consume a single JSON stream per invocation. Wrapped child-command stdout/stderr are preserved inside the JSON result objects.
+The run summary includes an `advisories` rollup key when advisories are present (org-report and diff commands).
 
 ---
 
@@ -218,8 +424,8 @@ Unlike the direct CLI, the orchestrator writes both success payloads and its own
 Pattern:
 
 ```bash
-uv run cja_auto_sdr --org-report --fail-on-threshold --duplicate-threshold 5 \
-  --format json --output report.json
+uv run cja_auto_sdr --org-report --agent-mode --fail-on-threshold --duplicate-threshold 5 \
+  --output report.json
 EXIT=$?
 
 if [ $EXIT -eq 2 ]; then
@@ -227,6 +433,22 @@ if [ $EXIT -eq 2 ]; then
   curl -s -X POST "$SLACK_WEBHOOK" \
     -H 'Content-Type: application/json' \
     -d "$PAYLOAD"
+fi
+```
+
+### Reacting to advisories
+
+For richer notifications, read `recommended_actions` from the advisories block:
+
+```bash
+ACTIONS=$(jq -r '.advisories.recommended_actions[]' report.json 2>/dev/null || echo "")
+
+if echo "$ACTIONS" | grep -q "remediate_threshold_breach"; then
+  # Page on-call for critical threshold breach
+  curl -s -X POST https://events.pagerduty.com/v2/enqueue \
+    -H 'Authorization: Token token='"$PD_TOKEN" \
+    -H 'Content-Type: application/json' \
+    -d '{"routing_key":"'"$PD_KEY"'","event_action":"trigger","payload":{"summary":"CJA governance threshold breach","severity":"critical","source":"cja_auto_sdr"}}'
 fi
 ```
 
@@ -256,3 +478,4 @@ fi
 | JSON parse error on `--output -`         | Banner or progress text mixed into stdout      | Ensure `--output -` is used (it implies `--quiet`); do not use `--format console` with stdout    |
 | `--validate-config` passes but SDR fails | Data view ID not accessible to service account | Confirm data view ID exists and the service account has the correct CJA product profile access   |
 | Exit 2 on governance run without alert   | `--fail-on-threshold` not set                  | Add `--fail-on-threshold` to enable exit code 2 on threshold breach                             |
+| `advisories` block absent from JSON output | Command family or format does not emit advisories | Advisories are emitted for org-report and diff commands with `--format json`; use `--agent-mode` |

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -23,6 +23,7 @@ Complete command-line interface documentation for the CJA SDR Generator.
   - [Git Integration](#git-integration)
   - [Reliability & Auto-Tuning](#reliability--auto-tuning)
   - [Inventory Options](#inventory-options)
+  - [Agent Integration](#agent-integration)
   - [Environment Variables](#environment-variables)
 - [Usage Examples](#usage-examples)
   - [Single Data View](#single-data-view)
@@ -39,6 +40,7 @@ Complete command-line interface documentation for the CJA SDR Generator.
   - [Org-Wide Analysis Examples](#org-wide-analysis-1)
   - [Git Integration Examples](#git-integration)
   - [Inventory Options Examples](#inventory-options-1)
+  - [Agent Integration Examples](#agent-integration-examples)
 - [Output Files](#output-files)
   - [Excel Workbook](#excel-workbook)
   - [Log Files](#log-files)
@@ -487,6 +489,20 @@ Cache is stored in `~/.cja_auto_sdr/cache/org_report_cache.json`.
 > **Derived Fields:** `--include-derived` is for **SDR generation only**, not diff. Derived fields are already included in the standard metrics/dimensions API output, so changes to derived fields are automatically captured in the Metrics/Dimensions diff sections. The `--include-derived` flag provides additional logic analysis (complexity scores, functions used, branch counts) that is valuable for SDR documentation but would be duplicative in diff mode.
 >
 > **Snapshot/Diff Tip:** `--include-all-inventory` automatically excludes `--include-derived` in `--snapshot`, `--diff-snapshot`, `--compare-snapshots`, and `--compare-with-prev` modes.
+
+### Agent Integration
+
+Preset flag for running CJA SDR Generator from AI agents, scripts, and automation pipelines.
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--agent-mode` | Agent-friendly preset: defaults to `--format json`, `--output -` (stdout), and `--log-format json`. Existing stdout behavior (`--output -`) still implies `--quiet`. Explicit `--format`, `--output`, or `--log-format` flags override the preset values. | False |
+
+> **Interaction constraints:** `--agent-mode` cannot be combined with `--interactive`/`-i` (interactive prompts are incompatible with agent pipelines).
+>
+> **Override behavior:** All three preset values (`--format json`, `--output -`, `--log-format json`) can be overridden by explicitly passing the corresponding flag. For example, `--agent-mode --format csv` produces CSV on stdout with JSON logs.
+>
+> **Log stream:** With `--agent-mode`, structured JSON logs are written to stderr. Successful output (SDR JSON, discovery JSON, etc.) is written to stdout. This keeps both streams independently parseable.
 
 ### Environment Variables
 
@@ -1144,6 +1160,32 @@ cja_auto_sdr dv_12345 --compare-with-prev --include-calculated
 cja_auto_sdr dv_12345 --diff-snapshot ./baseline.json \
   --include-segments --format excel --changes-only
 ```
+
+### Agent Integration Examples
+
+```bash
+# Agent-friendly JSON on stdout (default agent-mode preset)
+uv run cja_auto_sdr dv_123 --agent-mode
+
+# Agent mode with explicit format override (CSV on stdout, JSON logs on stderr)
+uv run cja_auto_sdr dv_123 --agent-mode --format csv
+
+# Agent mode with org report
+uv run cja_auto_sdr --org-report --agent-mode
+
+# Agent mode with diff
+uv run cja_auto_sdr --diff dv_a dv_b --agent-mode
+
+# Pipe agent output directly to jq
+uv run cja_auto_sdr dv_123 --agent-mode | jq '.metrics[]'
+
+# Agent mode with run-summary JSON also on stdout (explanation to stderr)
+uv run cja_auto_sdr dv_123 --agent-mode --run-summary-json -
+```
+
+> **Note:** `--agent-mode` is incompatible with `--interactive`/`-i`. Combining them exits with an error.
+>
+> **Streams:** Output goes to stdout; structured JSON logs go to stderr. Use shell redirection to separate them: `cja_auto_sdr dv_123 --agent-mode 2>logs.jsonl`.
 
 ## Output Files
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -496,13 +496,13 @@ Preset flag for running CJA SDR Generator from AI agents, scripts, and automatio
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `--agent-mode` | Agent-friendly preset: defaults to `--format json`, `--output -` (stdout), and `--log-format json`. Existing stdout behavior (`--output -`) still implies `--quiet`. Explicit `--format`, `--output`, or `--log-format` flags override the preset values. | False |
+| `--agent-mode` | Agent-friendly preset: defaults to `--format json`, `--output -` (stdout), and `--log-format json`. Existing stdout behavior (`--output -`) still implies `--quiet`. Explicit `--format`, `--output`, or `--log-format` flags override the preset values. Command-family runtime behavior still applies, so some flows continue to write auto-named artifacts under `--output-dir`. | False |
 
 > **Interaction constraints:** `--agent-mode` cannot be combined with `--interactive`/`-i` (interactive prompts are incompatible with agent pipelines).
 >
-> **Override behavior:** All three preset values (`--format json`, `--output -`, `--log-format json`) can be overridden by explicitly passing the corresponding flag. For example, `--agent-mode --format csv` produces CSV on stdout with JSON logs.
+> **Override behavior:** All three preset values (`--format json`, `--output -`, `--log-format json`) can be overridden by explicitly passing the corresponding flag. For example, `--list-dataviews --agent-mode --format csv` produces CSV on stdout with JSON logs.
 >
-> **Log stream:** With `--agent-mode`, structured JSON logs are written to stderr. Successful output (SDR JSON, discovery JSON, etc.) is written to stdout. This keeps both streams independently parseable.
+> **Log stream:** With `--agent-mode`, structured JSON logs are written to stderr. Command families that honor stdout write their payload to stdout; single-SDR generation currently still writes auto-named artifacts under `--output-dir`.
 
 ### Environment Variables
 
@@ -1164,11 +1164,11 @@ cja_auto_sdr dv_12345 --diff-snapshot ./baseline.json \
 ### Agent Integration Examples
 
 ```bash
-# Agent-friendly JSON on stdout (default agent-mode preset)
-uv run cja_auto_sdr dv_123 --agent-mode
+# Agent-friendly discovery JSON on stdout
+uv run cja_auto_sdr --list-dataviews --agent-mode
 
 # Agent mode with explicit format override (CSV on stdout, JSON logs on stderr)
-uv run cja_auto_sdr dv_123 --agent-mode --format csv
+uv run cja_auto_sdr --list-dataviews --agent-mode --format csv
 
 # Agent mode with org report
 uv run cja_auto_sdr --org-report --agent-mode
@@ -1176,16 +1176,21 @@ uv run cja_auto_sdr --org-report --agent-mode
 # Agent mode with diff
 uv run cja_auto_sdr --diff dv_a dv_b --agent-mode
 
-# Pipe agent output directly to jq
-uv run cja_auto_sdr dv_123 --agent-mode | jq '.metrics[]'
+# Single SDR keeps agent defaults but still writes an auto-named artifact
+uv run cja_auto_sdr dv_123 --agent-mode --output-dir ./reports
 
-# Agent mode with run-summary JSON also on stdout (explanation to stderr)
-uv run cja_auto_sdr dv_123 --agent-mode --run-summary-json -
+# Pipe org-report agent output directly to jq
+uv run cja_auto_sdr --org-report --agent-mode | jq '.advisories'
+
+# Single SDR with a machine-readable run summary file
+uv run cja_auto_sdr dv_123 --agent-mode --run-summary-json run_summary.json
 ```
 
 > **Note:** `--agent-mode` is incompatible with `--interactive`/`-i`. Combining them exits with an error.
 >
-> **Streams:** Output goes to stdout; structured JSON logs go to stderr. Use shell redirection to separate them: `cja_auto_sdr dv_123 --agent-mode 2>logs.jsonl`.
+> **Streams:** When the selected command family honors stdout, output goes to stdout and structured JSON logs go to stderr. Single-SDR generation currently still writes auto-named artifacts under `--output-dir`.
+>
+> **Run-summary constraint:** `--agent-mode` implies stdout output, so `--run-summary-json -` cannot be combined with agent-mode stdout flows such as single-SDR generation.
 
 ## Output Files
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -924,7 +924,7 @@ cja_auto_sdr --list-dataviews --log-level DEBUG
 At launch, the tool logs diagnostic lines containing the tool version, Python version, platform, active log level, inferred run mode (batch, single, or discovery), and dependency versions. These appear automatically at `INFO` level and are useful for troubleshooting environment issues in CI/CD logs or support requests:
 
 ```text
-CJA SDR Generator v3.4.9 | Python 3.14.2 | darwin | log_level=INFO | mode=single
+CJA SDR Generator v3.5.0 | Python 3.14.2 | darwin | log_level=INFO | mode=single
 Dependencies: cjapy=0.2.4.post3, pandas=2.3.3, numpy=2.2.1, xlsxwriter=3.2.9, tqdm=4.67.0
 ```
 

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -203,7 +203,7 @@ This command:
 
 ```bash
 $ uv run cja_auto_sdr -V
-cja_auto_sdr 3.4.9
+cja_auto_sdr 3.5.0
 ```
 
 > **Important:** All commands in this guide assume you're in the `cja_auto_sdr` directory. If you see "command not found", make sure you're in the right directory and have run `uv sync`.

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -345,6 +345,7 @@ cja_auto_sdr --list-dataviews  # Uses client-a
 | `--quality-report FORMAT` | Generate standalone quality issues report (`json` or `csv`) without SDR files (requires validation; incompatible with `--skip-validation`) | SDR only |
 | `--allow-partial` | Opt-in exploratory SDR mode: continue on required component fetch or validation runtime failures (not supported with `--quality-report` or `--fail-on-quality`) | SDR only |
 | `--quality-policy PATH` | Load quality defaults from JSON (`fail_on_quality`, `quality_report`, `max_issues`, `allow_partial`); explicit CLI flags take precedence | SDR only |
+| `--agent-mode` | Agent-friendly preset: `--format json --output - --log-format json`. Stdout behavior still implies `--quiet`. Individual flags override preset values. Incompatible with `--interactive` | All modes |
 | `--run-summary-json PATH` | Write machine-readable run summary JSON; use `-` for stdout | All modes |
 | `--explain-exit-code CODE` | Print human-readable explanation for an exit code and exit 0 | All modes |
 | `--lock-stale-threshold SECONDS` | Stale-lease recovery threshold for org-report lock (> 0) | Org-report only |
@@ -510,6 +511,20 @@ cja_auto_sdr dv_12345 --include-segments --include-calculated --inventory-summar
 
 # Save summary to JSON
 cja_auto_sdr dv_12345 --include-segments --inventory-summary --format json
+
+# --- Agent Integration ---
+
+# Agent-friendly JSON on stdout
+cja_auto_sdr dv_12345 --agent-mode
+
+# Agent mode with explicit format override
+cja_auto_sdr dv_12345 --agent-mode --format csv
+
+# Agent mode with org report
+cja_auto_sdr --org-report --agent-mode
+
+# Agent mode with diff
+cja_auto_sdr --diff dv_a dv_b --agent-mode
 
 # --- Inventory Diff (same data view over time) ---
 

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -345,7 +345,7 @@ cja_auto_sdr --list-dataviews  # Uses client-a
 | `--quality-report FORMAT` | Generate standalone quality issues report (`json` or `csv`) without SDR files (requires validation; incompatible with `--skip-validation`) | SDR only |
 | `--allow-partial` | Opt-in exploratory SDR mode: continue on required component fetch or validation runtime failures (not supported with `--quality-report` or `--fail-on-quality`) | SDR only |
 | `--quality-policy PATH` | Load quality defaults from JSON (`fail_on_quality`, `quality_report`, `max_issues`, `allow_partial`); explicit CLI flags take precedence | SDR only |
-| `--agent-mode` | Agent-friendly preset: `--format json --output - --log-format json`. Stdout behavior still implies `--quiet`. Individual flags override preset values. Incompatible with `--interactive` | All modes |
+| `--agent-mode` | Agent-friendly preset: `--format json --output - --log-format json`. Stdout behavior still implies `--quiet`. Individual flags override preset values. Command-family runtime behavior still applies, so single-SDR generation may still write auto-named artifacts under `--output-dir`. Incompatible with `--interactive` | All modes |
 | `--run-summary-json PATH` | Write machine-readable run summary JSON; use `-` for stdout | All modes |
 | `--explain-exit-code CODE` | Print human-readable explanation for an exit code and exit 0 | All modes |
 | `--lock-stale-threshold SECONDS` | Stale-lease recovery threshold for org-report lock (> 0) | Org-report only |
@@ -514,17 +514,20 @@ cja_auto_sdr dv_12345 --include-segments --inventory-summary --format json
 
 # --- Agent Integration ---
 
-# Agent-friendly JSON on stdout
-cja_auto_sdr dv_12345 --agent-mode
+# Agent-friendly discovery JSON on stdout
+cja_auto_sdr --list-dataviews --agent-mode
 
 # Agent mode with explicit format override
-cja_auto_sdr dv_12345 --agent-mode --format csv
+cja_auto_sdr --list-dataviews --agent-mode --format csv
 
 # Agent mode with org report
 cja_auto_sdr --org-report --agent-mode
 
 # Agent mode with diff
 cja_auto_sdr --diff dv_a dv_b --agent-mode
+
+# Single SDR keeps agent defaults but still writes an auto-named artifact
+cja_auto_sdr dv_12345 --agent-mode --output-dir ./reports
 
 # --- Inventory Diff (same data view over time) ---
 

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Quick Reference Card
 
-Single-page command cheat sheet for CJA SDR Generator v3.4.9.
+Single-page command cheat sheet for CJA SDR Generator v3.5.0.
 
 ## Four Main Modes
 

--- a/docs/agent-playbooks/README.md
+++ b/docs/agent-playbooks/README.md
@@ -1,0 +1,32 @@
+# Agent Playbooks
+
+Reusable task guides for common CJA SDR Generator workflows. These playbooks
+are repo-native, cross-agent documents — they work with any agent framework
+or manual operator.
+
+## Playbooks
+
+| Playbook | Purpose |
+|----------|---------|
+| [sdr-auditor.md](sdr-auditor.md) | Org-wide governance review with threshold triage |
+| [diff-reviewer.md](diff-reviewer.md) | Change review and drift detection |
+| [onboarding-guide.md](onboarding-guide.md) | First-run setup and initial SDR generation |
+| [quality-monitor.md](quality-monitor.md) | Quality-gate enforcement and reporting |
+| [snapshot-manager.md](snapshot-manager.md) | Snapshot lifecycle, comparison, and pruning |
+
+## When to Start With AGENTS.md
+
+Start with [AGENTS.md](../../AGENTS.md) when you need:
+- The authoritative CLI contract (flags, exit codes, output formats)
+- Setup and authentication instructions
+- The complete command reference
+
+Start with a playbook when you need:
+- A guided workflow for a specific task
+- Step-by-step decision points and branching logic
+- Success criteria and follow-up actions
+
+## Important
+
+These playbooks are explicit guides. They are **not** auto-discovered by any
+agent platform. Reference them by path when needed.

--- a/docs/agent-playbooks/TEMPLATE.md
+++ b/docs/agent-playbooks/TEMPLATE.md
@@ -1,0 +1,33 @@
+# [Playbook Name]
+
+## Purpose
+
+[One-paragraph description of what this playbook accomplishes.]
+
+## When To Use
+
+[Conditions or triggers that make this playbook appropriate.]
+
+## Inputs
+
+[Required and optional inputs: credentials, data view IDs, config files, etc.]
+
+## Constraints
+
+[Limitations, prerequisites, and things this playbook does NOT do.]
+
+## Primary CLI Flows
+
+[Step-by-step CLI commands with expected outputs and exit-code handling.]
+
+## Success Criteria
+
+[How to determine that the playbook completed successfully.]
+
+## Follow-Up Actions
+
+[What to do next after this playbook completes.]
+
+---
+
+> For authoritative CLI contracts, see [AGENTS.md](../../AGENTS.md).

--- a/docs/agent-playbooks/diff-reviewer.md
+++ b/docs/agent-playbooks/diff-reviewer.md
@@ -4,7 +4,8 @@
 
 Reviews schema changes between two CJA data view snapshots, identifies
 breaking changes and regressions, and produces a structured advisory report.
-Supports both point-in-time comparisons and sliding-window drift detection.
+Supports file-to-file snapshot comparisons, compare-with-previous review for a
+live data view, and org-report trending review across cached snapshots.
 
 ## When To Use
 
@@ -16,21 +17,25 @@ Supports both point-in-time comparisons and sliding-window drift detection.
 ## Inputs
 
 **Required (point-in-time diff):**
-- `<source>` and `<target>` — snapshot labels or file paths
-- `CJA_CLIENT_ID`, `CJA_CLIENT_SECRET`, `CJA_ORG_ID` — API credentials
+- `<source_snapshot.json>` and `<target_snapshot.json>` — snapshot file paths
+- No API credentials are required for `--compare-snapshots`
 
 **Required (compare with previous):**
 - `<dv_id>` — data view ID to compare against its most recent snapshot
+- `ORG_ID`, `CLIENT_ID`, `SECRET`, `SCOPES` — API credentials (or `--profile <name>`)
 - An existing snapshot created by `snapshot-manager.md`
 
 **Optional:**
-- `--format json` — machine-readable output (recommended for automation)
-- `--output <path>` — write diff report to file
-- `--fail-on-advisory breaking` — non-zero exit on breaking changes
+- `--agent-mode` — machine-readable JSON on stdout (recommended for automation)
+- `--changes-only` — omit unchanged components
+- `--warn-threshold <percent>` — return exit 3 when change volume exceeds the threshold
+- `--output-dir <path>` — write auto-named diff artifacts for file formats such as markdown/html/excel/json
 - `--profile <name>` — named credential profile
 
 ## Constraints
 
+- `--compare-snapshots` is the snapshot-file workflow. `--diff` is reserved for
+  comparing two live data view IDs.
 - Requires at least one prior snapshot to exist for `--compare-with-prev`.
 - Does not create snapshots; use `snapshot-manager.md` for that step.
 - Does not modify CJA data views.
@@ -38,54 +43,53 @@ Supports both point-in-time comparisons and sliding-window drift detection.
 
 ## Primary CLI Flows
 
-**1. Compare two named snapshots (unattended):**
+**1. Compare two snapshot files (unattended):**
 
 ```bash
-uv run cja_auto_sdr --diff baseline current --agent-mode \
-  --format json \
-  --output /tmp/diff-report.json
+uv run cja_auto_sdr --compare-snapshots \
+  ./snapshots/pre-migration.json \
+  ./snapshots/post-migration.json \
+  --agent-mode > /tmp/diff-report.json
 echo "Exit: $?"
 ```
 
-Exit 0 — diff complete, no breaking changes detected.
-Exit 2 — breaking changes present (when `--fail-on-advisory breaking` is set).
+Exit 0 — comparison complete, no changes detected.
+Exit 2 — comparison complete, changes detected.
+Exit 3 — warn-threshold exceeded.
 
 **2. Compare a data view against its previous snapshot:**
 
 ```bash
-uv run cja_auto_sdr <dv_id> --compare-with-prev --agent-mode \
-  --format json \
-  --output /tmp/diff-report.json
+uv run cja_auto_sdr <dv_id> --compare-with-prev --agent-mode > /tmp/diff-report.json
 ```
 
-**3. Drift detection over a time window:**
+**3. Drift detection over a cached snapshot window:**
 
 ```bash
-uv run cja_auto_sdr --org-report --trending-window 30 --agent-mode \
-  --format json \
-  --output /tmp/drift-report.json
+uv run cja_auto_sdr --org-report --trending-window 10 --agent-mode > /tmp/drift-report.json
 ```
+
+`--trending-window 10` means the last 10 cached org-report snapshots, not 10 days.
 
 **4. Parse diff output for breaking changes:**
 
-From the JSON report, inspect the `diff.changes` array. Breaking changes have
-`breaking: true`. Fields of interest:
-- `change_type`: `"removed"` | `"modified"` | `"added"`
-- `component`: component type and ID
-- `breaking`: boolean
-- `advisory_code`: machine-readable code for downstream routing
+Inspect these top-level keys in the diff JSON:
+- `summary.has_changes` and `summary.total_changes` for the overall decision.
+- `metric_diffs` and `dimension_diffs` for item-level additions, removals, and modifications.
+- `advisories.findings` for breaking-change rollups. Look for findings with
+  `type == "breaking_changes"` or `type == "schema_changes"`.
 
 ## Success Criteria
 
-- Exit code 0 from the diff command.
-- JSON output is valid and contains a `diff` key.
-- If `breaking_changes_count == 0`, the schema is stable.
-- Any breaking changes are routed to the appropriate escalation workflow.
+- Exit code 0, 2, or 3 from the diff command means the comparison itself succeeded.
+- JSON output is valid and contains a top-level `summary` key.
+- If `advisories.summary.by_severity.critical` is absent or `0`, no breaking-change advisory was raised.
+- Any critical advisory findings are routed to the appropriate escalation workflow.
 
 ## Follow-Up Actions
 
-- **Breaking changes found:** Block deployment; notify schema owners with the diff report path.
-- **Non-breaking changes:** Log for audit trail; proceed with deployment.
+- **Critical breaking-change advisory:** Block deployment; notify schema owners with the diff report path.
+- **Changes without critical advisory:** Log the diff for audit trail; review whether the drift is expected.
 - **No changes:** Confirm snapshot is up to date; no action needed.
 - **Recurring drift detection:** Pair with `snapshot-manager.md` to capture and compare snapshots on a schedule.
 

--- a/docs/agent-playbooks/diff-reviewer.md
+++ b/docs/agent-playbooks/diff-reviewer.md
@@ -1,0 +1,94 @@
+# Diff Reviewer
+
+## Purpose
+
+Reviews schema changes between two CJA data view snapshots, identifies
+breaking changes and regressions, and produces a structured advisory report.
+Supports both point-in-time comparisons and sliding-window drift detection.
+
+## When To Use
+
+- After a deployment or schema migration to verify expected changes only
+- Before approving a pull request that touches data view configurations
+- Scheduled drift detection to catch unannounced changes
+- Any time two snapshots need to be compared for audit or compliance purposes
+
+## Inputs
+
+**Required (point-in-time diff):**
+- `<source>` and `<target>` — snapshot labels or file paths
+- `CJA_CLIENT_ID`, `CJA_CLIENT_SECRET`, `CJA_ORG_ID` — API credentials
+
+**Required (compare with previous):**
+- `<dv_id>` — data view ID to compare against its most recent snapshot
+- An existing snapshot created by `snapshot-manager.md`
+
+**Optional:**
+- `--format json` — machine-readable output (recommended for automation)
+- `--output <path>` — write diff report to file
+- `--fail-on-advisory breaking` — non-zero exit on breaking changes
+- `--profile <name>` — named credential profile
+
+## Constraints
+
+- Requires at least one prior snapshot to exist for `--compare-with-prev`.
+- Does not create snapshots; use `snapshot-manager.md` for that step.
+- Does not modify CJA data views.
+- Renamed components may appear as add+remove pairs rather than renames.
+
+## Primary CLI Flows
+
+**1. Compare two named snapshots (unattended):**
+
+```bash
+uv run cja_auto_sdr --diff baseline current --agent-mode \
+  --format json \
+  --output /tmp/diff-report.json
+echo "Exit: $?"
+```
+
+Exit 0 — diff complete, no breaking changes detected.
+Exit 2 — breaking changes present (when `--fail-on-advisory breaking` is set).
+
+**2. Compare a data view against its previous snapshot:**
+
+```bash
+uv run cja_auto_sdr <dv_id> --compare-with-prev --agent-mode \
+  --format json \
+  --output /tmp/diff-report.json
+```
+
+**3. Drift detection over a time window:**
+
+```bash
+uv run cja_auto_sdr --org-report --trending-window 30 --agent-mode \
+  --format json \
+  --output /tmp/drift-report.json
+```
+
+**4. Parse diff output for breaking changes:**
+
+From the JSON report, inspect the `diff.changes` array. Breaking changes have
+`breaking: true`. Fields of interest:
+- `change_type`: `"removed"` | `"modified"` | `"added"`
+- `component`: component type and ID
+- `breaking`: boolean
+- `advisory_code`: machine-readable code for downstream routing
+
+## Success Criteria
+
+- Exit code 0 from the diff command.
+- JSON output is valid and contains a `diff` key.
+- If `breaking_changes_count == 0`, the schema is stable.
+- Any breaking changes are routed to the appropriate escalation workflow.
+
+## Follow-Up Actions
+
+- **Breaking changes found:** Block deployment; notify schema owners with the diff report path.
+- **Non-breaking changes:** Log for audit trail; proceed with deployment.
+- **No changes:** Confirm snapshot is up to date; no action needed.
+- **Recurring drift detection:** Pair with `snapshot-manager.md` to capture and compare snapshots on a schedule.
+
+---
+
+> For authoritative CLI contracts, see [AGENTS.md](../../AGENTS.md).

--- a/docs/agent-playbooks/onboarding-guide.md
+++ b/docs/agent-playbooks/onboarding-guide.md
@@ -17,14 +17,16 @@ snapshot for future diff comparisons.
 ## Inputs
 
 **Required:**
-- `CJA_CLIENT_ID`, `CJA_CLIENT_SECRET`, `CJA_ORG_ID` — Adobe IMS credentials
+- `ORG_ID`, `CLIENT_ID`, `SECRET`, `SCOPES` — Adobe IMS credentials
   (set as environment variables or in a `.env` file)
 
 **Optional:**
-- `--profile <name>` — create a named profile for multi-org environments
+- `--profile-add <name>` — create a named profile for multi-org environments
+- `--profile <name>` — reuse an existing named profile
 - `<dv_id>` — a specific data view ID to target for the initial SDR; if
   unknown, use `--list-dataviews` to discover available IDs
-- `--output <path>` — write SDR to file instead of stdout
+- `--output-dir <path>` — directory for auto-named SDR artifacts
+- `--run-summary-json <path>` — stable machine-readable completion metadata
 - `--format excel` | `json` | `csv` | `markdown` — output format
 
 ## Constraints
@@ -45,7 +47,7 @@ echo "Exit: $?"
 ```
 
 Exit 0 — credentials valid, API reachable.
-Exit 64 — authentication failure; verify `CJA_CLIENT_ID` / `CJA_CLIENT_SECRET`.
+Exit 1 — validation failed; verify `CLIENT_ID` / `SECRET` / `ORG_ID` / `SCOPES`.
 
 **2. Discover available data views:**
 
@@ -66,18 +68,18 @@ uv run cja_auto_sdr --describe-dataview <DATA_VIEW_ID>
 
 ```bash
 uv run cja_auto_sdr <DATA_VIEW_ID> --agent-mode \
-  --format json \
-  --output /tmp/initial-sdr.json
+  --output-dir /tmp/reports \
+  --run-summary-json /tmp/initial-sdr-run-summary.json
 echo "Exit: $?"
 ```
 
-Exit 0 — SDR generated successfully.
-Exit 1 — partial failure (some components skipped); review warnings in output.
+This writes the SDR artifact under `/tmp/reports` and records completion metadata
+in `/tmp/initial-sdr-run-summary.json`.
 
 **5. Capture a baseline snapshot for future comparisons:**
 
 ```bash
-uv run cja_auto_sdr <DATA_VIEW_ID> --snapshot baseline
+uv run cja_auto_sdr <DATA_VIEW_ID> --snapshot ./snapshots/<DATA_VIEW_ID>_baseline.json
 ```
 
 This snapshot can be used with `diff-reviewer.md` to detect future changes.
@@ -85,7 +87,7 @@ This snapshot can be used with `diff-reviewer.md` to detect future changes.
 **6. (Optional) Save a named profile for reuse:**
 
 ```bash
-uv run cja_auto_sdr --config --profile production
+uv run cja_auto_sdr --profile-add production
 ```
 
 Follow the interactive prompts to store credentials. Subsequent commands can
@@ -95,7 +97,7 @@ use `--profile production` instead of environment variables.
 
 - `--validate-config` exits 0.
 - `--list-dataviews` returns at least one data view.
-- SDR generation exits 0 and produces a non-empty output file.
+- SDR generation exits 0 and writes an auto-named artifact under the requested `--output-dir`.
 - Baseline snapshot is recorded (verify with `--list-snapshots`).
 
 ## Follow-Up Actions
@@ -103,7 +105,7 @@ use `--profile production` instead of environment variables.
 - Store credentials in a secrets manager or CI secret store; do not commit to version control.
 - Schedule `sdr-auditor.md` for recurring org-wide governance reviews.
 - Configure `snapshot-manager.md` to capture snapshots on a regular cadence.
-- Document the baseline SDR path and snapshot label for the team.
+- Document the baseline SDR path and snapshot file path for the team.
 
 ---
 

--- a/docs/agent-playbooks/onboarding-guide.md
+++ b/docs/agent-playbooks/onboarding-guide.md
@@ -1,0 +1,110 @@
+# Onboarding Guide
+
+## Purpose
+
+Walks through first-run setup for a new CJA SDR Generator installation,
+validates credentials and API access, discovers available data views, and
+generates an initial SDR for a target data view. Establishes a baseline
+snapshot for future diff comparisons.
+
+## When To Use
+
+- Initial setup on a new machine or CI environment
+- Onboarding a new Adobe CJA organization or workspace
+- Verifying that credentials and API connectivity are functional after rotation
+- Generating a first baseline SDR before any automated workflows begin
+
+## Inputs
+
+**Required:**
+- `CJA_CLIENT_ID`, `CJA_CLIENT_SECRET`, `CJA_ORG_ID` — Adobe IMS credentials
+  (set as environment variables or in a `.env` file)
+
+**Optional:**
+- `--profile <name>` — create a named profile for multi-org environments
+- `<dv_id>` — a specific data view ID to target for the initial SDR; if
+  unknown, use `--list-dataviews` to discover available IDs
+- `--output <path>` — write SDR to file instead of stdout
+- `--format excel` | `json` | `csv` | `markdown` — output format
+
+## Constraints
+
+- Requires network access to the Adobe CJA API (`analytics.adobe.io`).
+- Credentials must have read access to at least one data view.
+- Does not create or modify CJA configurations.
+- The `--validate-config` flag verifies credentials without generating output;
+  it is a prerequisite check, not a full SDR generation step.
+
+## Primary CLI Flows
+
+**1. Validate credentials and API connectivity:**
+
+```bash
+uv run cja_auto_sdr --validate-config
+echo "Exit: $?"
+```
+
+Exit 0 — credentials valid, API reachable.
+Exit 64 — authentication failure; verify `CJA_CLIENT_ID` / `CJA_CLIENT_SECRET`.
+
+**2. Discover available data views:**
+
+```bash
+uv run cja_auto_sdr --list-dataviews --format json
+```
+
+Note the `id` field for each data view. Use these IDs (not display names) in
+all subsequent automation steps.
+
+**3. Inspect a target data view before generating the SDR:**
+
+```bash
+uv run cja_auto_sdr --describe-dataview <DATA_VIEW_ID>
+```
+
+**4. Generate the initial SDR:**
+
+```bash
+uv run cja_auto_sdr <DATA_VIEW_ID> --agent-mode \
+  --format json \
+  --output /tmp/initial-sdr.json
+echo "Exit: $?"
+```
+
+Exit 0 — SDR generated successfully.
+Exit 1 — partial failure (some components skipped); review warnings in output.
+
+**5. Capture a baseline snapshot for future comparisons:**
+
+```bash
+uv run cja_auto_sdr <DATA_VIEW_ID> --snapshot baseline
+```
+
+This snapshot can be used with `diff-reviewer.md` to detect future changes.
+
+**6. (Optional) Save a named profile for reuse:**
+
+```bash
+uv run cja_auto_sdr --config --profile production
+```
+
+Follow the interactive prompts to store credentials. Subsequent commands can
+use `--profile production` instead of environment variables.
+
+## Success Criteria
+
+- `--validate-config` exits 0.
+- `--list-dataviews` returns at least one data view.
+- SDR generation exits 0 and produces a non-empty output file.
+- Baseline snapshot is recorded (verify with `--list-snapshots`).
+
+## Follow-Up Actions
+
+- Store credentials in a secrets manager or CI secret store; do not commit to version control.
+- Schedule `sdr-auditor.md` for recurring org-wide governance reviews.
+- Configure `snapshot-manager.md` to capture snapshots on a regular cadence.
+- Document the baseline SDR path and snapshot label for the team.
+
+---
+
+> For authoritative CLI contracts, see [AGENTS.md](../../AGENTS.md).

--- a/docs/agent-playbooks/quality-monitor.md
+++ b/docs/agent-playbooks/quality-monitor.md
@@ -1,0 +1,103 @@
+# Quality Monitor
+
+## Purpose
+
+Enforces data quality gates against CJA data views, generates quality reports
+with severity-classified findings, and integrates quality checks into CI/CD
+pipelines or scheduled monitoring workflows. Fails fast on critical violations
+to prevent downstream data issues.
+
+## When To Use
+
+- CI gate before promoting a data view schema change to production
+- Scheduled quality sweeps (daily or per-deployment)
+- Post-migration validation to confirm component descriptions and metadata are intact
+- Any time a data view's quality score needs to be measured and reported
+
+## Inputs
+
+**Required:**
+- `<dv_id>` — the data view ID to quality-check (or `--org-report` for all views)
+- `CJA_CLIENT_ID`, `CJA_CLIENT_SECRET`, `CJA_ORG_ID` — API credentials
+
+**Optional:**
+- `--fail-on-quality` — exit non-zero if any quality threshold is breached
+- `--format json` — machine-readable output for pipeline consumption
+- `--output <path>` — write quality report to file
+- `--profile <name>` — named credential profile
+- `--workers <n>` — parallel API workers (default: auto-tuned)
+
+## Constraints
+
+- Quality checks are read-only; this playbook does not remediate issues.
+- `--fail-on-quality` uses built-in thresholds; custom thresholds are configured
+  via the profile or config file, not per-invocation flags.
+- Org-wide quality checks (`--org-report`) may be slow for large organizations;
+  plan for several minutes of runtime and use `--workers` to optimize.
+- Missing descriptions and empty display names are the most common quality
+  findings; prepare remediation scripts separately.
+
+## Primary CLI Flows
+
+**1. Quality gate for a single data view (unattended CI):**
+
+```bash
+uv run cja_auto_sdr <DATA_VIEW_ID> --agent-mode \
+  --fail-on-quality \
+  --format json \
+  --output /tmp/quality-report.json
+echo "Exit: $?"
+```
+
+Exit 0 — all quality thresholds passed.
+Exit 2 — quality threshold breached; inspect `quality` section of JSON output.
+Exit 64 — authentication failure.
+
+**2. Org-wide quality sweep:**
+
+```bash
+uv run cja_auto_sdr --org-report --agent-mode \
+  --fail-on-quality \
+  --format json \
+  --output /tmp/org-quality.json
+```
+
+**3. Parse quality findings from JSON output:**
+
+The `quality` object in the report includes:
+- `score`: 0–100 composite quality score
+- `findings`: array of issues, each with `severity`, `code`, `component_id`, `message`
+- `thresholds_breached`: boolean
+
+Filter `findings` where `severity == "critical"` for blocking issues.
+Filter `severity == "warning"` for advisory items.
+
+**4. Generate a human-readable quality report:**
+
+```bash
+uv run cja_auto_sdr <DATA_VIEW_ID> --agent-mode \
+  --fail-on-quality \
+  --format markdown \
+  --output /tmp/quality-report.md
+```
+
+## Success Criteria
+
+- Exit code 0 from the quality-check command.
+- `quality.thresholds_breached` is `false` in JSON output.
+- `quality.score` meets or exceeds the configured minimum (default: 70).
+- No `critical` findings in the `quality.findings` array.
+
+## Follow-Up Actions
+
+- **Thresholds breached (exit 2):** Block the pipeline; route `quality.findings`
+  to schema owners for remediation. Reference component IDs for targeted fixes.
+- **Warnings only (exit 0):** Log findings; schedule remediation for next sprint.
+- **Clean pass:** Record quality score and timestamp; optionally commit a snapshot
+  via `snapshot-manager.md` to track score trends over time.
+- **Recurring monitoring:** Pair with `sdr-auditor.md` for governance context and
+  `diff-reviewer.md` to detect quality regressions between releases.
+
+---
+
+> For authoritative CLI contracts, see [AGENTS.md](../../AGENTS.md).

--- a/docs/agent-playbooks/quality-monitor.md
+++ b/docs/agent-playbooks/quality-monitor.md
@@ -12,17 +12,17 @@ to prevent downstream data issues.
 - CI gate before promoting a data view schema change to production
 - Scheduled quality sweeps (daily or per-deployment)
 - Post-migration validation to confirm component descriptions and metadata are intact
-- Any time a data view's quality score needs to be measured and reported
+- Any time a data view's quality issues need to be measured and reported
 
 ## Inputs
 
 **Required:**
-- `<dv_id>` — the data view ID to quality-check (or `--org-report` for all views)
-- `CJA_CLIENT_ID`, `CJA_CLIENT_SECRET`, `CJA_ORG_ID` — API credentials
+- One or more exact data view IDs (`<dv_id> [<dv_id> ...]`)
+- `ORG_ID`, `CLIENT_ID`, `SECRET`, `SCOPES` — API credentials (or `--profile <name>`)
 
 **Optional:**
-- `--fail-on-quality` — exit non-zero if any quality threshold is breached
-- `--format json` — machine-readable output for pipeline consumption
+- `--fail-on-quality <SEVERITY>` — exit 2 if any issue at or above the threshold is found
+- `--quality-report json|csv` — emit a standalone quality report without SDR artifacts
 - `--output <path>` — write quality report to file
 - `--profile <name>` — named credential profile
 - `--workers <n>` — parallel API workers (default: auto-tuned)
@@ -30,10 +30,9 @@ to prevent downstream data issues.
 ## Constraints
 
 - Quality checks are read-only; this playbook does not remediate issues.
-- `--fail-on-quality` uses built-in thresholds; custom thresholds are configured
-  via the profile or config file, not per-invocation flags.
-- Org-wide quality checks (`--org-report`) may be slow for large organizations;
-  plan for several minutes of runtime and use `--workers` to optimize.
+- `--quality-report` supports `json` and `csv` only.
+- `--fail-on-quality` is supported in SDR/quality-report flows, not with `--org-report`.
+- Org-wide sweeps require a resolved list of data view IDs; start with discovery if needed.
 - Missing descriptions and empty display names are the most common quality
   findings; prepare remediation scripts separately.
 
@@ -42,59 +41,62 @@ to prevent downstream data issues.
 **1. Quality gate for a single data view (unattended CI):**
 
 ```bash
-uv run cja_auto_sdr <DATA_VIEW_ID> --agent-mode \
-  --fail-on-quality \
-  --format json \
-  --output /tmp/quality-report.json
+uv run cja_auto_sdr <DATA_VIEW_ID> \
+  --quality-report json \
+  --output /tmp/quality-report.json \
+  --fail-on-quality HIGH
 echo "Exit: $?"
 ```
 
 Exit 0 — all quality thresholds passed.
-Exit 2 — quality threshold breached; inspect `quality` section of JSON output.
-Exit 64 — authentication failure.
+Exit 2 — quality threshold breached; inspect the emitted issue rows in the JSON report.
+Exit 1 — configuration, auth, or processing failure.
 
 **2. Org-wide quality sweep:**
 
 ```bash
-uv run cja_auto_sdr --org-report --agent-mode \
-  --fail-on-quality \
-  --format json \
-  --output /tmp/org-quality.json
+uv run cja_auto_sdr <DATA_VIEW_ID_1> <DATA_VIEW_ID_2> <DATA_VIEW_ID_3> \
+  --quality-report json \
+  --output /tmp/org-quality.json \
+  --continue-on-error
 ```
 
 **3. Parse quality findings from JSON output:**
 
-The `quality` object in the report includes:
-- `score`: 0–100 composite quality score
-- `findings`: array of issues, each with `severity`, `code`, `component_id`, `message`
-- `thresholds_breached`: boolean
+Standalone quality-report JSON is an array of issue objects. Inspect fields such as:
+- `Severity`
+- `Issue`
+- `Data View ID`
+- `Data View Name`
+- `Type`
 
-Filter `findings` where `severity == "critical"` for blocking issues.
-Filter `severity == "warning"` for advisory items.
+Filter rows where `Severity == "CRITICAL"` for blocking issues.
+Filter rows where `Severity == "HIGH"`, `Severity == "MEDIUM"`, `Severity == "LOW"`, or `Severity == "INFO"` for advisory review.
 
 **4. Generate a human-readable quality report:**
 
 ```bash
-uv run cja_auto_sdr <DATA_VIEW_ID> --agent-mode \
-  --fail-on-quality \
+uv run cja_auto_sdr <DATA_VIEW_ID> \
   --format markdown \
-  --output /tmp/quality-report.md
+  --output-dir /tmp/reports \
+  --fail-on-quality HIGH \
+  --run-summary-json /tmp/quality-run-summary.json
 ```
 
 ## Success Criteria
 
 - Exit code 0 from the quality-check command.
-- `quality.thresholds_breached` is `false` in JSON output.
-- `quality.score` meets or exceeds the configured minimum (default: 70).
-- No `critical` findings in the `quality.findings` array.
+- The standalone quality report is valid JSON or CSV and is non-empty.
+- No report entries meet or exceed the configured `--fail-on-quality` threshold.
+- If a run summary is written, `quality_gate_failed` is `false`.
 
 ## Follow-Up Actions
 
-- **Thresholds breached (exit 2):** Block the pipeline; route `quality.findings`
-  to schema owners for remediation. Reference component IDs for targeted fixes.
+- **Thresholds breached (exit 2):** Block the pipeline; route the emitted issue rows
+  to schema owners for remediation. Reference the affected `Data View ID` and issue rows for targeted fixes.
 - **Warnings only (exit 0):** Log findings; schedule remediation for next sprint.
-- **Clean pass:** Record quality score and timestamp; optionally commit a snapshot
-  via `snapshot-manager.md` to track score trends over time.
+- **Clean pass:** Record the issue counts by severity and timestamp; optionally commit a snapshot
+  via `snapshot-manager.md` to track trend changes over time.
 - **Recurring monitoring:** Pair with `sdr-auditor.md` for governance context and
   `diff-reviewer.md` to detect quality regressions between releases.
 

--- a/docs/agent-playbooks/sdr-auditor.md
+++ b/docs/agent-playbooks/sdr-auditor.md
@@ -17,14 +17,15 @@ escalation.
 ## Inputs
 
 **Required:**
-- `CJA_CLIENT_ID`, `CJA_CLIENT_SECRET`, `CJA_ORG_ID` — API credentials (env or profile)
+- `ORG_ID`, `CLIENT_ID`, `SECRET`, `SCOPES` — API credentials (env or profile)
 
 **Optional:**
 - `--profile <name>` — named credential profile (overrides env vars)
-- `--output <path>` — write report to file instead of stdout
-- `--format json` — machine-readable output (recommended for automation)
-- `--fail-on-advisory critical` — non-zero exit when critical advisories present
-- `--threshold-missing-description <n>` — flag data views where > n% of components lack descriptions
+- `--agent-mode` — machine-readable JSON on stdout (recommended for automation)
+- `--duplicate-threshold <n>` — maximum allowed high-overlap pairs
+- `--isolated-threshold <percent>` — maximum isolated-component percentage
+- `--fail-on-threshold` — exit 2 when a configured governance threshold is exceeded
+- `--trending-window <n>` — include drift analysis across the last N cached org-report snapshots
 
 ## Constraints
 
@@ -32,56 +33,56 @@ escalation.
 - Does not auto-remediate quality issues; it only reports them.
 - Requires read access to all target data views; inaccessible views are logged and skipped.
 - Large orgs (100+ data views) may take several minutes; use `--workers` to tune parallelism.
+- Threshold-based exits are driven by governance thresholds, not by advisory severity alone.
 
 ## Primary CLI Flows
 
 **1. Full org audit with JSON output (unattended):**
 
 ```bash
-uv run cja_auto_sdr --org-report --agent-mode \
-  --format json \
-  --output /tmp/org-audit.json
+uv run cja_auto_sdr --org-report --agent-mode > /tmp/org-audit.json
 echo "Exit: $?"
 ```
 
-Exit 0 — audit complete, no critical issues.
-Exit 2 — critical advisories present (when `--fail-on-advisory critical` is set).
-Exit 64 — authentication failure; check credentials.
+Exit 0 — audit complete.
+Exit 1 — configuration, auth, or processing failure.
 
-**2. Audit with quality threshold enforcement:**
+**2. Audit with governance threshold enforcement:**
 
 ```bash
 uv run cja_auto_sdr --org-report --agent-mode \
-  --fail-on-quality \
-  --format json \
-  --output /tmp/org-audit.json
+  --duplicate-threshold 5 \
+  --fail-on-threshold > /tmp/org-audit.json
 ```
 
 **3. Triage advisories from JSON output:**
 
-Parse `advisories` array from the JSON report. Each entry has:
-- `severity`: `"critical"` | `"warning"` | `"info"`
-- `code`: machine-readable advisory code
-- `data_view_id`: affected data view
-- `message`: human-readable description
+Parse the `advisories.findings` array from the JSON report. Each finding has:
+- `type`
+- `severity`
+- `message`
+- `details`
+- `recommended_actions`
 
 Filter `severity == "critical"` for immediate action items.
 
 **4. Target a specific data view for deep audit:**
 
 ```bash
-uv run cja_auto_sdr <dv_id> --agent-mode \
-  --fail-on-quality \
-  --format json \
-  --output /tmp/dv-audit.json
+uv run cja_auto_sdr <dv_id> \
+  --quality-report json \
+  --output /tmp/dv-audit.json \
+  --fail-on-quality HIGH
 ```
 
 ## Success Criteria
 
-- Exit code 0 from the org-report command.
-- JSON output is valid and contains a `summary` key with `data_views_audited` > 0.
-- No `critical` severity advisories in the output (or escalation workflow triggered if present).
-- Output file written to the expected path (if `--output` was specified).
+- Exit code 0 means the default org-report run completed.
+- If `--fail-on-threshold` is used, exit code 2 indicates a configured governance threshold breach.
+- JSON output is valid and reports at least one analyzed data view.
+- If `--fail-on-threshold` is used, exit 0 means the configured governance thresholds passed.
+- Advisory findings are present and parseable when issues are detected.
+- Output file written to the expected path when stdout is redirected or a per-view quality report path is specified.
 
 ## Follow-Up Actions
 

--- a/docs/agent-playbooks/sdr-auditor.md
+++ b/docs/agent-playbooks/sdr-auditor.md
@@ -1,0 +1,95 @@
+# SDR Auditor
+
+## Purpose
+
+Performs an org-wide governance review of all CJA data views, identifies data
+quality issues and coverage gaps, and triages findings by severity. Produces
+a structured advisory report suitable for automated decision-making or human
+escalation.
+
+## When To Use
+
+- Scheduled governance sweeps (weekly, monthly)
+- Pre-release validation before deploying schema changes
+- Post-migration audits after onboarding new data views
+- Any time a quality threshold violation is suspected org-wide
+
+## Inputs
+
+**Required:**
+- `CJA_CLIENT_ID`, `CJA_CLIENT_SECRET`, `CJA_ORG_ID` — API credentials (env or profile)
+
+**Optional:**
+- `--profile <name>` — named credential profile (overrides env vars)
+- `--output <path>` — write report to file instead of stdout
+- `--format json` — machine-readable output (recommended for automation)
+- `--fail-on-advisory critical` — non-zero exit when critical advisories present
+- `--threshold-missing-description <n>` — flag data views where > n% of components lack descriptions
+
+## Constraints
+
+- Does not modify any data views or CJA configurations.
+- Does not auto-remediate quality issues; it only reports them.
+- Requires read access to all target data views; inaccessible views are logged and skipped.
+- Large orgs (100+ data views) may take several minutes; use `--workers` to tune parallelism.
+
+## Primary CLI Flows
+
+**1. Full org audit with JSON output (unattended):**
+
+```bash
+uv run cja_auto_sdr --org-report --agent-mode \
+  --format json \
+  --output /tmp/org-audit.json
+echo "Exit: $?"
+```
+
+Exit 0 — audit complete, no critical issues.
+Exit 2 — critical advisories present (when `--fail-on-advisory critical` is set).
+Exit 64 — authentication failure; check credentials.
+
+**2. Audit with quality threshold enforcement:**
+
+```bash
+uv run cja_auto_sdr --org-report --agent-mode \
+  --fail-on-quality \
+  --format json \
+  --output /tmp/org-audit.json
+```
+
+**3. Triage advisories from JSON output:**
+
+Parse `advisories` array from the JSON report. Each entry has:
+- `severity`: `"critical"` | `"warning"` | `"info"`
+- `code`: machine-readable advisory code
+- `data_view_id`: affected data view
+- `message`: human-readable description
+
+Filter `severity == "critical"` for immediate action items.
+
+**4. Target a specific data view for deep audit:**
+
+```bash
+uv run cja_auto_sdr <dv_id> --agent-mode \
+  --fail-on-quality \
+  --format json \
+  --output /tmp/dv-audit.json
+```
+
+## Success Criteria
+
+- Exit code 0 from the org-report command.
+- JSON output is valid and contains a `summary` key with `data_views_audited` > 0.
+- No `critical` severity advisories in the output (or escalation workflow triggered if present).
+- Output file written to the expected path (if `--output` was specified).
+
+## Follow-Up Actions
+
+- **Critical advisories:** Open tickets for each affected data view; assign to schema owners.
+- **Warning advisories:** Log for next scheduled review; do not block pipeline.
+- **Clean audit:** Record timestamp and commit snapshot for drift tracking (see `snapshot-manager.md`).
+- **Recurring audits:** Schedule this playbook on a cron or CI trigger; compare results with previous run using `diff-reviewer.md`.
+
+---
+
+> For authoritative CLI contracts, see [AGENTS.md](../../AGENTS.md).

--- a/docs/agent-playbooks/snapshot-manager.md
+++ b/docs/agent-playbooks/snapshot-manager.md
@@ -19,21 +19,22 @@ and change tracking.
 
 **Required (capture):**
 - `<dv_id>` — data view ID to snapshot
-- `CJA_CLIENT_ID`, `CJA_CLIENT_SECRET`, `CJA_ORG_ID` — API credentials
+- `ORG_ID`, `CLIENT_ID`, `SECRET`, `SCOPES` — API credentials (or `--profile <name>`)
 
 **Required (compare):**
-- Either two named snapshot labels, or `--compare-with-prev` for the most recent pair
+- Either two snapshot JSON file paths, or `--compare-with-prev` for the most recent snapshot of one data view
 
 **Optional:**
-- `--snapshot <label>` — name the snapshot (defaults to timestamp-based label)
-- `--output <path>` — write snapshot metadata to file
-- `--format json` — machine-readable output
+- `--snapshot <path.json>` — write a snapshot to an explicit file path
+- `--snapshot-dir <dir>` — directory scanned by `--compare-with-prev` and `--list-snapshots`
+- `--agent-mode` — machine-readable JSON on stdout for compare flows
 - `--profile <name>` — named credential profile
 
 ## Constraints
 
 - Snapshots are stored locally (or in the configured snapshot directory); they
   are not uploaded to CJA or any remote service.
+- `--compare-snapshots` compares snapshot files directly and does not call the API.
 - Git-backed snapshots require a git repository at or above the working directory;
   configure with `--git-snapshot` if desired.
 - Pruning is irreversible; verify the snapshot list before deleting.
@@ -44,32 +45,31 @@ and change tracking.
 **1. Capture a named snapshot before a schema change:**
 
 ```bash
-uv run cja_auto_sdr <DATA_VIEW_ID> --snapshot pre-migration --agent-mode \
-  --format json
+uv run cja_auto_sdr <DATA_VIEW_ID> --snapshot ./snapshots/pre-migration.json
 echo "Exit: $?"
 ```
 
 **2. Capture a snapshot after the change:**
 
 ```bash
-uv run cja_auto_sdr <DATA_VIEW_ID> --snapshot post-migration --agent-mode \
-  --format json
+uv run cja_auto_sdr <DATA_VIEW_ID> --snapshot ./snapshots/post-migration.json
 ```
 
 **3. List all snapshots for a data view:**
 
 ```bash
-uv run cja_auto_sdr --list-snapshots <DATA_VIEW_ID> --format json
+uv run cja_auto_sdr --list-snapshots <DATA_VIEW_ID> --format json --output -
 ```
 
-Each entry includes `label`, `timestamp`, and `data_view_id`.
+Each entry includes `filename`, `created_at`, and `data_view_id`.
 
 **4. Compare two named snapshots:**
 
 ```bash
-uv run cja_auto_sdr --diff pre-migration post-migration --agent-mode \
-  --format json \
-  --output /tmp/migration-diff.json
+uv run cja_auto_sdr --compare-snapshots \
+  ./snapshots/pre-migration.json \
+  ./snapshots/post-migration.json \
+  --agent-mode > /tmp/migration-diff.json
 ```
 
 See `diff-reviewer.md` for full diff workflow.
@@ -77,38 +77,33 @@ See `diff-reviewer.md` for full diff workflow.
 **5. Compare a data view against its most recent snapshot:**
 
 ```bash
-uv run cja_auto_sdr <DATA_VIEW_ID> --compare-with-prev --agent-mode \
-  --format json \
-  --output /tmp/incremental-diff.json
+uv run cja_auto_sdr <DATA_VIEW_ID> --compare-with-prev --agent-mode > /tmp/incremental-diff.json
 ```
 
 **6. Capture a timestamped snapshot for scheduled drift tracking:**
 
 ```bash
-LABEL="scheduled-$(date +%Y%m%d)"
-uv run cja_auto_sdr <DATA_VIEW_ID> --snapshot "$LABEL" --agent-mode \
-  --format json
+SNAPSHOT_FILE="./snapshots/${DATA_VIEW_ID}_$(date +%Y%m%d).json"
+uv run cja_auto_sdr <DATA_VIEW_ID> --snapshot "$SNAPSHOT_FILE"
 ```
 
-**7. Scheduled drift window query (rolling 7 days):**
+**7. Scheduled drift window query (last 7 cached org-report snapshots):**
 
 ```bash
-uv run cja_auto_sdr --org-report --trending-window 7 --agent-mode \
-  --format json \
-  --output /tmp/weekly-drift.json
+uv run cja_auto_sdr --org-report --trending-window 7 --agent-mode > /tmp/weekly-drift.json
 ```
 
 ## Success Criteria
 
-- Snapshot capture exits 0 and the new label appears in `--list-snapshots` output.
-- Diff between pre/post snapshots exits 0 and `diff` key is present in JSON output.
+- Snapshot capture exits 0 and the new filename appears in `--list-snapshots` output.
+- Diff between pre/post snapshots exits 0 or 2 and `summary` is present in JSON output.
 - Snapshot count grows monotonically over scheduled runs.
 - Pruned snapshots no longer appear in `--list-snapshots` output.
 
 ## Follow-Up Actions
 
 - **After capturing pre/post snapshots:** Run `diff-reviewer.md` to validate changes.
-- **After a clean drift window:** No action needed; log the snapshot label for audit trail.
+- **After a clean drift window:** No action needed; log the snapshot filename for audit trail.
 - **Drift detected:** Route drift report to `diff-reviewer.md` for full analysis.
 - **Snapshot storage growing large:** Prune snapshots older than your retention policy;
   keep at minimum the last baseline and the most recent snapshot per data view.

--- a/docs/agent-playbooks/snapshot-manager.md
+++ b/docs/agent-playbooks/snapshot-manager.md
@@ -1,0 +1,120 @@
+# Snapshot Manager
+
+## Purpose
+
+Manages the full lifecycle of CJA data view snapshots: creation, listing,
+comparison, and pruning. Provides the snapshot infrastructure that other
+playbooks (`diff-reviewer.md`, `sdr-auditor.md`) depend on for drift detection
+and change tracking.
+
+## When To Use
+
+- Before and after any schema change to capture a before/after pair
+- On a scheduled cadence to build a snapshot history for drift detection
+- Before running `diff-reviewer.md` (snapshots must exist first)
+- When cleaning up stale snapshots to manage storage
+- As part of a CI pipeline to record the state of data views at each deployment
+
+## Inputs
+
+**Required (capture):**
+- `<dv_id>` — data view ID to snapshot
+- `CJA_CLIENT_ID`, `CJA_CLIENT_SECRET`, `CJA_ORG_ID` — API credentials
+
+**Required (compare):**
+- Either two named snapshot labels, or `--compare-with-prev` for the most recent pair
+
+**Optional:**
+- `--snapshot <label>` — name the snapshot (defaults to timestamp-based label)
+- `--output <path>` — write snapshot metadata to file
+- `--format json` — machine-readable output
+- `--profile <name>` — named credential profile
+
+## Constraints
+
+- Snapshots are stored locally (or in the configured snapshot directory); they
+  are not uploaded to CJA or any remote service.
+- Git-backed snapshots require a git repository at or above the working directory;
+  configure with `--git-snapshot` if desired.
+- Pruning is irreversible; verify the snapshot list before deleting.
+- `--compare-with-prev` requires at least one prior snapshot for the target data view.
+
+## Primary CLI Flows
+
+**1. Capture a named snapshot before a schema change:**
+
+```bash
+uv run cja_auto_sdr <DATA_VIEW_ID> --snapshot pre-migration --agent-mode \
+  --format json
+echo "Exit: $?"
+```
+
+**2. Capture a snapshot after the change:**
+
+```bash
+uv run cja_auto_sdr <DATA_VIEW_ID> --snapshot post-migration --agent-mode \
+  --format json
+```
+
+**3. List all snapshots for a data view:**
+
+```bash
+uv run cja_auto_sdr --list-snapshots <DATA_VIEW_ID> --format json
+```
+
+Each entry includes `label`, `timestamp`, and `data_view_id`.
+
+**4. Compare two named snapshots:**
+
+```bash
+uv run cja_auto_sdr --diff pre-migration post-migration --agent-mode \
+  --format json \
+  --output /tmp/migration-diff.json
+```
+
+See `diff-reviewer.md` for full diff workflow.
+
+**5. Compare a data view against its most recent snapshot:**
+
+```bash
+uv run cja_auto_sdr <DATA_VIEW_ID> --compare-with-prev --agent-mode \
+  --format json \
+  --output /tmp/incremental-diff.json
+```
+
+**6. Capture a timestamped snapshot for scheduled drift tracking:**
+
+```bash
+LABEL="scheduled-$(date +%Y%m%d)"
+uv run cja_auto_sdr <DATA_VIEW_ID> --snapshot "$LABEL" --agent-mode \
+  --format json
+```
+
+**7. Scheduled drift window query (rolling 7 days):**
+
+```bash
+uv run cja_auto_sdr --org-report --trending-window 7 --agent-mode \
+  --format json \
+  --output /tmp/weekly-drift.json
+```
+
+## Success Criteria
+
+- Snapshot capture exits 0 and the new label appears in `--list-snapshots` output.
+- Diff between pre/post snapshots exits 0 and `diff` key is present in JSON output.
+- Snapshot count grows monotonically over scheduled runs.
+- Pruned snapshots no longer appear in `--list-snapshots` output.
+
+## Follow-Up Actions
+
+- **After capturing pre/post snapshots:** Run `diff-reviewer.md` to validate changes.
+- **After a clean drift window:** No action needed; log the snapshot label for audit trail.
+- **Drift detected:** Route drift report to `diff-reviewer.md` for full analysis.
+- **Snapshot storage growing large:** Prune snapshots older than your retention policy;
+  keep at minimum the last baseline and the most recent snapshot per data view.
+- **CI integration:** Add snapshot capture as a post-deploy step; compare with
+  previous on every run to catch unintended schema changes automatically.
+
+---
+
+> For authoritative CLI contracts, see [AGENTS.md](../../AGENTS.md).

--- a/examples/agent-workflows/_common.sh
+++ b/examples/agent-workflows/_common.sh
@@ -13,8 +13,67 @@ require_env() {
     fi
 }
 
+load_auth_from_project_dotenv() {
+    local project_root="$1"
+    local dotenv_path="${2:-$project_root/.env}"
+    local dotenv_values=""
+    local key=""
+    local value=""
+
+    if [[ -n "${ORG_ID:-}" && -n "${CLIENT_ID:-}" && -n "${SECRET:-}" && -n "${SCOPES:-}" ]]; then
+        return 0
+    fi
+
+    if [[ ! -f "$dotenv_path" ]]; then
+        return 0
+    fi
+
+    dotenv_values="$(
+        (
+            set -a
+            # shellcheck source=/dev/null
+            source "$dotenv_path"
+            set +a
+
+            printf 'ORG_ID=%s\n' "${ORG_ID:-}"
+            printf 'CLIENT_ID=%s\n' "${CLIENT_ID:-}"
+            printf 'SECRET=%s\n' "${SECRET:-}"
+            printf 'SCOPES=%s\n' "${SCOPES:-}"
+        )
+    )" || return 1
+
+    while IFS='=' read -r key value; do
+        case "$key" in
+            ORG_ID)
+                if [[ -z "${ORG_ID:-}" && -n "$value" ]]; then
+                    ORG_ID="$value"
+                    export ORG_ID
+                fi
+                ;;
+            CLIENT_ID)
+                if [[ -z "${CLIENT_ID:-}" && -n "$value" ]]; then
+                    CLIENT_ID="$value"
+                    export CLIENT_ID
+                fi
+                ;;
+            SECRET)
+                if [[ -z "${SECRET:-}" && -n "$value" ]]; then
+                    SECRET="$value"
+                    export SECRET
+                fi
+                ;;
+            SCOPES)
+                if [[ -z "${SCOPES:-}" && -n "$value" ]]; then
+                    SCOPES="$value"
+                    export SCOPES
+                fi
+                ;;
+        esac
+    done <<< "$dotenv_values"
+}
+
 # --- Exit Code Handling ---
-# Only documented exit codes: 0 (success), 1 (error), 2 (threshold/changes), 3 (partial), 130 (interrupted)
+# Only documented exit codes: 0 (success), 1 (error), 2 (threshold/changes), 3 (warning threshold), 130 (interrupted)
 handle_exit_code() {
     local exit_code="$1"
     local context="${2:-command}"
@@ -22,20 +81,15 @@ handle_exit_code() {
         0) echo "[$context] Success" ;;
         1) echo "[$context] Error — aborting" >&2; exit 1 ;;
         2) echo "[$context] Threshold/policy breach or changes detected" ;;
-        3) echo "[$context] Partial success" ;;
+        3) echo "[$context] Warning threshold exceeded" ;;
         130) echo "[$context] Interrupted" >&2; exit 130 ;;
         *) echo "[$context] Unexpected exit code: $exit_code" >&2; exit 1 ;;
     esac
 }
 
-CJA_SIGNAL_EXIT_BASE=128
-CJA_MAX_SIGNAL_NUMBER=64
-
 is_signal_exit_code() {
     local code="${1:-0}"
-
-    [[ "$code" =~ ^[0-9]+$ ]] || return 1
-    (( code > CJA_SIGNAL_EXIT_BASE && code <= CJA_SIGNAL_EXIT_BASE + CJA_MAX_SIGNAL_NUMBER ))
+    [[ "$code" == "130" ]]
 }
 
 capture_command_exit() {
@@ -91,6 +145,28 @@ extract_json_field() {
 extract_advisory_severity() {
     local json="$1"
     printf '%s' "$json" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('advisories',{}).get('severity','info'))"
+}
+
+extract_advisory_finding_count() {
+    local json="$1"
+    printf '%s' "$json" | python3 -c "
+import sys, json
+
+data = json.load(sys.stdin)
+findings = (data.get('advisories') or {}).get('findings') or []
+print(len(findings))
+"
+}
+
+extract_advisory_recommended_actions() {
+    local json="$1"
+    printf '%s' "$json" | python3 -c "
+import sys, json
+
+data = json.load(sys.stdin)
+actions = (data.get('advisories') or {}).get('recommended_actions') or []
+print(','.join(actions))
+"
 }
 
 extract_highest_quality_severity_from_run_summary() {

--- a/examples/agent-workflows/_common.sh
+++ b/examples/agent-workflows/_common.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Shared helpers for agent workflow scripts.
+# Source this file: source "$(dirname "$0")/_common.sh"
+
+set -euo pipefail
+
+# --- Environment Validation ---
+require_env() {
+    local var_name="$1"
+    if [[ -z "${!var_name:-}" ]]; then
+        echo "ERROR: Required environment variable $var_name is not set" >&2
+        exit 1
+    fi
+}
+
+# --- Exit Code Handling ---
+# Only documented exit codes: 0 (success), 1 (error), 2 (threshold/changes), 3 (partial), 130 (interrupted)
+handle_exit_code() {
+    local exit_code="$1"
+    local context="${2:-command}"
+    case "$exit_code" in
+        0) echo "[$context] Success" ;;
+        1) echo "[$context] Error — aborting" >&2; exit 1 ;;
+        2) echo "[$context] Threshold/policy breach or changes detected" ;;
+        3) echo "[$context] Partial success" ;;
+        130) echo "[$context] Interrupted" >&2; exit 130 ;;
+        *) echo "[$context] Unexpected exit code: $exit_code" >&2; exit 1 ;;
+    esac
+}
+
+CJA_SIGNAL_EXIT_BASE=128
+CJA_MAX_SIGNAL_NUMBER=64
+
+is_signal_exit_code() {
+    local code="${1:-0}"
+
+    [[ "$code" =~ ^[0-9]+$ ]] || return 1
+    (( code > CJA_SIGNAL_EXIT_BASE && code <= CJA_SIGNAL_EXIT_BASE + CJA_MAX_SIGNAL_NUMBER ))
+}
+
+capture_command_exit() {
+    local exit_var_name="$1"
+    shift
+
+    local exit_code=0
+    if "$@"; then
+        exit_code=0
+    else
+        exit_code=$?
+    fi
+
+    printf -v "$exit_var_name" '%s' "$exit_code"
+}
+
+capture_command_output() {
+    local exit_var_name="$1"
+    local output_var_name="$2"
+    shift 2
+
+    local exit_code=0
+    local output=""
+    if output="$("$@")"; then
+        exit_code=0
+    else
+        exit_code=$?
+    fi
+
+    printf -v "$exit_var_name" '%s' "$exit_code"
+    printf -v "$output_var_name" '%s' "$output"
+}
+
+exit_on_signal_exit() {
+    local code="${1:-0}"
+    shift
+
+    if is_signal_exit_code "$code"; then
+        if [[ $# -gt 0 ]]; then
+            echo "$* (exit $code)" >&2
+        fi
+        exit "$code"
+    fi
+}
+
+# --- JSON Extraction Helpers ---
+extract_json_field() {
+    local json="$1"
+    local field="$2"
+    printf '%s' "$json" | python3 -c "import sys,json; print(json.load(sys.stdin).get('$field',''))"
+}
+
+extract_advisory_severity() {
+    local json="$1"
+    printf '%s' "$json" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('advisories',{}).get('severity','info'))"
+}
+
+extract_dataview_ids() {
+    local json="$1"
+    printf '%s' "$json" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+for dv in data.get('dataViews', []):
+    print(dv.get('id', ''))
+"
+}
+
+# --- Notification Placeholder ---
+notify() {
+    local message="$1"
+    # Override this function in your workflow for real notifications
+    echo "[NOTIFY] $message"
+}

--- a/examples/agent-workflows/_common.sh
+++ b/examples/agent-workflows/_common.sh
@@ -93,6 +93,30 @@ extract_advisory_severity() {
     printf '%s' "$json" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('advisories',{}).get('severity','info'))"
 }
 
+extract_highest_quality_severity_from_run_summary() {
+    local json="$1"
+    printf '%s' "$json" | python3 -c "
+import json, sys
+
+order = ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW', 'INFO']
+
+try:
+    payload = json.load(sys.stdin)
+except Exception:
+    print('unknown')
+    raise SystemExit(0)
+
+for result in payload.get('results', []):
+    counts = result.get('dq_severity_counts') or {}
+    for severity in order:
+        if int(counts.get(severity, 0) or 0) > 0:
+            print(severity)
+            raise SystemExit(0)
+
+print('unknown')
+"
+}
+
 extract_dataview_ids() {
     local json="$1"
     printf '%s' "$json" | python3 -c "
@@ -100,6 +124,17 @@ import sys, json
 data = json.load(sys.stdin)
 for dv in data.get('dataViews', []):
     print(dv.get('id', ''))
+"
+}
+
+extract_snapshot_count() {
+    local json="$1"
+    printf '%s' "$json" | python3 -c "
+import sys, json
+
+data = json.load(sys.stdin)
+snapshots = data if isinstance(data, list) else data.get('snapshots', [])
+print(len(snapshots))
 "
 }
 

--- a/examples/agent-workflows/audit_and_report.sh
+++ b/examples/agent-workflows/audit_and_report.sh
@@ -50,16 +50,34 @@ update_overall_exit() {
     esac
 }
 
+inspect_advisories() {
+    local context="$1"
+    local json="${2:-}"
+    local severity="info"
+    local finding_count="0"
+    local actions=""
+
+    [[ -n "$json" ]] || return 0
+
+    severity="$(extract_advisory_severity "$json" 2>/dev/null || echo "info")"
+    finding_count="$(extract_advisory_finding_count "$json" 2>/dev/null || echo "0")"
+
+    [[ "$finding_count" =~ ^[0-9]+$ ]] || finding_count="0"
+    if [[ "$finding_count" -eq 0 ]]; then
+        return 0
+    fi
+
+    actions="$(extract_advisory_recommended_actions "$json" 2>/dev/null || true)"
+
+    echo "$LOG_PREFIX  Advisories for $context: count=$finding_count severity=$severity"
+    if [[ -n "$actions" ]]; then
+        echo "$LOG_PREFIX  Recommended actions for $context: $actions"
+    fi
+}
+
 # Prefer credentials injected by the caller/CI. Fall back to a repo-local
 # .env only for workstation-style usage of this example script.
-if [[ -z "${ORG_ID:-}" || -z "${CLIENT_ID:-}" || -z "${SECRET:-}" || -z "${SCOPES:-}" ]]; then
-    if [[ -f "$PROJECT_ROOT/.env" ]]; then
-        set -a
-        # shellcheck source=/dev/null
-        source "$PROJECT_ROOT/.env"
-        set +a
-    fi
-fi
+load_auth_from_project_dotenv "$PROJECT_ROOT"
 
 cd "$PROJECT_ROOT"
 
@@ -98,7 +116,7 @@ for DV_ID in $DATA_VIEW_IDS; do
 
     # Detect whether prior snapshots exist for this data view
     capture_command_output SNAP_LIST_EXIT SNAP_LIST_OUTPUT \
-        uv run cja_auto_sdr --list-snapshots --format json --output - "$DV_ID" 2>/dev/null
+        uv run cja_auto_sdr --list-snapshots --snapshot-dir "$SNAPSHOT_DIR" --format json --output - "$DV_ID" 2>/dev/null
     exit_on_signal_exit "$SNAP_LIST_EXIT" "$LOG_PREFIX ERROR: Snapshot list interrupted for $DV_ID"
 
     if [[ $SNAP_LIST_EXIT -ne 0 ]]; then
@@ -128,6 +146,7 @@ for DV_ID in $DATA_VIEW_IDS; do
         if [[ -n "$DIFF_OUTPUT" ]]; then
             printf '%s\n' "$DIFF_OUTPUT" > "$REPORT_RUN_DIR/${DV_ID}_diff.json"
         fi
+        inspect_advisories "diff $DV_ID" "$DIFF_OUTPUT"
 
         case $DIFF_EXIT in
             0) echo "$LOG_PREFIX  No changes detected for $DV_ID" ;;
@@ -171,6 +190,7 @@ exit_on_signal_exit "$ORG_EXIT" "$LOG_PREFIX ERROR: Org report interrupted"
 if [[ -n "$ORG_OUTPUT" ]]; then
     printf '%s\n' "$ORG_OUTPUT" > "$REPORT_RUN_DIR/org_report.json"
 fi
+inspect_advisories "org report" "$ORG_OUTPUT"
 
 case $ORG_EXIT in
     0) echo "$LOG_PREFIX Org report: OK" ;;

--- a/examples/agent-workflows/audit_and_report.sh
+++ b/examples/agent-workflows/audit_and_report.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# audit_and_report.sh — Periodic audit: discover all data views, compare with
+# prior snapshots (or create baselines), then run org-wide report.
+#
+# Designed for agent/automation use:
+#   - Uses --agent-mode (expands to --format json --output - --log-format json)
+#   - Parses discovery output using the dataViews JSON shape
+#   - Detects first-run and creates baselines without --compare-with-prev
+#   - Remains ID-first throughout; never uses display names for unattended ops
+#
+# Environment variables:
+#   REPORT_DIR      — output directory for reports (default: ./reports)
+#   SNAPSHOT_DIR    — snapshot directory (default: ./snapshots)
+#
+# Exit codes follow cja_auto_sdr conventions:
+#   0 = success, 1 = error, 2 = policy/changes detected, 3 = warning
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+REPORT_DIR="${REPORT_DIR:-$PROJECT_ROOT/reports}"
+SNAPSHOT_DIR="${SNAPSHOT_DIR:-$PROJECT_ROOT/snapshots}"
+LOG_PREFIX="[$(date '+%Y-%m-%d %H:%M:%S')]"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/_common.sh"
+
+update_overall_exit() {
+    local code="${1:-0}"
+
+    if is_signal_exit_code "$OVERALL_EXIT"; then
+        return
+    fi
+
+    if is_signal_exit_code "$code"; then
+        OVERALL_EXIT="$code"
+        return
+    fi
+
+    case "$code" in
+        0) ;;
+        1) OVERALL_EXIT=1 ;;
+        2) [[ $OVERALL_EXIT -ne 1 ]] && OVERALL_EXIT=2 ;;
+        3) [[ $OVERALL_EXIT -eq 0 ]] && OVERALL_EXIT=3 ;;
+        *) OVERALL_EXIT=1 ;;
+    esac
+}
+
+# Prefer credentials injected by the caller/CI. Fall back to a repo-local
+# .env only for workstation-style usage of this example script.
+if [[ -z "${ORG_ID:-}" || -z "${CLIENT_ID:-}" || -z "${SECRET:-}" || -z "${SCOPES:-}" ]]; then
+    if [[ -f "$PROJECT_ROOT/.env" ]]; then
+        set -a
+        # shellcheck source=/dev/null
+        source "$PROJECT_ROOT/.env"
+        set +a
+    fi
+fi
+
+cd "$PROJECT_ROOT"
+
+echo "$LOG_PREFIX Starting audit and report"
+
+# --- Step 1: Discover data views (ID-first, agent-mode JSON output) ---
+# --agent-mode expands to --format json --output - --log-format json
+capture_command_output DISCOVER_EXIT DISCOVER_OUTPUT \
+    uv run cja_auto_sdr --list-dataviews --agent-mode
+exit_on_signal_exit "$DISCOVER_EXIT" "$LOG_PREFIX ERROR: Discovery interrupted"
+
+if [[ $DISCOVER_EXIT -ne 0 ]]; then
+    echo "$LOG_PREFIX ERROR: Failed to list data views (exit $DISCOVER_EXIT)" >&2
+    exit 1
+fi
+
+# Parse IDs from the dataViews array in the JSON response
+DATA_VIEW_IDS=$(extract_dataview_ids "$DISCOVER_OUTPUT") || {
+    echo "$LOG_PREFIX ERROR: Failed to parse data view IDs from discovery output" >&2
+    exit 1
+}
+
+if [[ -z "$DATA_VIEW_IDS" ]]; then
+    echo "$LOG_PREFIX ERROR: No data view IDs found in discovery output" >&2
+    exit 1
+fi
+
+mkdir -p "$REPORT_DIR" "$SNAPSHOT_DIR"
+
+OVERALL_EXIT=0
+
+# --- Step 2: Per-data-view snapshot comparison or baseline creation ---
+for DV_ID in $DATA_VIEW_IDS; do
+    echo "$LOG_PREFIX Processing data view: $DV_ID"
+
+    # Detect whether prior snapshots exist for this data view
+    capture_command_output SNAP_LIST_EXIT SNAP_LIST_OUTPUT \
+        uv run cja_auto_sdr --list-snapshots --format json --output - "$DV_ID" 2>/dev/null
+    exit_on_signal_exit "$SNAP_LIST_EXIT" "$LOG_PREFIX ERROR: Snapshot list interrupted for $DV_ID"
+
+    HAS_SNAPSHOTS=0
+    if [[ $SNAP_LIST_EXIT -eq 0 && -n "$SNAP_LIST_OUTPUT" ]]; then
+        # Check if there are any snapshots in the list
+        SNAP_COUNT=$(printf '%s' "$SNAP_LIST_OUTPUT" | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+    snaps = data if isinstance(data, list) else data.get('snapshots', [])
+    print(len(snaps))
+except Exception:
+    print(0)
+" 2>/dev/null) || SNAP_COUNT=0
+        [[ "${SNAP_COUNT:-0}" -gt 0 ]] && HAS_SNAPSHOTS=1
+    fi
+
+    if [[ $HAS_SNAPSHOTS -eq 1 ]]; then
+        # Prior snapshots exist — run comparison and auto-update snapshot
+        echo "$LOG_PREFIX  Comparing with previous snapshot for $DV_ID"
+        capture_command_output DIFF_EXIT DIFF_OUTPUT \
+            uv run cja_auto_sdr "$DV_ID" --compare-with-prev --agent-mode \
+                --auto-snapshot --snapshot-dir "$SNAPSHOT_DIR" 2>/dev/null
+        exit_on_signal_exit "$DIFF_EXIT" "$LOG_PREFIX  ERROR: Diff comparison interrupted for $DV_ID"
+
+        case $DIFF_EXIT in
+            0) echo "$LOG_PREFIX  No changes detected for $DV_ID" ;;
+            2)
+                echo "$LOG_PREFIX  Changes detected for $DV_ID"
+                update_overall_exit 2
+                ;;
+            3)
+                echo "$LOG_PREFIX  Warning threshold exceeded for $DV_ID"
+                update_overall_exit 3
+                ;;
+            *)
+                echo "$LOG_PREFIX  ERROR: Diff comparison failed for $DV_ID (exit $DIFF_EXIT)" >&2
+                update_overall_exit 1
+                ;;
+        esac
+    else
+        # First run — create baseline snapshot without attempting --compare-with-prev
+        echo "$LOG_PREFIX  No prior snapshots found. Creating baseline for $DV_ID"
+        capture_command_exit BASELINE_EXIT \
+            uv run cja_auto_sdr "$DV_ID" --snapshot "$SNAPSHOT_DIR/${DV_ID}_baseline.json"
+        exit_on_signal_exit "$BASELINE_EXIT" "$LOG_PREFIX  ERROR: Baseline creation interrupted for $DV_ID"
+
+        case $BASELINE_EXIT in
+            0) echo "$LOG_PREFIX  Baseline created for $DV_ID" ;;
+            *)
+                echo "$LOG_PREFIX  ERROR: Baseline creation failed for $DV_ID (exit $BASELINE_EXIT)" >&2
+                update_overall_exit 1
+                ;;
+        esac
+    fi
+done
+
+# --- Step 3: Org-wide report ---
+echo "$LOG_PREFIX Running org-wide report"
+
+capture_command_output ORG_EXIT ORG_OUTPUT \
+    uv run cja_auto_sdr --org-report --agent-mode
+exit_on_signal_exit "$ORG_EXIT" "$LOG_PREFIX ERROR: Org report interrupted"
+
+case $ORG_EXIT in
+    0) echo "$LOG_PREFIX Org report: OK" ;;
+    2)
+        echo "$LOG_PREFIX Org report: thresholds exceeded"
+        update_overall_exit 2
+        ;;
+    3)
+        echo "$LOG_PREFIX Org report: warning threshold exceeded"
+        update_overall_exit 3
+        ;;
+    *)
+        echo "$LOG_PREFIX ERROR: Org report failed (exit $ORG_EXIT)" >&2
+        update_overall_exit 1
+        ;;
+esac
+
+echo "$LOG_PREFIX Audit and report complete (exit: $OVERALL_EXIT)"
+notify "CJA audit complete — exit $OVERALL_EXIT"
+
+exit "$OVERALL_EXIT"

--- a/examples/agent-workflows/audit_and_report.sh
+++ b/examples/agent-workflows/audit_and_report.sh
@@ -6,6 +6,7 @@
 #   - Uses --agent-mode (expands to --format json --output - --log-format json)
 #   - Parses discovery output using the dataViews JSON shape
 #   - Detects first-run and creates baselines without --compare-with-prev
+#   - Persists machine-readable diff and org-report JSON artifacts under REPORT_DIR
 #   - Remains ID-first throughout; never uses display names for unattended ops
 #
 # Environment variables:
@@ -21,6 +22,8 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 REPORT_DIR="${REPORT_DIR:-$PROJECT_ROOT/reports}"
 SNAPSHOT_DIR="${SNAPSHOT_DIR:-$PROJECT_ROOT/snapshots}"
+RUN_ID="$(date '+%Y%m%dT%H%M%S')"
+REPORT_RUN_DIR="$REPORT_DIR/audit-$RUN_ID"
 LOG_PREFIX="[$(date '+%Y-%m-%d %H:%M:%S')]"
 
 # shellcheck source=/dev/null
@@ -84,7 +87,8 @@ if [[ -z "$DATA_VIEW_IDS" ]]; then
     exit 1
 fi
 
-mkdir -p "$REPORT_DIR" "$SNAPSHOT_DIR"
+mkdir -p "$REPORT_RUN_DIR" "$SNAPSHOT_DIR"
+printf '%s\n' "$DISCOVER_OUTPUT" > "$REPORT_RUN_DIR/discovery.json"
 
 OVERALL_EXIT=0
 
@@ -97,18 +101,19 @@ for DV_ID in $DATA_VIEW_IDS; do
         uv run cja_auto_sdr --list-snapshots --format json --output - "$DV_ID" 2>/dev/null
     exit_on_signal_exit "$SNAP_LIST_EXIT" "$LOG_PREFIX ERROR: Snapshot list interrupted for $DV_ID"
 
+    if [[ $SNAP_LIST_EXIT -ne 0 ]]; then
+        echo "$LOG_PREFIX  ERROR: Snapshot list failed for $DV_ID (exit $SNAP_LIST_EXIT)" >&2
+        update_overall_exit 1
+        continue
+    fi
+
     HAS_SNAPSHOTS=0
-    if [[ $SNAP_LIST_EXIT -eq 0 && -n "$SNAP_LIST_OUTPUT" ]]; then
-        # Check if there are any snapshots in the list
-        SNAP_COUNT=$(printf '%s' "$SNAP_LIST_OUTPUT" | python3 -c "
-import sys, json
-try:
-    data = json.load(sys.stdin)
-    snaps = data if isinstance(data, list) else data.get('snapshots', [])
-    print(len(snaps))
-except Exception:
-    print(0)
-" 2>/dev/null) || SNAP_COUNT=0
+    if [[ -n "$SNAP_LIST_OUTPUT" ]]; then
+        SNAP_COUNT="$(extract_snapshot_count "$SNAP_LIST_OUTPUT" 2>/dev/null)" || {
+            echo "$LOG_PREFIX  ERROR: Failed to parse snapshot inventory for $DV_ID" >&2
+            update_overall_exit 1
+            continue
+        }
         [[ "${SNAP_COUNT:-0}" -gt 0 ]] && HAS_SNAPSHOTS=1
     fi
 
@@ -119,6 +124,10 @@ except Exception:
             uv run cja_auto_sdr "$DV_ID" --compare-with-prev --agent-mode \
                 --auto-snapshot --snapshot-dir "$SNAPSHOT_DIR" 2>/dev/null
         exit_on_signal_exit "$DIFF_EXIT" "$LOG_PREFIX  ERROR: Diff comparison interrupted for $DV_ID"
+
+        if [[ -n "$DIFF_OUTPUT" ]]; then
+            printf '%s\n' "$DIFF_OUTPUT" > "$REPORT_RUN_DIR/${DV_ID}_diff.json"
+        fi
 
         case $DIFF_EXIT in
             0) echo "$LOG_PREFIX  No changes detected for $DV_ID" ;;
@@ -159,6 +168,10 @@ capture_command_output ORG_EXIT ORG_OUTPUT \
     uv run cja_auto_sdr --org-report --agent-mode
 exit_on_signal_exit "$ORG_EXIT" "$LOG_PREFIX ERROR: Org report interrupted"
 
+if [[ -n "$ORG_OUTPUT" ]]; then
+    printf '%s\n' "$ORG_OUTPUT" > "$REPORT_RUN_DIR/org_report.json"
+fi
+
 case $ORG_EXIT in
     0) echo "$LOG_PREFIX Org report: OK" ;;
     2)
@@ -175,6 +188,7 @@ case $ORG_EXIT in
         ;;
 esac
 
+echo "$LOG_PREFIX Reports saved to: $REPORT_RUN_DIR"
 echo "$LOG_PREFIX Audit and report complete (exit: $OVERALL_EXIT)"
 notify "CJA audit complete — exit $OVERALL_EXIT"
 

--- a/examples/agent-workflows/onboard_dataview.sh
+++ b/examples/agent-workflows/onboard_dataview.sh
@@ -33,14 +33,7 @@ source "$SCRIPT_DIR/_common.sh"
 
 # Prefer credentials injected by the caller/CI. Fall back to a repo-local
 # .env only for workstation-style usage of this example script.
-if [[ -z "${ORG_ID:-}" || -z "${CLIENT_ID:-}" || -z "${SECRET:-}" || -z "${SCOPES:-}" ]]; then
-    if [[ -f "$PROJECT_ROOT/.env" ]]; then
-        set -a
-        # shellcheck source=/dev/null
-        source "$PROJECT_ROOT/.env"
-        set +a
-    fi
-fi
+load_auth_from_project_dotenv "$PROJECT_ROOT"
 
 require_env DATA_VIEW_ID
 
@@ -50,8 +43,12 @@ echo "$LOG_PREFIX Onboarding data view: $DATA_VIEW_ID"
 
 # --- Step 1: Config preflight ---
 echo "$LOG_PREFIX Running config preflight"
-if ! uv run cja_auto_sdr --validate-config; then
-    echo "$LOG_PREFIX ERROR: Configuration validation failed" >&2
+capture_command_exit VALIDATE_EXIT \
+    uv run cja_auto_sdr --validate-config
+exit_on_signal_exit "$VALIDATE_EXIT" "$LOG_PREFIX ERROR: Configuration validation interrupted"
+
+if [[ $VALIDATE_EXIT -ne 0 ]]; then
+    echo "$LOG_PREFIX ERROR: Configuration validation failed (exit $VALIDATE_EXIT)" >&2
     exit 1
 fi
 echo "$LOG_PREFIX Configuration validated"

--- a/examples/agent-workflows/onboard_dataview.sh
+++ b/examples/agent-workflows/onboard_dataview.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# onboard_dataview.sh — Onboard a new data view: validate config, inspect,
+# generate SDR with quality gating, and save a baseline snapshot.
+#
+# Designed for agent/automation use:
+#   - Uses --agent-mode (expands to --format json --output - --log-format json)
+#   - Uses IDs, never display names, for unattended operations
+#   - Exits non-zero on quality gate failure (--fail-on-quality MEDIUM)
+#
+# Usage:
+#   DATA_VIEW_ID=dv_abc123 ./onboard_dataview.sh
+#
+# Environment variables:
+#   DATA_VIEW_ID    — data view to onboard (required)
+#   SNAPSHOT_DIR    — snapshot directory (default: ./snapshots)
+#   QUALITY_GATE    — quality level for --fail-on-quality (default: MEDIUM)
+#
+# Exit codes follow cja_auto_sdr conventions:
+#   0 = success, 1 = error, 2 = quality gate breached
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SNAPSHOT_DIR="${SNAPSHOT_DIR:-$PROJECT_ROOT/snapshots}"
+QUALITY_GATE="${QUALITY_GATE:-MEDIUM}"
+LOG_PREFIX="[$(date '+%Y-%m-%d %H:%M:%S')]"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/_common.sh"
+
+# Prefer credentials injected by the caller/CI. Fall back to a repo-local
+# .env only for workstation-style usage of this example script.
+if [[ -z "${ORG_ID:-}" || -z "${CLIENT_ID:-}" || -z "${SECRET:-}" || -z "${SCOPES:-}" ]]; then
+    if [[ -f "$PROJECT_ROOT/.env" ]]; then
+        set -a
+        # shellcheck source=/dev/null
+        source "$PROJECT_ROOT/.env"
+        set +a
+    fi
+fi
+
+require_env DATA_VIEW_ID
+
+cd "$PROJECT_ROOT"
+
+echo "$LOG_PREFIX Onboarding data view: $DATA_VIEW_ID"
+
+# --- Step 1: Config preflight ---
+echo "$LOG_PREFIX Running config preflight"
+if ! uv run cja_auto_sdr --validate-config; then
+    echo "$LOG_PREFIX ERROR: Configuration validation failed" >&2
+    exit 1
+fi
+echo "$LOG_PREFIX Configuration validated"
+
+# --- Step 2: Inspect data view metadata ---
+echo "$LOG_PREFIX Inspecting data view $DATA_VIEW_ID"
+capture_command_output DESCRIBE_EXIT DESCRIBE_OUTPUT \
+    uv run cja_auto_sdr --describe-dataview "$DATA_VIEW_ID" --agent-mode
+exit_on_signal_exit "$DESCRIBE_EXIT" "$LOG_PREFIX ERROR: Describe interrupted"
+
+if [[ $DESCRIBE_EXIT -ne 0 ]]; then
+    echo "$LOG_PREFIX ERROR: Failed to describe data view $DATA_VIEW_ID (exit $DESCRIBE_EXIT)" >&2
+    exit 1
+fi
+echo "$LOG_PREFIX Data view inspection complete"
+
+# --- Step 3: Generate SDR with quality gating ---
+echo "$LOG_PREFIX Generating SDR with quality gate: $QUALITY_GATE"
+
+mkdir -p "$SNAPSHOT_DIR"
+
+capture_command_output SDR_EXIT SDR_OUTPUT \
+    uv run cja_auto_sdr "$DATA_VIEW_ID" --agent-mode \
+        --fail-on-quality "$QUALITY_GATE"
+exit_on_signal_exit "$SDR_EXIT" "$LOG_PREFIX ERROR: SDR generation interrupted"
+
+case $SDR_EXIT in
+    0)
+        echo "$LOG_PREFIX SDR generated successfully"
+        ;;
+    2)
+        echo "$LOG_PREFIX Quality gate breached ($QUALITY_GATE) for $DATA_VIEW_ID" >&2
+        # Capture advisory severity for notification
+        SEVERITY=$(extract_advisory_severity "$SDR_OUTPUT" 2>/dev/null || echo "unknown")
+        notify "Quality gate breach — $DATA_VIEW_ID severity=$SEVERITY"
+        exit 2
+        ;;
+    *)
+        echo "$LOG_PREFIX ERROR: SDR generation failed for $DATA_VIEW_ID (exit $SDR_EXIT)" >&2
+        exit 1
+        ;;
+esac
+
+# --- Step 4: Save baseline snapshot ---
+echo "$LOG_PREFIX Saving baseline snapshot"
+
+BASELINE="$SNAPSHOT_DIR/${DATA_VIEW_ID}_baseline.json"
+capture_command_exit SNAPSHOT_EXIT \
+    uv run cja_auto_sdr "$DATA_VIEW_ID" --snapshot "$BASELINE"
+exit_on_signal_exit "$SNAPSHOT_EXIT" "$LOG_PREFIX ERROR: Baseline snapshot interrupted"
+
+case $SNAPSHOT_EXIT in
+    0)
+        echo "$LOG_PREFIX Baseline snapshot saved: $BASELINE"
+        ;;
+    *)
+        echo "$LOG_PREFIX ERROR: Baseline snapshot failed (exit $SNAPSHOT_EXIT)" >&2
+        exit 1
+        ;;
+esac
+
+echo "$LOG_PREFIX Onboarding complete for $DATA_VIEW_ID"
+notify "Onboarding complete — $DATA_VIEW_ID"
+
+exit 0

--- a/examples/agent-workflows/onboard_dataview.sh
+++ b/examples/agent-workflows/onboard_dataview.sh
@@ -12,6 +12,7 @@
 #
 # Environment variables:
 #   DATA_VIEW_ID    — data view to onboard (required)
+#   REPORT_DIR      — output directory for SDR artifacts and run summary (default: ./reports)
 #   SNAPSHOT_DIR    — snapshot directory (default: ./snapshots)
 #   QUALITY_GATE    — quality level for --fail-on-quality (default: MEDIUM)
 #
@@ -22,6 +23,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+REPORT_DIR="${REPORT_DIR:-$PROJECT_ROOT/reports}"
 SNAPSHOT_DIR="${SNAPSHOT_DIR:-$PROJECT_ROOT/snapshots}"
 QUALITY_GATE="${QUALITY_GATE:-MEDIUM}"
 LOG_PREFIX="[$(date '+%Y-%m-%d %H:%M:%S')]"
@@ -69,21 +71,30 @@ echo "$LOG_PREFIX Data view inspection complete"
 # --- Step 3: Generate SDR with quality gating ---
 echo "$LOG_PREFIX Generating SDR with quality gate: $QUALITY_GATE"
 
-mkdir -p "$SNAPSHOT_DIR"
+mkdir -p "$REPORT_DIR" "$SNAPSHOT_DIR"
+
+RUN_SUMMARY_FILE="$REPORT_DIR/${DATA_VIEW_ID}_run_summary.json"
 
 capture_command_output SDR_EXIT SDR_OUTPUT \
     uv run cja_auto_sdr "$DATA_VIEW_ID" --agent-mode \
-        --fail-on-quality "$QUALITY_GATE"
+        --output-dir "$REPORT_DIR" \
+        --fail-on-quality "$QUALITY_GATE" \
+        --run-summary-json "$RUN_SUMMARY_FILE"
 exit_on_signal_exit "$SDR_EXIT" "$LOG_PREFIX ERROR: SDR generation interrupted"
 
 case $SDR_EXIT in
     0)
         echo "$LOG_PREFIX SDR generated successfully"
+        echo "$LOG_PREFIX SDR artifacts written to: $REPORT_DIR"
+        echo "$LOG_PREFIX Run summary written to: $RUN_SUMMARY_FILE"
         ;;
     2)
         echo "$LOG_PREFIX Quality gate breached ($QUALITY_GATE) for $DATA_VIEW_ID" >&2
-        # Capture advisory severity for notification
-        SEVERITY=$(extract_advisory_severity "$SDR_OUTPUT" 2>/dev/null || echo "unknown")
+        SEVERITY="unknown"
+        if [[ -f "$RUN_SUMMARY_FILE" ]]; then
+            RUN_SUMMARY_JSON="$(<"$RUN_SUMMARY_FILE")"
+            SEVERITY=$(extract_highest_quality_severity_from_run_summary "$RUN_SUMMARY_JSON" 2>/dev/null || echo "unknown")
+        fi
         notify "Quality gate breach — $DATA_VIEW_ID severity=$SEVERITY"
         exit 2
         ;;

--- a/examples/agent-workflows/quarterly_governance.sh
+++ b/examples/agent-workflows/quarterly_governance.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# quarterly_governance.sh — Quarterly governance review: trending analysis,
+# threshold enforcement, and human-facing artifact generation.
+#
+# Designed for agent/automation use:
+#   - Uses --agent-mode (expands to --format json --output - --log-format json)
+#   - Parses structured JSON from org-report for programmatic decisions
+#   - Generates human-facing artifacts (markdown) as a separate pass
+#   - Emits a compact summary at completion
+#
+# Environment variables:
+#   REPORT_DIR       — output directory for reports (default: ./reports)
+#   TRENDING_WINDOW  — number of snapshots for drift window (default: 4)
+#
+# Exit codes follow cja_auto_sdr conventions:
+#   0 = success, 1 = error, 2 = policy threshold exceeded
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+REPORT_DIR="${REPORT_DIR:-$PROJECT_ROOT/reports}"
+TRENDING_WINDOW="${TRENDING_WINDOW:-4}"
+QUARTER="Q$(( ($(date +%-m) - 1) / 3 + 1 ))-$(date +%Y)"
+QUARTER_DIR="$REPORT_DIR/$QUARTER"
+LOG_PREFIX="[$(date '+%Y-%m-%d %H:%M:%S')]"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/_common.sh"
+
+# Prefer credentials injected by the caller/CI. Fall back to a repo-local
+# .env only for workstation-style usage of this example script.
+if [[ -z "${ORG_ID:-}" || -z "${CLIENT_ID:-}" || -z "${SECRET:-}" || -z "${SCOPES:-}" ]]; then
+    if [[ -f "$PROJECT_ROOT/.env" ]]; then
+        set -a
+        # shellcheck source=/dev/null
+        source "$PROJECT_ROOT/.env"
+        set +a
+    fi
+fi
+
+cd "$PROJECT_ROOT"
+
+echo "$LOG_PREFIX === Quarterly governance: $QUARTER (window=$TRENDING_WINDOW) ==="
+
+mkdir -p "$QUARTER_DIR"
+
+OVERALL_EXIT=0
+
+# --- Step 1: Org-report with trending analysis (machine-readable, agent-mode) ---
+echo "$LOG_PREFIX Running org-report with trending (window=$TRENDING_WINDOW)"
+
+capture_command_output ORG_EXIT ORG_OUTPUT \
+    uv run cja_auto_sdr --org-report \
+        --trending-window "$TRENDING_WINDOW" \
+        --fail-on-threshold \
+        --agent-mode
+exit_on_signal_exit "$ORG_EXIT" "$LOG_PREFIX ERROR: Org report interrupted"
+
+# Persist the machine-readable report for downstream tooling
+printf '%s\n' "$ORG_OUTPUT" > "$QUARTER_DIR/org_governance.json"
+
+case $ORG_EXIT in
+    0)
+        echo "$LOG_PREFIX Org governance report: PASS"
+        ;;
+    2)
+        echo "$LOG_PREFIX Org governance report: THRESHOLDS EXCEEDED — see $QUARTER_DIR/org_governance.json"
+        OVERALL_EXIT=2
+        notify "Quarterly governance threshold exceeded — $QUARTER"
+        ;;
+    *)
+        echo "$LOG_PREFIX ERROR: Org governance report failed (exit $ORG_EXIT)" >&2
+        exit 1
+        ;;
+esac
+
+# --- Step 2: Human-facing artifact (markdown) — generated separately ---
+echo "$LOG_PREFIX Generating human-facing governance report (markdown)"
+
+capture_command_exit MD_EXIT \
+    uv run cja_auto_sdr --org-report \
+        --trending-window "$TRENDING_WINDOW" \
+        --format markdown \
+        --output "$QUARTER_DIR/org_governance.md"
+exit_on_signal_exit "$MD_EXIT" "$LOG_PREFIX ERROR: Markdown export interrupted"
+
+case $MD_EXIT in
+    0)
+        echo "$LOG_PREFIX Markdown governance report saved: $QUARTER_DIR/org_governance.md"
+        ;;
+    2)
+        echo "$LOG_PREFIX Markdown report: threshold exceeded (recorded)"
+        [[ $OVERALL_EXIT -ne 1 ]] && OVERALL_EXIT=2
+        ;;
+    *)
+        echo "$LOG_PREFIX WARNING: Markdown export failed (exit $MD_EXIT); continuing" >&2
+        [[ $OVERALL_EXIT -ne 2 ]] && OVERALL_EXIT=1
+        ;;
+esac
+
+# --- Step 3: Compact summary ---
+GOVERNANCE_STATUS="PASS"
+[[ $OVERALL_EXIT -eq 2 ]] && GOVERNANCE_STATUS="THRESHOLDS_EXCEEDED"
+[[ $OVERALL_EXIT -eq 1 ]] && GOVERNANCE_STATUS="ERROR"
+
+echo "$LOG_PREFIX === Summary: quarter=$QUARTER status=$GOVERNANCE_STATUS exit=$OVERALL_EXIT ==="
+echo "$LOG_PREFIX Reports saved to: $QUARTER_DIR"
+
+notify "Quarterly governance $QUARTER — $GOVERNANCE_STATUS"
+
+exit "$OVERALL_EXIT"

--- a/examples/agent-workflows/quarterly_governance.sh
+++ b/examples/agent-workflows/quarterly_governance.sh
@@ -10,7 +10,11 @@
 #
 # Environment variables:
 #   REPORT_DIR       — output directory for reports (default: ./reports)
-#   TRENDING_WINDOW  — number of snapshots for drift window (default: 4)
+#   SNAPSHOT_DIR     — snapshot directory to prune (default: ./snapshots)
+#   KEEP_LAST        — number of snapshots to retain after pruning (default: 4)
+#   TRENDING_WINDOW  — number of snapshots for drift window (default: 10)
+#   DUPLICATE_THRESHOLD — max allowed high-similarity pairs (default: 5)
+#   ISOLATED_THRESHOLD  — max allowed isolated component percentage (default: 0.35)
 #
 # Exit codes follow cja_auto_sdr conventions:
 #   0 = success, 1 = error, 2 = policy threshold exceeded
@@ -20,7 +24,11 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 REPORT_DIR="${REPORT_DIR:-$PROJECT_ROOT/reports}"
-TRENDING_WINDOW="${TRENDING_WINDOW:-4}"
+SNAPSHOT_DIR="${SNAPSHOT_DIR:-$PROJECT_ROOT/snapshots}"
+KEEP_LAST="${KEEP_LAST:-4}"
+TRENDING_WINDOW="${TRENDING_WINDOW:-10}"
+DUPLICATE_THRESHOLD="${DUPLICATE_THRESHOLD:-5}"
+ISOLATED_THRESHOLD="${ISOLATED_THRESHOLD:-0.35}"
 QUARTER="Q$(( ($(date +%-m) - 1) / 3 + 1 ))-$(date +%Y)"
 QUARTER_DIR="$REPORT_DIR/$QUARTER"
 LOG_PREFIX="[$(date '+%Y-%m-%d %H:%M:%S')]"
@@ -30,20 +38,13 @@ source "$SCRIPT_DIR/_common.sh"
 
 # Prefer credentials injected by the caller/CI. Fall back to a repo-local
 # .env only for workstation-style usage of this example script.
-if [[ -z "${ORG_ID:-}" || -z "${CLIENT_ID:-}" || -z "${SECRET:-}" || -z "${SCOPES:-}" ]]; then
-    if [[ -f "$PROJECT_ROOT/.env" ]]; then
-        set -a
-        # shellcheck source=/dev/null
-        source "$PROJECT_ROOT/.env"
-        set +a
-    fi
-fi
+load_auth_from_project_dotenv "$PROJECT_ROOT"
 
 cd "$PROJECT_ROOT"
 
 echo "$LOG_PREFIX === Quarterly governance: $QUARTER (window=$TRENDING_WINDOW) ==="
 
-mkdir -p "$QUARTER_DIR"
+mkdir -p "$QUARTER_DIR" "$SNAPSHOT_DIR"
 
 OVERALL_EXIT=0
 
@@ -53,6 +54,8 @@ echo "$LOG_PREFIX Running org-report with trending (window=$TRENDING_WINDOW)"
 capture_command_output ORG_EXIT ORG_OUTPUT \
     uv run cja_auto_sdr --org-report \
         --trending-window "$TRENDING_WINDOW" \
+        --duplicate-threshold "$DUPLICATE_THRESHOLD" \
+        --isolated-threshold "$ISOLATED_THRESHOLD" \
         --fail-on-threshold \
         --agent-mode
 exit_on_signal_exit "$ORG_EXIT" "$LOG_PREFIX ERROR: Org report interrupted"
@@ -81,6 +84,9 @@ echo "$LOG_PREFIX Generating human-facing governance report (markdown)"
 capture_command_exit MD_EXIT \
     uv run cja_auto_sdr --org-report \
         --trending-window "$TRENDING_WINDOW" \
+        --duplicate-threshold "$DUPLICATE_THRESHOLD" \
+        --isolated-threshold "$ISOLATED_THRESHOLD" \
+        --fail-on-threshold \
         --format markdown \
         --output "$QUARTER_DIR/org_governance.md"
 exit_on_signal_exit "$MD_EXIT" "$LOG_PREFIX ERROR: Markdown export interrupted"
@@ -95,11 +101,30 @@ case $MD_EXIT in
         ;;
     *)
         echo "$LOG_PREFIX WARNING: Markdown export failed (exit $MD_EXIT); continuing" >&2
-        [[ $OVERALL_EXIT -ne 2 ]] && OVERALL_EXIT=1
+        OVERALL_EXIT=1
         ;;
 esac
 
-# --- Step 3: Compact summary ---
+# --- Step 3: Snapshot pruning ---
+echo "$LOG_PREFIX Pruning snapshots (keeping last $KEEP_LAST)"
+
+capture_command_exit PRUNE_EXIT \
+    uv run cja_auto_sdr --prune-snapshots \
+        --keep-last "$KEEP_LAST" \
+        --snapshot-dir "$SNAPSHOT_DIR"
+exit_on_signal_exit "$PRUNE_EXIT" "$LOG_PREFIX ERROR: Snapshot pruning interrupted"
+
+case $PRUNE_EXIT in
+    0)
+        echo "$LOG_PREFIX Snapshot pruning complete"
+        ;;
+    *)
+        echo "$LOG_PREFIX WARNING: Snapshot pruning failed (exit $PRUNE_EXIT); continuing" >&2
+        OVERALL_EXIT=1
+        ;;
+esac
+
+# --- Step 4: Compact summary ---
 GOVERNANCE_STATUS="PASS"
 [[ $OVERALL_EXIT -eq 2 ]] && GOVERNANCE_STATUS="THRESHOLDS_EXCEEDED"
 [[ $OVERALL_EXIT -eq 1 ]] && GOVERNANCE_STATUS="ERROR"

--- a/sample_outputs/agent/README.md
+++ b/sample_outputs/agent/README.md
@@ -1,0 +1,21 @@
+# Agent Contract Fixtures
+
+Representative JSON payloads for agent-facing output contracts.
+
+These fixtures document the stable structural shape of machine-readable output.
+They are intentionally small and exist for contract validation, not as complete
+examples.
+
+## Fixtures
+
+| File | Source Command | Contract Surface |
+|------|--------------|-----------------|
+| `sample_list_dataviews_agent_mode.json` | `--list-dataviews --agent-mode` | `dataViews` collection |
+| `sample_org_report_with_advisories.json` | `--org-report --agent-mode` | Top-level `advisories` |
+| `sample_diff_with_advisories.json` | `--diff --agent-mode` | Top-level `advisories` |
+| `sample_run_summary_with_advisories.json` | `--run-summary-json` | `details.advisories` |
+
+## Stability
+
+These fixtures are tested by `tests/test_agent_contract_samples.py`. Structural
+keys are stable; field values are illustrative.

--- a/sample_outputs/agent/sample_diff_with_advisories.json
+++ b/sample_outputs/agent/sample_diff_with_advisories.json
@@ -1,0 +1,18 @@
+{
+  "metadata": {"generated_at": "2026-03-28T00:00:00Z", "tool_version": "3.5.0"},
+  "summary": {"has_changes": true, "total_changes": 3, "metrics_removed": 1},
+  "advisories": {
+    "advisories_version": "1.0",
+    "severity": "critical",
+    "findings": [
+      {
+        "type": "breaking_changes",
+        "severity": "critical",
+        "message": "1 component removed",
+        "details": {"removed_count": 1},
+        "recommended_actions": ["review_breaking_changes", "update_downstream_dependencies"]
+      }
+    ],
+    "summary": {"total_findings": 1, "by_severity": {"critical": 1}}
+  }
+}

--- a/sample_outputs/agent/sample_diff_with_advisories.json
+++ b/sample_outputs/agent/sample_diff_with_advisories.json
@@ -13,6 +13,7 @@
         "recommended_actions": ["review_breaking_changes", "update_downstream_dependencies"]
       }
     ],
-    "summary": {"total_findings": 1, "by_severity": {"critical": 1}}
+    "summary": {"total_findings": 1, "by_severity": {"critical": 1}},
+    "recommended_actions": ["review_breaking_changes", "update_downstream_dependencies"]
   }
 }

--- a/sample_outputs/agent/sample_list_dataviews_agent_mode.json
+++ b/sample_outputs/agent/sample_list_dataviews_agent_mode.json
@@ -1,0 +1,22 @@
+{
+  "dataViews": [
+    {
+      "id": "dv_example_001",
+      "name": "Web Analytics Production",
+      "description": "Primary web analytics data view",
+      "owner": {
+        "id": 200501,
+        "name": "admin@example.com"
+      }
+    },
+    {
+      "id": "dv_example_002",
+      "name": "Mobile App Events",
+      "description": "Mobile application event tracking",
+      "owner": {
+        "id": 200502,
+        "name": "analyst@example.com"
+      }
+    }
+  ]
+}

--- a/sample_outputs/agent/sample_org_report_with_advisories.json
+++ b/sample_outputs/agent/sample_org_report_with_advisories.json
@@ -1,5 +1,5 @@
 {
-  "report_type": "org_report",
+  "report_type": "org_analysis",
   "data_views_analyzed": 5,
   "advisories": {
     "advisories_version": "1.0",
@@ -8,8 +8,20 @@
       {
         "type": "high_overlap",
         "severity": "warning",
-        "message": "2 data view pairs exceed overlap threshold",
-        "details": {"pairs_count": 2, "threshold": 0.8},
+        "message": "1 data view pair exceeds the effective overlap threshold of 90%.",
+        "details": {
+          "pairs": [
+            {
+              "dv1_id": "dv_prod",
+              "dv1_name": "Production",
+              "dv2_id": "dv_stage",
+              "dv2_name": "Staging",
+              "jaccard_similarity": 0.93
+            }
+          ],
+          "threshold": 0.9,
+          "max_similarity": 0.93
+        },
         "recommended_actions": ["review_overlap_pairs", "verify_intentional_duplicates"]
       }
     ],

--- a/sample_outputs/agent/sample_org_report_with_advisories.json
+++ b/sample_outputs/agent/sample_org_report_with_advisories.json
@@ -1,0 +1,18 @@
+{
+  "report_type": "org_report",
+  "data_views_analyzed": 5,
+  "advisories": {
+    "advisories_version": "1.0",
+    "severity": "warning",
+    "findings": [
+      {
+        "type": "high_overlap",
+        "severity": "warning",
+        "message": "2 data view pairs exceed overlap threshold",
+        "details": {"pairs_count": 2, "threshold": 0.8},
+        "recommended_actions": ["review_overlap_pairs", "verify_intentional_duplicates"]
+      }
+    ],
+    "summary": {"total_findings": 1, "by_severity": {"warning": 1}}
+  }
+}

--- a/sample_outputs/agent/sample_org_report_with_advisories.json
+++ b/sample_outputs/agent/sample_org_report_with_advisories.json
@@ -13,6 +13,7 @@
         "recommended_actions": ["review_overlap_pairs", "verify_intentional_duplicates"]
       }
     ],
-    "summary": {"total_findings": 1, "by_severity": {"warning": 1}}
+    "summary": {"total_findings": 1, "by_severity": {"warning": 1}},
+    "recommended_actions": ["review_overlap_pairs", "verify_intentional_duplicates"]
   }
 }

--- a/sample_outputs/agent/sample_run_summary_with_advisories.json
+++ b/sample_outputs/agent/sample_run_summary_with_advisories.json
@@ -1,0 +1,15 @@
+{
+  "summary_version": "1.1",
+  "exit_code": 0,
+  "mode": "org_report",
+  "details": {
+    "operation_success": true,
+    "advisories": {
+      "advisories_version": "1.0",
+      "severity": "info",
+      "summary": {"total_findings": 0, "by_severity": {}},
+      "types": [],
+      "recommended_actions": []
+    }
+  }
+}

--- a/src/cja_auto_sdr/cli/option_resolution.py
+++ b/src/cja_auto_sdr/cli/option_resolution.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from typing import NamedTuple
 
 
@@ -29,3 +30,25 @@ def resolve_long_option_token(option_text: str, known_long_options: frozenset[st
     if len(matches) > 1:
         return LongOptionResolution(canonical_option=None, is_ambiguous=True)
     return LongOptionResolution(canonical_option=None, is_ambiguous=False)
+
+
+def explicit_long_option_dests(
+    argv: list[str] | None,
+    *,
+    tracked_options: set[str],
+    known_long_options: frozenset[str],
+) -> set[str]:
+    """Return argparse dest names for explicitly provided long options.
+
+    Only checks options in tracked_options. Resolves abbreviations against
+    the full known_long_options set. When argv is None, falls back to sys.argv[1:].
+    """
+    tokens = argv if argv is not None else sys.argv[1:]
+    found_dests: set[str] = set()
+    for token in tokens:
+        resolution = resolve_long_option_token(token, known_long_options)
+        if resolution.canonical_option is not None and resolution.canonical_option in tracked_options:
+            # Convert --log-format to log_format
+            dest = resolution.canonical_option.lstrip("-").replace("-", "_")
+            found_dests.add(dest)
+    return found_dests

--- a/src/cja_auto_sdr/cli/parser.py
+++ b/src/cja_auto_sdr/cli/parser.py
@@ -22,6 +22,44 @@ from cja_auto_sdr.core.constants import (
     QUALITY_SEVERITY_ORDER,
 )
 from cja_auto_sdr.core.version import __version__
+from cja_auto_sdr.cli.option_resolution import explicit_long_option_dests
+
+_AGENT_MODE_DEFAULTS: dict[str, str] = {
+    "format": "json",
+    "output": "-",
+    "log_format": "json",
+}
+
+
+def _configured_long_options(parser: argparse.ArgumentParser) -> frozenset[str]:
+    """Extract all configured long-option strings from an ArgumentParser."""
+    options: set[str] = set()
+    for action in parser._actions:
+        for opt in action.option_strings:
+            if opt.startswith("--"):
+                options.add(opt)
+    return frozenset(options)
+
+
+def _apply_agent_mode_defaults(
+    args: argparse.Namespace,
+    argv: list[str] | None,
+    *,
+    known_long_options: frozenset[str],
+) -> None:
+    """Apply --agent-mode preset defaults for options not explicitly provided."""
+    if not getattr(args, "agent_mode", False):
+        return
+
+    explicit_dests = explicit_long_option_dests(
+        argv,
+        tracked_options={"--format", "--output", "--log-format"},
+        known_long_options=known_long_options,
+    )
+    for dest, default_value in _AGENT_MODE_DEFAULTS.items():
+        if dest not in explicit_dests:
+            setattr(args, dest, default_value)
+
 
 # Attempt to load argcomplete for shell tab-completion (optional dependency)
 _ARGCOMPLETE_AVAILABLE = False
@@ -1422,4 +1460,6 @@ Requirements:
     if return_parser:
         return parser
 
-    return parser.parse_args(argv)
+    args = parser.parse_args(argv)
+    _apply_agent_mode_defaults(args, argv, known_long_options=_configured_long_options(parser))
+    return args

--- a/src/cja_auto_sdr/cli/parser.py
+++ b/src/cja_auto_sdr/cli/parser.py
@@ -12,6 +12,7 @@ import logging
 import os
 from collections.abc import Callable
 
+from cja_auto_sdr.cli.option_resolution import explicit_long_option_dests
 from cja_auto_sdr.core.constants import (
     DEFAULT_AUTO_PRUNE_KEEP_LAST,
     DEFAULT_AUTO_PRUNE_KEEP_SINCE,
@@ -22,7 +23,6 @@ from cja_auto_sdr.core.constants import (
     QUALITY_SEVERITY_ORDER,
 )
 from cja_auto_sdr.core.version import __version__
-from cja_auto_sdr.cli.option_resolution import explicit_long_option_dests
 
 _AGENT_MODE_DEFAULTS: dict[str, str] = {
     "format": "json",

--- a/src/cja_auto_sdr/cli/parser.py
+++ b/src/cja_auto_sdr/cli/parser.py
@@ -1403,6 +1403,18 @@ Requirements:
         help="Stale lease recovery threshold in seconds for the org-report concurrency lock (default: 3600)",
     )
 
+    # --- Agent Integration ---------------------------------------------------
+    agent_group = parser.add_argument_group("Agent Integration")
+    agent_group.add_argument(
+        "--agent-mode",
+        action="store_true",
+        default=False,
+        help=(
+            "Agent-friendly preset: defaults to --format json --output - --log-format json. "
+            "Existing stdout behavior still implies --quiet."
+        ),
+    )
+
     # Enable shell tab-completion if argcomplete is installed
     if enable_autocomplete and _ARGCOMPLETE_AVAILABLE:
         argcomplete.autocomplete(parser)  # pragma: no cover

--- a/src/cja_auto_sdr/cli/standalone_policy.py
+++ b/src/cja_auto_sdr/cli/standalone_policy.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 
 from cja_auto_sdr.cli.mode_scoped_options import org_report_mode_scoped_dests
 
-_STANDALONE_FAST_PATH_METADATA_DESTS = frozenset({"config_file", "format", "output_dir", "profile"})
+_STANDALONE_FAST_PATH_METADATA_DESTS = frozenset({"agent_mode", "config_file", "format", "output_dir", "profile"})
 _ORG_REPORT_MODE_SCOPED_DESTS = org_report_mode_scoped_dests()
 
 _WRAPPER_EXECUTION_TOLERATED_SEMANTIC_DESTS = frozenset(

--- a/src/cja_auto_sdr/core/advisories.py
+++ b/src/cja_auto_sdr/core/advisories.py
@@ -1,0 +1,51 @@
+# src/cja_auto_sdr/core/advisories.py
+"""Advisory data model for machine-readable interpretation of org/diff results.
+
+Advisories are a derived convenience layer over existing JSON fields. They help
+agents branch faster without hiding or replacing the base data.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+_ADVISORY_SEVERITY_ORDER = ("info", "warning", "critical")
+
+
+@dataclass
+class AdvisoryFinding:
+    """A single advisory finding derived from existing result data."""
+
+    type: str
+    severity: str  # "info" | "warning" | "critical"
+    message: str
+    details: dict[str, Any]
+    recommended_actions: list[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "type": self.type,
+            "severity": self.severity,
+            "message": self.message,
+            "details": self.details,
+            "recommended_actions": self.recommended_actions,
+        }
+
+
+@dataclass
+class AdvisorySummary:
+    """Versioned advisory summary block for JSON output."""
+
+    advisories_version: str  # "1.0"
+    severity: str
+    findings: list[AdvisoryFinding]
+    summary: dict[str, Any]  # {"total_findings": N, "by_severity": {...}}
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "advisories_version": self.advisories_version,
+            "severity": self.severity,
+            "findings": [f.to_dict() for f in self.findings],
+            "summary": self.summary,
+        }

--- a/src/cja_auto_sdr/core/advisories.py
+++ b/src/cja_auto_sdr/core/advisories.py
@@ -7,7 +7,7 @@ agents branch faster without hiding or replacing the base data.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
 _ADVISORY_SEVERITY_ORDER = ("info", "warning", "critical")

--- a/src/cja_auto_sdr/core/advisories.py
+++ b/src/cja_auto_sdr/core/advisories.py
@@ -13,6 +13,15 @@ from typing import Any
 _ADVISORY_SEVERITY_ORDER = ("info", "warning", "critical")
 
 
+def _dedupe_preserving_order(values: list[str]) -> list[str]:
+    """Return unique values while preserving their first-seen order."""
+    unique_values: list[str] = []
+    for value in values:
+        if value not in unique_values:
+            unique_values.append(value)
+    return unique_values
+
+
 @dataclass
 class AdvisoryFinding:
     """A single advisory finding derived from existing result data."""
@@ -42,10 +51,19 @@ class AdvisorySummary:
     findings: list[AdvisoryFinding]
     summary: dict[str, Any]  # {"total_findings": N, "by_severity": {...}}
 
+    def finding_types(self) -> list[str]:
+        """Return the distinct finding types in first-seen order."""
+        return _dedupe_preserving_order([finding.type for finding in self.findings])
+
+    def recommended_actions(self) -> list[str]:
+        """Return the distinct recommended actions in first-seen order."""
+        return _dedupe_preserving_order([action for finding in self.findings for action in finding.recommended_actions])
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "advisories_version": self.advisories_version,
             "severity": self.severity,
             "findings": [f.to_dict() for f in self.findings],
             "summary": self.summary,
+            "recommended_actions": self.recommended_actions(),
         }

--- a/src/cja_auto_sdr/core/advisory_builders.py
+++ b/src/cja_auto_sdr/core/advisory_builders.py
@@ -262,19 +262,10 @@ def build_diff_advisories(
 
 def build_advisory_rollup(summary: AdvisorySummary) -> dict[str, Any]:
     """Build a compact advisory rollup for run-summary integration."""
-    seen_types: list[str] = []
-    seen_actions: list[str] = []
-    for f in summary.findings:
-        if f.type not in seen_types:
-            seen_types.append(f.type)
-        for action in f.recommended_actions:
-            if action not in seen_actions:
-                seen_actions.append(action)
-
     return {
         "advisories_version": summary.advisories_version,
         "severity": summary.severity,
         "summary": summary.summary,
-        "types": seen_types,
-        "recommended_actions": seen_actions,
+        "types": summary.finding_types(),
+        "recommended_actions": summary.recommended_actions(),
     }

--- a/src/cja_auto_sdr/core/advisory_builders.py
+++ b/src/cja_auto_sdr/core/advisory_builders.py
@@ -1,0 +1,154 @@
+# src/cja_auto_sdr/core/advisory_builders.py
+"""Advisory builders — pure functions that derive advisories from result objects.
+
+Each builder consumes canonical in-memory result objects and produces an
+AdvisorySummary. JSON writers serialize builder output; they must not
+independently recalculate findings.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import TYPE_CHECKING, Any
+
+from cja_auto_sdr.core.advisories import (
+    _ADVISORY_SEVERITY_ORDER,
+    AdvisoryFinding,
+    AdvisorySummary,
+)
+
+if TYPE_CHECKING:
+    from cja_auto_sdr.org.models import OrgReportResult, OrgReportTrending
+
+
+def _max_severity(severities: list[str]) -> str:
+    """Return the highest severity level from a list, defaulting to 'info'."""
+    if not severities:
+        return "info"
+    order = {s: i for i, s in enumerate(_ADVISORY_SEVERITY_ORDER)}
+    return max(severities, key=lambda s: order.get(s, 0))
+
+
+def _make_summary_block(findings: list[AdvisoryFinding]) -> dict[str, Any]:
+    """Build the summary dict for an AdvisorySummary."""
+    by_severity: Counter[str] = Counter(f.severity for f in findings)
+    return {
+        "total_findings": len(findings),
+        "by_severity": dict(by_severity),
+    }
+
+
+def build_org_report_advisories(
+    result: OrgReportResult,
+    trending: OrgReportTrending | None = None,
+) -> AdvisorySummary:
+    """Derive an AdvisorySummary from an OrgReportResult.
+
+    This is a pure function — it does not mutate *result* or *trending*.
+
+    Checks performed:
+    - fetch_failures: Any data views with errors → severity warning
+    - high_overlap: Similarity pairs whose Jaccard score >= overlap_threshold → warning
+    - governance_threshold_breach: thresholds_exceeded=True with violations → critical
+    - drift_activity: trending provided with non-empty drift_scores → warning
+    """
+    findings: list[AdvisoryFinding] = []
+
+    # 1. Fetch failures
+    failed_ids = list(result.failed_data_view_ids)
+    if failed_ids:
+        reason_counts = dict(result.failed_data_view_reason_counts)
+        findings.append(
+            AdvisoryFinding(
+                type="fetch_failures",
+                severity="warning",
+                message=f"{len(failed_ids)} data view(s) could not be fetched.",
+                details={
+                    "data_view_ids": failed_ids,
+                    "reason_counts": reason_counts,
+                },
+                recommended_actions=["investigate_fetch_failures"],
+            )
+        )
+
+    # 2. High overlap
+    if result.similarity_pairs is not None:
+        threshold = result.parameters.overlap_threshold
+        high_pairs = [p for p in result.similarity_pairs if p.jaccard_similarity >= threshold]
+        if high_pairs:
+            pair_details = [
+                {
+                    "dv1_id": p.dv1_id,
+                    "dv1_name": p.dv1_name,
+                    "dv2_id": p.dv2_id,
+                    "dv2_name": p.dv2_name,
+                    "jaccard_similarity": p.jaccard_similarity,
+                }
+                for p in high_pairs
+            ]
+            findings.append(
+                AdvisoryFinding(
+                    type="high_overlap",
+                    severity="warning",
+                    message=(f"{len(high_pairs)} data view pair(s) exceed the overlap threshold of {threshold:.0%}."),
+                    details={
+                        "pair_count": len(high_pairs),
+                        "threshold": threshold,
+                        "pairs": pair_details,
+                    },
+                    recommended_actions=[
+                        "review_overlap_pairs",
+                        "verify_intentional_duplicates",
+                    ],
+                )
+            )
+
+    # 3. Governance threshold breach
+    if result.thresholds_exceeded:
+        violations = list(result.governance_violations or [])
+        findings.append(
+            AdvisoryFinding(
+                type="governance_threshold_breach",
+                severity="critical",
+                message="One or more governance thresholds have been exceeded.",
+                details={
+                    "violations": violations,
+                    "violation_count": len(violations),
+                },
+                recommended_actions=[
+                    "review_governance_thresholds",
+                    "remediate_threshold_breach",
+                ],
+            )
+        )
+
+    # 4. Drift activity from trending
+    if trending is not None and trending.drift_scores:
+        drift_scores = dict(trending.drift_scores)
+        findings.append(
+            AdvisoryFinding(
+                type="drift_activity",
+                severity="warning",
+                message=(
+                    f"Drift activity detected across {len(drift_scores)} data view(s) "
+                    f"over a {trending.window_size}-snapshot window."
+                ),
+                details={
+                    "drift_scores": drift_scores,
+                    "data_view_count": len(drift_scores),
+                    "window_size": trending.window_size,
+                },
+                recommended_actions=[
+                    "review_drift_activity",
+                    "compare_recent_reports",
+                ],
+            )
+        )
+
+    severity = _max_severity([f.severity for f in findings])
+    return AdvisorySummary(
+        advisories_version="1.0",
+        severity=severity,
+        findings=findings,
+        summary=_make_summary_block(findings),
+    )

--- a/src/cja_auto_sdr/core/advisory_builders.py
+++ b/src/cja_auto_sdr/core/advisory_builders.py
@@ -191,8 +191,7 @@ def build_diff_advisories(
     removed = [d for d in all_diffs + inv_diffs if d.change_type == ChangeType.REMOVED]
     if removed:
         component_details = [
-            {"component_id": d.id, "component_name": d.name, "change_type": d.change_type.value}
-            for d in removed
+            {"component_id": d.id, "component_name": d.name, "change_type": d.change_type.value} for d in removed
         ]
         findings.append(
             AdvisoryFinding(
@@ -245,10 +244,7 @@ def build_diff_advisories(
     total_added = summary.total_added
     if total_added > 0 and total_removed == 0 and total_modified == 0:
         added = [d for d in all_diffs + inv_diffs if d.change_type == ChangeType.ADDED]
-        component_details = [
-            {"component_id": d.id, "component_name": d.name}
-            for d in added
-        ]
+        component_details = [{"component_id": d.id, "component_name": d.name} for d in added]
         findings.append(
             AdvisoryFinding(
                 type="additions_only",

--- a/src/cja_auto_sdr/core/advisory_builders.py
+++ b/src/cja_auto_sdr/core/advisory_builders.py
@@ -18,6 +18,7 @@ from cja_auto_sdr.core.advisories import (
 )
 
 if TYPE_CHECKING:
+    from cja_auto_sdr.diff.models import DiffResult
     from cja_auto_sdr.org.models import OrgReportResult, OrgReportTrending
 
 
@@ -152,3 +153,140 @@ def build_org_report_advisories(
         findings=findings,
         summary=_make_summary_block(findings),
     )
+
+
+def build_diff_advisories(
+    diff_result: DiffResult,
+    *,
+    changes_only: bool = False,
+) -> AdvisorySummary:
+    """Derive an AdvisorySummary from a DiffResult.
+
+    This is a pure function — it does not mutate *diff_result*.
+
+    Checks performed:
+    - breaking_changes: Any REMOVED components → severity critical
+    - schema_changes: Any MODIFIED components → severity warning
+    - additions_only: All changes are additions and no removals/modifications → severity info
+
+    Excluded types: high_change_volume, rename-derived findings.
+    """
+    from cja_auto_sdr.diff.models import ChangeType
+
+    findings: list[AdvisoryFinding] = []
+    summary = diff_result.summary
+
+    # Collect all component diffs across types
+    all_diffs = list(diff_result.metric_diffs or []) + list(diff_result.dimension_diffs or [])
+    inv_diffs = list(diff_result.calc_metrics_diffs or []) + list(diff_result.segments_diffs or [])
+
+    if changes_only:
+        active_diffs = [d for d in all_diffs if d.change_type != ChangeType.UNCHANGED]
+        active_inv_diffs = [d for d in inv_diffs if d.change_type != ChangeType.UNCHANGED]
+    else:
+        active_diffs = all_diffs
+        active_inv_diffs = inv_diffs
+
+    # 1. Breaking changes — REMOVED components
+    removed = [d for d in all_diffs + inv_diffs if d.change_type == ChangeType.REMOVED]
+    if removed:
+        component_details = [
+            {"component_id": d.id, "component_name": d.name, "change_type": d.change_type.value}
+            for d in removed
+        ]
+        findings.append(
+            AdvisoryFinding(
+                type="breaking_changes",
+                severity="critical",
+                message=f"{len(removed)} component(s) removed — downstream dependencies may break.",
+                details={
+                    "removed_count": len(removed),
+                    "components": component_details,
+                    "total_components": len(active_diffs) + len(active_inv_diffs),
+                },
+                recommended_actions=[
+                    "review_breaking_changes",
+                    "update_downstream_dependencies",
+                ],
+            )
+        )
+
+    # 2. Schema changes — MODIFIED components (only when no breaking changes already cover it)
+    modified = [d for d in all_diffs + inv_diffs if d.change_type == ChangeType.MODIFIED]
+    if modified and not removed:
+        component_details = [
+            {
+                "component_id": d.id,
+                "component_name": d.name,
+                "changed_fields": list(d.changed_fields.keys()) if d.changed_fields else [],
+            }
+            for d in modified
+        ]
+        findings.append(
+            AdvisoryFinding(
+                type="schema_changes",
+                severity="warning",
+                message=f"{len(modified)} component(s) modified — validate field mappings.",
+                details={
+                    "modified_count": len(modified),
+                    "components": component_details,
+                    "total_components": len(active_diffs) + len(active_inv_diffs),
+                },
+                recommended_actions=[
+                    "review_schema_changes",
+                    "validate_mappings",
+                ],
+            )
+        )
+
+    # 3. Additions only — all changes are additions, no removals or modifications
+    total_removed = summary.total_removed
+    total_modified = summary.total_modified
+    total_added = summary.total_added
+    if total_added > 0 and total_removed == 0 and total_modified == 0:
+        added = [d for d in all_diffs + inv_diffs if d.change_type == ChangeType.ADDED]
+        component_details = [
+            {"component_id": d.id, "component_name": d.name}
+            for d in added
+        ]
+        findings.append(
+            AdvisoryFinding(
+                type="additions_only",
+                severity="info",
+                message=f"{total_added} component(s) added — no removals or modifications detected.",
+                details={
+                    "added_count": total_added,
+                    "components": component_details,
+                    "total_components": len(active_diffs) + len(active_inv_diffs),
+                },
+                recommended_actions=["acknowledge_additive_change"],
+            )
+        )
+
+    severity = _max_severity([f.severity for f in findings])
+    return AdvisorySummary(
+        advisories_version="1.0",
+        severity=severity,
+        findings=findings,
+        summary=_make_summary_block(findings),
+    )
+
+
+def build_advisory_rollup(summary: AdvisorySummary) -> dict[str, Any]:
+    """Build a compact advisory rollup for run-summary integration."""
+    seen_types: list[str] = []
+    seen_actions: list[str] = []
+    for f in summary.findings:
+        if f.type not in seen_types:
+            seen_types.append(f.type)
+        for action in f.recommended_actions:
+            if action not in seen_actions:
+                seen_actions.append(action)
+
+    return {
+        "advisories_version": summary.advisories_version,
+        "severity": summary.severity,
+        "summary": summary.summary,
+        "types": seen_types,
+        "recommended_actions": seen_actions,
+    }

--- a/src/cja_auto_sdr/core/advisory_builders.py
+++ b/src/cja_auto_sdr/core/advisory_builders.py
@@ -165,13 +165,14 @@ def build_diff_advisories(
     This is a pure function — it does not mutate *diff_result*.
 
     Checks performed:
-    - breaking_changes: Any REMOVED components → severity critical
-    - schema_changes: Any MODIFIED components → severity warning
+    - breaking_changes: Any breaking change detected by detect_breaking_changes() → severity critical
+    - schema_changes: Breaking-change subset with type/schema changes → severity warning
     - additions_only: All changes are additions and no removals/modifications → severity info
 
     Excluded types: high_change_volume, rename-derived findings.
     """
     from cja_auto_sdr.diff.models import ChangeType
+    from cja_auto_sdr.output.diff.common import detect_breaking_changes
 
     findings: list[AdvisoryFinding] = []
     summary = diff_result.summary
@@ -187,20 +188,17 @@ def build_diff_advisories(
         active_diffs = all_diffs
         active_inv_diffs = inv_diffs
 
-    # 1. Breaking changes — REMOVED components
-    removed = [d for d in all_diffs + inv_diffs if d.change_type == ChangeType.REMOVED]
-    if removed:
-        component_details = [
-            {"component_id": d.id, "component_name": d.name, "change_type": d.change_type.value} for d in removed
-        ]
+    # 1. Breaking changes — use the canonical breaking-change detector.
+    breaking_changes = detect_breaking_changes(diff_result)
+    if breaking_changes:
         findings.append(
             AdvisoryFinding(
                 type="breaking_changes",
                 severity="critical",
-                message=f"{len(removed)} component(s) removed — downstream dependencies may break.",
+                message=f"{len(breaking_changes)} breaking change(s) detected — downstream dependencies may break.",
                 details={
-                    "removed_count": len(removed),
-                    "components": component_details,
+                    "count": len(breaking_changes),
+                    "changes": breaking_changes,
                     "total_components": len(active_diffs) + len(active_inv_diffs),
                 },
                 recommended_actions=[
@@ -210,25 +208,19 @@ def build_diff_advisories(
             )
         )
 
-    # 2. Schema changes — MODIFIED components (only when no breaking changes already cover it)
-    modified = [d for d in all_diffs + inv_diffs if d.change_type == ChangeType.MODIFIED]
-    if modified and not removed:
-        component_details = [
-            {
-                "component_id": d.id,
-                "component_name": d.name,
-                "changed_fields": list(d.changed_fields.keys()) if d.changed_fields else [],
-            }
-            for d in modified
-        ]
+    # 2. Schema changes — breaking-change subset for type/schema deltas.
+    schema_changes = [
+        change for change in breaking_changes if change.get("change_type") in {"type_changed", "schema_changed"}
+    ]
+    if schema_changes:
         findings.append(
             AdvisoryFinding(
                 type="schema_changes",
                 severity="warning",
-                message=f"{len(modified)} component(s) modified — validate field mappings.",
+                message=f"{len(schema_changes)} schema-level breaking change(s) detected — validate field mappings.",
                 details={
-                    "modified_count": len(modified),
-                    "components": component_details,
+                    "count": len(schema_changes),
+                    "changes": schema_changes,
                     "total_components": len(active_diffs) + len(active_inv_diffs),
                 },
                 recommended_actions=[

--- a/src/cja_auto_sdr/core/advisory_builders.py
+++ b/src/cja_auto_sdr/core/advisory_builders.py
@@ -16,6 +16,7 @@ from cja_auto_sdr.core.advisories import (
     AdvisoryFinding,
     AdvisorySummary,
 )
+from cja_auto_sdr.core.constants import effective_governance_overlap_threshold
 
 if TYPE_CHECKING:
     from cja_auto_sdr.diff.models import DiffResult
@@ -39,6 +40,15 @@ def _make_summary_block(findings: list[AdvisoryFinding]) -> dict[str, Any]:
     }
 
 
+def _top_nonzero_drift_scores(drift_scores: dict[str, float], *, limit: int = 10) -> list[dict[str, Any]]:
+    """Return the highest non-zero drift scores in stable order."""
+    ranked = sorted(
+        ({"data_view_id": data_view_id, "score": score} for data_view_id, score in drift_scores.items() if score > 0),
+        key=lambda entry: (-entry["score"], entry["data_view_id"]),
+    )
+    return ranked[:limit]
+
+
 def build_org_report_advisories(
     result: OrgReportResult,
     trending: OrgReportTrending | None = None,
@@ -49,9 +59,11 @@ def build_org_report_advisories(
 
     Checks performed:
     - fetch_failures: Any data views with errors → severity warning
-    - high_overlap: Similarity pairs whose Jaccard score >= overlap_threshold → warning
+    - high_overlap: Similarity pairs whose Jaccard score >= effective overlap threshold → warning
+    - isolated_review: existing review_isolated recommendations → info
+    - metadata_hygiene: missing_descriptions and stale_data_view recommendations → warning
     - governance_threshold_breach: thresholds_exceeded=True with violations → critical
-    - drift_activity: trending provided with non-empty drift_scores → warning
+    - drift_activity: trending provided with non-zero drift_scores → info
     """
     findings: list[AdvisoryFinding] = []
 
@@ -65,8 +77,9 @@ def build_org_report_advisories(
                 severity="warning",
                 message=f"{len(failed_ids)} data view(s) could not be fetched.",
                 details={
+                    "count": len(failed_ids),
                     "data_view_ids": failed_ids,
-                    "reason_counts": reason_counts,
+                    "failure_reason_counts": reason_counts,
                 },
                 recommended_actions=["investigate_fetch_failures"],
             )
@@ -74,7 +87,8 @@ def build_org_report_advisories(
 
     # 2. High overlap
     if result.similarity_pairs is not None:
-        threshold = result.parameters.overlap_threshold
+        configured_threshold = result.parameters.overlap_threshold
+        threshold = effective_governance_overlap_threshold(configured_threshold)
         high_pairs = [p for p in result.similarity_pairs if p.jaccard_similarity >= threshold]
         if high_pairs:
             pair_details = [
@@ -91,11 +105,15 @@ def build_org_report_advisories(
                 AdvisoryFinding(
                     type="high_overlap",
                     severity="warning",
-                    message=(f"{len(high_pairs)} data view pair(s) exceed the overlap threshold of {threshold:.0%}."),
+                    message=(
+                        f"{len(high_pairs)} data view pair(s) exceed the "
+                        f"{'effective ' if configured_threshold > threshold else ''}"
+                        f"overlap threshold of {threshold:.0%}."
+                    ),
                     details={
-                        "pair_count": len(high_pairs),
-                        "threshold": threshold,
                         "pairs": pair_details,
+                        "threshold": threshold,
+                        "max_similarity": max(p.jaccard_similarity for p in high_pairs),
                     },
                     recommended_actions=[
                         "review_overlap_pairs",
@@ -104,7 +122,61 @@ def build_org_report_advisories(
                 )
             )
 
-    # 3. Governance threshold breach
+    # 3. Isolated review
+    isolated_recommendations = [rec for rec in result.recommendations if rec.get("type") == "review_isolated"]
+    if isolated_recommendations:
+        data_views = [
+            {
+                "data_view_id": rec.get("data_view"),
+                "data_view_name": rec.get("data_view_name"),
+                "isolated_count": rec.get("isolated_count"),
+            }
+            for rec in isolated_recommendations
+        ]
+        findings.append(
+            AdvisoryFinding(
+                type="isolated_review",
+                severity="info",
+                message=f"{len(data_views)} data view(s) have high isolated-component counts.",
+                details={
+                    "data_views": data_views,
+                    "count": len(data_views),
+                },
+                recommended_actions=["review_isolated_views"],
+            )
+        )
+
+    # 4. Metadata hygiene
+    stale_recommendations = [rec for rec in result.recommendations if rec.get("type") == "stale_data_view"]
+    missing_description_recommendations = [
+        rec for rec in result.recommendations if rec.get("type") == "missing_descriptions"
+    ]
+    if stale_recommendations or missing_description_recommendations:
+        missing_description_count = sum(int(rec.get("count", 0) or 0) for rec in missing_description_recommendations)
+        stale_view_ids = [rec.get("data_view") for rec in stale_recommendations if rec.get("data_view")]
+        recommended_actions: list[str] = []
+        if missing_description_count > 0:
+            recommended_actions.append("add_descriptions")
+        if stale_view_ids:
+            recommended_actions.append("review_stale_views")
+
+        findings.append(
+            AdvisoryFinding(
+                type="metadata_hygiene",
+                severity="warning",
+                message=(
+                    f"Metadata hygiene issues detected across {missing_description_count} undocumented "
+                    f"and {len(stale_view_ids)} stale data view(s)."
+                ),
+                details={
+                    "missing_description_count": missing_description_count,
+                    "stale_view_ids": stale_view_ids,
+                },
+                recommended_actions=recommended_actions,
+            )
+        )
+
+    # 5. Governance threshold breach
     if result.thresholds_exceeded:
         violations = list(result.governance_violations or [])
         findings.append(
@@ -114,7 +186,7 @@ def build_org_report_advisories(
                 message="One or more governance thresholds have been exceeded.",
                 details={
                     "violations": violations,
-                    "violation_count": len(violations),
+                    "count": len(violations),
                 },
                 recommended_actions=[
                     "review_governance_thresholds",
@@ -123,28 +195,28 @@ def build_org_report_advisories(
             )
         )
 
-    # 4. Drift activity from trending
+    # 6. Drift activity from trending
     if trending is not None and trending.drift_scores:
-        drift_scores = dict(trending.drift_scores)
-        findings.append(
-            AdvisoryFinding(
-                type="drift_activity",
-                severity="warning",
-                message=(
-                    f"Drift activity detected across {len(drift_scores)} data view(s) "
-                    f"over a {trending.window_size}-snapshot window."
-                ),
-                details={
-                    "drift_scores": drift_scores,
-                    "data_view_count": len(drift_scores),
-                    "window_size": trending.window_size,
-                },
-                recommended_actions=[
-                    "review_drift_activity",
-                    "compare_recent_reports",
-                ],
+        top_drift_scores = _top_nonzero_drift_scores(dict(trending.drift_scores))
+        if top_drift_scores:
+            findings.append(
+                AdvisoryFinding(
+                    type="drift_activity",
+                    severity="info",
+                    message=(
+                        f"Drift activity detected across {len(top_drift_scores)} data view(s) "
+                        f"over a {trending.window_size}-snapshot window."
+                    ),
+                    details={
+                        "top_drift_scores": top_drift_scores,
+                        "window": trending.window_size,
+                    },
+                    recommended_actions=[
+                        "review_drift_activity",
+                        "compare_recent_reports",
+                    ],
+                )
             )
-        )
 
     severity = _max_severity([f.severity for f in findings])
     return AdvisorySummary(

--- a/src/cja_auto_sdr/core/constants.py
+++ b/src/cja_auto_sdr/core/constants.py
@@ -59,6 +59,12 @@ DEFAULT_ORG_REPORT_WORKERS: int = 10  # Max concurrent workers for org-wide data
 # Pairs >= 90% similarity are always flagged for governance, regardless of --overlap-threshold
 GOVERNANCE_MAX_OVERLAP_THRESHOLD: float = 0.9
 
+
+def effective_governance_overlap_threshold(overlap_threshold: float) -> float:
+    """Return the effective overlap threshold after applying the governance cap."""
+    return min(overlap_threshold, GOVERNANCE_MAX_OVERLAP_THRESHOLD)
+
+
 # ==================== CACHE DEFAULTS ====================
 
 DEFAULT_CACHE_SIZE: int = 1000  # Maximum cached validation results

--- a/src/cja_auto_sdr/core/version.py
+++ b/src/cja_auto_sdr/core/version.py
@@ -1,3 +1,3 @@
 """Version information for CJA Auto SDR."""
 
-__version__ = "3.4.9"
+__version__ = "3.5.0"

--- a/src/cja_auto_sdr/diff/cli.py
+++ b/src/cja_auto_sdr/diff/cli.py
@@ -23,9 +23,39 @@ def _diff_output_to_stdout_requested(
     args: argparse.Namespace,
     *,
     output_format: str,
+    output_path: str | None = None,
 ) -> bool:
     """Return whether a diff-family JSON request should emit to stdout."""
-    return output_format == "json" and getattr(args, "output", None) in ("-", "stdout")
+    effective_output_path = output_path if output_path is not None else getattr(args, "output", None)
+    return output_format == "json" and effective_output_path in ("-", "stdout")
+
+
+def _resolve_diff_output_path(args: argparse.Namespace, *, output_format: str) -> str | None:
+    """Resolve the effective diff-family output path after agent-mode defaults.
+
+    Keep the parser contract literal, but suppress inherited agent-mode stdout
+    only when the caller did not explicitly pass ``--output`` and the chosen
+    diff format is not the supported JSON stdout path.
+    """
+    output_path = getattr(args, "output", None)
+    if not getattr(args, "agent_mode", False):
+        return output_path
+
+    generator = _generator_module()
+    if generator._cli_option_specified("--output"):
+        return output_path
+
+    if output_format == "json":
+        return output_path
+    return None
+
+
+def _resolve_diff_quiet(args: argparse.Namespace, *, output_path: str | None) -> bool:
+    """Resolve the effective diff-family quiet flag after output coercion."""
+    generator = _generator_module()
+    if generator._cli_option_specified("--quiet"):
+        return True
+    return getattr(args, "run_summary_json", None) in ("-", "stdout") or output_path in ("-", "stdout")
 
 
 def _exit_with_diff_result(
@@ -218,7 +248,13 @@ def dispatch_cross_data_view_diff_cli_mode(
         run_state["resolved_data_views"] = list(resolved_ids)
 
     diff_format = args.format or "console"
-    _diff_output_to_stdout = _diff_output_to_stdout_requested(args, output_format=diff_format)
+    resolved_output_path = _resolve_diff_output_path(args, output_format=diff_format)
+    diff_quiet = _resolve_diff_quiet(args, output_path=resolved_output_path)
+    _diff_output_to_stdout = _diff_output_to_stdout_requested(
+        args,
+        output_format=diff_format,
+        output_path=resolved_output_path,
+    )
     diff_runtime_details: dict[str, Any] = {}
     success, has_changes, exit_code_override = generator.handle_diff_command(
         source_id=resolved_ids[0],
@@ -230,7 +266,7 @@ def dispatch_cross_data_view_diff_cli_mode(
         summary_only=getattr(args, "summary", False),
         ignore_fields=ignore_fields,
         labels=labels,
-        quiet=args.quiet,
+        quiet=diff_quiet,
         show_only=show_only,
         metrics_only=getattr(args, "metrics_only", False),
         dimensions_only=getattr(args, "dimensions_only", False),
@@ -482,7 +518,13 @@ def dispatch_snapshot_cli_modes(
             sys.exit(1)
 
         diff_format = args.format or "console"
-        _cs_output_to_stdout = _diff_output_to_stdout_requested(args, output_format=diff_format)
+        resolved_output_path = _resolve_diff_output_path(args, output_format=diff_format)
+        diff_quiet = _resolve_diff_quiet(args, output_path=resolved_output_path)
+        _cs_output_to_stdout = _diff_output_to_stdout_requested(
+            args,
+            output_format=diff_format,
+            output_path=resolved_output_path,
+        )
         cs_runtime_details: dict[str, Any] = {}
         success, has_changes, exit_code_override = generator.handle_compare_snapshots_command(
             source_file=source_file,
@@ -493,7 +535,7 @@ def dispatch_snapshot_cli_modes(
             summary_only=getattr(args, "summary", False),
             ignore_fields=ignore_fields,
             labels=labels,
-            quiet=args.quiet,
+            quiet=diff_quiet,
             show_only=show_only,
             metrics_only=getattr(args, "metrics_only", False),
             dimensions_only=getattr(args, "dimensions_only", False),
@@ -594,7 +636,9 @@ def dispatch_snapshot_cli_modes(
             print("Or use --auto-snapshot with --diff to automatically save snapshots.", file=sys.stderr)
             sys.exit(1)
 
-        if not args.quiet:
+        resolved_output_path = _resolve_diff_output_path(args, output_format=args.format or "console")
+        diff_quiet = _resolve_diff_quiet(args, output_path=resolved_output_path)
+        if not diff_quiet:
             print(f"Comparing against previous snapshot: {prev_snapshot}")
 
         args.diff_snapshot = prev_snapshot
@@ -626,7 +670,13 @@ def dispatch_snapshot_cli_modes(
         )
 
         diff_format = args.format or "console"
-        _ds_output_to_stdout = _diff_output_to_stdout_requested(args, output_format=diff_format)
+        resolved_output_path = _resolve_diff_output_path(args, output_format=diff_format)
+        diff_quiet = _resolve_diff_quiet(args, output_path=resolved_output_path)
+        _ds_output_to_stdout = _diff_output_to_stdout_requested(
+            args,
+            output_format=diff_format,
+            output_path=resolved_output_path,
+        )
         ds_runtime_details: dict[str, Any] = {}
         success, has_changes, exit_code_override = generator.handle_diff_snapshot_command(
             data_view_id=resolved_ids[0],
@@ -638,7 +688,7 @@ def dispatch_snapshot_cli_modes(
             summary_only=getattr(args, "summary", False),
             ignore_fields=ignore_fields,
             labels=labels,
-            quiet=args.quiet,
+            quiet=diff_quiet,
             show_only=show_only,
             metrics_only=getattr(args, "metrics_only", False),
             dimensions_only=getattr(args, "dimensions_only", False),

--- a/src/cja_auto_sdr/diff/cli.py
+++ b/src/cja_auto_sdr/diff/cli.py
@@ -209,6 +209,7 @@ def dispatch_cross_data_view_diff_cli_mode(
         run_state["resolved_data_views"] = list(resolved_ids)
 
     diff_format = args.format or "console"
+    _diff_output_to_stdout = getattr(args, "output", None) == "-" and diff_format == "json"
     success, has_changes, exit_code_override = generator.handle_diff_command(
         source_id=resolved_ids[0],
         target_id=resolved_ids[1],
@@ -241,6 +242,7 @@ def dispatch_cross_data_view_diff_cli_mode(
         keep_last_specified=keep_last_specified,
         keep_since_specified=keep_since_specified,
         profile=getattr(args, "profile", None),
+        output_to_stdout=_diff_output_to_stdout,
     )
     if run_state is not None:
         run_state["output_format"] = diff_format
@@ -466,6 +468,7 @@ def dispatch_snapshot_cli_modes(
             sys.exit(1)
 
         diff_format = args.format or "console"
+        _cs_output_to_stdout = getattr(args, "output", None) == "-" and diff_format == "json"
         success, has_changes, exit_code_override = generator.handle_compare_snapshots_command(
             source_file=source_file,
             target_file=target_file,
@@ -491,6 +494,7 @@ def dispatch_snapshot_cli_modes(
             format_pr_comment=getattr(args, "format_pr_comment", False),
             include_calc_metrics=getattr(args, "include_calculated_metrics", False),
             include_segments=getattr(args, "include_segments_inventory", False),
+            output_to_stdout=_cs_output_to_stdout,
         )
         if run_state is not None:
             run_state["output_format"] = diff_format
@@ -603,6 +607,7 @@ def dispatch_snapshot_cli_modes(
         )
 
         diff_format = args.format or "console"
+        _ds_output_to_stdout = getattr(args, "output", None) == "-" and diff_format == "json"
         success, has_changes, exit_code_override = generator.handle_diff_snapshot_command(
             data_view_id=resolved_ids[0],
             snapshot_file=args.diff_snapshot,
@@ -637,6 +642,7 @@ def dispatch_snapshot_cli_modes(
             profile=getattr(args, "profile", None),
             include_calc_metrics=include_calc_metrics,
             include_segments=include_segments,
+            output_to_stdout=_ds_output_to_stdout,
         )
         if run_state is not None:
             run_state["output_format"] = diff_format

--- a/src/cja_auto_sdr/diff/cli.py
+++ b/src/cja_auto_sdr/diff/cli.py
@@ -19,6 +19,15 @@ def _generator_module():
     return _generator
 
 
+def _diff_output_to_stdout_requested(
+    args: argparse.Namespace,
+    *,
+    output_format: str,
+) -> bool:
+    """Return whether a diff-family JSON request should emit to stdout."""
+    return output_format == "json" and getattr(args, "output", None) in ("-", "stdout")
+
+
 def _exit_with_diff_result(
     *,
     success: bool,
@@ -209,7 +218,7 @@ def dispatch_cross_data_view_diff_cli_mode(
         run_state["resolved_data_views"] = list(resolved_ids)
 
     diff_format = args.format or "console"
-    _diff_output_to_stdout = getattr(args, "output", None) == "-" and diff_format == "json"
+    _diff_output_to_stdout = _diff_output_to_stdout_requested(args, output_format=diff_format)
     diff_runtime_details: dict[str, Any] = {}
     success, has_changes, exit_code_override = generator.handle_diff_command(
         source_id=resolved_ids[0],
@@ -473,7 +482,7 @@ def dispatch_snapshot_cli_modes(
             sys.exit(1)
 
         diff_format = args.format or "console"
-        _cs_output_to_stdout = getattr(args, "output", None) == "-" and diff_format == "json"
+        _cs_output_to_stdout = _diff_output_to_stdout_requested(args, output_format=diff_format)
         cs_runtime_details: dict[str, Any] = {}
         success, has_changes, exit_code_override = generator.handle_compare_snapshots_command(
             source_file=source_file,
@@ -617,7 +626,7 @@ def dispatch_snapshot_cli_modes(
         )
 
         diff_format = args.format or "console"
-        _ds_output_to_stdout = getattr(args, "output", None) == "-" and diff_format == "json"
+        _ds_output_to_stdout = _diff_output_to_stdout_requested(args, output_format=diff_format)
         ds_runtime_details: dict[str, Any] = {}
         success, has_changes, exit_code_override = generator.handle_diff_snapshot_command(
             data_view_id=resolved_ids[0],

--- a/src/cja_auto_sdr/diff/cli.py
+++ b/src/cja_auto_sdr/diff/cli.py
@@ -210,6 +210,7 @@ def dispatch_cross_data_view_diff_cli_mode(
 
     diff_format = args.format or "console"
     _diff_output_to_stdout = getattr(args, "output", None) == "-" and diff_format == "json"
+    diff_runtime_details: dict[str, Any] = {}
     success, has_changes, exit_code_override = generator.handle_diff_command(
         source_id=resolved_ids[0],
         target_id=resolved_ids[1],
@@ -243,6 +244,7 @@ def dispatch_cross_data_view_diff_cli_mode(
         keep_since_specified=keep_since_specified,
         profile=getattr(args, "profile", None),
         output_to_stdout=_diff_output_to_stdout,
+        runtime_details=diff_runtime_details,
     )
     if run_state is not None:
         run_state["output_format"] = diff_format
@@ -251,6 +253,9 @@ def dispatch_cross_data_view_diff_cli_mode(
             "has_changes": has_changes,
             "warn_threshold_exit_code": exit_code_override,
         }
+        advisory_rollup = diff_runtime_details.get("advisory_rollup")
+        if advisory_rollup is not None:
+            run_state["details"]["advisories"] = advisory_rollup
 
     _exit_with_diff_result(
         success=success,
@@ -469,6 +474,7 @@ def dispatch_snapshot_cli_modes(
 
         diff_format = args.format or "console"
         _cs_output_to_stdout = getattr(args, "output", None) == "-" and diff_format == "json"
+        cs_runtime_details: dict[str, Any] = {}
         success, has_changes, exit_code_override = generator.handle_compare_snapshots_command(
             source_file=source_file,
             target_file=target_file,
@@ -495,6 +501,7 @@ def dispatch_snapshot_cli_modes(
             include_calc_metrics=getattr(args, "include_calculated_metrics", False),
             include_segments=getattr(args, "include_segments_inventory", False),
             output_to_stdout=_cs_output_to_stdout,
+            runtime_details=cs_runtime_details,
         )
         if run_state is not None:
             run_state["output_format"] = diff_format
@@ -503,6 +510,9 @@ def dispatch_snapshot_cli_modes(
                 "has_changes": has_changes,
                 "warn_threshold_exit_code": exit_code_override,
             }
+            advisory_rollup = cs_runtime_details.get("advisory_rollup")
+            if advisory_rollup is not None:
+                run_state["details"]["advisories"] = advisory_rollup
         _exit_with_diff_result(
             success=success,
             has_changes=has_changes,
@@ -608,6 +618,7 @@ def dispatch_snapshot_cli_modes(
 
         diff_format = args.format or "console"
         _ds_output_to_stdout = getattr(args, "output", None) == "-" and diff_format == "json"
+        ds_runtime_details: dict[str, Any] = {}
         success, has_changes, exit_code_override = generator.handle_diff_snapshot_command(
             data_view_id=resolved_ids[0],
             snapshot_file=args.diff_snapshot,
@@ -643,6 +654,7 @@ def dispatch_snapshot_cli_modes(
             include_calc_metrics=include_calc_metrics,
             include_segments=include_segments,
             output_to_stdout=_ds_output_to_stdout,
+            runtime_details=ds_runtime_details,
         )
         if run_state is not None:
             run_state["output_format"] = diff_format
@@ -652,6 +664,9 @@ def dispatch_snapshot_cli_modes(
                 "has_changes": has_changes,
                 "warn_threshold_exit_code": exit_code_override,
             }
+            advisory_rollup = ds_runtime_details.get("advisory_rollup")
+            if advisory_rollup is not None:
+                run_state["details"]["advisories"] = advisory_rollup
         _exit_with_diff_result(
             success=success,
             has_changes=has_changes,

--- a/src/cja_auto_sdr/diff/commands.py
+++ b/src/cja_auto_sdr/diff/commands.py
@@ -9,6 +9,7 @@ import os
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 __all__ = [
     "handle_compare_snapshots_command",
@@ -22,6 +23,21 @@ def _generator_module():
     from cja_auto_sdr import generator as _generator
 
     return _generator
+
+
+def _populate_diff_advisory_rollup(
+    runtime_details: dict[str, Any] | None,
+    diff_result: object,
+    *,
+    changes_only: bool,
+) -> None:
+    """Compute diff advisory rollup and store it in *runtime_details* if provided."""
+    if runtime_details is None:
+        return
+    from cja_auto_sdr.core.advisory_builders import build_advisory_rollup, build_diff_advisories
+
+    advisory_summary = build_diff_advisories(diff_result, changes_only=changes_only)
+    runtime_details["advisory_rollup"] = build_advisory_rollup(advisory_summary)
 
 
 def handle_snapshot_command(
@@ -130,6 +146,7 @@ def handle_diff_command(
     profile: str | None = None,
     diff_config=None,
     output_to_stdout: bool = False,
+    runtime_details: dict[str, Any] | None = None,
 ) -> tuple[bool, bool, int | None]:
     """Handle the --diff command to compare two data views."""
     generator = _generator_module()
@@ -330,6 +347,7 @@ def handle_diff_command(
                 print(generator.ConsoleColors.success("Diff report generated successfully"))
 
         generator.append_github_step_summary(generator.build_diff_step_summary(diff_result), logger)
+        _populate_diff_advisory_rollup(runtime_details, diff_result, changes_only=changes_only)
         return True, diff_result.summary.has_changes, exit_code_override
     except (KeyboardInterrupt, SystemExit):
         raise
@@ -375,6 +393,7 @@ def handle_diff_snapshot_command(
     include_segments: bool = False,
     diff_snapshot_config=None,
     output_to_stdout: bool = False,
+    runtime_details: dict[str, Any] | None = None,
 ) -> tuple[bool, bool, int | None]:
     """Handle the --diff-snapshot command to compare a data view against a saved snapshot."""
     generator = _generator_module()
@@ -645,6 +664,7 @@ def handle_diff_snapshot_command(
                 print(generator.ConsoleColors.success("Diff report generated successfully"))
 
         generator.append_github_step_summary(generator.build_diff_step_summary(diff_result), logger)
+        _populate_diff_advisory_rollup(runtime_details, diff_result, changes_only=changes_only)
         return True, diff_result.summary.has_changes, exit_code_override
     except FileNotFoundError:
         print(generator.ConsoleColors.error(f"ERROR: Snapshot file not found: {snapshot_file}"), file=sys.stderr)
@@ -686,6 +706,7 @@ def handle_compare_snapshots_command(
     include_calc_metrics: bool = False,
     include_segments: bool = False,
     output_to_stdout: bool = False,
+    runtime_details: dict[str, Any] | None = None,
 ) -> tuple[bool, bool, int | None]:
     """Handle the --compare-snapshots command to compare two snapshot files directly."""
     generator = _generator_module()
@@ -820,6 +841,7 @@ def handle_compare_snapshots_command(
                 print(generator.ConsoleColors.success("Diff report generated successfully"))
 
         generator.append_github_step_summary(generator.build_diff_step_summary(diff_result), logger)
+        _populate_diff_advisory_rollup(runtime_details, diff_result, changes_only=changes_only)
         return True, diff_result.summary.has_changes, exit_code_override
     except FileNotFoundError as e:
         print(generator.ConsoleColors.error(f"ERROR: Snapshot file not found: {e!s}"), file=sys.stderr)

--- a/src/cja_auto_sdr/diff/commands.py
+++ b/src/cja_auto_sdr/diff/commands.py
@@ -34,13 +34,20 @@ def _populate_diff_advisory_rollup(
     *,
     changes_only: bool,
 ) -> None:
-    """Compute diff advisory rollup and store it in *runtime_details* if provided."""
+    """Compute diff advisory rollup and store it in *runtime_details* if provided.
+
+    This is a best-effort helper — failures are silently ignored so that
+    advisory computation never breaks the diff flow.
+    """
     if runtime_details is None:
         return
-    from cja_auto_sdr.core.advisory_builders import build_advisory_rollup, build_diff_advisories
+    try:
+        from cja_auto_sdr.core.advisory_builders import build_advisory_rollup, build_diff_advisories
 
-    advisory_summary = build_diff_advisories(diff_result, changes_only=changes_only)
-    runtime_details["advisory_rollup"] = build_advisory_rollup(advisory_summary)
+        advisory_summary = build_diff_advisories(diff_result, changes_only=changes_only)
+        runtime_details["advisory_rollup"] = build_advisory_rollup(advisory_summary)
+    except Exception:
+        logging.getLogger("diff").debug("Advisory rollup computation failed", exc_info=True)
 
 
 def handle_snapshot_command(

--- a/src/cja_auto_sdr/diff/commands.py
+++ b/src/cja_auto_sdr/diff/commands.py
@@ -9,7 +9,10 @@ import os
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from cja_auto_sdr.diff.models import DiffResult
 
 __all__ = [
     "handle_compare_snapshots_command",
@@ -27,7 +30,7 @@ def _generator_module():
 
 def _populate_diff_advisory_rollup(
     runtime_details: dict[str, Any] | None,
-    diff_result: object,
+    diff_result: DiffResult,
     *,
     changes_only: bool,
 ) -> None:

--- a/src/cja_auto_sdr/diff/commands.py
+++ b/src/cja_auto_sdr/diff/commands.py
@@ -129,6 +129,7 @@ def handle_diff_command(
     keep_since_specified: bool = False,
     profile: str | None = None,
     diff_config=None,
+    output_to_stdout: bool = False,
 ) -> tuple[bool, bool, int | None]:
     """Handle the --diff command to compare two data views."""
     generator = _generator_module()
@@ -317,13 +318,14 @@ def handle_diff_command(
                 use_color=generator.ConsoleColors.is_enabled() and not no_color,
                 group_by_field=group_by_field,
                 group_by_field_limit=group_by_field_limit,
+                output_to_stdout=output_to_stdout,
             )
             if diff_output and output_content:
                 with open(diff_output, "w", encoding="utf-8") as f:
                     f.write(output_content)
                 if not quiet:
                     print(f"Diff output written to: {diff_output}")
-            if not quiet and output_format != "console":
+            if not quiet and output_format != "console" and not output_to_stdout:
                 print()
                 print(generator.ConsoleColors.success("Diff report generated successfully"))
 
@@ -372,6 +374,7 @@ def handle_diff_snapshot_command(
     include_calc_metrics: bool = False,
     include_segments: bool = False,
     diff_snapshot_config=None,
+    output_to_stdout: bool = False,
 ) -> tuple[bool, bool, int | None]:
     """Handle the --diff-snapshot command to compare a data view against a saved snapshot."""
     generator = _generator_module()
@@ -630,13 +633,14 @@ def handle_diff_snapshot_command(
                 use_color=generator.ConsoleColors.is_enabled() and not no_color,
                 group_by_field=group_by_field,
                 group_by_field_limit=group_by_field_limit,
+                output_to_stdout=output_to_stdout,
             )
             if diff_output and output_content:
                 with open(diff_output, "w", encoding="utf-8") as f:
                     f.write(output_content)
                 if not quiet:
                     print(f"Diff output written to: {diff_output}")
-            if not quiet and output_format != "console":
+            if not quiet and output_format != "console" and not output_to_stdout:
                 print()
                 print(generator.ConsoleColors.success("Diff report generated successfully"))
 
@@ -681,6 +685,7 @@ def handle_compare_snapshots_command(
     format_pr_comment: bool = False,
     include_calc_metrics: bool = False,
     include_segments: bool = False,
+    output_to_stdout: bool = False,
 ) -> tuple[bool, bool, int | None]:
     """Handle the --compare-snapshots command to compare two snapshot files directly."""
     generator = _generator_module()
@@ -803,13 +808,14 @@ def handle_compare_snapshots_command(
                 use_color=generator.ConsoleColors.is_enabled() and not no_color,
                 group_by_field=group_by_field,
                 group_by_field_limit=group_by_field_limit,
+                output_to_stdout=output_to_stdout,
             )
             if diff_output and output_content:
                 with open(diff_output, "w", encoding="utf-8") as f:
                     f.write(output_content)
                 if not quiet:
                     print(f"Diff output written to: {diff_output}")
-            if not quiet and output_format != "console":
+            if not quiet and output_format != "console" and not output_to_stdout:
                 print()
                 print(generator.ConsoleColors.success("Diff report generated successfully"))
 

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -6242,6 +6242,18 @@ def _resolve_org_report_output_path(args: argparse.Namespace, *, output_format: 
     return None
 
 
+def _resolve_org_report_quiet(args: argparse.Namespace, *, output_path: str | None) -> bool:
+    """Resolve the effective org-report quiet flag after output-path coercion.
+
+    Keep explicit ``--quiet`` intact, but otherwise let quiet follow the
+    effective stdout destination rather than the parser-level ``--agent-mode``
+    default that may be suppressed for file-only org-report formats.
+    """
+    if _cli_option_specified("--quiet"):
+        return True
+    return getattr(args, "run_summary_json", None) in ("-", "stdout") or output_path in ("-", "stdout")
+
+
 def _dispatch_post_validation_report_modes(
     args: argparse.Namespace,
     *,
@@ -6335,6 +6347,10 @@ def _dispatch_post_validation_report_modes(
         sys.exit(0 if success else 1)
 
     if getattr(args, "org_report", False):
+        output_format = args.format or "console"
+        resolved_output_path = _resolve_org_report_output_path(args, output_format=output_format)
+        org_report_quiet = _resolve_org_report_quiet(args, output_path=resolved_output_path)
+
         org_config = OrgReportConfig(
             filter_pattern=getattr(args, "org_filter", None),
             exclude_pattern=getattr(args, "org_exclude", None),
@@ -6362,7 +6378,7 @@ def _dispatch_post_validation_report_modes(
             memory_limit_mb=getattr(args, "org_memory_limit", None),
             enable_clustering=getattr(args, "org_cluster", False),
             cluster_method=getattr(args, "org_cluster_method", "average"),
-            quiet=args.quiet,
+            quiet=org_report_quiet,
             cja_per_thread=not getattr(args, "org_shared_client", False),
             duplicate_threshold=getattr(args, "org_duplicate_threshold", None),
             isolated_threshold=getattr(args, "org_isolated_threshold", None),
@@ -6375,18 +6391,17 @@ def _dispatch_post_validation_report_modes(
             lock_stale_threshold_seconds=getattr(args, "org_lock_stale_threshold", 3600),
         )
 
-        output_format = args.format or "console"
         trending_window = getattr(args, "trending_window", None)
 
         lock_details: dict[str, Any] = {}
         success, thresholds_exceeded = run_org_report(
             config_file=args.config_file,
             output_format=output_format,
-            output_path=_resolve_org_report_output_path(args, output_format=output_format),
+            output_path=resolved_output_path,
             output_dir=args.output_dir,
             org_config=org_config,
             profile=getattr(args, "profile", None),
-            quiet=args.quiet,
+            quiet=org_report_quiet,
             trending_window=trending_window,
             runtime_details=lock_details,
         )

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -2114,6 +2114,7 @@ def _merge_org_report_run_summary_details(
     fail_on_threshold: bool,
     lock_details: Mapping[str, Any],
     org_config: OrgReportConfig,
+    advisory_rollup: dict[str, Any] | None = None,
 ) -> None:
     """Merge org-report run-summary details with one shared formatter."""
     if run_state is None:
@@ -2137,6 +2138,9 @@ def _merge_org_report_run_summary_details(
             )
         },
     )
+
+    if advisory_rollup is not None:
+        _merge_run_details(run_state, advisories=advisory_rollup)
 
 
 def _build_run_summary_payload(
@@ -5237,6 +5241,27 @@ write_org_report_csv = _make_org_writer_compat_wrapper(
 )
 
 
+def _populate_org_report_advisory_rollup(
+    runtime_details: dict[str, Any] | None,
+    result: Any,
+    trending: Any | None,
+) -> None:
+    """Compute advisory rollup from org-report result and store in runtime_details.
+
+    This is a best-effort helper — failures are silently ignored so that
+    advisory computation never breaks the org-report flow.
+    """
+    if runtime_details is None:
+        return
+    try:
+        from cja_auto_sdr.core.advisory_builders import build_advisory_rollup, build_org_report_advisories
+
+        advisory_summary = build_org_report_advisories(result, trending=trending)
+        runtime_details["advisory_rollup"] = build_advisory_rollup(advisory_summary)
+    except Exception:  # noqa: BLE001
+        pass
+
+
 def run_org_report(
     config_file: str,
     output_format: str,
@@ -5383,6 +5408,7 @@ def run_org_report(
                     if not quiet:
                         _status_print(f"JSON saved to: {file_path}")
             append_github_step_summary(build_org_step_summary(result), logger)
+            _populate_org_report_advisory_rollup(runtime_details, result, trending)
             return True, result.thresholds_exceeded
 
         # Handle format aliases (reports, data, ci)
@@ -5480,6 +5506,7 @@ def run_org_report(
             _status_print("=" * 110)
 
         append_github_step_summary(build_org_step_summary(result), logger)
+        _populate_org_report_advisory_rollup(runtime_details, result, trending)
         return True, result.thresholds_exceeded
 
     except ConcurrentOrgReportError as e:
@@ -5604,6 +5631,8 @@ def handle_diff_command(
     keep_since_specified: bool = False,
     profile: str | None = None,
     diff_config: DiffConfig | None = None,
+    output_to_stdout: bool = False,
+    runtime_details: dict[str, Any] | None = None,
 ) -> tuple[bool, bool, int | None]:
     from cja_auto_sdr.diff.commands import handle_diff_command as _impl
 
@@ -5640,6 +5669,8 @@ def handle_diff_command(
         keep_since_specified=keep_since_specified,
         profile=profile,
         diff_config=diff_config,
+        output_to_stdout=output_to_stdout,
+        runtime_details=runtime_details,
     )
 
 
@@ -5678,6 +5709,8 @@ def handle_diff_snapshot_command(
     include_calc_metrics: bool = False,
     include_segments: bool = False,
     diff_snapshot_config: DiffSnapshotConfig | None = None,
+    output_to_stdout: bool = False,
+    runtime_details: dict[str, Any] | None = None,
 ) -> tuple[bool, bool, int | None]:
     from cja_auto_sdr.diff.commands import handle_diff_snapshot_command as _impl
 
@@ -5716,6 +5749,8 @@ def handle_diff_snapshot_command(
         include_calc_metrics=include_calc_metrics,
         include_segments=include_segments,
         diff_snapshot_config=diff_snapshot_config,
+        output_to_stdout=output_to_stdout,
+        runtime_details=runtime_details,
     )
 
 
@@ -5744,6 +5779,8 @@ def handle_compare_snapshots_command(
     format_pr_comment: bool = False,
     include_calc_metrics: bool = False,
     include_segments: bool = False,
+    output_to_stdout: bool = False,
+    runtime_details: dict[str, Any] | None = None,
 ) -> tuple[bool, bool, int | None]:
     from cja_auto_sdr.diff.commands import handle_compare_snapshots_command as _impl
 
@@ -5772,6 +5809,8 @@ def handle_compare_snapshots_command(
         format_pr_comment=format_pr_comment,
         include_calc_metrics=include_calc_metrics,
         include_segments=include_segments,
+        output_to_stdout=output_to_stdout,
+        runtime_details=runtime_details,
     )
 
 
@@ -6329,6 +6368,7 @@ def _dispatch_post_validation_report_modes(
             trending_window=trending_window,
             runtime_details=lock_details,
         )
+        advisory_rollup = lock_details.pop("advisory_rollup", None)
         if run_state is not None:
             run_state["output_format"] = output_format
             _merge_org_report_run_summary_details(
@@ -6338,6 +6378,7 @@ def _dispatch_post_validation_report_modes(
                 fail_on_threshold=org_config.fail_on_threshold,
                 lock_details=lock_details,
                 org_config=org_config,
+                advisory_rollup=advisory_rollup,
             )
 
         if success:

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -5296,6 +5296,8 @@ def run_org_report(
     output_format = _normalize_org_report_output_format(output_format)
     output_to_stdout = output_path in ("-", "stdout")
     status_to_stderr = output_to_stdout and output_format == "json"
+    render_console_payload_to_stdout = output_to_stdout and output_format == "console"
+    console_writer_quiet = quiet and not render_console_payload_to_stdout
     status_stream = sys.stderr if status_to_stderr else sys.stdout
 
     def _status_print(*args, **kwargs) -> None:
@@ -5360,7 +5362,7 @@ def run_org_report(
                     _status_print(f"\nComparing to previous report: {requested_baseline_path}")
                 comparison = compare_org_reports(result, str(requested_baseline_path))
                 with contextlib.redirect_stdout(status_stream):
-                    write_org_report_comparison_console(comparison, quiet)
+                    write_org_report_comparison_console(comparison, console_writer_quiet)
             except FileNotFoundError:
                 _status_print(ConsoleColors.error(f"ERROR: Previous report not found: {requested_baseline_path}"))
             except json.JSONDecodeError:
@@ -5395,7 +5397,7 @@ def run_org_report(
         # Handle org-stats mode (Feature 2) - minimal output
         if org_config.org_stats_only:
             with contextlib.redirect_stdout(status_stream):
-                write_org_report_stats_only(result, quiet=quiet, trending=trending)
+                write_org_report_stats_only(result, quiet=console_writer_quiet, trending=trending)
             # Still output JSON if requested for CI integration
             if output_format == "json":
                 if output_to_stdout:
@@ -5437,7 +5439,7 @@ def run_org_report(
                 for f in generated_files:
                     _status_print(f"  - {f}")
         elif output_format == "console" or (output_format is None and output_path is None):
-            write_org_report_console(result, org_config, quiet, trending=trending)
+            write_org_report_console(result, org_config, console_writer_quiet, trending=trending)
         elif output_format == "json":
             if output_to_stdout:
                 json.dump(

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -6220,6 +6220,26 @@ def _handle_org_report_snapshot_cli(
     sys.exit(0)
 
 
+def _resolve_org_report_output_path(args: argparse.Namespace, *, output_format: str) -> str | None:
+    """Resolve the effective org-report output path for the current CLI invocation.
+
+    Keep parser-level ``--agent-mode`` preset semantics intact, then let the
+    org-report CLI seam suppress only the inherited stdout default when the
+    caller explicitly selected a file-only format without explicitly choosing
+    ``--output``.
+    """
+    output_path = getattr(args, "output", None)
+    if not getattr(args, "agent_mode", False):
+        return output_path
+    if _cli_option_specified("--output"):
+        return output_path
+
+    normalized_format = _normalize_org_report_output_format(output_format)
+    if normalized_format in {"json", "console"}:
+        return output_path
+    return None
+
+
 def _dispatch_post_validation_report_modes(
     args: argparse.Namespace,
     *,
@@ -6360,7 +6380,7 @@ def _dispatch_post_validation_report_modes(
         success, thresholds_exceeded = run_org_report(
             config_file=args.config_file,
             output_format=output_format,
-            output_path=getattr(args, "output", None),
+            output_path=_resolve_org_report_output_path(args, output_format=output_format),
             output_dir=args.output_dir,
             org_config=org_config,
             profile=getattr(args, "profile", None),

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -5243,8 +5243,8 @@ write_org_report_csv = _make_org_writer_compat_wrapper(
 
 def _populate_org_report_advisory_rollup(
     runtime_details: dict[str, Any] | None,
-    result: Any,
-    trending: Any | None,
+    result: OrgReportResult,
+    trending: OrgReportTrending | None,
 ) -> None:
     """Compute advisory rollup from org-report result and store in runtime_details.
 

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -5258,8 +5258,8 @@ def _populate_org_report_advisory_rollup(
 
         advisory_summary = build_org_report_advisories(result, trending=trending)
         runtime_details["advisory_rollup"] = build_advisory_rollup(advisory_summary)
-    except Exception:  # noqa: BLE001
-        pass
+    except Exception:
+        logging.getLogger("org_report").debug("Advisory rollup computation failed", exc_info=True)
 
 
 def run_org_report(

--- a/src/cja_auto_sdr/org/analyzer.py
+++ b/src/cja_auto_sdr/org/analyzer.py
@@ -25,6 +25,7 @@ from tqdm import tqdm
 from cja_auto_sdr.core.constants import (
     DEFAULT_ORG_REPORT_WORKERS,
     GOVERNANCE_MAX_OVERLAP_THRESHOLD,
+    effective_governance_overlap_threshold,
 )
 from cja_auto_sdr.core.exceptions import LockOwnershipLostError
 from cja_auto_sdr.inventory.utils import extract_owner
@@ -445,7 +446,7 @@ class OrgComponentAnalyzer:
         if need_similarity and not similarity_guardrail_blocked:
             self.logger.info("Computing similarity matrix...")
             similarity_pairs = self._compute_similarity_matrix(summaries, precomputed=pairwise_data)
-            effective_threshold = min(self.config.overlap_threshold, GOVERNANCE_MAX_OVERLAP_THRESHOLD)
+            effective_threshold = effective_governance_overlap_threshold(self.config.overlap_threshold)
             self.logger.info(f"Found {len(similarity_pairs)} pairs above threshold (>= {effective_threshold})")
         elif self.config.org_stats_only:
             self.logger.info("Skipping similarity matrix (--org-stats mode)")
@@ -1183,7 +1184,7 @@ class OrgComponentAnalyzer:
             valid_summaries, pairwise = self._compute_pairwise_jaccard(summaries)
 
         pairs = []
-        min_similarity_threshold = min(self.config.overlap_threshold, GOVERNANCE_MAX_OVERLAP_THRESHOLD)
+        min_similarity_threshold = effective_governance_overlap_threshold(self.config.overlap_threshold)
 
         for (i, j), similarity in pairwise.items():
             if similarity >= min_similarity_threshold:

--- a/src/cja_auto_sdr/org/writers/console.py
+++ b/src/cja_auto_sdr/org/writers/console.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from cja_auto_sdr.core.constants import BANNER_WIDTH
+from cja_auto_sdr.core.constants import BANNER_WIDTH, effective_governance_overlap_threshold
 from cja_auto_sdr.org.models import (
     OrgReportComparison,
     OrgReportConfig,
@@ -198,7 +198,7 @@ def write_org_report_console(
         print("-" * 110)
         print("HIGH OVERLAP PAIRS")
         print("-" * 110)
-        effective_threshold = min(config.overlap_threshold, 0.9)
+        effective_threshold = effective_governance_overlap_threshold(config.overlap_threshold)
         threshold_note = ""
         if config.overlap_threshold > 0.9:
             threshold_note = f" (configured {config.overlap_threshold * 100:.0f}%, capped at 90% for governance checks)"

--- a/src/cja_auto_sdr/org/writers/csv.py
+++ b/src/cja_auto_sdr/org/writers/csv.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import pandas as pd
 
+from cja_auto_sdr.core.constants import effective_governance_overlap_threshold
 from cja_auto_sdr.org.models import (
     OrgReportResult,
     OrgReportTrending,
@@ -107,7 +108,7 @@ def write_org_report_csv(
     total_derived_metrics = sum(dv.derived_metric_count for dv in result.data_view_summaries if dv.error is None)
     total_derived_dimensions = sum(dv.derived_dimension_count for dv in result.data_view_summaries if dv.error is None)
     total_derived_fields = total_derived_metrics + total_derived_dimensions
-    effective_overlap_threshold = min(result.parameters.overlap_threshold, 0.9)
+    effective_overlap_threshold = effective_governance_overlap_threshold(result.parameters.overlap_threshold)
 
     summary_data = [
         {
@@ -221,7 +222,7 @@ def write_org_report_csv(
 
     # 5. Similarity CSV (if computed)
     if result.similarity_pairs:
-        effective_overlap_threshold = min(result.parameters.overlap_threshold, 0.9)
+        effective_overlap_threshold = effective_governance_overlap_threshold(result.parameters.overlap_threshold)
         sim_data = [
             {
                 "Data View 1 ID": pair.dv1_id,

--- a/src/cja_auto_sdr/org/writers/excel.py
+++ b/src/cja_auto_sdr/org/writers/excel.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import pandas as pd
 
+from cja_auto_sdr.core.constants import effective_governance_overlap_threshold
 from cja_auto_sdr.org.models import (
     ComponentInfo,
     OrgReportResult,
@@ -131,7 +132,7 @@ def write_org_report_excel(
             dv.derived_dimension_count for dv in result.data_view_summaries if dv.error is None
         )
         total_derived_fields = total_derived_metrics + total_derived_dimensions
-        effective_overlap_threshold = min(result.parameters.overlap_threshold, 0.9)
+        effective_overlap_threshold = effective_governance_overlap_threshold(result.parameters.overlap_threshold)
 
         metrics = [
             "Organization ID",

--- a/src/cja_auto_sdr/org/writers/html.py
+++ b/src/cja_auto_sdr/org/writers/html.py
@@ -10,6 +10,7 @@ import logging
 from datetime import UTC, datetime
 from pathlib import Path
 
+from cja_auto_sdr.core.constants import effective_governance_overlap_threshold
 from cja_auto_sdr.org.models import (
     OrgReportResult,
     OrgReportTrending,
@@ -309,7 +310,7 @@ def write_org_report_html(
 
     # Similarity Pairs
     if result.similarity_pairs:
-        effective_threshold = min(result.parameters.overlap_threshold, 0.9)
+        effective_threshold = effective_governance_overlap_threshold(result.parameters.overlap_threshold)
         threshold_note = ""
         if result.parameters.overlap_threshold > 0.9:
             threshold_note = (

--- a/src/cja_auto_sdr/org/writers/json.py
+++ b/src/cja_auto_sdr/org/writers/json.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from cja_auto_sdr.core.advisory_builders import build_org_report_advisories
 from cja_auto_sdr.org.models import (
     OrgReportResult,
     OrgReportTrending,
@@ -207,6 +208,8 @@ def build_org_report_json_data(
     }
     if trending is not None and len(trending.snapshots) >= 2:
         data["trending"] = _trending_snapshots_to_dicts(trending)
+    advisory_summary = build_org_report_advisories(result, trending=trending)
+    data["advisories"] = advisory_summary.to_dict()
     return data
 
 

--- a/src/cja_auto_sdr/org/writers/json.py
+++ b/src/cja_auto_sdr/org/writers/json.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from cja_auto_sdr.core.advisory_builders import build_org_report_advisories
+from cja_auto_sdr.core.constants import effective_governance_overlap_threshold
 from cja_auto_sdr.org.models import (
     OrgReportResult,
     OrgReportTrending,
@@ -40,7 +41,7 @@ def build_org_report_json_data(
     trending: OrgReportTrending | None = None,
 ) -> dict[str, Any]:
     """Build org report JSON payload."""
-    effective_overlap_threshold = min(result.parameters.overlap_threshold, 0.9)
+    effective_overlap_threshold = effective_governance_overlap_threshold(result.parameters.overlap_threshold)
     similarity_analysis_complete = result.similarity_pairs is not None
     if result.parameters.org_stats_only:
         similarity_analysis_mode = "org_stats_only"

--- a/src/cja_auto_sdr/org/writers/markdown.py
+++ b/src/cja_auto_sdr/org/writers/markdown.py
@@ -9,6 +9,7 @@ import logging
 from datetime import UTC, datetime
 from pathlib import Path
 
+from cja_auto_sdr.core.constants import effective_governance_overlap_threshold
 from cja_auto_sdr.core.version import __version__
 from cja_auto_sdr.org.models import (
     OrgReportResult,
@@ -210,7 +211,7 @@ def write_org_report_markdown(
     if result.similarity_pairs:
         lines.append("## High Overlap Pairs")
         lines.append("")
-        effective_threshold = min(result.parameters.overlap_threshold, 0.9)
+        effective_threshold = effective_governance_overlap_threshold(result.parameters.overlap_threshold)
         threshold_note = ""
         if result.parameters.overlap_threshold > 0.9:
             threshold_note = (

--- a/src/cja_auto_sdr/output/diff/__init__.py
+++ b/src/cja_auto_sdr/output/diff/__init__.py
@@ -39,7 +39,7 @@ from cja_auto_sdr.output.diff.csv import write_diff_csv_output
 from cja_auto_sdr.output.diff.excel import write_diff_excel_output
 from cja_auto_sdr.output.diff.grouped import write_diff_grouped_by_field_output
 from cja_auto_sdr.output.diff.html import write_diff_html_output
-from cja_auto_sdr.output.diff.json import write_diff_json_output
+from cja_auto_sdr.output.diff.json import build_diff_json_data, write_diff_json_output
 from cja_auto_sdr.output.diff.markdown import (
     _format_markdown_side_by_side,
     write_diff_markdown_output,
@@ -64,6 +64,7 @@ def write_diff_output(
     use_color: bool = True,
     group_by_field: bool = False,
     group_by_field_limit: int = 10,
+    output_to_stdout: bool = False,
 ) -> str | None:
     """
     Write diff comparison output in specified format(s).
@@ -84,7 +85,15 @@ def write_diff_output(
     Returns:
         Console output string (for console/pr-comment format) or None
     """
+    import json as _json
+
     from cja_auto_sdr.core.constants import should_generate_format
+
+    # Stdout JSON fast-path: emit JSON to stdout and skip file creation
+    if output_to_stdout and output_format == "json":
+        data = build_diff_json_data(diff_result, changes_only=changes_only)
+        print(_json.dumps(data, indent=2, ensure_ascii=False))  # noqa: T201
+        return None
 
     os.makedirs(output_dir, exist_ok=True)
     console_output = None
@@ -137,6 +146,7 @@ __all__ = [
     "_get_change_symbol",
     "_get_colored_symbol",
     "_get_inventory_change_detail",
+    "build_diff_json_data",
     "detect_breaking_changes",
     "write_diff_console_output",
     "write_diff_csv_output",

--- a/src/cja_auto_sdr/output/diff/json.py
+++ b/src/cja_auto_sdr/output/diff/json.py
@@ -1,6 +1,7 @@
 """JSON diff file output writer.
 
 Extracted from generator.py. Provides:
+- build_diff_json_data: Build diff JSON payload dict (pure, no I/O)
 - write_diff_json_output: Write diff comparison to JSON format
 """
 
@@ -10,7 +11,9 @@ import json
 import logging
 import os
 from pathlib import Path
+from typing import Any
 
+from cja_auto_sdr.core.advisory_builders import build_diff_advisories
 from cja_auto_sdr.core.colors import _format_error_msg
 from cja_auto_sdr.diff.models import (
     ChangeType,
@@ -18,6 +21,139 @@ from cja_auto_sdr.diff.models import (
     DiffResult,
     InventoryItemDiff,
 )
+
+
+def _serialize_component_diff(d: ComponentDiff) -> dict:
+    return {
+        "id": d.id,
+        "name": d.name,
+        "change_type": d.change_type.value,
+        "changed_fields": {k: {"source": v[0], "target": v[1]} for k, v in (d.changed_fields or {}).items()},
+        "source_data": d.source_data,
+        "target_data": d.target_data,
+    }
+
+
+def _serialize_inventory_diff(d: InventoryItemDiff) -> dict:
+    return {
+        "id": d.id,
+        "name": d.name,
+        "change_type": d.change_type.value,
+        "inventory_type": d.inventory_type,
+        "changed_fields": {k: {"source": v[0], "target": v[1]} for k, v in (d.changed_fields or {}).items()},
+        "source_data": d.source_data,
+        "target_data": d.target_data,
+    }
+
+
+def build_diff_json_data(
+    diff_result: DiffResult,
+    *,
+    changes_only: bool = False,
+) -> dict[str, Any]:
+    """Build diff JSON payload dict (pure function, no I/O).
+
+    Args:
+        diff_result: The DiffResult to serialize
+        changes_only: Only include changed items
+
+    Returns:
+        JSON-serializable dict with diff data and advisories
+    """
+    summary = diff_result.summary
+    meta = diff_result.metadata_diff
+
+    # Filter diffs if changes_only
+    metric_diffs = diff_result.metric_diffs
+    dimension_diffs = diff_result.dimension_diffs
+    if changes_only:
+        metric_diffs = [d for d in metric_diffs if d.change_type != ChangeType.UNCHANGED]
+        dimension_diffs = [d for d in dimension_diffs if d.change_type != ChangeType.UNCHANGED]
+
+    json_data: dict[str, Any] = {
+        "metadata": {
+            "generated_at": diff_result.generated_at,
+            "tool_version": diff_result.tool_version,
+            "source_label": diff_result.source_label,
+            "target_label": diff_result.target_label,
+        },
+        "source": {
+            "id": meta.source_id,
+            "name": meta.source_name,
+            "owner": meta.source_owner,
+            "description": meta.source_description,
+        },
+        "target": {
+            "id": meta.target_id,
+            "name": meta.target_name,
+            "owner": meta.target_owner,
+            "description": meta.target_description,
+        },
+        "summary": {
+            "source_metrics_count": summary.source_metrics_count,
+            "target_metrics_count": summary.target_metrics_count,
+            "source_dimensions_count": summary.source_dimensions_count,
+            "target_dimensions_count": summary.target_dimensions_count,
+            "metrics_added": summary.metrics_added,
+            "metrics_removed": summary.metrics_removed,
+            "metrics_modified": summary.metrics_modified,
+            "metrics_unchanged": summary.metrics_unchanged,
+            "metrics_change_percent": summary.metrics_change_percent,
+            "dimensions_added": summary.dimensions_added,
+            "dimensions_removed": summary.dimensions_removed,
+            "dimensions_modified": summary.dimensions_modified,
+            "dimensions_unchanged": summary.dimensions_unchanged,
+            "dimensions_change_percent": summary.dimensions_change_percent,
+            "has_changes": summary.has_changes,
+            "total_changes": summary.total_changes,
+            "total_added": summary.total_added,
+            "total_removed": summary.total_removed,
+            "total_modified": summary.total_modified,
+            "total_summary": summary.total_summary,
+        },
+        "metric_diffs": [_serialize_component_diff(d) for d in metric_diffs],
+        "dimension_diffs": [_serialize_component_diff(d) for d in dimension_diffs],
+    }
+
+    # Add inventory diffs if present
+    if diff_result.has_inventory_diffs:
+        inventory_summary: dict[str, Any] = {}
+        if summary.source_calc_metrics_count > 0 or summary.target_calc_metrics_count > 0:
+            inventory_summary["calculated_metrics"] = {
+                "source_count": summary.source_calc_metrics_count,
+                "target_count": summary.target_calc_metrics_count,
+                "added": summary.calc_metrics_added,
+                "removed": summary.calc_metrics_removed,
+                "modified": summary.calc_metrics_modified,
+                "unchanged": summary.calc_metrics_unchanged,
+            }
+        if summary.source_segments_count > 0 or summary.target_segments_count > 0:
+            inventory_summary["segments"] = {
+                "source_count": summary.source_segments_count,
+                "target_count": summary.target_segments_count,
+                "added": summary.segments_added,
+                "removed": summary.segments_removed,
+                "modified": summary.segments_modified,
+                "unchanged": summary.segments_unchanged,
+            }
+        json_data["inventory_summary"] = inventory_summary
+
+        if diff_result.calc_metrics_diffs is not None:
+            calc_diffs = diff_result.calc_metrics_diffs
+            if changes_only:
+                calc_diffs = [d for d in calc_diffs if d.change_type != ChangeType.UNCHANGED]
+            json_data["calculated_metrics_diffs"] = [_serialize_inventory_diff(d) for d in calc_diffs]
+
+        if diff_result.segments_diffs is not None:
+            seg_diffs = diff_result.segments_diffs
+            if changes_only:
+                seg_diffs = [d for d in seg_diffs if d.change_type != ChangeType.UNCHANGED]
+            json_data["segments_diffs"] = [_serialize_inventory_diff(d) for d in seg_diffs]
+
+    # Advisories — derived convenience layer
+    advisory_summary = build_diff_advisories(diff_result, changes_only=changes_only)
+    json_data["advisories"] = advisory_summary.to_dict()
+    return json_data
 
 
 def write_diff_json_output(
@@ -43,116 +179,7 @@ def write_diff_json_output(
     try:
         logger.info("Generating diff JSON output...")
 
-        summary = diff_result.summary
-        meta = diff_result.metadata_diff
-
-        def serialize_component_diff(d: ComponentDiff) -> dict:
-            return {
-                "id": d.id,
-                "name": d.name,
-                "change_type": d.change_type.value,
-                "changed_fields": {k: {"source": v[0], "target": v[1]} for k, v in (d.changed_fields or {}).items()},
-                "source_data": d.source_data,
-                "target_data": d.target_data,
-            }
-
-        def serialize_inventory_diff(d: InventoryItemDiff) -> dict:
-            return {
-                "id": d.id,
-                "name": d.name,
-                "change_type": d.change_type.value,
-                "inventory_type": d.inventory_type,
-                "changed_fields": {k: {"source": v[0], "target": v[1]} for k, v in (d.changed_fields or {}).items()},
-                "source_data": d.source_data,
-                "target_data": d.target_data,
-            }
-
-        # Filter diffs if changes_only
-        metric_diffs = diff_result.metric_diffs
-        dimension_diffs = diff_result.dimension_diffs
-        if changes_only:
-            metric_diffs = [d for d in metric_diffs if d.change_type != ChangeType.UNCHANGED]
-            dimension_diffs = [d for d in dimension_diffs if d.change_type != ChangeType.UNCHANGED]
-
-        json_data = {
-            "metadata": {
-                "generated_at": diff_result.generated_at,
-                "tool_version": diff_result.tool_version,
-                "source_label": diff_result.source_label,
-                "target_label": diff_result.target_label,
-            },
-            "source": {
-                "id": meta.source_id,
-                "name": meta.source_name,
-                "owner": meta.source_owner,
-                "description": meta.source_description,
-            },
-            "target": {
-                "id": meta.target_id,
-                "name": meta.target_name,
-                "owner": meta.target_owner,
-                "description": meta.target_description,
-            },
-            "summary": {
-                "source_metrics_count": summary.source_metrics_count,
-                "target_metrics_count": summary.target_metrics_count,
-                "source_dimensions_count": summary.source_dimensions_count,
-                "target_dimensions_count": summary.target_dimensions_count,
-                "metrics_added": summary.metrics_added,
-                "metrics_removed": summary.metrics_removed,
-                "metrics_modified": summary.metrics_modified,
-                "metrics_unchanged": summary.metrics_unchanged,
-                "metrics_change_percent": summary.metrics_change_percent,
-                "dimensions_added": summary.dimensions_added,
-                "dimensions_removed": summary.dimensions_removed,
-                "dimensions_modified": summary.dimensions_modified,
-                "dimensions_unchanged": summary.dimensions_unchanged,
-                "dimensions_change_percent": summary.dimensions_change_percent,
-                "has_changes": summary.has_changes,
-                "total_changes": summary.total_changes,
-                "total_added": summary.total_added,
-                "total_removed": summary.total_removed,
-                "total_modified": summary.total_modified,
-                "total_summary": summary.total_summary,
-            },
-            "metric_diffs": [serialize_component_diff(d) for d in metric_diffs],
-            "dimension_diffs": [serialize_component_diff(d) for d in dimension_diffs],
-        }
-
-        # Add inventory diffs if present
-        if diff_result.has_inventory_diffs:
-            inventory_summary = {}
-            if summary.source_calc_metrics_count > 0 or summary.target_calc_metrics_count > 0:
-                inventory_summary["calculated_metrics"] = {
-                    "source_count": summary.source_calc_metrics_count,
-                    "target_count": summary.target_calc_metrics_count,
-                    "added": summary.calc_metrics_added,
-                    "removed": summary.calc_metrics_removed,
-                    "modified": summary.calc_metrics_modified,
-                    "unchanged": summary.calc_metrics_unchanged,
-                }
-            if summary.source_segments_count > 0 or summary.target_segments_count > 0:
-                inventory_summary["segments"] = {
-                    "source_count": summary.source_segments_count,
-                    "target_count": summary.target_segments_count,
-                    "added": summary.segments_added,
-                    "removed": summary.segments_removed,
-                    "modified": summary.segments_modified,
-                    "unchanged": summary.segments_unchanged,
-                }
-            json_data["inventory_summary"] = inventory_summary
-
-            if diff_result.calc_metrics_diffs is not None:
-                calc_diffs = diff_result.calc_metrics_diffs
-                if changes_only:
-                    calc_diffs = [d for d in calc_diffs if d.change_type != ChangeType.UNCHANGED]
-                json_data["calculated_metrics_diffs"] = [serialize_inventory_diff(d) for d in calc_diffs]
-
-            if diff_result.segments_diffs is not None:
-                seg_diffs = diff_result.segments_diffs
-                if changes_only:
-                    seg_diffs = [d for d in seg_diffs if d.change_type != ChangeType.UNCHANGED]
-                json_data["segments_diffs"] = [serialize_inventory_diff(d) for d in seg_diffs]
+        json_data = build_diff_json_data(diff_result, changes_only=changes_only)
 
         json_file = os.path.join(output_dir, f"{base_filename}.json")
         with open(json_file, "w", encoding="utf-8") as f:

--- a/tests/README.md
+++ b/tests/README.md
@@ -139,7 +139,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 7,527 comprehensive tests**
+**Total: 7,543 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -148,16 +148,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,421 | 121 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,437 | 121 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 7 | 1 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **7,527** | **127** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **7,543** | **127** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,414 | 120 | `-m "unit and not slow"` |
+| `test-unit` | 7,430 | 120 | `-m "unit and not slow"` |
 | `test-integration` | 103 | 6 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -291,10 +291,10 @@ tests/
 | `test_agent_contract_docs.py` | 21 | Agent contract documentation validation tests |
 | `test_agent_contract_samples.py` | 6 | Agent contract sample fixture validation tests |
 | `test_agent_mode.py` | 33 | --agent-mode CLI preset and resolution tests |
-| `test_agent_playbooks.py` | 27 | Agent playbook structural validation tests |
-| `test_agent_workflows.py` | 44 | Agent workflow shell script validation tests |
-| `test_tool_manifests.py` | 36 | Tool manifest schema and content tests |
-| **Total** | **7,527** | **Collected via pytest --collect-only** |
+| `test_agent_playbooks.py` | 38 | Agent playbook structural validation tests |
+| `test_agent_workflows.py` | 48 | Agent workflow shell script validation tests |
+| `test_tool_manifests.py` | 37 | Tool manifest schema and content tests |
+| **Total** | **7,543** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -752,7 +752,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (7,527 tests total)
+- [x] Comprehensive test coverage (7,543 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 209 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 77 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -139,7 +139,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 7,509 comprehensive tests**
+**Total: 7,521 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -148,16 +148,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,403 | 121 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,415 | 121 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 7 | 1 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **7,509** | **127** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **7,521** | **127** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,396 | 120 | `-m "unit and not slow"` |
+| `test-unit` | 7,408 | 120 | `-m "unit and not slow"` |
 | `test-integration` | 103 | 6 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -287,14 +287,14 @@ tests/
 | `test_quality_edge_cases.py` | 19 | Quality edge-case tests |
 | `test_tuning_edge_cases.py` | 15 | Tuning edge-case tests |
 | `test_fetch_edge_cases.py` | 9 | Fetch edge-case tests |
-| `test_advisories.py` | 46 | Advisory model, builder, and rollup tests |
-| `test_agent_contract_docs.py` | 16 | Agent contract documentation validation tests |
+| `test_advisories.py` | 48 | Advisory model, builder, and rollup tests |
+| `test_agent_contract_docs.py` | 21 | Agent contract documentation validation tests |
 | `test_agent_contract_samples.py` | 6 | Agent contract sample fixture validation tests |
 | `test_agent_mode.py` | 28 | --agent-mode CLI preset and resolution tests |
 | `test_agent_playbooks.py` | 27 | Agent playbook structural validation tests |
 | `test_agent_workflows.py` | 44 | Agent workflow shell script validation tests |
-| `test_tool_manifests.py` | 31 | Tool manifest schema and content tests |
-| **Total** | **7,509** | **Collected via pytest --collect-only** |
+| `test_tool_manifests.py` | 36 | Tool manifest schema and content tests |
+| **Total** | **7,521** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -752,7 +752,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (7,509 tests total)
+- [x] Comprehensive test coverage (7,521 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 209 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 77 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -129,10 +129,17 @@ tests/
 ├── test_example_automation_scripts.py # Automation shell script validation tests
 ├── test_exit_codes.py               # Exit code helpers and signal detection tests
 ├── test_json_io.py                  # JSON I/O atomic write and read tests
+├── test_advisories.py               # Advisory model, builder, and rollup tests
+├── test_agent_contract_docs.py      # Agent contract documentation validation tests
+├── test_agent_contract_samples.py   # Agent contract sample fixture validation tests
+├── test_agent_mode.py               # --agent-mode CLI preset and resolution tests
+├── test_agent_playbooks.py          # Agent playbook structural validation tests
+├── test_agent_workflows.py          # Agent workflow shell script validation tests
+├── test_tool_manifests.py           # Tool manifest schema and content tests
 └── README.md                        # This file
 ```
 
-**Total: 7,294 comprehensive tests**
+**Total: 7,509 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -141,16 +148,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,188 | 114 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,403 | 121 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 7 | 1 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **7,294** | **120** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **7,509** | **127** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,181 | 113 | `-m "unit and not slow"` |
+| `test-unit` | 7,396 | 120 | `-m "unit and not slow"` |
 | `test-integration` | 103 | 6 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -164,7 +171,7 @@ tests/
 | `test_ux_features.py` | 123 | UX features: --open, --stats, --output, --list-dataviews formats, inventory validation, inventory summary, include-all-inventory |
 | `test_org_report.py` | 209 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
 | `test_org_report_integration.py` | 17 | Org-wide analysis integration tests: end-to-end flows, caching, filtering, governance |
-| `test_cli.py` | 410 | Command-line interface and argument parsing |
+| `test_cli.py` | 412 | Command-line interface and argument parsing |
 | `test_profiles.py` | 77 | Multi-organization profile support |
 | `test_derived_inventory.py` | 62 | Derived fields inventory feature |
 | `test_inventory_utils.py` | 56 | Inventory utilities and helpers |
@@ -201,10 +208,10 @@ tests/
 | `test_discovery_extraction.py` | 46 | Discovery module extraction and backwards-compat contracts |
 | `test_diagnostic_events.py` | 23 | Structured diagnostic event vocabulary, logger adapters, and redaction |
 | `test_output_content_validation.py` | 29 | Output format content validation (CSV, JSON, HTML, Excel, Markdown roundtrip) |
-| `test_output_extraction_contracts.py` | 338 | Extraction contracts for output.diff and output.inventory |
+| `test_output_extraction_contracts.py` | 345 | Extraction contracts for output.diff and output.inventory |
 | `test_malformed_api_responses.py` | 20 | Negative tests for malformed/unexpected API responses |
 | `test_main_entry_points.py` | 43 | main() and _main_impl() entry points, dispatch, run_state, run summary |
-| `test_quality_policy_and_run_summary.py` | 163 | Quality policy functions and run summary/status inference |
+| `test_quality_policy_and_run_summary.py` | 169 | Quality policy functions and run summary/status inference |
 | `test_e2e_integration.py` | 16 | End-to-end integration tests with real pipeline, mocked API boundary |
 | `test_api_client.py` | 29 | API client exception paths and error handling |
 | `test_config_validation.py` | 55 | Configuration validation logic |
@@ -239,7 +246,7 @@ tests/
 | `test_main_impl_cli_coverage.py` | 90 | _main_impl CLI path coverage |
 | `test_main_impl_coverage.py` | 57 | _main_impl coverage edge cases |
 | `test_org_cache_branches.py` | 51 | Org cache branch coverage |
-| `test_org_writer_compat_contracts.py` | 106 | Org writer compatibility boundary contract tests |
+| `test_org_writer_compat_contracts.py` | 107 | Org writer compatibility boundary contract tests |
 | `test_org_writer_coverage.py` | 143 | Org writer edge cases and coverage |
 | `test_output_writer_coverage.py` | 37 | Output writer edge cases and coverage |
 | `test_backwards_compat.py` | 34 | Backwards compatibility tests |
@@ -247,7 +254,7 @@ tests/
 | `test_update_test_counts.py` | 7 | Test count validation tests |
 | `test_cli_smoke_modes.py` | 10 | CLI smoke tests for core command modes |
 | `test_generator_mock_contract.py` | 2 | Generator mock symbol contract tests |
-| `test_completion.py` | 55 | Shell completion flag (--completion bash/zsh/fish) |
+| `test_completion.py` | 56 | Shell completion flag (--completion bash/zsh/fish) |
 | `test_exception_narrowing.py` | 50 | Exception narrowing boundary tests |
 | `test_coverage_hardening.py` | 99 | Coverage hardening tests |
 | `test_trending_models.py` | 53 | Trending dataclass construction and bridge tests |
@@ -280,7 +287,14 @@ tests/
 | `test_quality_edge_cases.py` | 19 | Quality edge-case tests |
 | `test_tuning_edge_cases.py` | 15 | Tuning edge-case tests |
 | `test_fetch_edge_cases.py` | 9 | Fetch edge-case tests |
-| **Total** | **7,294** | **Collected via pytest --collect-only** |
+| `test_advisories.py` | 46 | Advisory model, builder, and rollup tests |
+| `test_agent_contract_docs.py` | 16 | Agent contract documentation validation tests |
+| `test_agent_contract_samples.py` | 6 | Agent contract sample fixture validation tests |
+| `test_agent_mode.py` | 28 | --agent-mode CLI preset and resolution tests |
+| `test_agent_playbooks.py` | 27 | Agent playbook structural validation tests |
+| `test_agent_workflows.py` | 44 | Agent workflow shell script validation tests |
+| `test_tool_manifests.py` | 31 | Tool manifest schema and content tests |
+| **Total** | **7,509** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -738,7 +752,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (7,294 tests total)
+- [x] Comprehensive test coverage (7,509 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 209 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 77 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -139,7 +139,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 7,566 comprehensive tests**
+**Total: 7,578 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -148,16 +148,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,460 | 121 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,472 | 121 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 7 | 1 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **7,566** | **127** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **7,578** | **127** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,453 | 120 | `-m "unit and not slow"` |
+| `test-unit` | 7,465 | 120 | `-m "unit and not slow"` |
 | `test-integration` | 103 | 6 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -287,14 +287,14 @@ tests/
 | `test_quality_edge_cases.py` | 19 | Quality edge-case tests |
 | `test_tuning_edge_cases.py` | 15 | Tuning edge-case tests |
 | `test_fetch_edge_cases.py` | 9 | Fetch edge-case tests |
-| `test_advisories.py` | 49 | Advisory model, builder, and rollup tests |
-| `test_agent_contract_docs.py` | 23 | Agent contract documentation validation tests |
+| `test_advisories.py` | 53 | Advisory model, builder, and rollup tests |
+| `test_agent_contract_docs.py` | 27 | Agent contract documentation validation tests |
 | `test_agent_contract_samples.py` | 6 | Agent contract sample fixture validation tests |
-| `test_agent_mode.py` | 33 | --agent-mode CLI preset and resolution tests |
+| `test_agent_mode.py` | 36 | --agent-mode CLI preset and resolution tests |
 | `test_agent_playbooks.py` | 38 | Agent playbook structural validation tests |
 | `test_agent_workflows.py` | 69 | Agent workflow shell script validation tests |
-| `test_tool_manifests.py` | 37 | Tool manifest schema and content tests |
-| **Total** | **7,566** | **Collected via pytest --collect-only** |
+| `test_tool_manifests.py` | 38 | Tool manifest schema and content tests |
+| **Total** | **7,578** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -752,7 +752,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (7,566 tests total)
+- [x] Comprehensive test coverage (7,578 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 209 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 77 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -139,7 +139,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 7,578 comprehensive tests**
+**Total: 7,580 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -148,16 +148,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,472 | 121 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,474 | 121 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 7 | 1 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **7,578** | **127** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **7,580** | **127** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,465 | 120 | `-m "unit and not slow"` |
+| `test-unit` | 7,467 | 120 | `-m "unit and not slow"` |
 | `test-integration` | 103 | 6 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -169,7 +169,7 @@ tests/
 |-----------|-------|---------------|
 | `test_diff_comparison.py` | 169 | Data view diff comparison feature with inventory support |
 | `test_ux_features.py` | 123 | UX features: --open, --stats, --output, --list-dataviews formats, inventory validation, inventory summary, include-all-inventory |
-| `test_org_report.py` | 209 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
+| `test_org_report.py` | 211 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
 | `test_org_report_integration.py` | 17 | Org-wide analysis integration tests: end-to-end flows, caching, filtering, governance |
 | `test_cli.py` | 412 | Command-line interface and argument parsing |
 | `test_profiles.py` | 77 | Multi-organization profile support |
@@ -294,7 +294,7 @@ tests/
 | `test_agent_playbooks.py` | 38 | Agent playbook structural validation tests |
 | `test_agent_workflows.py` | 69 | Agent workflow shell script validation tests |
 | `test_tool_manifests.py` | 38 | Tool manifest schema and content tests |
-| **Total** | **7,578** | **Collected via pytest --collect-only** |
+| **Total** | **7,580** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -752,8 +752,8 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (7,578 tests total)
-- [x] Org-wide analysis tests (test_org_report.py) - 209 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
+- [x] Comprehensive test coverage (7,580 tests total)
+- [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 77 tests
 - [x] API worker auto-tuning tests (test_api_tuning.py) - 24 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -139,7 +139,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 7,583 comprehensive tests**
+**Total: 7,590 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -148,16 +148,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,477 | 121 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,484 | 121 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 7 | 1 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **7,583** | **127** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **7,590** | **127** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,470 | 120 | `-m "unit and not slow"` |
+| `test-unit` | 7,477 | 120 | `-m "unit and not slow"` |
 | `test-integration` | 103 | 6 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -290,11 +290,11 @@ tests/
 | `test_advisories.py` | 53 | Advisory model, builder, and rollup tests |
 | `test_agent_contract_docs.py` | 27 | Agent contract documentation validation tests |
 | `test_agent_contract_samples.py` | 6 | Agent contract sample fixture validation tests |
-| `test_agent_mode.py` | 39 | --agent-mode CLI preset and resolution tests |
+| `test_agent_mode.py` | 44 | --agent-mode CLI preset and resolution tests |
 | `test_agent_playbooks.py` | 38 | Agent playbook structural validation tests |
 | `test_agent_workflows.py` | 69 | Agent workflow shell script validation tests |
-| `test_tool_manifests.py` | 38 | Tool manifest schema and content tests |
-| **Total** | **7,583** | **Collected via pytest --collect-only** |
+| `test_tool_manifests.py` | 40 | Tool manifest schema and content tests |
+| **Total** | **7,590** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -752,7 +752,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (7,583 tests total)
+- [x] Comprehensive test coverage (7,590 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 77 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -139,7 +139,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 7,543 comprehensive tests**
+**Total: 7,566 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -148,16 +148,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,437 | 121 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,460 | 121 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 7 | 1 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **7,543** | **127** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **7,566** | **127** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,430 | 120 | `-m "unit and not slow"` |
+| `test-unit` | 7,453 | 120 | `-m "unit and not slow"` |
 | `test-integration` | 103 | 6 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -288,13 +288,13 @@ tests/
 | `test_tuning_edge_cases.py` | 15 | Tuning edge-case tests |
 | `test_fetch_edge_cases.py` | 9 | Fetch edge-case tests |
 | `test_advisories.py` | 49 | Advisory model, builder, and rollup tests |
-| `test_agent_contract_docs.py` | 21 | Agent contract documentation validation tests |
+| `test_agent_contract_docs.py` | 23 | Agent contract documentation validation tests |
 | `test_agent_contract_samples.py` | 6 | Agent contract sample fixture validation tests |
 | `test_agent_mode.py` | 33 | --agent-mode CLI preset and resolution tests |
 | `test_agent_playbooks.py` | 38 | Agent playbook structural validation tests |
-| `test_agent_workflows.py` | 48 | Agent workflow shell script validation tests |
+| `test_agent_workflows.py` | 69 | Agent workflow shell script validation tests |
 | `test_tool_manifests.py` | 37 | Tool manifest schema and content tests |
-| **Total** | **7,543** | **Collected via pytest --collect-only** |
+| **Total** | **7,566** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -752,7 +752,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (7,543 tests total)
+- [x] Comprehensive test coverage (7,566 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 209 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 77 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -139,7 +139,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 7,580 comprehensive tests**
+**Total: 7,583 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -148,16 +148,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,474 | 121 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,477 | 121 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 7 | 1 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **7,580** | **127** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **7,583** | **127** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,467 | 120 | `-m "unit and not slow"` |
+| `test-unit` | 7,470 | 120 | `-m "unit and not slow"` |
 | `test-integration` | 103 | 6 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -290,11 +290,11 @@ tests/
 | `test_advisories.py` | 53 | Advisory model, builder, and rollup tests |
 | `test_agent_contract_docs.py` | 27 | Agent contract documentation validation tests |
 | `test_agent_contract_samples.py` | 6 | Agent contract sample fixture validation tests |
-| `test_agent_mode.py` | 36 | --agent-mode CLI preset and resolution tests |
+| `test_agent_mode.py` | 39 | --agent-mode CLI preset and resolution tests |
 | `test_agent_playbooks.py` | 38 | Agent playbook structural validation tests |
 | `test_agent_workflows.py` | 69 | Agent workflow shell script validation tests |
 | `test_tool_manifests.py` | 38 | Tool manifest schema and content tests |
-| **Total** | **7,580** | **Collected via pytest --collect-only** |
+| **Total** | **7,583** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -752,7 +752,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (7,580 tests total)
+- [x] Comprehensive test coverage (7,583 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 77 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -139,7 +139,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 7,521 comprehensive tests**
+**Total: 7,527 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -148,16 +148,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,415 | 121 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,421 | 121 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 7 | 1 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **7,521** | **127** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **7,527** | **127** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,408 | 120 | `-m "unit and not slow"` |
+| `test-unit` | 7,414 | 120 | `-m "unit and not slow"` |
 | `test-integration` | 103 | 6 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -287,14 +287,14 @@ tests/
 | `test_quality_edge_cases.py` | 19 | Quality edge-case tests |
 | `test_tuning_edge_cases.py` | 15 | Tuning edge-case tests |
 | `test_fetch_edge_cases.py` | 9 | Fetch edge-case tests |
-| `test_advisories.py` | 48 | Advisory model, builder, and rollup tests |
+| `test_advisories.py` | 49 | Advisory model, builder, and rollup tests |
 | `test_agent_contract_docs.py` | 21 | Agent contract documentation validation tests |
 | `test_agent_contract_samples.py` | 6 | Agent contract sample fixture validation tests |
-| `test_agent_mode.py` | 28 | --agent-mode CLI preset and resolution tests |
+| `test_agent_mode.py` | 33 | --agent-mode CLI preset and resolution tests |
 | `test_agent_playbooks.py` | 27 | Agent playbook structural validation tests |
 | `test_agent_workflows.py` | 44 | Agent workflow shell script validation tests |
 | `test_tool_manifests.py` | 36 | Tool manifest schema and content tests |
-| **Total** | **7,521** | **Collected via pytest --collect-only** |
+| **Total** | **7,527** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -752,7 +752,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (7,521 tests total)
+- [x] Comprehensive test coverage (7,527 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 209 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 77 tests

--- a/tests/test_advisories.py
+++ b/tests/test_advisories.py
@@ -599,3 +599,65 @@ class TestOrgReportJsonAdvisories:
             "recommendations",
         ):
             assert key in data, f"Expected key {key!r} missing after advisories injection"
+
+
+# ---------------------------------------------------------------------------
+# Diff JSON advisory integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestDiffJsonAdvisories:
+    """Verify advisories block appears in diff JSON output."""
+
+    def test_build_diff_json_data_exists(self):
+        from cja_auto_sdr.output.diff.json import build_diff_json_data
+
+        result = _make_minimal_diff_result()
+        data = build_diff_json_data(result)
+        assert "metadata" in data
+        assert "summary" in data
+
+    def test_advisories_present_in_diff_json(self):
+        from cja_auto_sdr.output.diff.json import build_diff_json_data
+
+        result = _make_minimal_diff_result()
+        data = build_diff_json_data(result)
+        assert "advisories" in data
+        assert data["advisories"]["advisories_version"] == "1.0"
+
+    def test_diff_json_data_matches_file_writer_shape(self):
+        from cja_auto_sdr.output.diff.json import build_diff_json_data
+
+        result = _make_minimal_diff_result()
+        data = build_diff_json_data(result)
+        expected_keys = {"metadata", "source", "target", "summary", "metric_diffs", "dimension_diffs", "advisories"}
+        assert expected_keys.issubset(set(data.keys()))
+
+    def test_advisories_empty_when_no_changes(self):
+        from cja_auto_sdr.output.diff.json import build_diff_json_data
+
+        result = _make_minimal_diff_result()
+        data = build_diff_json_data(result)
+        assert data["advisories"]["findings"] == []
+        assert data["advisories"]["summary"]["total_findings"] == 0
+
+    def test_advisories_reflects_breaking_changes(self):
+        from cja_auto_sdr.diff.models import ChangeType, ComponentDiff, DiffSummary
+        from cja_auto_sdr.output.diff.json import build_diff_json_data
+
+        removed = ComponentDiff(id="m1", name="Revenue", change_type=ChangeType.REMOVED)
+        result = _make_minimal_diff_result(
+            summary=DiffSummary(metrics_removed=1),
+            metric_diffs=[removed],
+        )
+        data = build_diff_json_data(result)
+        types = [f["type"] for f in data["advisories"]["findings"]]
+        assert "breaking_changes" in types
+
+    def test_advisories_is_additive_does_not_remove_existing_keys(self):
+        from cja_auto_sdr.output.diff.json import build_diff_json_data
+
+        result = _make_minimal_diff_result()
+        data = build_diff_json_data(result)
+        for key in ("metadata", "source", "target", "summary", "metric_diffs", "dimension_diffs"):
+            assert key in data, f"Expected key {key!r} missing after advisories injection"

--- a/tests/test_advisories.py
+++ b/tests/test_advisories.py
@@ -1,0 +1,74 @@
+# tests/test_advisories.py
+"""Tests for the advisory data model and builders."""
+
+from __future__ import annotations
+
+import pytest
+
+from cja_auto_sdr.core.advisories import (
+    AdvisoryFinding,
+    AdvisorySummary,
+    _ADVISORY_SEVERITY_ORDER,
+)
+
+
+class TestAdvisoryModel:
+    """Verify advisory data model serialization and invariants."""
+
+    def test_severity_order(self):
+        assert _ADVISORY_SEVERITY_ORDER == ("info", "warning", "critical")
+
+    def test_finding_creation(self):
+        finding = AdvisoryFinding(
+            type="high_overlap",
+            severity="warning",
+            message="High overlap detected",
+            details={"pairs": 3, "threshold": 0.8},
+            recommended_actions=["review_overlap_pairs"],
+        )
+        assert finding.type == "high_overlap"
+        assert finding.severity == "warning"
+
+    def test_empty_summary_to_dict(self):
+        summary = AdvisorySummary(
+            advisories_version="1.0",
+            severity="info",
+            findings=[],
+            summary={"total_findings": 0, "by_severity": {}},
+        )
+        d = summary.to_dict()
+        assert d["advisories_version"] == "1.0"
+        assert d["severity"] == "info"
+        assert d["findings"] == []
+        assert d["summary"]["total_findings"] == 0
+        assert d["summary"]["by_severity"] == {}
+
+    def test_summary_with_findings_to_dict(self):
+        finding = AdvisoryFinding(
+            type="governance_threshold_breach",
+            severity="critical",
+            message="Threshold breach detected",
+            details={"violations": [], "count": 1},
+            recommended_actions=["review_governance_thresholds"],
+        )
+        summary = AdvisorySummary(
+            advisories_version="1.0",
+            severity="critical",
+            findings=[finding],
+            summary={"total_findings": 1, "by_severity": {"critical": 1}},
+        )
+        d = summary.to_dict()
+        assert d["severity"] == "critical"
+        assert len(d["findings"]) == 1
+        assert d["findings"][0]["type"] == "governance_threshold_breach"
+        assert d["findings"][0]["recommended_actions"] == ["review_governance_thresholds"]
+
+    def test_advisories_version_always_present(self):
+        summary = AdvisorySummary(
+            advisories_version="1.0",
+            severity="info",
+            findings=[],
+            summary={"total_findings": 0, "by_severity": {}},
+        )
+        d = summary.to_dict()
+        assert "advisories_version" in d

--- a/tests/test_advisories.py
+++ b/tests/test_advisories.py
@@ -506,3 +506,96 @@ class TestAdvisoryRollup:
         )
         rollup = build_advisory_rollup(summary)
         assert rollup["severity"] == "warning"
+
+
+# ---------------------------------------------------------------------------
+# Org-report JSON advisory integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestOrgReportJsonAdvisories:
+    """Verify advisories block appears in org-report JSON output."""
+
+    def test_advisories_present_in_org_json(self):
+        from cja_auto_sdr.org.writers.json import build_org_report_json_data
+
+        result = _make_minimal_org_result()
+        data = build_org_report_json_data(result)
+        assert "advisories" in data
+        assert data["advisories"]["advisories_version"] == "1.0"
+
+    def test_advisories_empty_when_no_issues(self):
+        from cja_auto_sdr.org.writers.json import build_org_report_json_data
+
+        result = _make_minimal_org_result()
+        data = build_org_report_json_data(result)
+        assert data["advisories"]["findings"] == []
+        assert data["advisories"]["summary"]["total_findings"] == 0
+
+    def test_advisories_reflects_fetch_failures(self):
+        from cja_auto_sdr.org.models import DataViewSummary
+        from cja_auto_sdr.org.writers.json import build_org_report_json_data
+
+        failed_dv = DataViewSummary(
+            data_view_id="dv-fail",
+            data_view_name="Failing DV",
+            error="Connection timeout",
+        )
+        result = _make_minimal_org_result(data_view_summaries=[failed_dv])
+        data = build_org_report_json_data(result)
+        types = [f["type"] for f in data["advisories"]["findings"]]
+        assert "fetch_failures" in types
+
+    def test_advisories_includes_drift_when_trending_provided(self):
+        from cja_auto_sdr.org.models import OrgReportTrending, TrendingSnapshot
+        from cja_auto_sdr.org.writers.json import build_org_report_json_data
+
+        snapshots = [
+            TrendingSnapshot(
+                timestamp="2025-01-01T00:00:00",
+                data_view_count=3,
+                component_count=10,
+                core_count=5,
+                isolated_count=1,
+                high_sim_pair_count=0,
+            ),
+            TrendingSnapshot(
+                timestamp="2025-02-01T00:00:00",
+                data_view_count=4,
+                component_count=14,
+                core_count=6,
+                isolated_count=2,
+                high_sim_pair_count=1,
+            ),
+        ]
+        trending = OrgReportTrending(
+            snapshots=snapshots,
+            drift_scores={"dv1": 0.72},
+            window_size=2,
+        )
+        result = _make_minimal_org_result()
+        data = build_org_report_json_data(result, trending=trending)
+        types = [f["type"] for f in data["advisories"]["findings"]]
+        assert "drift_activity" in types
+
+    def test_advisories_is_additive_does_not_remove_existing_keys(self):
+        from cja_auto_sdr.org.writers.json import build_org_report_json_data
+
+        result = _make_minimal_org_result()
+        data = build_org_report_json_data(result)
+        # Core existing top-level keys must all still be present
+        for key in (
+            "report_type",
+            "version",
+            "generated_at",
+            "org_id",
+            "parameters",
+            "summary",
+            "data_view_fetch_failures",
+            "distribution",
+            "data_views",
+            "component_index",
+            "similarity_pairs",
+            "recommendations",
+        ):
+            assert key in data, f"Expected key {key!r} missing after advisories injection"

--- a/tests/test_advisories.py
+++ b/tests/test_advisories.py
@@ -661,3 +661,232 @@ class TestDiffJsonAdvisories:
         data = build_diff_json_data(result)
         for key in ("metadata", "source", "target", "summary", "metric_diffs", "dimension_diffs"):
             assert key in data, f"Expected key {key!r} missing after advisories injection"
+
+
+# ---------------------------------------------------------------------------
+# Diff run-summary advisory rollup tests
+# ---------------------------------------------------------------------------
+
+
+class TestDiffRunSummaryAdvisoryRollup:
+    """Verify _populate_diff_advisory_rollup plumbing in diff handlers."""
+
+    def test_populate_diff_advisory_rollup_populates_dict(self):
+        from cja_auto_sdr.diff.commands import _populate_diff_advisory_rollup
+
+        result = _make_minimal_diff_result()
+        details: dict = {}
+        _populate_diff_advisory_rollup(details, result, changes_only=False)
+        assert "advisory_rollup" in details
+        rollup = details["advisory_rollup"]
+        assert rollup["advisories_version"] == "1.0"
+        assert rollup["severity"] == "info"
+        assert "summary" in rollup
+
+    def test_populate_diff_advisory_rollup_noop_when_none(self):
+        from cja_auto_sdr.diff.commands import _populate_diff_advisory_rollup
+
+        result = _make_minimal_diff_result()
+        _populate_diff_advisory_rollup(None, result, changes_only=False)  # no error
+
+    def test_populate_diff_advisory_rollup_with_breaking_changes(self):
+        from cja_auto_sdr.diff.commands import _populate_diff_advisory_rollup
+        from cja_auto_sdr.diff.models import ChangeType, ComponentDiff, DiffSummary
+
+        removed = ComponentDiff(id="m1", name="Revenue", change_type=ChangeType.REMOVED)
+        result = _make_minimal_diff_result(
+            summary=DiffSummary(metrics_removed=1),
+            metric_diffs=[removed],
+        )
+        details: dict = {}
+        _populate_diff_advisory_rollup(details, result, changes_only=False)
+        rollup = details["advisory_rollup"]
+        assert rollup["severity"] == "critical"
+        assert "breaking_changes" in rollup["types"]
+
+    def test_populate_diff_advisory_rollup_changes_only_flag(self):
+        from cja_auto_sdr.diff.commands import _populate_diff_advisory_rollup
+        from cja_auto_sdr.diff.models import ChangeType, ComponentDiff, DiffSummary
+
+        added = ComponentDiff(id="m1", name="NewMetric", change_type=ChangeType.ADDED)
+        result = _make_minimal_diff_result(
+            summary=DiffSummary(metrics_added=1),
+            metric_diffs=[added],
+        )
+        details: dict = {}
+        _populate_diff_advisory_rollup(details, result, changes_only=True)
+        rollup = details["advisory_rollup"]
+        assert "additions_only" in rollup["types"]
+
+    def test_handler_runtime_details_param_exists(self):
+        """All three diff handlers accept runtime_details parameter."""
+        from inspect import signature
+
+        from cja_auto_sdr.diff.commands import (
+            handle_compare_snapshots_command,
+            handle_diff_command,
+            handle_diff_snapshot_command,
+        )
+
+        for fn in (handle_diff_command, handle_diff_snapshot_command, handle_compare_snapshots_command):
+            params = signature(fn).parameters
+            assert "runtime_details" in params, f"{fn.__name__} missing runtime_details param"
+
+    def test_generator_wrappers_accept_runtime_details(self):
+        """Generator wrapper functions forward runtime_details."""
+        from inspect import signature
+
+        from cja_auto_sdr.generator import (
+            handle_compare_snapshots_command,
+            handle_diff_command,
+            handle_diff_snapshot_command,
+        )
+
+        for fn in (handle_diff_command, handle_diff_snapshot_command, handle_compare_snapshots_command):
+            params = signature(fn).parameters
+            assert "runtime_details" in params, f"generator.{fn.__name__} missing runtime_details param"
+
+
+# ---------------------------------------------------------------------------
+# Org-report run-summary advisory rollup integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestOrgReportRunSummaryAdvisories:
+    """Verify org-report advisory rollup appears in run-summary details."""
+
+    def test_advisory_rollup_in_runtime_details(self):
+        """run_org_report populates runtime_details with advisory_rollup."""
+        from cja_auto_sdr.generator import _populate_org_report_advisory_rollup
+
+        result = _make_minimal_org_result()
+        runtime_details: dict = {}
+        _populate_org_report_advisory_rollup(runtime_details, result, trending=None)
+        assert "advisory_rollup" in runtime_details
+        rollup = runtime_details["advisory_rollup"]
+        assert rollup["advisories_version"] == "1.0"
+        assert rollup["severity"] == "info"
+        assert "summary" in rollup
+        assert "types" in rollup
+        assert "recommended_actions" in rollup
+
+    def test_advisory_rollup_none_runtime_details_is_noop(self):
+        """Passing None runtime_details does not raise."""
+        from cja_auto_sdr.generator import _populate_org_report_advisory_rollup
+
+        result = _make_minimal_org_result()
+        _populate_org_report_advisory_rollup(None, result, trending=None)  # no error
+
+    def test_advisory_rollup_with_failures(self):
+        """Advisory rollup captures fetch_failures from OrgReportResult."""
+        from cja_auto_sdr.generator import _populate_org_report_advisory_rollup
+        from cja_auto_sdr.org.models import DataViewSummary
+
+        failed_dv = DataViewSummary(
+            data_view_id="dv_fail_1",
+            data_view_name="Failed View",
+            error="API Error",
+        )
+        result = _make_minimal_org_result(
+            data_view_summaries=[failed_dv],
+        )
+        runtime_details: dict = {}
+        _populate_org_report_advisory_rollup(runtime_details, result, trending=None)
+        rollup = runtime_details["advisory_rollup"]
+        assert rollup["severity"] == "warning"
+        assert "fetch_failures" in rollup["types"]
+
+    def test_advisory_rollup_with_trending(self):
+        """Advisory rollup includes drift_activity when trending is provided."""
+        from cja_auto_sdr.generator import _populate_org_report_advisory_rollup
+        from cja_auto_sdr.org.models import OrgReportTrending, TrendingSnapshot
+
+        result = _make_minimal_org_result()
+        trending = OrgReportTrending(
+            snapshots=[
+                TrendingSnapshot(
+                    timestamp="2025-01-01T00:00:00",
+                    data_view_count=3,
+                    component_count=10,
+                    core_count=5,
+                    isolated_count=1,
+                    high_sim_pair_count=0,
+                ),
+            ],
+            drift_scores={"dv1": 0.72},
+            window_size=2,
+        )
+        runtime_details: dict = {}
+        _populate_org_report_advisory_rollup(runtime_details, result, trending=trending)
+        rollup = runtime_details["advisory_rollup"]
+        assert "drift_activity" in rollup["types"]
+
+    def test_merge_org_report_details_includes_advisories(self):
+        """_merge_org_report_run_summary_details merges advisory_rollup into details."""
+        from cja_auto_sdr.generator import _merge_org_report_run_summary_details
+        from cja_auto_sdr.org.models import OrgReportConfig
+
+        advisory_rollup = {
+            "advisories_version": "1.0",
+            "severity": "warning",
+            "summary": {"total_findings": 1, "by_severity": {"warning": 1}},
+            "types": ["fetch_failures"],
+            "recommended_actions": ["investigate_fetch_failures"],
+        }
+        run_state: dict = {"details": {}}
+        _merge_org_report_run_summary_details(
+            run_state,
+            success=True,
+            thresholds_exceeded=False,
+            fail_on_threshold=False,
+            lock_details={},
+            org_config=OrgReportConfig(),
+            advisory_rollup=advisory_rollup,
+        )
+        assert run_state["details"]["advisories"] == advisory_rollup
+
+    def test_merge_org_report_details_no_advisories_when_none(self):
+        """advisory_rollup=None leaves no advisories key in details."""
+        from cja_auto_sdr.generator import _merge_org_report_run_summary_details
+        from cja_auto_sdr.org.models import OrgReportConfig
+
+        run_state: dict = {"details": {}}
+        _merge_org_report_run_summary_details(
+            run_state,
+            success=True,
+            thresholds_exceeded=False,
+            fail_on_threshold=False,
+            lock_details={},
+            org_config=OrgReportConfig(),
+        )
+        assert "advisories" not in run_state["details"]
+
+    def test_merge_preserves_existing_detail_fields(self):
+        """Advisory merge does not clobber operation_success, lock, or execution_settings."""
+        from cja_auto_sdr.generator import _merge_org_report_run_summary_details
+        from cja_auto_sdr.org.models import OrgReportConfig
+
+        advisory_rollup = {
+            "advisories_version": "1.0",
+            "severity": "info",
+            "summary": {"total_findings": 0, "by_severity": {}},
+            "types": [],
+            "recommended_actions": [],
+        }
+        run_state: dict = {"details": {}}
+        _merge_org_report_run_summary_details(
+            run_state,
+            success=True,
+            thresholds_exceeded=True,
+            fail_on_threshold=True,
+            lock_details={"lock_acquired": True, "lock_contention": False, "lock_stale_threshold_seconds": 3600},
+            org_config=OrgReportConfig(),
+            advisory_rollup=advisory_rollup,
+        )
+        details = run_state["details"]
+        assert details["operation_success"] is True
+        assert details["thresholds_exceeded"] is True
+        assert details["fail_on_threshold"] is True
+        assert "lock" in details
+        assert "execution_settings" in details
+        assert details["advisories"] == advisory_rollup

--- a/tests/test_advisories.py
+++ b/tests/test_advisories.py
@@ -358,6 +358,55 @@ class TestDiffAdvisoryBuilder:
 
         finding = next(f for f in summary.findings if f.type == "schema_changes")
         assert finding.severity == "warning"
+        assert finding.details["count"] == 1
+        assert finding.details["changes"][0]["change_type"] == "type_changed"
+
+    def test_schema_changes_ignore_non_breaking_modified_fields(self):
+        from cja_auto_sdr.core.advisory_builders import build_diff_advisories
+        from cja_auto_sdr.diff.models import ChangeType, ComponentDiff, DiffSummary
+
+        modified = ComponentDiff(
+            id="d1",
+            name="Page Name",
+            change_type=ChangeType.MODIFIED,
+            changed_fields={"description": ("Old description", "New description")},
+        )
+        diff = _make_minimal_diff_result(
+            summary=DiffSummary(dimensions_modified=1),
+            dimension_diffs=[modified],
+        )
+
+        summary = build_diff_advisories(diff)
+
+        types = [f.type for f in summary.findings]
+        assert "schema_changes" not in types
+
+    def test_schema_changes_emitted_alongside_breaking_changes(self):
+        from cja_auto_sdr.core.advisory_builders import build_diff_advisories
+        from cja_auto_sdr.diff.models import ChangeType, ComponentDiff, DiffSummary
+
+        removed = ComponentDiff(id="m1", name="Revenue", change_type=ChangeType.REMOVED)
+        modified = ComponentDiff(
+            id="d1",
+            name="Page Name",
+            change_type=ChangeType.MODIFIED,
+            changed_fields={"type": ("string", "integer")},
+        )
+        diff = _make_minimal_diff_result(
+            summary=DiffSummary(metrics_removed=1, dimensions_modified=1),
+            metric_diffs=[removed],
+            dimension_diffs=[modified],
+        )
+
+        summary = build_diff_advisories(diff)
+
+        types = [f.type for f in summary.findings]
+        assert "breaking_changes" in types
+        assert "schema_changes" in types
+
+        schema_finding = next(f for f in summary.findings if f.type == "schema_changes")
+        assert schema_finding.details["count"] == 1
+        assert "validate_mappings" in schema_finding.recommended_actions
 
     def test_additions_only_produces_info(self):
         from cja_auto_sdr.core.advisory_builders import build_diff_advisories

--- a/tests/test_advisories.py
+++ b/tests/test_advisories.py
@@ -40,6 +40,7 @@ class TestAdvisoryModel:
         assert d["findings"] == []
         assert d["summary"]["total_findings"] == 0
         assert d["summary"]["by_severity"] == {}
+        assert d["recommended_actions"] == []
 
     def test_summary_with_findings_to_dict(self):
         finding = AdvisoryFinding(
@@ -60,6 +61,7 @@ class TestAdvisoryModel:
         assert len(d["findings"]) == 1
         assert d["findings"][0]["type"] == "governance_threshold_breach"
         assert d["findings"][0]["recommended_actions"] == ["review_governance_thresholds"]
+        assert d["recommended_actions"] == ["review_governance_thresholds"]
 
     def test_advisories_version_always_present(self):
         summary = AdvisorySummary(
@@ -70,6 +72,38 @@ class TestAdvisoryModel:
         )
         d = summary.to_dict()
         assert "advisories_version" in d
+
+    def test_summary_to_dict_deduplicates_top_level_recommended_actions(self):
+        findings = [
+            AdvisoryFinding(
+                type="breaking_changes",
+                severity="critical",
+                message="test",
+                details={},
+                recommended_actions=["review_breaking_changes", "update_downstream_dependencies"],
+            ),
+            AdvisoryFinding(
+                type="schema_changes",
+                severity="warning",
+                message="test",
+                details={},
+                recommended_actions=["validate_mappings", "review_breaking_changes"],
+            ),
+        ]
+        summary = AdvisorySummary(
+            advisories_version="1.0",
+            severity="critical",
+            findings=findings,
+            summary={"total_findings": 2, "by_severity": {"critical": 1, "warning": 1}},
+        )
+
+        d = summary.to_dict()
+
+        assert d["recommended_actions"] == [
+            "review_breaking_changes",
+            "update_downstream_dependencies",
+            "validate_mappings",
+        ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_advisories.py
+++ b/tests/test_advisories.py
@@ -268,3 +268,241 @@ class TestOrgReportAdvisoryBuilder:
 
         all_actions = {action for finding in summary.findings for action in finding.recommended_actions}
         assert all_actions <= _DOCUMENTED_RECOMMENDED_ACTIONS
+
+
+# ---------------------------------------------------------------------------
+# Diff advisory builder tests
+# ---------------------------------------------------------------------------
+
+_DOCUMENTED_DIFF_RECOMMENDED_ACTIONS = {
+    "review_breaking_changes",
+    "update_downstream_dependencies",
+    "review_schema_changes",
+    "validate_mappings",
+    "acknowledge_additive_change",
+}
+
+
+def _make_minimal_diff_result(**overrides):
+    """Build a valid DiffResult with sensible defaults using real types."""
+    from cja_auto_sdr.diff.models import (
+        DiffResult,
+        DiffSummary,
+        MetadataDiff,
+    )
+
+    defaults = {
+        "summary": DiffSummary(),
+        "metadata_diff": MetadataDiff(
+            source_name="Source DV",
+            target_name="Target DV",
+            source_id="dv-src",
+            target_id="dv-tgt",
+        ),
+        "metric_diffs": [],
+        "dimension_diffs": [],
+    }
+    defaults.update(overrides)
+    return DiffResult(**defaults)
+
+
+class TestDiffAdvisoryBuilder:
+    """Verify build_diff_advisories() produces correct advisory summaries."""
+
+    def test_empty_diff_produces_info_severity(self):
+        from cja_auto_sdr.core.advisory_builders import build_diff_advisories
+
+        diff = _make_minimal_diff_result()
+        summary = build_diff_advisories(diff)
+
+        assert isinstance(summary, AdvisorySummary)
+        assert summary.severity == "info"
+        assert summary.advisories_version == "1.0"
+
+    def test_breaking_changes_produce_critical(self):
+        from cja_auto_sdr.core.advisory_builders import build_diff_advisories
+        from cja_auto_sdr.diff.models import ChangeType, ComponentDiff, DiffSummary
+
+        removed = ComponentDiff(id="m1", name="Revenue", change_type=ChangeType.REMOVED)
+        diff = _make_minimal_diff_result(
+            summary=DiffSummary(metrics_removed=1),
+            metric_diffs=[removed],
+        )
+        summary = build_diff_advisories(diff)
+
+        types = [f.type for f in summary.findings]
+        assert "breaking_changes" in types
+
+        finding = next(f for f in summary.findings if f.type == "breaking_changes")
+        assert finding.severity == "critical"
+        assert summary.severity == "critical"
+
+    def test_schema_changes_from_modified(self):
+        from cja_auto_sdr.core.advisory_builders import build_diff_advisories
+        from cja_auto_sdr.diff.models import ChangeType, ComponentDiff, DiffSummary
+
+        modified = ComponentDiff(
+            id="d1",
+            name="Page Name",
+            change_type=ChangeType.MODIFIED,
+            changed_fields={"type": ("string", "integer")},
+        )
+        diff = _make_minimal_diff_result(
+            summary=DiffSummary(dimensions_modified=1),
+            dimension_diffs=[modified],
+        )
+        summary = build_diff_advisories(diff)
+
+        types = [f.type for f in summary.findings]
+        assert "schema_changes" in types
+
+        finding = next(f for f in summary.findings if f.type == "schema_changes")
+        assert finding.severity == "warning"
+
+    def test_additions_only_produces_info(self):
+        from cja_auto_sdr.core.advisory_builders import build_diff_advisories
+        from cja_auto_sdr.diff.models import ChangeType, ComponentDiff, DiffSummary
+
+        added = ComponentDiff(id="m2", name="New Metric", change_type=ChangeType.ADDED)
+        diff = _make_minimal_diff_result(
+            summary=DiffSummary(metrics_added=1),
+            metric_diffs=[added],
+        )
+        summary = build_diff_advisories(diff)
+
+        types = [f.type for f in summary.findings]
+        assert "additions_only" in types
+
+        finding = next(f for f in summary.findings if f.type == "additions_only")
+        assert finding.severity == "info"
+
+    def test_changes_only_filters_unchanged_from_details(self):
+        from cja_auto_sdr.core.advisory_builders import build_diff_advisories
+        from cja_auto_sdr.diff.models import ChangeType, ComponentDiff, DiffSummary
+
+        added = ComponentDiff(id="m2", name="New Metric", change_type=ChangeType.ADDED)
+        unchanged = ComponentDiff(id="m3", name="Old Metric", change_type=ChangeType.UNCHANGED)
+        diff = _make_minimal_diff_result(
+            summary=DiffSummary(metrics_added=1, metrics_unchanged=1),
+            metric_diffs=[added, unchanged],
+        )
+
+        summary_all = build_diff_advisories(diff, changes_only=False)
+        summary_filtered = build_diff_advisories(diff, changes_only=True)
+
+        # With changes_only=True, total component count in details should be smaller
+        finding_all = next((f for f in summary_all.findings if f.type == "additions_only"), None)
+        finding_filtered = next((f for f in summary_filtered.findings if f.type == "additions_only"), None)
+
+        # Both should still produce a finding; filtered version should report fewer total components
+        assert finding_all is not None
+        assert finding_filtered is not None
+        assert finding_filtered.details.get("total_components", 0) <= finding_all.details.get("total_components", 0)
+
+    def test_no_high_change_volume_emitted(self):
+        from cja_auto_sdr.core.advisory_builders import build_diff_advisories
+        from cja_auto_sdr.diff.models import ChangeType, ComponentDiff, DiffSummary
+
+        # Even with many changes, high_change_volume must NOT appear
+        diffs = [ComponentDiff(id=f"m{i}", name=f"Metric {i}", change_type=ChangeType.MODIFIED) for i in range(50)]
+        diff = _make_minimal_diff_result(
+            summary=DiffSummary(metrics_modified=50),
+            metric_diffs=diffs,
+        )
+        summary = build_diff_advisories(diff)
+
+        types = [f.type for f in summary.findings]
+        assert "high_change_volume" not in types
+
+    def test_recommended_actions_in_registry(self):
+        from cja_auto_sdr.core.advisory_builders import build_diff_advisories
+        from cja_auto_sdr.diff.models import ChangeType, ComponentDiff, DiffSummary
+
+        removed = ComponentDiff(id="m1", name="Revenue", change_type=ChangeType.REMOVED)
+        added = ComponentDiff(id="m2", name="New Metric", change_type=ChangeType.ADDED)
+        modified = ComponentDiff(id="d1", name="Page", change_type=ChangeType.MODIFIED)
+
+        diff = _make_minimal_diff_result(
+            summary=DiffSummary(metrics_removed=1, metrics_added=1, dimensions_modified=1),
+            metric_diffs=[removed, added],
+            dimension_diffs=[modified],
+        )
+        summary = build_diff_advisories(diff)
+
+        all_actions = {action for finding in summary.findings for action in finding.recommended_actions}
+        assert all_actions <= _DOCUMENTED_DIFF_RECOMMENDED_ACTIONS
+
+
+# ---------------------------------------------------------------------------
+# Advisory rollup builder tests
+# ---------------------------------------------------------------------------
+
+
+class TestAdvisoryRollup:
+    """Verify compact advisory rollup for run-summary integration."""
+
+    def test_rollup_from_empty_summary(self):
+        from cja_auto_sdr.core.advisory_builders import build_advisory_rollup
+
+        summary = AdvisorySummary(
+            advisories_version="1.0",
+            severity="info",
+            findings=[],
+            summary={"total_findings": 0, "by_severity": {}},
+        )
+        rollup = build_advisory_rollup(summary)
+        assert rollup["advisories_version"] == "1.0"
+        assert rollup["severity"] == "info"
+        assert rollup["summary"]["total_findings"] == 0
+        assert rollup["types"] == []
+        assert rollup["recommended_actions"] == []
+
+    def test_rollup_deduplicates_types_and_actions(self):
+        from cja_auto_sdr.core.advisory_builders import build_advisory_rollup
+
+        findings = [
+            AdvisoryFinding(
+                type="breaking_changes",
+                severity="critical",
+                message="test",
+                details={},
+                recommended_actions=["review_breaking_changes", "update_downstream_dependencies"],
+            ),
+            AdvisoryFinding(
+                type="schema_changes",
+                severity="warning",
+                message="test",
+                details={},
+                recommended_actions=["review_schema_changes", "review_breaking_changes"],
+            ),
+        ]
+        summary = AdvisorySummary(
+            advisories_version="1.0",
+            severity="critical",
+            findings=findings,
+            summary={"total_findings": 2, "by_severity": {"critical": 1, "warning": 1}},
+        )
+        rollup = build_advisory_rollup(summary)
+        assert sorted(rollup["types"]) == ["breaking_changes", "schema_changes"]
+        assert len(rollup["recommended_actions"]) == len(set(rollup["recommended_actions"]))
+
+    def test_rollup_severity_matches_summary(self):
+        from cja_auto_sdr.core.advisory_builders import build_advisory_rollup
+
+        findings = [
+            AdvisoryFinding(
+                type="fetch_failures",
+                severity="warning",
+                message="test",
+                details={},
+                recommended_actions=["investigate_fetch_failures"],
+            ),
+        ]
+        summary = AdvisorySummary(
+            advisories_version="1.0",
+            severity="warning",
+            findings=findings,
+            summary={"total_findings": 1, "by_severity": {"warning": 1}},
+        )
+        rollup = build_advisory_rollup(summary)
+        assert rollup["severity"] == "warning"

--- a/tests/test_advisories.py
+++ b/tests/test_advisories.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from cja_auto_sdr.core.advisories import (
     _ADVISORY_SEVERITY_ORDER,
     AdvisoryFinding,
@@ -186,8 +188,9 @@ class TestOrgReportAdvisoryBuilder:
 
         finding = next(f for f in summary.findings if f.type == "fetch_failures")
         assert finding.severity == "warning"
+        assert finding.details["count"] == 1
         assert "dv-fail" in finding.details.get("data_view_ids", [])
-        assert "reason_counts" in finding.details
+        assert finding.details["failure_reason_counts"] == {"Connection timeout": 1}
         assert summary.severity in ("warning", "critical")
 
     def test_high_overlap_produces_warning(self):
@@ -215,6 +218,91 @@ class TestOrgReportAdvisoryBuilder:
 
         finding = next(f for f in summary.findings if f.type == "high_overlap")
         assert finding.severity == "warning"
+        assert finding.details["threshold"] == pytest.approx(0.8)
+        assert finding.details["max_similarity"] == pytest.approx(0.95)
+        assert len(finding.details["pairs"]) == 1
+
+    def test_high_overlap_uses_effective_governance_threshold(self):
+        from cja_auto_sdr.core.advisory_builders import build_org_report_advisories
+        from cja_auto_sdr.org.models import OrgReportConfig, SimilarityPair
+
+        pair = SimilarityPair(
+            dv1_id="dv1",
+            dv1_name="DV One",
+            dv2_id="dv2",
+            dv2_name="DV Two",
+            jaccard_similarity=0.91,
+            shared_count=10,
+            union_count=11,
+        )
+        result = _make_minimal_org_result(
+            parameters=OrgReportConfig(overlap_threshold=0.95),
+            similarity_pairs=[pair],
+        )
+
+        summary = build_org_report_advisories(result)
+
+        finding = next(f for f in summary.findings if f.type == "high_overlap")
+        assert finding.details["threshold"] == pytest.approx(0.9)
+        assert finding.details["max_similarity"] == pytest.approx(0.91)
+        assert len(finding.details["pairs"]) == 1
+        assert "effective overlap threshold" in finding.message
+
+    def test_isolated_review_uses_existing_recommendation_shape(self):
+        from cja_auto_sdr.core.advisory_builders import build_org_report_advisories
+
+        result = _make_minimal_org_result(
+            recommendations=[
+                {
+                    "type": "review_isolated",
+                    "data_view": "dv1",
+                    "data_view_name": "Data View 1",
+                    "isolated_count": 23,
+                }
+            ]
+        )
+
+        summary = build_org_report_advisories(result)
+
+        finding = next(f for f in summary.findings if f.type == "isolated_review")
+        assert finding.severity == "info"
+        assert finding.details == {
+            "data_views": [
+                {
+                    "data_view_id": "dv1",
+                    "data_view_name": "Data View 1",
+                    "isolated_count": 23,
+                }
+            ],
+            "count": 1,
+        }
+        assert finding.recommended_actions == ["review_isolated_views"]
+
+    def test_metadata_hygiene_aggregates_existing_recommendation_types(self):
+        from cja_auto_sdr.core.advisory_builders import build_org_report_advisories
+
+        result = _make_minimal_org_result(
+            recommendations=[
+                {
+                    "type": "missing_descriptions",
+                    "count": 2,
+                },
+                {
+                    "type": "stale_data_view",
+                    "data_view": "dv-old",
+                },
+            ]
+        )
+
+        summary = build_org_report_advisories(result)
+
+        finding = next(f for f in summary.findings if f.type == "metadata_hygiene")
+        assert finding.severity == "warning"
+        assert finding.details == {
+            "missing_description_count": 2,
+            "stale_view_ids": ["dv-old"],
+        }
+        assert finding.recommended_actions == ["add_descriptions", "review_stale_views"]
 
     def test_governance_threshold_breach_produces_critical(self):
         from cja_auto_sdr.core.advisory_builders import build_org_report_advisories
@@ -231,6 +319,7 @@ class TestOrgReportAdvisoryBuilder:
 
         finding = next(f for f in summary.findings if f.type == "governance_threshold_breach")
         assert finding.severity == "critical"
+        assert finding.details["count"] == 1
         assert summary.severity == "critical"
 
     def test_drift_activity_from_trending(self):
@@ -248,7 +337,29 @@ class TestOrgReportAdvisoryBuilder:
         assert "drift_activity" in types
 
         finding = next(f for f in summary.findings if f.type == "drift_activity")
-        assert finding.severity in ("info", "warning", "critical")
+        assert finding.severity == "info"
+        assert finding.details == {
+            "top_drift_scores": [
+                {"data_view_id": "dv1", "score": 0.72},
+                {"data_view_id": "dv2", "score": 0.45},
+            ],
+            "window": 3,
+        }
+        assert finding.recommended_actions == ["review_drift_activity", "compare_recent_reports"]
+
+    def test_drift_activity_ignores_zero_only_scores(self):
+        from cja_auto_sdr.core.advisory_builders import build_org_report_advisories
+        from cja_auto_sdr.org.models import OrgReportTrending
+
+        trending = OrgReportTrending(
+            drift_scores={"dv1": 0.0, "dv2": 0.0},
+            window_size=3,
+        )
+        result = _make_minimal_org_result()
+
+        summary = build_org_report_advisories(result, trending=trending)
+
+        assert all(f.type != "drift_activity" for f in summary.findings)
 
     def test_no_mutation_of_input(self):
         from cja_auto_sdr.core.advisory_builders import build_org_report_advisories

--- a/tests/test_advisories.py
+++ b/tests/test_advisories.py
@@ -3,12 +3,10 @@
 
 from __future__ import annotations
 
-import pytest
-
 from cja_auto_sdr.core.advisories import (
+    _ADVISORY_SEVERITY_ORDER,
     AdvisoryFinding,
     AdvisorySummary,
-    _ADVISORY_SEVERITY_ORDER,
 )
 
 
@@ -72,3 +70,201 @@ class TestAdvisoryModel:
         )
         d = summary.to_dict()
         assert "advisories_version" in d
+
+
+# ---------------------------------------------------------------------------
+# Org-report advisory builder tests
+# ---------------------------------------------------------------------------
+
+_DOCUMENTED_RECOMMENDED_ACTIONS = {
+    "review_overlap_pairs",
+    "verify_intentional_duplicates",
+    "review_isolated_views",
+    "add_descriptions",
+    "review_stale_views",
+    "review_governance_thresholds",
+    "remediate_threshold_breach",
+    "investigate_fetch_failures",
+    "review_drift_activity",
+    "compare_recent_reports",
+}
+
+
+def _make_minimal_org_result(**overrides):
+    """Build a valid OrgReportResult with sensible defaults."""
+    from cja_auto_sdr.org.models import (
+        ComponentDistribution,
+        DataViewSummary,
+        OrgReportConfig,
+        OrgReportResult,
+    )
+
+    defaults = {
+        "timestamp": "2026-03-28T00:00:00Z",
+        "org_id": "test-org",
+        "parameters": OrgReportConfig(),
+        "data_view_summaries": [
+            DataViewSummary(
+                data_view_id="dv1",
+                data_view_name="Data View 1",
+                metric_count=10,
+                dimension_count=5,
+            )
+        ],
+        "component_index": {},
+        "distribution": ComponentDistribution(),
+        "similarity_pairs": None,
+        "recommendations": [],
+        "duration": 1.0,
+    }
+    defaults.update(overrides)
+    return OrgReportResult(**defaults)
+
+
+class TestOrgReportAdvisoryBuilder:
+    """Verify build_org_report_advisories() produces correct advisory summaries."""
+
+    def test_empty_result_produces_info_severity(self):
+        from cja_auto_sdr.core.advisory_builders import build_org_report_advisories
+
+        result = _make_minimal_org_result()
+        summary = build_org_report_advisories(result)
+
+        assert isinstance(summary, AdvisorySummary)
+        assert summary.severity == "info"
+        assert summary.findings == []
+        assert summary.advisories_version == "1.0"
+
+    def test_fetch_failures_produce_warning(self):
+        from cja_auto_sdr.core.advisory_builders import build_org_report_advisories
+        from cja_auto_sdr.org.models import DataViewSummary
+
+        failed_dv = DataViewSummary(
+            data_view_id="dv-fail",
+            data_view_name="Failing DV",
+            error="Connection timeout",
+        )
+        result = _make_minimal_org_result(data_view_summaries=[failed_dv])
+        summary = build_org_report_advisories(result)
+
+        types = [f.type for f in summary.findings]
+        assert "fetch_failures" in types
+
+        finding = next(f for f in summary.findings if f.type == "fetch_failures")
+        assert finding.severity == "warning"
+        assert "dv-fail" in finding.details.get("data_view_ids", [])
+        assert "reason_counts" in finding.details
+        assert summary.severity in ("warning", "critical")
+
+    def test_high_overlap_produces_warning(self):
+        from cja_auto_sdr.core.advisory_builders import build_org_report_advisories
+        from cja_auto_sdr.org.models import OrgReportConfig, SimilarityPair
+
+        # overlap_threshold defaults to 0.8 — use a pair that exceeds it
+        pair = SimilarityPair(
+            dv1_id="dv1",
+            dv1_name="DV One",
+            dv2_id="dv2",
+            dv2_name="DV Two",
+            jaccard_similarity=0.95,
+            shared_count=19,
+            union_count=20,
+        )
+        result = _make_minimal_org_result(
+            parameters=OrgReportConfig(overlap_threshold=0.8),
+            similarity_pairs=[pair],
+        )
+        summary = build_org_report_advisories(result)
+
+        types = [f.type for f in summary.findings]
+        assert "high_overlap" in types
+
+        finding = next(f for f in summary.findings if f.type == "high_overlap")
+        assert finding.severity == "warning"
+
+    def test_governance_threshold_breach_produces_critical(self):
+        from cja_auto_sdr.core.advisory_builders import build_org_report_advisories
+
+        violation = {"type": "duplicate_threshold", "count": 5, "limit": 3}
+        result = _make_minimal_org_result(
+            thresholds_exceeded=True,
+            governance_violations=[violation],
+        )
+        summary = build_org_report_advisories(result)
+
+        types = [f.type for f in summary.findings]
+        assert "governance_threshold_breach" in types
+
+        finding = next(f for f in summary.findings if f.type == "governance_threshold_breach")
+        assert finding.severity == "critical"
+        assert summary.severity == "critical"
+
+    def test_drift_activity_from_trending(self):
+        from cja_auto_sdr.core.advisory_builders import build_org_report_advisories
+        from cja_auto_sdr.org.models import OrgReportTrending
+
+        trending = OrgReportTrending(
+            drift_scores={"dv1": 0.72, "dv2": 0.45},
+            window_size=3,
+        )
+        result = _make_minimal_org_result()
+        summary = build_org_report_advisories(result, trending=trending)
+
+        types = [f.type for f in summary.findings]
+        assert "drift_activity" in types
+
+        finding = next(f for f in summary.findings if f.type == "drift_activity")
+        assert finding.severity in ("info", "warning", "critical")
+
+    def test_no_mutation_of_input(self):
+        from cja_auto_sdr.core.advisory_builders import build_org_report_advisories
+        from cja_auto_sdr.org.models import OrgReportTrending
+
+        result = _make_minimal_org_result()
+        trending = OrgReportTrending(drift_scores={"dv1": 0.5}, window_size=2)
+
+        # Capture state before
+        original_summaries = list(result.data_view_summaries)
+        original_similarity = result.similarity_pairs
+        original_thresholds_exceeded = result.thresholds_exceeded
+        original_drift_scores = dict(trending.drift_scores)
+
+        build_org_report_advisories(result, trending=trending)
+
+        assert result.data_view_summaries == original_summaries
+        assert result.similarity_pairs == original_similarity
+        assert result.thresholds_exceeded == original_thresholds_exceeded
+        assert trending.drift_scores == original_drift_scores
+
+    def test_recommended_actions_in_registry(self):
+        from cja_auto_sdr.core.advisory_builders import build_org_report_advisories
+        from cja_auto_sdr.org.models import DataViewSummary, OrgReportConfig, OrgReportTrending, SimilarityPair
+
+        pair = SimilarityPair(
+            dv1_id="dv1",
+            dv1_name="DV One",
+            dv2_id="dv2",
+            dv2_name="DV Two",
+            jaccard_similarity=0.95,
+            shared_count=19,
+            union_count=20,
+        )
+        failed_dv = DataViewSummary(
+            data_view_id="dv-fail",
+            data_view_name="Failing DV",
+            error="Timeout",
+        )
+        violation = {"type": "duplicate_threshold", "count": 5, "limit": 3}
+        trending = OrgReportTrending(drift_scores={"dv1": 0.6}, window_size=2)
+
+        result = _make_minimal_org_result(
+            parameters=OrgReportConfig(overlap_threshold=0.8),
+            similarity_pairs=[pair],
+            data_view_summaries=[failed_dv],
+            thresholds_exceeded=True,
+            governance_violations=[violation],
+        )
+        summary = build_org_report_advisories(result, trending=trending)
+
+        all_actions = {action for finding in summary.findings for action in finding.recommended_actions}
+        assert all_actions <= _DOCUMENTED_RECOMMENDED_ACTIONS

--- a/tests/test_agent_contract_docs.py
+++ b/tests/test_agent_contract_docs.py
@@ -86,3 +86,24 @@ class TestAgentContractDocs:
         for line in lines:
             if "--run-summary-json -" in line and "--output -" in line:
                 pytest.fail("AGENTS.md documents invalid --run-summary-json - + --output - pair")
+
+
+class TestAgentAutomationDoc:
+    """Verify docs/AGENT_AUTOMATION.md contract surface."""
+
+    def test_references_tool_manifests(self):
+        content = AGENT_AUTOMATION_MD.read_text()
+        assert "tools/" in content
+        # If inline tool JSON remains, it should be marked illustrative
+        if '"parameters"' in content and '"type": "object"' in content:
+            assert "illustrative" in content.lower() or "example" in content.lower()
+
+    def test_agent_mode_documented(self):
+        content = AGENT_AUTOMATION_MD.read_text()
+        assert "--agent-mode" in content
+
+    def test_advisories_registry_documented(self):
+        content = AGENT_AUTOMATION_MD.read_text()
+        assert "recommended_actions" in content
+        assert "review_breaking_changes" in content
+        assert "investigate_fetch_failures" in content

--- a/tests/test_agent_contract_docs.py
+++ b/tests/test_agent_contract_docs.py
@@ -33,6 +33,21 @@ class TestAgentContractDocs:
         content = AGENTS_MD.read_text()
         assert "advisories" in content.lower()
 
+    def test_advisories_block_shape_documented(self):
+        content = AGENTS_MD.read_text().lower()
+        assert "`advisories` block" in content
+        assert "advisories array" not in content
+        assert "advisories.findings" in content
+        assert "advisories.recommended_actions" in content
+        assert "findings: []" in content
+        assert "when issues requiring attention are detected" not in content
+
+    def test_run_summary_advisories_rollup_documented(self):
+        content = AGENTS_MD.read_text().lower()
+        assert "details.advisories" in content
+        assert "types" in content
+        assert "recommended_actions" in content
+
     def test_tools_directory_referenced(self):
         content = AGENTS_MD.read_text()
         assert "tools/" in content

--- a/tests/test_agent_contract_docs.py
+++ b/tests/test_agent_contract_docs.py
@@ -9,6 +9,7 @@ import pytest
 
 AGENTS_MD = Path(__file__).resolve().parent.parent / "AGENTS.md"
 AGENT_AUTOMATION_MD = Path(__file__).resolve().parent.parent / "docs" / "AGENT_AUTOMATION.md"
+QUICK_REFERENCE_MD = Path(__file__).resolve().parent.parent / "docs" / "QUICK_REFERENCE.md"
 
 
 class TestAgentContractDocs:
@@ -107,3 +108,34 @@ class TestAgentAutomationDoc:
         assert "recommended_actions" in content
         assert "review_breaking_changes" in content
         assert "investigate_fetch_failures" in content
+
+    def test_does_not_document_agent_mode_run_summary_stdout_pair(self):
+        content = AGENT_AUTOMATION_MD.read_text()
+        for line in content.split("\n"):
+            if "--agent-mode" in line and "--run-summary-json -" in line:
+                pytest.fail("docs/AGENT_AUTOMATION.md documents invalid --agent-mode + --run-summary-json - pair")
+
+    def test_fast_path_tolerance_documented(self):
+        content = AGENT_AUTOMATION_MD.read_text()
+        assert "--version" in content
+        assert "--completion" in content
+        assert "partial" in content.lower()
+
+
+class TestQuickReferenceDoc:
+    """Verify docs/QUICK_REFERENCE.md stays aligned with the agent contract."""
+
+    def test_quick_reference_exists(self):
+        assert QUICK_REFERENCE_MD.exists()
+
+    def test_agent_mode_examples_match_command_family_behavior(self):
+        content = QUICK_REFERENCE_MD.read_text()
+        assert "--list-dataviews --agent-mode" in content
+        assert "--org-report --agent-mode" in content
+        assert "--diff dv_a dv_b --agent-mode" in content
+        assert "dv_12345 --agent-mode --output-dir ./reports" in content
+
+    def test_agent_mode_single_sdr_caveat_documented(self):
+        content = QUICK_REFERENCE_MD.read_text().lower()
+        assert "--output-dir" in content
+        assert "single-sdr generation" in content

--- a/tests/test_agent_contract_docs.py
+++ b/tests/test_agent_contract_docs.py
@@ -1,0 +1,88 @@
+# tests/test_agent_contract_docs.py
+"""Smoke tests for root agent-contract documentation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+AGENTS_MD = Path(__file__).resolve().parent.parent / "AGENTS.md"
+AGENT_AUTOMATION_MD = Path(__file__).resolve().parent.parent / "docs" / "AGENT_AUTOMATION.md"
+
+
+class TestAgentContractDocs:
+    """Verify AGENTS.md and docs/AGENT_AUTOMATION.md expose the required contract surface."""
+
+    def test_agents_md_exists(self):
+        assert AGENTS_MD.exists()
+
+    def test_agent_automation_md_exists(self):
+        assert AGENT_AUTOMATION_MD.exists()
+
+    def test_agent_integration_section_exists(self):
+        content = AGENTS_MD.read_text()
+        assert "## Agent Integration" in content or "# Agent Integration" in content
+
+    def test_agent_mode_documented(self):
+        content = AGENTS_MD.read_text()
+        assert "--agent-mode" in content
+
+    def test_advisories_documented(self):
+        content = AGENTS_MD.read_text()
+        assert "advisories" in content.lower()
+
+    def test_tools_directory_referenced(self):
+        content = AGENTS_MD.read_text()
+        assert "tools/" in content
+
+    def test_playbooks_referenced(self):
+        content = AGENTS_MD.read_text()
+        assert "agent-playbooks" in content
+
+    def test_workflows_referenced(self):
+        content = AGENTS_MD.read_text()
+        assert "agent-workflows" in content
+
+    def test_agent_mode_applicability_documented(self):
+        content = AGENTS_MD.read_text()
+        assert "applicability" in content.lower() or "command-family" in content.lower()
+
+    def test_exact_id_guidance_documented(self):
+        content = AGENTS_MD.read_text()
+        assert "prefer exact data view ids" in content.lower() or "prefer exact ids" in content.lower()
+
+    def test_orchestrator_scope_documented(self):
+        content = AGENTS_MD.read_text().lower()
+        assert "scripts/orchestrator.py" in content
+        assert "not a full" in content or "not the primary" in content or "batched sdr" in content
+
+    def test_inspection_commands_use_current_form(self):
+        """Inspection commands should use --flag <VALUE> form, not positional."""
+        content = AGENTS_MD.read_text()
+        expected = [
+            "uv run cja_auto_sdr --describe-dataview <DATA_VIEW_ID_OR_NAME>",
+            "uv run cja_auto_sdr --list-metrics <DATA_VIEW_ID_OR_NAME>",
+            "uv run cja_auto_sdr --list-dimensions <DATA_VIEW_ID_OR_NAME>",
+            "uv run cja_auto_sdr --list-segments <DATA_VIEW_ID_OR_NAME>",
+            "uv run cja_auto_sdr --list-calculated-metrics <DATA_VIEW_ID_OR_NAME>",
+        ]
+        disallowed = [
+            "uv run cja_auto_sdr <dv_id> --describe-dataview",
+            "uv run cja_auto_sdr <dv_id> --list-metrics",
+            "uv run cja_auto_sdr <dv_id> --list-dimensions",
+            "uv run cja_auto_sdr <dv_id> --list-segments",
+            "uv run cja_auto_sdr <dv_id> --list-calculated-metrics",
+        ]
+        for line in expected:
+            assert line in content, f"Missing expected command form: {line}"
+        for line in disallowed:
+            assert line not in content, f"Found disallowed command form: {line}"
+
+    def test_no_invalid_stdout_pair(self):
+        """AGENTS.md should not document --run-summary-json - with --output - together."""
+        content = AGENTS_MD.read_text()
+        lines = content.split("\n")
+        for line in lines:
+            if "--run-summary-json -" in line and "--output -" in line:
+                pytest.fail("AGENTS.md documents invalid --run-summary-json - + --output - pair")

--- a/tests/test_agent_contract_docs.py
+++ b/tests/test_agent_contract_docs.py
@@ -124,6 +124,24 @@ class TestAgentAutomationDoc:
         assert "review_breaking_changes" in content
         assert "investigate_fetch_failures" in content
 
+    def test_advisories_example_uses_current_org_contract_fields(self):
+        content = AGENT_AUTOMATION_MD.read_text()
+        assert "violation_count" not in content
+        assert '"details": { "count": 3, "violations": [...] }' in content
+
+    def test_org_report_actions_are_documented_as_live_findings(self):
+        content = AGENT_AUTOMATION_MD.read_text()
+        assert "(future finding type)" not in content
+        assert "`isolated_review`" in content
+        assert "`metadata_hygiene`" in content
+
+    def test_applicability_matrix_uses_current_command_families(self):
+        content = AGENT_AUTOMATION_MD.read_text()
+        assert "--validate-config" in content
+        assert "--describe-dataview" in content
+        assert "--interactive" in content
+        assert "--show-config" not in content
+
     def test_does_not_document_agent_mode_run_summary_stdout_pair(self):
         content = AGENT_AUTOMATION_MD.read_text()
         for line in content.split("\n"):
@@ -135,6 +153,11 @@ class TestAgentAutomationDoc:
         assert "--version" in content
         assert "--completion" in content
         assert "partial" in content.lower()
+
+    def test_agents_md_mentions_org_report_console_stdout_exception(self):
+        content = AGENTS_MD.read_text().lower()
+        assert "org-report also supports `console` on stdout" in content
+        assert "only `json` and `csv` formats are valid with `--output -`" not in content
 
 
 class TestQuickReferenceDoc:

--- a/tests/test_agent_contract_samples.py
+++ b/tests/test_agent_contract_samples.py
@@ -29,6 +29,7 @@ class TestAgentContractSamples:
         assert "severity" in adv
         assert "findings" in adv
         assert "summary" in adv
+        assert "recommended_actions" in adv
 
     def test_diff_fixture_has_advisories(self):
         data = json.loads((SAMPLES_DIR / "sample_diff_with_advisories.json").read_text())
@@ -38,6 +39,7 @@ class TestAgentContractSamples:
         assert "severity" in adv
         assert "findings" in adv
         assert "summary" in adv
+        assert "recommended_actions" in adv
 
     def test_run_summary_fixture_has_details_advisories(self):
         data = json.loads((SAMPLES_DIR / "sample_run_summary_with_advisories.json").read_text())

--- a/tests/test_agent_contract_samples.py
+++ b/tests/test_agent_contract_samples.py
@@ -1,0 +1,55 @@
+"""Lightweight validation of representative sample_outputs/agent/ contract fixtures."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+SAMPLES_DIR = Path(__file__).resolve().parent.parent / "sample_outputs" / "agent"
+
+
+class TestAgentContractSamples:
+    """Validate structural expectations of agent contract fixtures."""
+
+    def test_readme_exists(self):
+        assert (SAMPLES_DIR / "README.md").exists()
+
+    def test_discovery_fixture_has_dataviews(self):
+        data = json.loads((SAMPLES_DIR / "sample_list_dataviews_agent_mode.json").read_text())
+        assert "dataViews" in data
+        assert isinstance(data["dataViews"], list)
+        assert len(data["dataViews"]) > 0
+        assert "id" in data["dataViews"][0]
+
+    def test_org_report_fixture_has_advisories(self):
+        data = json.loads((SAMPLES_DIR / "sample_org_report_with_advisories.json").read_text())
+        assert "advisories" in data
+        adv = data["advisories"]
+        assert adv["advisories_version"] == "1.0"
+        assert "severity" in adv
+        assert "findings" in adv
+        assert "summary" in adv
+
+    def test_diff_fixture_has_advisories(self):
+        data = json.loads((SAMPLES_DIR / "sample_diff_with_advisories.json").read_text())
+        assert "advisories" in data
+        adv = data["advisories"]
+        assert adv["advisories_version"] == "1.0"
+        assert "severity" in adv
+        assert "findings" in adv
+        assert "summary" in adv
+
+    def test_run_summary_fixture_has_details_advisories(self):
+        data = json.loads((SAMPLES_DIR / "sample_run_summary_with_advisories.json").read_text())
+        assert "details" in data
+        assert "advisories" in data["details"]
+        adv = data["details"]["advisories"]
+        assert "advisories_version" in adv
+        assert "types" in adv
+        assert "recommended_actions" in adv
+
+    def test_fixtures_are_small(self):
+        """Contract fixtures should be intentionally small."""
+        for path in SAMPLES_DIR.glob("*.json"):
+            content = path.read_text()
+            assert len(content) < 5000, f"{path.name} is too large for a contract fixture"

--- a/tests/test_agent_mode.py
+++ b/tests/test_agent_mode.py
@@ -82,7 +82,7 @@ class TestAgentModeResolution:
         """Explicit flags win regardless of order."""
         args = parse_arguments(["--agent-mode", "dv_123", "--format", "csv"])
         assert args.format == "csv"
-        assert args.output == "-"  # agent-mode still fills non-overridden
+        assert args.output == "-"
 
     def test_no_flag_behavior_unchanged(self):
         """Without --agent-mode, defaults remain as before."""
@@ -96,9 +96,19 @@ class TestAgentModeResolution:
         assert args.format == "json"
         assert args.output == "-"
 
+    def test_stdout_compatible_discovery_format_override_keeps_stdout(self):
+        args = parse_arguments(["--list-dataviews", "--agent-mode", "--format", "csv"])
+        assert args.format == "csv"
+        assert args.output == "-"
+
     def test_agent_mode_on_org_report(self):
         args = parse_arguments(["--org-report", "--agent-mode"])
         assert args.format == "json"
+        assert args.output == "-"
+
+    def test_file_only_org_report_format_override_keeps_agent_mode_stdout_default(self):
+        args = parse_arguments(["--org-report", "--agent-mode", "--format", "markdown"])
+        assert args.format == "markdown"
         assert args.output == "-"
 
     def test_agent_mode_on_diff(self):
@@ -245,3 +255,14 @@ class TestDiffStdoutAliasRuntime:
 
         assert exit_code == 0
         assert mock_compare.call_args.kwargs["output_to_stdout"] is True
+
+
+class TestAgentModeOrgReportRuntime:
+    """Verify org-report agent-mode overrides reach runtime without self-invalid stdout wiring."""
+
+    def test_file_only_org_report_format_override_does_not_pass_stdout_output(self):
+        with patch("cja_auto_sdr.generator.run_org_report", return_value=(True, False)) as mock_run:
+            exit_code = _run_main_impl(["--org-report", "--agent-mode", "--format", "markdown"])
+
+        assert exit_code == 0
+        assert mock_run.call_args.kwargs["output_path"] is None

--- a/tests/test_agent_mode.py
+++ b/tests/test_agent_mode.py
@@ -266,3 +266,27 @@ class TestAgentModeOrgReportRuntime:
 
         assert exit_code == 0
         assert mock_run.call_args.kwargs["output_path"] is None
+
+    def test_file_only_org_report_format_override_recomputes_quiet_after_stdout_suppression(self):
+        with patch("cja_auto_sdr.generator.run_org_report", return_value=(True, False)) as mock_run:
+            exit_code = _run_main_impl(["--org-report", "--agent-mode", "--format", "all"])
+
+        assert exit_code == 0
+        assert mock_run.call_args.kwargs["output_path"] is None
+        assert mock_run.call_args.kwargs["quiet"] is False
+
+    def test_org_stats_file_only_format_override_recomputes_quiet_after_stdout_suppression(self):
+        with patch("cja_auto_sdr.generator.run_org_report", return_value=(True, False)) as mock_run:
+            exit_code = _run_main_impl(["--org-report", "--org-stats", "--agent-mode", "--format", "markdown"])
+
+        assert exit_code == 0
+        assert mock_run.call_args.kwargs["output_path"] is None
+        assert mock_run.call_args.kwargs["quiet"] is False
+
+    def test_explicit_quiet_still_wins_when_org_report_suppresses_inherited_stdout(self):
+        with patch("cja_auto_sdr.generator.run_org_report", return_value=(True, False)) as mock_run:
+            exit_code = _run_main_impl(["--org-report", "--agent-mode", "--format", "markdown", "--quiet"])
+
+        assert exit_code == 0
+        assert mock_run.call_args.kwargs["output_path"] is None
+        assert mock_run.call_args.kwargs["quiet"] is True

--- a/tests/test_agent_mode.py
+++ b/tests/test_agent_mode.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import sys
 from unittest.mock import patch
 
 import pytest
@@ -12,6 +13,17 @@ from cja_auto_sdr.cli.standalone_policy import (
     _STANDALONE_FAST_PATH_METADATA_DESTS,
     standalone_prevalidation_policy,
 )
+from cja_auto_sdr.diff.cli import _diff_output_to_stdout_requested
+
+
+def _run_main_impl(argv_tail: list[str]) -> int:
+    """Execute _main_impl with argv and return the exit code."""
+    from cja_auto_sdr.generator import _main_impl
+
+    with patch.object(sys, "argv", ["cja_auto_sdr", *argv_tail]):
+        with pytest.raises(SystemExit) as exc_info:
+            _main_impl()
+    return int(exc_info.value.code)
 
 
 class TestAgentModeRegistration:
@@ -153,17 +165,20 @@ class TestAgentModeDiffStdout:
         assert args.format == "json"
         assert args.output == "-"
 
-    def test_diff_stdout_detection_logic(self):
-        """output=='-' and format=='json' should yield output_to_stdout=True."""
+    def test_diff_stdout_detection_logic_honors_dash_alias(self):
+        """The diff dispatch helper should treat '-' as stdout for JSON output."""
         args = parse_arguments(["--diff", "dv_a", "dv_b", "--agent-mode"])
-        output_to_stdout = getattr(args, "output", None) == "-" and args.format == "json"
-        assert output_to_stdout is True
+        assert _diff_output_to_stdout_requested(args, output_format=args.format) is True
+
+    def test_diff_stdout_detection_logic_honors_stdout_alias(self):
+        """The diff dispatch helper should treat 'stdout' as stdout for JSON output."""
+        args = parse_arguments(["--diff", "dv_a", "dv_b", "--format", "json", "--output", "stdout"])
+        assert _diff_output_to_stdout_requested(args, output_format=args.format) is True
 
     def test_diff_stdout_detection_false_for_csv(self):
         """Non-json format should not trigger stdout JSON path."""
         args = parse_arguments(["--diff", "dv_a", "dv_b", "--agent-mode", "--format", "csv"])
-        output_to_stdout = getattr(args, "output", None) == "-" and args.format == "json"
-        assert output_to_stdout is False
+        assert _diff_output_to_stdout_requested(args, output_format=args.format) is False
 
     def test_compare_snapshots_agent_mode_sets_json_stdout(self):
         """--agent-mode with --compare-snapshots should set json format and stdout output."""
@@ -176,3 +191,57 @@ class TestAgentModeDiffStdout:
         args = parse_arguments(["dv_123", "--diff-snapshot", "baseline.json", "--agent-mode"])
         assert args.format == "json"
         assert args.output == "-"
+
+
+class TestDiffStdoutAliasRuntime:
+    """Verify the documented 'stdout' alias reaches diff-family runtime handlers."""
+
+    def test_diff_stdout_alias_reaches_live_diff_handler(self):
+        with (
+            patch(
+                "cja_auto_sdr.generator.resolve_data_view_names",
+                side_effect=[(["dv_source"], {}), (["dv_target"], {})],
+            ),
+            patch("cja_auto_sdr.generator.handle_diff_command", return_value=(True, False, None)) as mock_diff,
+        ):
+            exit_code = _run_main_impl(["--diff", "dv_source", "dv_target", "--format", "json", "--output", "stdout"])
+
+        assert exit_code == 0
+        assert mock_diff.call_args.kwargs["output_to_stdout"] is True
+
+    def test_diff_snapshot_stdout_alias_reaches_handler(self):
+        with (
+            patch("cja_auto_sdr.generator.resolve_data_view_names", return_value=(["dv_123"], {})),
+            patch("cja_auto_sdr.generator.handle_diff_snapshot_command", return_value=(True, False, None)) as mock_diff,
+        ):
+            exit_code = _run_main_impl(
+                ["dv_123", "--diff-snapshot", "baseline.json", "--format", "json", "--output", "stdout"]
+            )
+
+        assert exit_code == 0
+        assert mock_diff.call_args.kwargs["output_to_stdout"] is True
+
+    def test_compare_with_prev_stdout_alias_reaches_handler(self):
+        with (
+            patch("cja_auto_sdr.generator.resolve_data_view_names", return_value=(["dv_123"], {})),
+            patch("cja_auto_sdr.generator.SnapshotManager") as mock_snapshot_manager,
+            patch("cja_auto_sdr.generator.handle_diff_snapshot_command", return_value=(True, False, None)) as mock_diff,
+        ):
+            mock_snapshot_manager.return_value.get_most_recent_snapshot.return_value = "./snapshots/prev.json"
+            exit_code = _run_main_impl(["dv_123", "--compare-with-prev", "--format", "json", "--output", "stdout"])
+
+        assert exit_code == 0
+        assert mock_diff.call_args.kwargs["snapshot_file"] == "./snapshots/prev.json"
+        assert mock_diff.call_args.kwargs["output_to_stdout"] is True
+
+    def test_compare_snapshots_stdout_alias_reaches_handler(self):
+        with patch(
+            "cja_auto_sdr.generator.handle_compare_snapshots_command",
+            return_value=(True, False, None),
+        ) as mock_compare:
+            exit_code = _run_main_impl(
+                ["--compare-snapshots", "source.json", "target.json", "--format", "json", "--output", "stdout"]
+            )
+
+        assert exit_code == 0
+        assert mock_compare.call_args.kwargs["output_to_stdout"] is True

--- a/tests/test_agent_mode.py
+++ b/tests/test_agent_mode.py
@@ -144,3 +144,37 @@ class TestAgentModeConstraints:
                 assert "agent_mode" in action_dests
                 return
         pytest.fail("Agent Integration group not found")
+
+
+class TestAgentModeDiffStdout:
+    """Verify --agent-mode diff stdout JSON behavior."""
+
+    def test_agent_mode_diff_sets_json_stdout(self):
+        """--agent-mode with --diff should set json format and stdout output."""
+        args = parse_arguments(["--diff", "dv_a", "dv_b", "--agent-mode"])
+        assert args.format == "json"
+        assert args.output == "-"
+
+    def test_diff_stdout_detection_logic(self):
+        """output=='-' and format=='json' should yield output_to_stdout=True."""
+        args = parse_arguments(["--diff", "dv_a", "dv_b", "--agent-mode"])
+        output_to_stdout = getattr(args, "output", None) == "-" and args.format == "json"
+        assert output_to_stdout is True
+
+    def test_diff_stdout_detection_false_for_csv(self):
+        """Non-json format should not trigger stdout JSON path."""
+        args = parse_arguments(["--diff", "dv_a", "dv_b", "--agent-mode", "--format", "csv"])
+        output_to_stdout = getattr(args, "output", None) == "-" and args.format == "json"
+        assert output_to_stdout is False
+
+    def test_compare_snapshots_agent_mode_sets_json_stdout(self):
+        """--agent-mode with --compare-snapshots should set json format and stdout output."""
+        args = parse_arguments(["--compare-snapshots", "a.json", "b.json", "--agent-mode"])
+        assert args.format == "json"
+        assert args.output == "-"
+
+    def test_diff_snapshot_agent_mode_sets_json_stdout(self):
+        """--agent-mode with --diff-snapshot should set json format and stdout output."""
+        args = parse_arguments(["dv_123", "--diff-snapshot", "baseline.json", "--agent-mode"])
+        assert args.format == "json"
+        assert args.output == "-"

--- a/tests/test_agent_mode.py
+++ b/tests/test_agent_mode.py
@@ -98,3 +98,29 @@ class TestAgentModeResolution:
         with patch("sys.argv", ["cja_auto_sdr", "dv_123", "--agent-mode", "--output", "report.json"]):
             args = parse_arguments()
         assert args.output == "report.json"
+
+
+from cja_auto_sdr.cli.standalone_policy import (
+    StandalonePrevalidationPolicy,
+    standalone_prevalidation_policy,
+    _STANDALONE_FAST_PATH_METADATA_DESTS,
+)
+
+
+class TestAgentModeFastPath:
+    """Verify --agent-mode is tolerated on fast-path modes."""
+
+    def test_agent_mode_in_metadata_dests(self):
+        assert "agent_mode" in _STANDALONE_FAST_PATH_METADATA_DESTS
+
+    def test_completion_fast_path_tolerates_agent_mode(self):
+        policy = standalone_prevalidation_policy("completion")
+        assert policy is not None
+        tolerated = policy.tolerated_fast_path_dests()
+        assert "agent_mode" in tolerated
+
+    def test_exit_codes_fast_path_tolerates_agent_mode(self):
+        policy = standalone_prevalidation_policy("exit_codes")
+        assert policy is not None
+        tolerated = policy.tolerated_fast_path_dests()
+        assert "agent_mode" in tolerated

--- a/tests/test_agent_mode.py
+++ b/tests/test_agent_mode.py
@@ -3,10 +3,15 @@
 
 from __future__ import annotations
 
-import pytest
 from unittest.mock import patch
 
+import pytest
+
 from cja_auto_sdr.cli.parser import parse_arguments
+from cja_auto_sdr.cli.standalone_policy import (
+    _STANDALONE_FAST_PATH_METADATA_DESTS,
+    standalone_prevalidation_policy,
+)
 
 
 class TestAgentModeRegistration:
@@ -98,13 +103,6 @@ class TestAgentModeResolution:
         with patch("sys.argv", ["cja_auto_sdr", "dv_123", "--agent-mode", "--output", "report.json"]):
             args = parse_arguments()
         assert args.output == "report.json"
-
-
-from cja_auto_sdr.cli.standalone_policy import (
-    StandalonePrevalidationPolicy,
-    standalone_prevalidation_policy,
-    _STANDALONE_FAST_PATH_METADATA_DESTS,
-)
 
 
 class TestAgentModeFastPath:

--- a/tests/test_agent_mode.py
+++ b/tests/test_agent_mode.py
@@ -124,3 +124,23 @@ class TestAgentModeFastPath:
         assert policy is not None
         tolerated = policy.tolerated_fast_path_dests()
         assert "agent_mode" in tolerated
+
+
+class TestAgentModeConstraints:
+    """Verify --agent-mode does not soften existing validation rules."""
+
+    def test_agent_mode_run_summary_json_stdout_conflict(self):
+        """--agent-mode --run-summary-json - should still fail when paired with stdout output."""
+        args = parse_arguments(["dv_123", "--agent-mode", "--run-summary-json", "-"])
+        assert args.output == "-"
+        assert args.run_summary_json == "-"
+
+    def test_agent_mode_help_text_under_agent_integration(self):
+        """--agent-mode help appears under Agent Integration group."""
+        parser = parse_arguments([], return_parser=True)
+        for group in parser._action_groups:
+            if group.title == "Agent Integration":
+                action_dests = [a.dest for a in group._group_actions]
+                assert "agent_mode" in action_dests
+                return
+        pytest.fail("Agent Integration group not found")

--- a/tests/test_agent_mode.py
+++ b/tests/test_agent_mode.py
@@ -24,3 +24,77 @@ class TestAgentModeRegistration:
         parser = parse_arguments([], return_parser=True)
         group_titles = [g.title for g in parser._action_groups]
         assert "Agent Integration" in group_titles
+
+
+class TestAgentModeResolution:
+    """Verify --agent-mode applies preset defaults and respects explicit overrides."""
+
+    def test_agent_mode_sets_format_json(self):
+        args = parse_arguments(["dv_123", "--agent-mode"])
+        assert args.format == "json"
+
+    def test_agent_mode_sets_output_stdout(self):
+        args = parse_arguments(["dv_123", "--agent-mode"])
+        assert args.output == "-"
+
+    def test_agent_mode_sets_log_format_json(self):
+        args = parse_arguments(["dv_123", "--agent-mode"])
+        assert args.log_format == "json"
+
+    def test_explicit_format_overrides_agent_mode(self):
+        args = parse_arguments(["dv_123", "--agent-mode", "--format", "csv"])
+        assert args.format == "csv"
+
+    def test_inline_format_overrides_agent_mode(self):
+        args = parse_arguments(["dv_123", "--agent-mode", "--format=csv"])
+        assert args.format == "csv"
+
+    def test_explicit_output_overrides_agent_mode(self):
+        args = parse_arguments(["dv_123", "--agent-mode", "--output", "report.json"])
+        assert args.output == "report.json"
+
+    def test_inline_output_overrides_agent_mode(self):
+        args = parse_arguments(["dv_123", "--agent-mode", "--output=report.json"])
+        assert args.output == "report.json"
+
+    def test_explicit_log_format_overrides_agent_mode(self):
+        args = parse_arguments(["dv_123", "--agent-mode", "--log-format", "text"])
+        assert args.log_format == "text"
+
+    def test_agent_mode_before_explicit_flags(self):
+        """Explicit flags win regardless of order."""
+        args = parse_arguments(["--agent-mode", "dv_123", "--format", "csv"])
+        assert args.format == "csv"
+        assert args.output == "-"  # agent-mode still fills non-overridden
+
+    def test_no_flag_behavior_unchanged(self):
+        """Without --agent-mode, defaults remain as before."""
+        args = parse_arguments(["dv_123"])
+        assert args.format is None
+        assert args.output is None
+        assert args.log_format == "text"
+
+    def test_agent_mode_on_discovery_command(self):
+        args = parse_arguments(["--list-dataviews", "--agent-mode"])
+        assert args.format == "json"
+        assert args.output == "-"
+
+    def test_agent_mode_on_org_report(self):
+        args = parse_arguments(["--org-report", "--agent-mode"])
+        assert args.format == "json"
+        assert args.output == "-"
+
+    def test_agent_mode_on_diff(self):
+        args = parse_arguments(["--diff", "dv_a", "dv_b", "--agent-mode"])
+        assert args.format == "json"
+        assert args.output == "-"
+
+    def test_agent_mode_on_batch(self):
+        args = parse_arguments(["--batch", "dv_a", "dv_b", "--agent-mode"])
+        assert args.format == "json"
+        assert args.output == "-"
+
+    def test_agent_mode_honors_real_sys_argv_when_argv_is_none(self):
+        with patch("sys.argv", ["cja_auto_sdr", "dv_123", "--agent-mode", "--output", "report.json"]):
+            args = parse_arguments()
+        assert args.output == "report.json"

--- a/tests/test_agent_mode.py
+++ b/tests/test_agent_mode.py
@@ -1,0 +1,26 @@
+# tests/test_agent_mode.py
+"""Tests for --agent-mode CLI preset flag."""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import patch
+
+from cja_auto_sdr.cli.parser import parse_arguments
+
+
+class TestAgentModeRegistration:
+    """Verify --agent-mode is registered correctly."""
+
+    def test_agent_mode_defaults_to_false(self):
+        args = parse_arguments(["dv_123"])
+        assert args.agent_mode is False
+
+    def test_agent_mode_flag_sets_true(self):
+        args = parse_arguments(["dv_123", "--agent-mode"])
+        assert args.agent_mode is True
+
+    def test_agent_mode_appears_in_agent_integration_group(self):
+        parser = parse_arguments([], return_parser=True)
+        group_titles = [g.title for g in parser._action_groups]
+        assert "Agent Integration" in group_titles

--- a/tests/test_agent_mode.py
+++ b/tests/test_agent_mode.py
@@ -257,6 +257,81 @@ class TestDiffStdoutAliasRuntime:
         assert mock_compare.call_args.kwargs["output_to_stdout"] is True
 
 
+class TestAgentModeDiffRuntime:
+    """Verify diff-family agent-mode file-format overrides resolve quiet from the effective output path."""
+
+    def test_file_only_diff_format_override_recomputes_quiet_after_stdout_suppression(self):
+        with (
+            patch(
+                "cja_auto_sdr.generator.resolve_data_view_names",
+                side_effect=[(["dv_source"], {}), (["dv_target"], {})],
+            ),
+            patch("cja_auto_sdr.generator.handle_diff_command", return_value=(True, False, None)) as mock_diff,
+        ):
+            exit_code = _run_main_impl(["--diff", "dv_source", "dv_target", "--agent-mode", "--format", "markdown"])
+
+        assert exit_code == 0
+        assert mock_diff.call_args.kwargs["output_to_stdout"] is False
+        assert mock_diff.call_args.kwargs["quiet"] is False
+
+    def test_explicit_quiet_still_wins_for_file_only_diff_format_override(self):
+        with (
+            patch(
+                "cja_auto_sdr.generator.resolve_data_view_names",
+                side_effect=[(["dv_source"], {}), (["dv_target"], {})],
+            ),
+            patch("cja_auto_sdr.generator.handle_diff_command", return_value=(True, False, None)) as mock_diff,
+        ):
+            exit_code = _run_main_impl(
+                ["--diff", "dv_source", "dv_target", "--agent-mode", "--format", "markdown", "--quiet"]
+            )
+
+        assert exit_code == 0
+        assert mock_diff.call_args.kwargs["output_to_stdout"] is False
+        assert mock_diff.call_args.kwargs["quiet"] is True
+
+    def test_file_only_diff_snapshot_format_override_recomputes_quiet(self):
+        with (
+            patch("cja_auto_sdr.generator.resolve_data_view_names", return_value=(["dv_123"], {})),
+            patch("cja_auto_sdr.generator.handle_diff_snapshot_command", return_value=(True, False, None)) as mock_diff,
+        ):
+            exit_code = _run_main_impl(
+                ["dv_123", "--diff-snapshot", "baseline.json", "--agent-mode", "--format", "csv"]
+            )
+
+        assert exit_code == 0
+        assert mock_diff.call_args.kwargs["output_to_stdout"] is False
+        assert mock_diff.call_args.kwargs["quiet"] is False
+
+    def test_compare_with_prev_file_only_format_override_recomputes_quiet(self, capsys):
+        with (
+            patch("cja_auto_sdr.generator.resolve_data_view_names", return_value=(["dv_123"], {})),
+            patch("cja_auto_sdr.generator.SnapshotManager") as mock_snapshot_manager,
+            patch("cja_auto_sdr.generator.handle_diff_snapshot_command", return_value=(True, False, None)) as mock_diff,
+        ):
+            mock_snapshot_manager.return_value.get_most_recent_snapshot.return_value = "./snapshots/prev.json"
+            exit_code = _run_main_impl(["dv_123", "--compare-with-prev", "--agent-mode", "--format", "markdown"])
+
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        assert "Comparing against previous snapshot: ./snapshots/prev.json" in captured.out
+        assert mock_diff.call_args.kwargs["output_to_stdout"] is False
+        assert mock_diff.call_args.kwargs["quiet"] is False
+
+    def test_file_only_compare_snapshots_format_override_recomputes_quiet(self):
+        with patch(
+            "cja_auto_sdr.generator.handle_compare_snapshots_command",
+            return_value=(True, False, None),
+        ) as mock_compare:
+            exit_code = _run_main_impl(
+                ["--compare-snapshots", "source.json", "target.json", "--agent-mode", "--format", "html"]
+            )
+
+        assert exit_code == 0
+        assert mock_compare.call_args.kwargs["output_to_stdout"] is False
+        assert mock_compare.call_args.kwargs["quiet"] is False
+
+
 class TestAgentModeOrgReportRuntime:
     """Verify org-report agent-mode overrides reach runtime without self-invalid stdout wiring."""
 

--- a/tests/test_agent_playbooks.py
+++ b/tests/test_agent_playbooks.py
@@ -57,7 +57,7 @@ class TestAgentPlaybooks:
                 idx = next(i for i, line in enumerate(lines) if line.strip() == section)
             except StopIteration:
                 pytest.fail(f"Missing '{section}' in {playbook_path.name}")
-            remaining = [line for line in lines[idx + 1:] if line.strip()]
+            remaining = [line for line in lines[idx + 1 :] if line.strip()]
             assert remaining, f"Empty section '{section}' in {playbook_path.name}"
             if remaining[0].startswith("## "):
                 pytest.fail(f"Empty section '{section}' in {playbook_path.name}")
@@ -75,4 +75,4 @@ class TestAgentPlaybooks:
                 # If it references a data view, it should use ID format
                 # Allow <dv_id>, <DATA_VIEW_ID>, dv_..., or $DV_ID variable patterns
                 if "my_data_view_name" in line.lower():
-                    pytest.fail(f"Line {i+1} in {playbook_path.name}: unattended example uses name instead of ID")
+                    pytest.fail(f"Line {i + 1} in {playbook_path.name}: unattended example uses name instead of ID")

--- a/tests/test_agent_playbooks.py
+++ b/tests/test_agent_playbooks.py
@@ -1,0 +1,78 @@
+# tests/test_agent_playbooks.py
+"""Tests for docs/agent-playbooks/ cross-agent task playbooks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+PLAYBOOKS_DIR = Path(__file__).resolve().parent.parent / "docs" / "agent-playbooks"
+
+REQUIRED_PLAYBOOKS = [
+    "sdr-auditor.md",
+    "diff-reviewer.md",
+    "onboarding-guide.md",
+    "quality-monitor.md",
+    "snapshot-manager.md",
+]
+
+REQUIRED_SECTIONS = [
+    "## Purpose",
+    "## When To Use",
+    "## Inputs",
+    "## Constraints",
+    "## Primary CLI Flows",
+    "## Success Criteria",
+    "## Follow-Up Actions",
+]
+
+
+class TestAgentPlaybooks:
+    """Validate playbook structure and content."""
+
+    def test_readme_exists(self):
+        assert (PLAYBOOKS_DIR / "README.md").exists()
+
+    def test_template_exists(self):
+        assert (PLAYBOOKS_DIR / "TEMPLATE.md").exists()
+
+    @pytest.fixture(params=REQUIRED_PLAYBOOKS)
+    def playbook_path(self, request):
+        return PLAYBOOKS_DIR / request.param
+
+    def test_playbook_exists(self, playbook_path):
+        assert playbook_path.exists(), f"Missing playbook: {playbook_path.name}"
+
+    def test_playbook_has_required_sections(self, playbook_path):
+        content = playbook_path.read_text()
+        for section in REQUIRED_SECTIONS:
+            assert section in content, f"Missing '{section}' in {playbook_path.name}"
+
+    def test_playbook_sections_have_content(self, playbook_path):
+        content = playbook_path.read_text()
+        lines = content.split("\n")
+        for section in REQUIRED_SECTIONS:
+            try:
+                idx = next(i for i, line in enumerate(lines) if line.strip() == section)
+            except StopIteration:
+                pytest.fail(f"Missing '{section}' in {playbook_path.name}")
+            remaining = [l for l in lines[idx + 1:] if l.strip()]
+            assert remaining, f"Empty section '{section}' in {playbook_path.name}"
+            if remaining[0].startswith("## "):
+                pytest.fail(f"Empty section '{section}' in {playbook_path.name}")
+
+    def test_playbook_links_to_agents_md(self, playbook_path):
+        content = playbook_path.read_text()
+        assert "AGENTS.md" in content, f"{playbook_path.name} must link to AGENTS.md"
+
+    def test_unattended_examples_are_id_first(self, playbook_path):
+        """Unattended automation examples should use exact IDs, not names."""
+        content = playbook_path.read_text()
+        lines = content.split("\n")
+        for i, line in enumerate(lines):
+            if "uv run cja_auto_sdr" in line and "--agent-mode" in line:
+                # If it references a data view, it should use ID format
+                # Allow <dv_id>, <DATA_VIEW_ID>, dv_..., or $DV_ID variable patterns
+                if "my_data_view_name" in line.lower():
+                    pytest.fail(f"Line {i+1} in {playbook_path.name}: unattended example uses name instead of ID")

--- a/tests/test_agent_playbooks.py
+++ b/tests/test_agent_playbooks.py
@@ -76,3 +76,68 @@ class TestAgentPlaybooks:
                 # Allow <dv_id>, <DATA_VIEW_ID>, dv_..., or $DV_ID variable patterns
                 if "my_data_view_name" in line.lower():
                     pytest.fail(f"Line {i + 1} in {playbook_path.name}: unattended example uses name instead of ID")
+
+    def test_playbooks_use_current_credential_env_names(self):
+        for name in REQUIRED_PLAYBOOKS:
+            content = (PLAYBOOKS_DIR / name).read_text()
+            assert "CJA_CLIENT_ID" not in content
+            assert "CJA_CLIENT_SECRET" not in content
+            assert "CJA_ORG_ID" not in content
+
+    def test_diff_reviewer_uses_compare_snapshots_for_snapshot_files(self):
+        content = (PLAYBOOKS_DIR / "diff-reviewer.md").read_text()
+        assert "--compare-snapshots" in content
+        assert "--diff baseline current" not in content
+
+    def test_playbooks_do_not_document_fail_on_advisory(self):
+        for name in REQUIRED_PLAYBOOKS:
+            content = (PLAYBOOKS_DIR / name).read_text()
+            assert "--fail-on-advisory" not in content
+
+    def test_quality_monitor_and_sdr_auditor_do_not_mix_org_report_with_fail_on_quality(self):
+        for name in ["quality-monitor.md", "sdr-auditor.md"]:
+            content = (PLAYBOOKS_DIR / name).read_text()
+            assert "--org-report --agent-mode \\\n  --fail-on-quality" not in content
+
+    def test_diff_reviewer_describes_current_diff_json_shape(self):
+        content = (PLAYBOOKS_DIR / "diff-reviewer.md").read_text()
+        assert "summary.has_changes" in content
+        assert "metric_diffs" in content
+        assert "dimension_diffs" in content
+        assert "advisories.findings" in content
+        assert "diff.changes" not in content
+        assert "breaking_changes_count" not in content
+
+    def test_snapshot_related_playbooks_describe_trending_window_as_snapshot_count(self):
+        for name in ["diff-reviewer.md", "snapshot-manager.md", "sdr-auditor.md"]:
+            content = (PLAYBOOKS_DIR / name).read_text().lower()
+            if "--trending-window" in content:
+                assert "cached org-report snapshots" in content or "snapshot window" in content
+
+    def test_onboarding_guide_uses_current_profile_creation_flow(self):
+        content = (PLAYBOOKS_DIR / "onboarding-guide.md").read_text()
+        assert "--profile-add production" in content
+        assert "--config --profile production" not in content
+
+    def test_playbooks_do_not_document_exit_64(self):
+        for name in REQUIRED_PLAYBOOKS:
+            content = (PLAYBOOKS_DIR / name).read_text()
+            assert "Exit 64" not in content
+
+    def test_quality_monitor_uses_supported_quality_severities(self):
+        content = (PLAYBOOKS_DIR / "quality-monitor.md").read_text()
+        assert 'Severity == "WARNING"' not in content
+        for severity in ["CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO"]:
+            assert f'Severity == "{severity}"' in content
+
+    def test_diff_reviewer_treats_warn_threshold_exit_as_completed_comparison(self):
+        content = (PLAYBOOKS_DIR / "diff-reviewer.md").read_text()
+        assert "Exit code 0, 2, or 3" in content
+
+    def test_sdr_auditor_default_org_report_flow_does_not_claim_exit_2(self):
+        content = (PLAYBOOKS_DIR / "sdr-auditor.md").read_text()
+        assert "Exit 2 — configured governance threshold exceeded." not in content
+        assert (
+            "If `--fail-on-threshold` is used, exit code 2 indicates a configured governance threshold breach."
+            in content
+        )

--- a/tests/test_agent_playbooks.py
+++ b/tests/test_agent_playbooks.py
@@ -57,7 +57,7 @@ class TestAgentPlaybooks:
                 idx = next(i for i, line in enumerate(lines) if line.strip() == section)
             except StopIteration:
                 pytest.fail(f"Missing '{section}' in {playbook_path.name}")
-            remaining = [l for l in lines[idx + 1:] if l.strip()]
+            remaining = [line for line in lines[idx + 1:] if line.strip()]
             assert remaining, f"Empty section '{section}' in {playbook_path.name}"
             if remaining[0].startswith("## "):
                 pytest.fail(f"Empty section '{section}' in {playbook_path.name}")

--- a/tests/test_agent_workflows.py
+++ b/tests/test_agent_workflows.py
@@ -136,8 +136,8 @@ def test_common_sh_sources_without_error(tmp_path: Path) -> None:
         (2, 0, False),
         (3, 0, False),
         (130, 130, True),
-        (4, 1, True),   # synthetic — must be rejected
-        (5, 1, True),   # synthetic — must be rejected
+        (4, 1, True),  # synthetic — must be rejected
+        (5, 1, True),  # synthetic — must be rejected
         (99, 1, True),  # unknown — must be rejected
     ],
 )
@@ -220,13 +220,13 @@ def _audit_env(tmp_path: Path, **extra: str) -> tuple[dict[str, str], Path]:
         "--list-dataviews --agent-mode": (0, discovery_json),
         "--org-report --agent-mode": (0, '{"status":"ok"}'),
     }
-    env, log_path =_base_env(tmp_path, responses)
+    env, log_path = _base_env(tmp_path, responses)
     env.update(extra)
     return env, log_path
 
 
 def test_audit_runs_to_completion(tmp_path: Path) -> None:
-    env, _log_path =_audit_env(tmp_path)
+    env, _log_path = _audit_env(tmp_path)
 
     result = subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "audit_and_report.sh")],
@@ -239,7 +239,7 @@ def test_audit_runs_to_completion(tmp_path: Path) -> None:
 
 
 def test_audit_calls_list_dataviews_with_agent_mode(tmp_path: Path) -> None:
-    env, log_path =_audit_env(tmp_path)
+    env, log_path = _audit_env(tmp_path)
 
     subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "audit_and_report.sh")],
@@ -253,7 +253,7 @@ def test_audit_calls_list_dataviews_with_agent_mode(tmp_path: Path) -> None:
 
 
 def test_audit_calls_org_report_with_agent_mode(tmp_path: Path) -> None:
-    env, log_path =_audit_env(tmp_path)
+    env, log_path = _audit_env(tmp_path)
 
     subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "audit_and_report.sh")],
@@ -275,7 +275,7 @@ def test_audit_first_run_creates_baseline_without_compare_with_prev(tmp_path: Pa
         "--list-snapshots": (0, '{"snapshots":[]}'),
         "--org-report --agent-mode": (0, '{"status":"ok"}'),
     }
-    env, log_path =_base_env(tmp_path, responses)
+    env, log_path = _base_env(tmp_path, responses)
 
     result = subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "audit_and_report.sh")],
@@ -302,7 +302,7 @@ def test_audit_subsequent_run_uses_compare_with_prev(tmp_path: Path) -> None:
         "--list-snapshots": (0, snapshots_json),
         "--org-report --agent-mode": (0, '{"status":"ok"}'),
     }
-    env, log_path =_base_env(tmp_path, responses)
+    env, log_path = _base_env(tmp_path, responses)
 
     result = subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "audit_and_report.sh")],
@@ -319,7 +319,7 @@ def test_audit_subsequent_run_uses_compare_with_prev(tmp_path: Path) -> None:
 
 def test_audit_never_combines_run_summary_json_with_output_dash(tmp_path: Path) -> None:
     """Must never emit --run-summary-json - combined with --output -."""
-    env, log_path =_audit_env(tmp_path)
+    env, log_path = _audit_env(tmp_path)
 
     subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "audit_and_report.sh")],
@@ -341,7 +341,7 @@ def test_audit_signal_exit_stops_workflow(tmp_path: Path) -> None:
     responses: dict[str, tuple[int, str]] = {
         "--list-dataviews --agent-mode": (130, discovery_json),
     }
-    env, log_path =_base_env(tmp_path, responses)
+    env, log_path = _base_env(tmp_path, responses)
 
     result = subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "audit_and_report.sh")],
@@ -364,7 +364,7 @@ def test_audit_uses_ids_not_names(tmp_path: Path) -> None:
         "--list-dataviews --agent-mode": (0, discovery_json),
         "--org-report --agent-mode": (0, '{"status":"ok"}'),
     }
-    env, log_path =_base_env(tmp_path, responses)
+    env, log_path = _base_env(tmp_path, responses)
 
     subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "audit_and_report.sh")],
@@ -392,14 +392,14 @@ def _onboard_env(tmp_path: Path, **extra: str) -> tuple[dict[str, str], Path]:
         "--describe-dataview": (0, describe_json),
         "--fail-on-quality": (0, sdr_json),
     }
-    env, log_path =_base_env(tmp_path, responses)
+    env, log_path = _base_env(tmp_path, responses)
     env["DATA_VIEW_ID"] = "dv_new"
     env.update(extra)
     return env, log_path
 
 
 def test_onboard_runs_to_completion(tmp_path: Path) -> None:
-    env, _log_path =_onboard_env(tmp_path)
+    env, _log_path = _onboard_env(tmp_path)
 
     result = subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "onboard_dataview.sh")],
@@ -412,7 +412,7 @@ def test_onboard_runs_to_completion(tmp_path: Path) -> None:
 
 
 def test_onboard_calls_validate_config_first(tmp_path: Path) -> None:
-    env, log_path =_onboard_env(tmp_path)
+    env, log_path = _onboard_env(tmp_path)
 
     subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "onboard_dataview.sh")],
@@ -427,7 +427,7 @@ def test_onboard_calls_validate_config_first(tmp_path: Path) -> None:
 
 
 def test_onboard_calls_describe_dataview(tmp_path: Path) -> None:
-    env, log_path =_onboard_env(tmp_path)
+    env, log_path = _onboard_env(tmp_path)
 
     subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "onboard_dataview.sh")],
@@ -441,7 +441,7 @@ def test_onboard_calls_describe_dataview(tmp_path: Path) -> None:
 
 
 def test_onboard_calls_sdr_with_agent_mode_and_quality_gate(tmp_path: Path) -> None:
-    env, log_path =_onboard_env(tmp_path)
+    env, log_path = _onboard_env(tmp_path)
 
     subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "onboard_dataview.sh")],
@@ -451,14 +451,13 @@ def test_onboard_calls_sdr_with_agent_mode_and_quality_gate(tmp_path: Path) -> N
         text=True,
     )
     calls = _read_calls(log_path)
-    assert any(
-        "dv_new" in c and "--agent-mode" in c and "--fail-on-quality" in c
-        for c in calls
-    ), "SDR generation must use --agent-mode and --fail-on-quality"
+    assert any("dv_new" in c and "--agent-mode" in c and "--fail-on-quality" in c for c in calls), (
+        "SDR generation must use --agent-mode and --fail-on-quality"
+    )
 
 
 def test_onboard_saves_baseline_snapshot(tmp_path: Path) -> None:
-    env, log_path =_onboard_env(tmp_path)
+    env, log_path = _onboard_env(tmp_path)
 
     subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "onboard_dataview.sh")],
@@ -479,7 +478,7 @@ def test_onboard_exits_2_on_quality_gate_breach(tmp_path: Path) -> None:
         "--describe-dataview": (0, describe_json),
         "--fail-on-quality": (2, sdr_json),
     }
-    env, log_path =_base_env(tmp_path, responses)
+    env, log_path = _base_env(tmp_path, responses)
     env["DATA_VIEW_ID"] = "dv_new"
 
     result = subprocess.run(
@@ -496,7 +495,7 @@ def test_onboard_exits_2_on_quality_gate_breach(tmp_path: Path) -> None:
 
 
 def test_onboard_exits_1_when_data_view_id_not_set(tmp_path: Path) -> None:
-    env, _log_path =_base_env(tmp_path)
+    env, _log_path = _base_env(tmp_path)
     env.pop("DATA_VIEW_ID", None)
 
     result = subprocess.run(
@@ -511,7 +510,7 @@ def test_onboard_exits_1_when_data_view_id_not_set(tmp_path: Path) -> None:
 
 
 def test_onboard_never_combines_run_summary_json_with_output_dash(tmp_path: Path) -> None:
-    env, log_path =_onboard_env(tmp_path)
+    env, log_path = _onboard_env(tmp_path)
 
     subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "onboard_dataview.sh")],
@@ -530,7 +529,7 @@ def test_onboard_signal_exit_stops_workflow(tmp_path: Path) -> None:
     responses: dict[str, tuple[int, str]] = {
         "--validate-config": (130, ""),
     }
-    env, log_path =_base_env(tmp_path, responses)
+    env, log_path = _base_env(tmp_path, responses)
     env["DATA_VIEW_ID"] = "dv_new"
 
     result = subprocess.run(
@@ -556,13 +555,13 @@ def _governance_env(tmp_path: Path, org_exit: int = 0, **extra: str) -> tuple[di
     responses: dict[str, tuple[int, str]] = {
         "--org-report": (org_exit, org_json),
     }
-    env, log_path =_base_env(tmp_path, responses)
+    env, log_path = _base_env(tmp_path, responses)
     env.update(extra)
     return env, log_path
 
 
 def test_governance_runs_to_completion(tmp_path: Path) -> None:
-    env, _log_path =_governance_env(tmp_path)
+    env, _log_path = _governance_env(tmp_path)
 
     result = subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "quarterly_governance.sh")],
@@ -575,7 +574,7 @@ def test_governance_runs_to_completion(tmp_path: Path) -> None:
 
 
 def test_governance_calls_org_report_with_trending_window(tmp_path: Path) -> None:
-    env, log_path =_governance_env(tmp_path, TRENDING_WINDOW="6")
+    env, log_path = _governance_env(tmp_path, TRENDING_WINDOW="6")
 
     subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "quarterly_governance.sh")],
@@ -589,7 +588,7 @@ def test_governance_calls_org_report_with_trending_window(tmp_path: Path) -> Non
 
 
 def test_governance_uses_agent_mode_for_machine_readable_pass(tmp_path: Path) -> None:
-    env, log_path =_governance_env(tmp_path)
+    env, log_path = _governance_env(tmp_path)
 
     subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "quarterly_governance.sh")],
@@ -603,7 +602,7 @@ def test_governance_uses_agent_mode_for_machine_readable_pass(tmp_path: Path) ->
 
 
 def test_governance_uses_fail_on_threshold(tmp_path: Path) -> None:
-    env, log_path =_governance_env(tmp_path)
+    env, log_path = _governance_env(tmp_path)
 
     subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "quarterly_governance.sh")],
@@ -618,7 +617,7 @@ def test_governance_uses_fail_on_threshold(tmp_path: Path) -> None:
 
 def test_governance_generates_human_artifact_separately(tmp_path: Path) -> None:
     """Markdown report must be a separate uv call from the machine-readable pass."""
-    env, log_path =_governance_env(tmp_path)
+    env, log_path = _governance_env(tmp_path)
 
     subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "quarterly_governance.sh")],
@@ -636,7 +635,7 @@ def test_governance_generates_human_artifact_separately(tmp_path: Path) -> None:
 
 
 def test_governance_exits_2_when_threshold_exceeded(tmp_path: Path) -> None:
-    env, _log_path =_governance_env(tmp_path, org_exit=2)
+    env, _log_path = _governance_env(tmp_path, org_exit=2)
 
     result = subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "quarterly_governance.sh")],
@@ -651,7 +650,7 @@ def test_governance_exits_2_when_threshold_exceeded(tmp_path: Path) -> None:
 def test_governance_never_invents_exit_code_4_or_5(tmp_path: Path) -> None:
     """Scripts must never exit with synthetic codes like 4 or 5."""
     for org_exit in [0, 1, 2, 3]:
-        env, _log_path =_governance_env(tmp_path, org_exit=org_exit)
+        env, _log_path = _governance_env(tmp_path, org_exit=org_exit)
         result = subprocess.run(
             ["bash", str(WORKFLOWS_DIR / "quarterly_governance.sh")],
             cwd=PROJECT_ROOT,
@@ -668,7 +667,7 @@ def test_governance_signal_exit_stops_workflow(tmp_path: Path) -> None:
     responses: dict[str, tuple[int, str]] = {
         "--org-report": (130, ""),
     }
-    env, _log_path =_base_env(tmp_path, responses)
+    env, _log_path = _base_env(tmp_path, responses)
 
     result = subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "quarterly_governance.sh")],
@@ -681,7 +680,7 @@ def test_governance_signal_exit_stops_workflow(tmp_path: Path) -> None:
 
 
 def test_governance_never_combines_run_summary_json_with_output_dash(tmp_path: Path) -> None:
-    env, log_path =_governance_env(tmp_path)
+    env, log_path = _governance_env(tmp_path)
 
     subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "quarterly_governance.sh")],

--- a/tests/test_agent_workflows.py
+++ b/tests/test_agent_workflows.py
@@ -182,6 +182,74 @@ def test_common_handle_exit_code_behaviour(
         assert result.stderr.strip() != ""
 
 
+def test_common_handle_exit_code_labels_warning_threshold_for_exit_3(tmp_path: Path) -> None:
+    harness = tmp_path / "harness.sh"
+    harness.write_text(
+        textwrap.dedent(
+            f"""\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            # shellcheck source=/dev/null
+            source "{WORKFLOWS_DIR}/_common.sh"
+            handle_exit_code 3 "diff"
+            """
+        ),
+        encoding="utf-8",
+    )
+    harness.chmod(0o755)
+    result = subprocess.run(["bash", str(harness)], capture_output=True, text=True)
+
+    assert result.returncode == 0
+    assert "[diff] Warning threshold exceeded" in result.stdout
+    assert result.stderr == ""
+
+
+def test_common_exit_on_signal_exit_only_propagates_documented_interrupt(tmp_path: Path) -> None:
+    harness = tmp_path / "harness.sh"
+    harness.write_text(
+        textwrap.dedent(
+            f"""\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            # shellcheck source=/dev/null
+            source "{WORKFLOWS_DIR}/_common.sh"
+            exit_on_signal_exit 143 "terminated"
+            echo "continued"
+            """
+        ),
+        encoding="utf-8",
+    )
+    harness.chmod(0o755)
+    result = subprocess.run(["bash", str(harness)], capture_output=True, text=True)
+
+    assert result.returncode == 0
+    assert "continued" in result.stdout
+    assert "terminated" not in result.stderr
+
+
+def test_common_exit_on_signal_exit_propagates_documented_interrupt(tmp_path: Path) -> None:
+    harness = tmp_path / "harness.sh"
+    harness.write_text(
+        textwrap.dedent(
+            f"""\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            # shellcheck source=/dev/null
+            source "{WORKFLOWS_DIR}/_common.sh"
+            exit_on_signal_exit 130 "interrupted"
+            echo "unreachable"
+            """
+        ),
+        encoding="utf-8",
+    )
+    harness.chmod(0o755)
+    result = subprocess.run(["bash", str(harness)], capture_output=True, text=True)
+
+    assert result.returncode == 130
+    assert "interrupted (exit 130)" in result.stderr
+    assert "unreachable" not in result.stdout
+
+
 def test_common_extract_dataview_ids(tmp_path: Path) -> None:
     """extract_dataview_ids() must parse the real dataViews JSON shape."""
     harness = tmp_path / "harness.sh"
@@ -224,6 +292,140 @@ def test_common_require_env_exits_when_unset(tmp_path: Path) -> None:
     result = subprocess.run(["bash", str(harness)], capture_output=True, text=True)
     assert result.returncode == 1
     assert "MISSING_VAR" in result.stderr
+
+
+def test_common_load_auth_from_project_dotenv_preserves_injected_values(tmp_path: Path) -> None:
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    (project_root / ".env").write_text(
+        textwrap.dedent(
+            """\
+            ORG_ID=file-org
+            CLIENT_ID=file-client
+            SECRET=file-secret
+            SCOPES=file-scopes
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    harness = tmp_path / "harness.sh"
+    harness.write_text(
+        textwrap.dedent(
+            f"""\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            export ORG_ID="injected-org"
+            unset CLIENT_ID SECRET SCOPES || true
+            # shellcheck source=/dev/null
+            source "{WORKFLOWS_DIR}/_common.sh"
+            load_auth_from_project_dotenv "{project_root}"
+            printf 'ORG_ID=%s\n' "$ORG_ID"
+            printf 'CLIENT_ID=%s\n' "$CLIENT_ID"
+            printf 'SECRET=%s\n' "$SECRET"
+            printf 'SCOPES=%s\n' "$SCOPES"
+            """
+        ),
+        encoding="utf-8",
+    )
+    harness.chmod(0o755)
+
+    result = subprocess.run(["bash", str(harness)], capture_output=True, text=True)
+
+    assert result.returncode == 0
+    assert "ORG_ID=injected-org" in result.stdout
+    assert "CLIENT_ID=file-client" in result.stdout
+    assert "SECRET=file-secret" in result.stdout
+    assert "SCOPES=file-scopes" in result.stdout
+
+
+def test_common_load_auth_from_project_dotenv_short_circuits_when_auth_is_complete(tmp_path: Path) -> None:
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    (project_root / ".env").write_text(
+        textwrap.dedent(
+            """\
+            ORG_ID=file-org
+            CLIENT_ID=file-client
+            SECRET=file-secret
+            SCOPES=file-scopes
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    harness = tmp_path / "harness.sh"
+    harness.write_text(
+        textwrap.dedent(
+            f"""\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            export ORG_ID="injected-org"
+            export CLIENT_ID="injected-client"
+            export SECRET="injected-secret"
+            export SCOPES="injected-scopes"
+            # shellcheck source=/dev/null
+            source "{WORKFLOWS_DIR}/_common.sh"
+            load_auth_from_project_dotenv "{project_root}"
+            printf 'ORG_ID=%s\n' "$ORG_ID"
+            printf 'CLIENT_ID=%s\n' "$CLIENT_ID"
+            printf 'SECRET=%s\n' "$SECRET"
+            printf 'SCOPES=%s\n' "$SCOPES"
+            """
+        ),
+        encoding="utf-8",
+    )
+    harness.chmod(0o755)
+
+    result = subprocess.run(["bash", str(harness)], capture_output=True, text=True)
+
+    assert result.returncode == 0
+    assert "ORG_ID=injected-org" in result.stdout
+    assert "CLIENT_ID=injected-client" in result.stdout
+    assert "SECRET=injected-secret" in result.stdout
+    assert "SCOPES=injected-scopes" in result.stdout
+
+
+def test_common_load_auth_from_project_dotenv_does_not_override_non_auth_vars(tmp_path: Path) -> None:
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    (project_root / ".env").write_text(
+        textwrap.dedent(
+            """\
+            ORG_ID=file-org
+            CLIENT_ID=file-client
+            SECRET=file-secret
+            SCOPES=file-scopes
+            REPORT_DIR=file-reports
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    harness = tmp_path / "harness.sh"
+    harness.write_text(
+        textwrap.dedent(
+            f"""\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            export REPORT_DIR="injected-reports"
+            unset ORG_ID CLIENT_ID SECRET SCOPES || true
+            # shellcheck source=/dev/null
+            source "{WORKFLOWS_DIR}/_common.sh"
+            load_auth_from_project_dotenv "{project_root}"
+            printf 'REPORT_DIR=%s\n' "$REPORT_DIR"
+            printf 'ORG_ID=%s\n' "$ORG_ID"
+            """
+        ),
+        encoding="utf-8",
+    )
+    harness.chmod(0o755)
+
+    result = subprocess.run(["bash", str(harness)], capture_output=True, text=True)
+
+    assert result.returncode == 0
+    assert "REPORT_DIR=injected-reports" in result.stdout
+    assert "ORG_ID=file-org" in result.stdout
 
 
 # ---------------------------------------------------------------------------
@@ -307,7 +509,7 @@ def test_audit_first_run_creates_baseline_without_compare_with_prev(tmp_path: Pa
     # Must not call --compare-with-prev on first run
     assert all("--compare-with-prev" not in c for c in calls), "Must not call --compare-with-prev on first run"
     # Must create a baseline snapshot instead
-    assert any("--snapshot" in c and "dv_1" in c for c in calls), "Must create baseline snapshot on first run"
+    assert any("--snapshot " in c and "dv_1" in c for c in calls), "Must create baseline snapshot on first run"
 
 
 def test_audit_subsequent_run_uses_compare_with_prev(tmp_path: Path) -> None:
@@ -334,6 +536,82 @@ def test_audit_subsequent_run_uses_compare_with_prev(tmp_path: Path) -> None:
     assert any("--compare-with-prev" in c for c in calls), "Must use --compare-with-prev when snapshots exist"
 
 
+def test_audit_passes_snapshot_dir_to_snapshot_inventory(tmp_path: Path) -> None:
+    discovery_json = '{"dataViews":[{"id":"dv_1"}]}'
+    snapshots_json = '{"snapshots":[{"id":"snap_001"}]}'
+    responses: dict[str, tuple[int, str]] = {
+        "--list-dataviews --agent-mode": (0, discovery_json),
+        "--list-snapshots": (0, snapshots_json),
+        "--org-report --agent-mode": (0, '{"status":"ok"}'),
+    }
+    env, log_path = _base_env(tmp_path, responses)
+    env["SNAPSHOT_DIR"] = str(tmp_path / "custom-snapshots")
+
+    result = subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "audit_and_report.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    calls = _read_calls(log_path)
+    snapshot_calls = [c for c in calls if "--list-snapshots" in c]
+
+    assert result.returncode == 0
+    assert len(snapshot_calls) == 1
+    assert f"--snapshot-dir {env['SNAPSHOT_DIR']}" in snapshot_calls[0]
+
+
+def test_audit_first_run_writes_baseline_to_configured_snapshot_dir(tmp_path: Path) -> None:
+    discovery_json = '{"dataViews":[{"id":"dv_1"}]}'
+    responses: dict[str, tuple[int, str]] = {
+        "--list-dataviews --agent-mode": (0, discovery_json),
+        "--list-snapshots": (0, '{"snapshots":[]}'),
+        "--org-report --agent-mode": (0, '{"status":"ok"}'),
+    }
+    env, log_path = _base_env(tmp_path, responses)
+    env["SNAPSHOT_DIR"] = str(tmp_path / "custom-snapshots")
+
+    result = subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "audit_and_report.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    calls = _read_calls(log_path)
+    snapshot_calls = [c for c in calls if "--snapshot " in c]
+
+    assert result.returncode == 0
+    assert len(snapshot_calls) == 1
+    assert f"--snapshot {env['SNAPSHOT_DIR']}/dv_1_baseline.json" in snapshot_calls[0]
+
+
+def test_audit_compare_with_prev_reuses_configured_snapshot_dir(tmp_path: Path) -> None:
+    discovery_json = '{"dataViews":[{"id":"dv_1"}]}'
+    responses: dict[str, tuple[int, str]] = {
+        "--list-dataviews --agent-mode": (0, discovery_json),
+        "--list-snapshots": (0, '{"snapshots":[{"id":"snap_001"}]}'),
+        "--org-report --agent-mode": (0, '{"status":"ok"}'),
+    }
+    env, log_path = _base_env(tmp_path, responses)
+    env["SNAPSHOT_DIR"] = str(tmp_path / "custom-snapshots")
+
+    result = subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "audit_and_report.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    calls = _read_calls(log_path)
+    compare_calls = [c for c in calls if "--compare-with-prev" in c]
+
+    assert result.returncode == 0
+    assert len(compare_calls) == 1
+    assert f"--snapshot-dir {env['SNAPSHOT_DIR']}" in compare_calls[0]
+
+
 def test_audit_snapshot_inventory_failure_does_not_create_baseline(tmp_path: Path) -> None:
     discovery_json = '{"dataViews":[{"id":"dv_1"}]}'
     responses: dict[str, tuple[int, str]] = {
@@ -353,7 +631,7 @@ def test_audit_snapshot_inventory_failure_does_not_create_baseline(tmp_path: Pat
     calls = _read_calls(log_path)
 
     assert result.returncode == 1
-    assert all("--snapshot" not in c for c in calls), "Must not create baseline when snapshot inventory fails"
+    assert all("--snapshot " not in c for c in calls), "Must not create baseline when snapshot inventory fails"
     assert "Snapshot list failed for dv_1" in result.stderr
 
 
@@ -372,6 +650,67 @@ def test_audit_persists_org_report_artifact(tmp_path: Path) -> None:
     org_reports = list((tmp_path / "reports").glob("audit-*/org_report.json"))
     assert len(org_reports) == 1
     assert json.loads(org_reports[0].read_text(encoding="utf-8")) == {"status": "ok"}
+
+
+def test_audit_logs_org_report_advisories_and_actions(tmp_path: Path) -> None:
+    advisory_json = json.dumps(
+        {
+            "status": "ok",
+            "advisories": {
+                "severity": "warning",
+                "findings": [{"type": "high_overlap", "severity": "warning"}],
+                "recommended_actions": ["review_overlap_pairs", "verify_intentional_duplicates"],
+            },
+        }
+    )
+    responses: dict[str, tuple[int, str]] = {
+        "--list-dataviews --agent-mode": (0, '{"dataViews":[{"id":"dv_1"}]}'),
+        "--list-snapshots": (0, '{"snapshots":[]}'),
+        "--org-report --agent-mode": (0, advisory_json),
+    }
+    env, _log_path = _base_env(tmp_path, responses)
+
+    result = subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "audit_and_report.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "Advisories for org report: count=1 severity=warning" in result.stdout
+    assert "Recommended actions for org report: review_overlap_pairs,verify_intentional_duplicates" in result.stdout
+
+
+def test_audit_critical_org_report_advisory_is_logged_without_changing_exit(tmp_path: Path) -> None:
+    advisory_json = json.dumps(
+        {
+            "status": "ok",
+            "advisories": {
+                "severity": "critical",
+                "findings": [{"type": "governance_threshold_breach", "severity": "critical"}],
+                "recommended_actions": ["review_governance_thresholds", "remediate_threshold_breach"],
+            },
+        }
+    )
+    responses: dict[str, tuple[int, str]] = {
+        "--list-dataviews --agent-mode": (0, '{"dataViews":[{"id":"dv_1"}]}'),
+        "--list-snapshots": (0, '{"snapshots":[]}'),
+        "--org-report --agent-mode": (0, advisory_json),
+    }
+    env, _log_path = _base_env(tmp_path, responses)
+
+    result = subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "audit_and_report.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "Advisories for org report: count=1 severity=critical" in result.stdout
 
 
 def test_audit_persists_diff_artifact_when_compare_with_prev_runs(tmp_path: Path) -> None:
@@ -399,6 +738,38 @@ def test_audit_persists_diff_artifact_when_compare_with_prev_runs(tmp_path: Path
     assert len(diff_reports) == 1
     payload = json.loads(diff_reports[0].read_text(encoding="utf-8"))
     assert payload["summary"]["has_changes"] is True
+
+
+def test_audit_logs_diff_advisories_when_compare_with_prev_runs(tmp_path: Path) -> None:
+    diff_json = json.dumps(
+        {
+            "summary": {"has_changes": False, "total_changes": 0},
+            "advisories": {
+                "severity": "warning",
+                "findings": [{"type": "schema_changes", "severity": "warning"}],
+                "recommended_actions": ["review_schema_changes", "validate_mappings"],
+            },
+        }
+    )
+    responses: dict[str, tuple[int, str]] = {
+        "--list-dataviews --agent-mode": (0, '{"dataViews":[{"id":"dv_1"}]}'),
+        "--list-snapshots": (0, '{"snapshots":[{"id":"snap_001"}]}'),
+        "--compare-with-prev --agent-mode": (0, diff_json),
+        "--org-report --agent-mode": (0, '{"status":"ok"}'),
+    }
+    env, _log_path = _base_env(tmp_path, responses)
+
+    result = subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "audit_and_report.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "Advisories for diff dv_1: count=1 severity=warning" in result.stdout
+    assert "Recommended actions for diff dv_1: review_schema_changes,validate_mappings" in result.stdout
 
 
 def test_audit_never_combines_run_summary_json_with_output_dash(tmp_path: Path) -> None:
@@ -562,7 +933,7 @@ def test_onboard_saves_baseline_snapshot(tmp_path: Path) -> None:
         text=True,
     )
     calls = _read_calls(log_path)
-    assert any("--snapshot" in c and "dv_new" in c for c in calls), "Must save baseline snapshot"
+    assert any("--snapshot " in c and "dv_new" in c for c in calls), "Must save baseline snapshot"
 
 
 def test_onboard_exits_2_on_quality_gate_breach(tmp_path: Path) -> None:
@@ -592,7 +963,7 @@ def test_onboard_exits_2_on_quality_gate_breach(tmp_path: Path) -> None:
     assert result.returncode == 2
     calls = _read_calls(log_path)
     # Snapshot must NOT be saved on quality gate breach
-    assert all("--snapshot" not in c for c in calls), "Must not save snapshot when quality gate is breached"
+    assert all("--snapshot " not in c for c in calls), "Must not save snapshot when quality gate is breached"
     assert "severity=HIGH" in result.stdout
     assert (tmp_path / "reports" / "dv_new_run_summary.json").exists()
 
@@ -643,6 +1014,27 @@ def test_onboard_exits_1_when_data_view_id_not_set(tmp_path: Path) -> None:
     assert "DATA_VIEW_ID" in result.stderr
 
 
+def test_onboard_validate_config_failure_exits_1(tmp_path: Path) -> None:
+    responses: dict[str, tuple[int, str]] = {
+        "--validate-config": (1, ""),
+    }
+    env, log_path = _base_env(tmp_path, responses)
+    env["DATA_VIEW_ID"] = "dv_new"
+
+    result = subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "onboard_dataview.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "Configuration validation failed (exit 1)" in result.stderr
+    calls = _read_calls(log_path)
+    assert all("--describe-dataview" not in c for c in calls)
+
+
 def test_onboard_never_combines_run_summary_json_with_output_dash(tmp_path: Path) -> None:
     env, log_path = _onboard_env(tmp_path)
 
@@ -673,7 +1065,7 @@ def test_onboard_signal_exit_stops_workflow(tmp_path: Path) -> None:
         capture_output=True,
         text=True,
     )
-    assert result.returncode != 0
+    assert result.returncode == 130
     calls = _read_calls(log_path)
     # No SDR generation after validate-config signal exit
     assert all("--describe-dataview" not in c for c in calls)
@@ -721,6 +1113,22 @@ def test_governance_calls_org_report_with_trending_window(tmp_path: Path) -> Non
     assert any("--org-report" in c and "--trending-window" in c and "6" in c for c in calls)
 
 
+def test_governance_uses_default_trending_window_from_spec(tmp_path: Path) -> None:
+    env, log_path = _governance_env(tmp_path)
+
+    subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "quarterly_governance.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    calls = [c for c in _read_calls(log_path) if "--org-report" in c]
+
+    assert len(calls) >= 2
+    assert all("--trending-window 10" in c for c in calls)
+
+
 def test_governance_uses_agent_mode_for_machine_readable_pass(tmp_path: Path) -> None:
     env, log_path = _governance_env(tmp_path)
 
@@ -747,6 +1155,141 @@ def test_governance_uses_fail_on_threshold(tmp_path: Path) -> None:
     )
     calls = _read_calls(log_path)
     assert any("--fail-on-threshold" in c for c in calls)
+
+
+def test_governance_passes_concrete_threshold_flags(tmp_path: Path) -> None:
+    env, log_path = _governance_env(
+        tmp_path,
+        DUPLICATE_THRESHOLD="7",
+        ISOLATED_THRESHOLD="0.4",
+    )
+
+    subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "quarterly_governance.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    calls = [c for c in _read_calls(log_path) if "--org-report" in c]
+
+    assert len(calls) >= 2
+    assert all("--duplicate-threshold 7" in c for c in calls)
+    assert all("--isolated-threshold 0.4" in c for c in calls)
+
+
+def test_governance_uses_default_threshold_values(tmp_path: Path) -> None:
+    env, log_path = _governance_env(tmp_path)
+
+    subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "quarterly_governance.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    calls = [c for c in _read_calls(log_path) if "--org-report" in c]
+
+    assert len(calls) >= 2
+    assert all("--duplicate-threshold 5" in c for c in calls)
+    assert all("--isolated-threshold 0.35" in c for c in calls)
+
+
+def test_governance_prunes_snapshots_with_defaults(tmp_path: Path) -> None:
+    env, log_path = _governance_env(tmp_path)
+
+    subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "quarterly_governance.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    calls = _read_calls(log_path)
+    prune_calls = [c for c in calls if "--prune-snapshots" in c]
+
+    assert len(prune_calls) == 1
+    assert "--keep-last 4" in prune_calls[0]
+    assert f"--snapshot-dir {env['SNAPSHOT_DIR']}" in prune_calls[0]
+
+
+def test_governance_prunes_snapshots_with_overrides(tmp_path: Path) -> None:
+    env, log_path = _governance_env(
+        tmp_path,
+        SNAPSHOT_DIR=str(tmp_path / "custom-snapshots"),
+        KEEP_LAST="9",
+    )
+
+    subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "quarterly_governance.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    calls = _read_calls(log_path)
+    prune_calls = [c for c in calls if "--prune-snapshots" in c]
+
+    assert len(prune_calls) == 1
+    assert "--keep-last 9" in prune_calls[0]
+    assert f"--snapshot-dir {env['SNAPSHOT_DIR']}" in prune_calls[0]
+
+
+def test_governance_prune_failure_updates_overall_exit(tmp_path: Path) -> None:
+    responses: dict[str, tuple[int, str]] = {
+        "--org-report": (0, '{"status":"ok","thresholds_exceeded":false}'),
+        "--prune-snapshots": (1, ""),
+    }
+    env, _log_path = _base_env(tmp_path, responses)
+
+    result = subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "quarterly_governance.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "Snapshot pruning failed" in result.stderr
+
+
+def test_governance_markdown_failure_takes_precedence_over_threshold_exit(tmp_path: Path) -> None:
+    responses: dict[str, tuple[int, str]] = {
+        "--agent-mode": (2, '{"status":"ok","thresholds_exceeded":true}'),
+        "--format markdown": (1, ""),
+    }
+    env, _log_path = _base_env(tmp_path, responses)
+
+    result = subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "quarterly_governance.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "Markdown export failed" in result.stderr
+
+
+def test_governance_prune_failure_takes_precedence_over_threshold_exit(tmp_path: Path) -> None:
+    responses: dict[str, tuple[int, str]] = {
+        "--agent-mode": (2, '{"status":"ok","thresholds_exceeded":true}'),
+        "--prune-snapshots": (1, ""),
+    }
+    env, _log_path = _base_env(tmp_path, responses)
+
+    result = subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "quarterly_governance.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "Snapshot pruning failed" in result.stderr
 
 
 def test_governance_generates_human_artifact_separately(tmp_path: Path) -> None:

--- a/tests/test_agent_workflows.py
+++ b/tests/test_agent_workflows.py
@@ -31,7 +31,7 @@ def _install_fake_uv(tmp_path: Path, responses: dict[str, tuple[int, str]] | Non
     for pattern, (code, out) in (responses or {}).items():
         escaped_out = out.replace("'", "'\\''")
         dispatch_lines.append(
-            f"if [[ \"$args\" == *{repr(pattern)}* ]]; then printf '%s\\n' '{escaped_out}'; exit {code}; fi"
+            f"if [[ \"$args\" == *{pattern!r}* ]]; then printf '%s\\n' '{escaped_out}'; exit {code}; fi"
         )
 
     dispatch_block = "\n".join(dispatch_lines)
@@ -220,13 +220,13 @@ def _audit_env(tmp_path: Path, **extra: str) -> tuple[dict[str, str], Path]:
         "--list-dataviews --agent-mode": (0, discovery_json),
         "--org-report --agent-mode": (0, '{"status":"ok"}'),
     }
-    env, log_path = _base_env(tmp_path, responses)
+    env, log_path =_base_env(tmp_path, responses)
     env.update(extra)
     return env, log_path
 
 
 def test_audit_runs_to_completion(tmp_path: Path) -> None:
-    env, log_path = _audit_env(tmp_path)
+    env, _log_path =_audit_env(tmp_path)
 
     result = subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "audit_and_report.sh")],
@@ -239,7 +239,7 @@ def test_audit_runs_to_completion(tmp_path: Path) -> None:
 
 
 def test_audit_calls_list_dataviews_with_agent_mode(tmp_path: Path) -> None:
-    env, log_path = _audit_env(tmp_path)
+    env, log_path =_audit_env(tmp_path)
 
     subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "audit_and_report.sh")],
@@ -253,7 +253,7 @@ def test_audit_calls_list_dataviews_with_agent_mode(tmp_path: Path) -> None:
 
 
 def test_audit_calls_org_report_with_agent_mode(tmp_path: Path) -> None:
-    env, log_path = _audit_env(tmp_path)
+    env, log_path =_audit_env(tmp_path)
 
     subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "audit_and_report.sh")],
@@ -275,7 +275,7 @@ def test_audit_first_run_creates_baseline_without_compare_with_prev(tmp_path: Pa
         "--list-snapshots": (0, '{"snapshots":[]}'),
         "--org-report --agent-mode": (0, '{"status":"ok"}'),
     }
-    env, log_path = _base_env(tmp_path, responses)
+    env, log_path =_base_env(tmp_path, responses)
 
     result = subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "audit_and_report.sh")],
@@ -302,7 +302,7 @@ def test_audit_subsequent_run_uses_compare_with_prev(tmp_path: Path) -> None:
         "--list-snapshots": (0, snapshots_json),
         "--org-report --agent-mode": (0, '{"status":"ok"}'),
     }
-    env, log_path = _base_env(tmp_path, responses)
+    env, log_path =_base_env(tmp_path, responses)
 
     result = subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "audit_and_report.sh")],
@@ -319,7 +319,7 @@ def test_audit_subsequent_run_uses_compare_with_prev(tmp_path: Path) -> None:
 
 def test_audit_never_combines_run_summary_json_with_output_dash(tmp_path: Path) -> None:
     """Must never emit --run-summary-json - combined with --output -."""
-    env, log_path = _audit_env(tmp_path)
+    env, log_path =_audit_env(tmp_path)
 
     subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "audit_and_report.sh")],
@@ -341,7 +341,7 @@ def test_audit_signal_exit_stops_workflow(tmp_path: Path) -> None:
     responses: dict[str, tuple[int, str]] = {
         "--list-dataviews --agent-mode": (130, discovery_json),
     }
-    env, log_path = _base_env(tmp_path, responses)
+    env, log_path =_base_env(tmp_path, responses)
 
     result = subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "audit_and_report.sh")],
@@ -364,7 +364,7 @@ def test_audit_uses_ids_not_names(tmp_path: Path) -> None:
         "--list-dataviews --agent-mode": (0, discovery_json),
         "--org-report --agent-mode": (0, '{"status":"ok"}'),
     }
-    env, log_path = _base_env(tmp_path, responses)
+    env, log_path =_base_env(tmp_path, responses)
 
     subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "audit_and_report.sh")],
@@ -392,14 +392,14 @@ def _onboard_env(tmp_path: Path, **extra: str) -> tuple[dict[str, str], Path]:
         "--describe-dataview": (0, describe_json),
         "--fail-on-quality": (0, sdr_json),
     }
-    env, log_path = _base_env(tmp_path, responses)
+    env, log_path =_base_env(tmp_path, responses)
     env["DATA_VIEW_ID"] = "dv_new"
     env.update(extra)
     return env, log_path
 
 
 def test_onboard_runs_to_completion(tmp_path: Path) -> None:
-    env, log_path = _onboard_env(tmp_path)
+    env, _log_path =_onboard_env(tmp_path)
 
     result = subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "onboard_dataview.sh")],
@@ -412,7 +412,7 @@ def test_onboard_runs_to_completion(tmp_path: Path) -> None:
 
 
 def test_onboard_calls_validate_config_first(tmp_path: Path) -> None:
-    env, log_path = _onboard_env(tmp_path)
+    env, log_path =_onboard_env(tmp_path)
 
     subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "onboard_dataview.sh")],
@@ -427,7 +427,7 @@ def test_onboard_calls_validate_config_first(tmp_path: Path) -> None:
 
 
 def test_onboard_calls_describe_dataview(tmp_path: Path) -> None:
-    env, log_path = _onboard_env(tmp_path)
+    env, log_path =_onboard_env(tmp_path)
 
     subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "onboard_dataview.sh")],
@@ -441,7 +441,7 @@ def test_onboard_calls_describe_dataview(tmp_path: Path) -> None:
 
 
 def test_onboard_calls_sdr_with_agent_mode_and_quality_gate(tmp_path: Path) -> None:
-    env, log_path = _onboard_env(tmp_path)
+    env, log_path =_onboard_env(tmp_path)
 
     subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "onboard_dataview.sh")],
@@ -458,7 +458,7 @@ def test_onboard_calls_sdr_with_agent_mode_and_quality_gate(tmp_path: Path) -> N
 
 
 def test_onboard_saves_baseline_snapshot(tmp_path: Path) -> None:
-    env, log_path = _onboard_env(tmp_path)
+    env, log_path =_onboard_env(tmp_path)
 
     subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "onboard_dataview.sh")],
@@ -479,7 +479,7 @@ def test_onboard_exits_2_on_quality_gate_breach(tmp_path: Path) -> None:
         "--describe-dataview": (0, describe_json),
         "--fail-on-quality": (2, sdr_json),
     }
-    env, log_path = _base_env(tmp_path, responses)
+    env, log_path =_base_env(tmp_path, responses)
     env["DATA_VIEW_ID"] = "dv_new"
 
     result = subprocess.run(
@@ -496,7 +496,7 @@ def test_onboard_exits_2_on_quality_gate_breach(tmp_path: Path) -> None:
 
 
 def test_onboard_exits_1_when_data_view_id_not_set(tmp_path: Path) -> None:
-    env, log_path = _base_env(tmp_path)
+    env, _log_path =_base_env(tmp_path)
     env.pop("DATA_VIEW_ID", None)
 
     result = subprocess.run(
@@ -511,7 +511,7 @@ def test_onboard_exits_1_when_data_view_id_not_set(tmp_path: Path) -> None:
 
 
 def test_onboard_never_combines_run_summary_json_with_output_dash(tmp_path: Path) -> None:
-    env, log_path = _onboard_env(tmp_path)
+    env, log_path =_onboard_env(tmp_path)
 
     subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "onboard_dataview.sh")],
@@ -530,7 +530,7 @@ def test_onboard_signal_exit_stops_workflow(tmp_path: Path) -> None:
     responses: dict[str, tuple[int, str]] = {
         "--validate-config": (130, ""),
     }
-    env, log_path = _base_env(tmp_path, responses)
+    env, log_path =_base_env(tmp_path, responses)
     env["DATA_VIEW_ID"] = "dv_new"
 
     result = subprocess.run(
@@ -556,13 +556,13 @@ def _governance_env(tmp_path: Path, org_exit: int = 0, **extra: str) -> tuple[di
     responses: dict[str, tuple[int, str]] = {
         "--org-report": (org_exit, org_json),
     }
-    env, log_path = _base_env(tmp_path, responses)
+    env, log_path =_base_env(tmp_path, responses)
     env.update(extra)
     return env, log_path
 
 
 def test_governance_runs_to_completion(tmp_path: Path) -> None:
-    env, log_path = _governance_env(tmp_path)
+    env, _log_path =_governance_env(tmp_path)
 
     result = subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "quarterly_governance.sh")],
@@ -575,7 +575,7 @@ def test_governance_runs_to_completion(tmp_path: Path) -> None:
 
 
 def test_governance_calls_org_report_with_trending_window(tmp_path: Path) -> None:
-    env, log_path = _governance_env(tmp_path, TRENDING_WINDOW="6")
+    env, log_path =_governance_env(tmp_path, TRENDING_WINDOW="6")
 
     subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "quarterly_governance.sh")],
@@ -589,7 +589,7 @@ def test_governance_calls_org_report_with_trending_window(tmp_path: Path) -> Non
 
 
 def test_governance_uses_agent_mode_for_machine_readable_pass(tmp_path: Path) -> None:
-    env, log_path = _governance_env(tmp_path)
+    env, log_path =_governance_env(tmp_path)
 
     subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "quarterly_governance.sh")],
@@ -603,7 +603,7 @@ def test_governance_uses_agent_mode_for_machine_readable_pass(tmp_path: Path) ->
 
 
 def test_governance_uses_fail_on_threshold(tmp_path: Path) -> None:
-    env, log_path = _governance_env(tmp_path)
+    env, log_path =_governance_env(tmp_path)
 
     subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "quarterly_governance.sh")],
@@ -618,7 +618,7 @@ def test_governance_uses_fail_on_threshold(tmp_path: Path) -> None:
 
 def test_governance_generates_human_artifact_separately(tmp_path: Path) -> None:
     """Markdown report must be a separate uv call from the machine-readable pass."""
-    env, log_path = _governance_env(tmp_path)
+    env, log_path =_governance_env(tmp_path)
 
     subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "quarterly_governance.sh")],
@@ -636,7 +636,7 @@ def test_governance_generates_human_artifact_separately(tmp_path: Path) -> None:
 
 
 def test_governance_exits_2_when_threshold_exceeded(tmp_path: Path) -> None:
-    env, log_path = _governance_env(tmp_path, org_exit=2)
+    env, _log_path =_governance_env(tmp_path, org_exit=2)
 
     result = subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "quarterly_governance.sh")],
@@ -651,7 +651,7 @@ def test_governance_exits_2_when_threshold_exceeded(tmp_path: Path) -> None:
 def test_governance_never_invents_exit_code_4_or_5(tmp_path: Path) -> None:
     """Scripts must never exit with synthetic codes like 4 or 5."""
     for org_exit in [0, 1, 2, 3]:
-        env, log_path = _governance_env(tmp_path, org_exit=org_exit)
+        env, _log_path =_governance_env(tmp_path, org_exit=org_exit)
         result = subprocess.run(
             ["bash", str(WORKFLOWS_DIR / "quarterly_governance.sh")],
             cwd=PROJECT_ROOT,
@@ -668,7 +668,7 @@ def test_governance_signal_exit_stops_workflow(tmp_path: Path) -> None:
     responses: dict[str, tuple[int, str]] = {
         "--org-report": (130, ""),
     }
-    env, log_path = _base_env(tmp_path, responses)
+    env, _log_path =_base_env(tmp_path, responses)
 
     result = subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "quarterly_governance.sh")],
@@ -681,7 +681,7 @@ def test_governance_signal_exit_stops_workflow(tmp_path: Path) -> None:
 
 
 def test_governance_never_combines_run_summary_json_with_output_dash(tmp_path: Path) -> None:
-    env, log_path = _governance_env(tmp_path)
+    env, log_path =_governance_env(tmp_path)
 
     subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "quarterly_governance.sh")],

--- a/tests/test_agent_workflows.py
+++ b/tests/test_agent_workflows.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import textwrap
@@ -45,6 +46,22 @@ def _install_fake_uv(tmp_path: Path, responses: dict[str, tuple[int, str]] | Non
 
             args="$*"
             printf '%s\n' "$args" >> "$FAKE_UV_LOG"
+
+            if [[ "$args" == *"--run-summary-json"* && -n "${{FAKE_UV_RUN_SUMMARY_JSON:-}}" ]]; then
+                summary_path=""
+                prev=""
+                for arg in "$@"; do
+                    if [[ "$prev" == "--run-summary-json" ]]; then
+                        summary_path="$arg"
+                        break
+                    fi
+                    prev="$arg"
+                done
+
+                if [[ -n "$summary_path" ]]; then
+                    printf '%s\n' "$FAKE_UV_RUN_SUMMARY_JSON" > "$summary_path"
+                fi
+            fi
 
             {dispatch_block}
 
@@ -317,6 +334,73 @@ def test_audit_subsequent_run_uses_compare_with_prev(tmp_path: Path) -> None:
     assert any("--compare-with-prev" in c for c in calls), "Must use --compare-with-prev when snapshots exist"
 
 
+def test_audit_snapshot_inventory_failure_does_not_create_baseline(tmp_path: Path) -> None:
+    discovery_json = '{"dataViews":[{"id":"dv_1"}]}'
+    responses: dict[str, tuple[int, str]] = {
+        "--list-dataviews --agent-mode": (0, discovery_json),
+        "--list-snapshots": (1, ""),
+        "--org-report --agent-mode": (0, '{"status":"ok"}'),
+    }
+    env, log_path = _base_env(tmp_path, responses)
+
+    result = subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "audit_and_report.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    calls = _read_calls(log_path)
+
+    assert result.returncode == 1
+    assert all("--snapshot" not in c for c in calls), "Must not create baseline when snapshot inventory fails"
+    assert "Snapshot list failed for dv_1" in result.stderr
+
+
+def test_audit_persists_org_report_artifact(tmp_path: Path) -> None:
+    env, _log_path = _audit_env(tmp_path)
+
+    result = subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "audit_and_report.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    org_reports = list((tmp_path / "reports").glob("audit-*/org_report.json"))
+    assert len(org_reports) == 1
+    assert json.loads(org_reports[0].read_text(encoding="utf-8")) == {"status": "ok"}
+
+
+def test_audit_persists_diff_artifact_when_compare_with_prev_runs(tmp_path: Path) -> None:
+    discovery_json = '{"dataViews":[{"id":"dv_1"}]}'
+    snapshots_json = '{"snapshots":[{"id":"snap_001"}]}'
+    diff_json = '{"summary":{"has_changes":true,"total_changes":1},"advisories":{"severity":"warning"}}'
+    responses: dict[str, tuple[int, str]] = {
+        "--list-dataviews --agent-mode": (0, discovery_json),
+        "--list-snapshots": (0, snapshots_json),
+        "--compare-with-prev --agent-mode": (2, diff_json),
+        "--org-report --agent-mode": (0, '{"status":"ok"}'),
+    }
+    env, _log_path = _base_env(tmp_path, responses)
+
+    result = subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "audit_and_report.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    diff_reports = list((tmp_path / "reports").glob("audit-*/dv_1_diff.json"))
+    assert len(diff_reports) == 1
+    payload = json.loads(diff_reports[0].read_text(encoding="utf-8"))
+    assert payload["summary"]["has_changes"] is True
+
+
 def test_audit_never_combines_run_summary_json_with_output_dash(tmp_path: Path) -> None:
     """Must never emit --run-summary-json - combined with --output -."""
     env, log_path = _audit_env(tmp_path)
@@ -386,14 +470,20 @@ def test_audit_uses_ids_not_names(tmp_path: Path) -> None:
 
 def _onboard_env(tmp_path: Path, **extra: str) -> tuple[dict[str, str], Path]:
     describe_json = '{"id":"dv_new","name":"New View"}'
-    sdr_json = '{"status":"ok","advisories":{"severity":"info"}}'
     responses: dict[str, tuple[int, str]] = {
         "--validate-config": (0, ""),
         "--describe-dataview": (0, describe_json),
-        "--fail-on-quality": (0, sdr_json),
+        "--fail-on-quality": (0, ""),
     }
     env, log_path = _base_env(tmp_path, responses)
     env["DATA_VIEW_ID"] = "dv_new"
+    env["FAKE_UV_RUN_SUMMARY_JSON"] = json.dumps(
+        {
+            "summary_version": "1.1",
+            "quality_gate_failed": False,
+            "results": [{"dq_severity_counts": {"INFO": 1}}],
+        }
+    )
     env.update(extra)
     return env, log_path
 
@@ -440,7 +530,7 @@ def test_onboard_calls_describe_dataview(tmp_path: Path) -> None:
     assert any("--describe-dataview" in c and "dv_new" in c for c in calls)
 
 
-def test_onboard_calls_sdr_with_agent_mode_and_quality_gate(tmp_path: Path) -> None:
+def test_onboard_calls_sdr_with_agent_mode_quality_gate_and_run_summary(tmp_path: Path) -> None:
     env, log_path = _onboard_env(tmp_path)
 
     subprocess.run(
@@ -451,9 +541,14 @@ def test_onboard_calls_sdr_with_agent_mode_and_quality_gate(tmp_path: Path) -> N
         text=True,
     )
     calls = _read_calls(log_path)
-    assert any("dv_new" in c and "--agent-mode" in c and "--fail-on-quality" in c for c in calls), (
-        "SDR generation must use --agent-mode and --fail-on-quality"
-    )
+    assert any(
+        "dv_new" in c
+        and "--agent-mode" in c
+        and "--fail-on-quality" in c
+        and "--run-summary-json" in c
+        and "--output-dir" in c
+        for c in calls
+    ), "SDR generation must use --agent-mode, --fail-on-quality, --output-dir, and --run-summary-json"
 
 
 def test_onboard_saves_baseline_snapshot(tmp_path: Path) -> None:
@@ -472,14 +567,20 @@ def test_onboard_saves_baseline_snapshot(tmp_path: Path) -> None:
 
 def test_onboard_exits_2_on_quality_gate_breach(tmp_path: Path) -> None:
     describe_json = '{"id":"dv_new"}'
-    sdr_json = '{"status":"quality_breach","advisories":{"severity":"high"}}'
     responses: dict[str, tuple[int, str]] = {
         "--validate-config": (0, ""),
         "--describe-dataview": (0, describe_json),
-        "--fail-on-quality": (2, sdr_json),
+        "--fail-on-quality": (2, ""),
     }
     env, log_path = _base_env(tmp_path, responses)
     env["DATA_VIEW_ID"] = "dv_new"
+    env["FAKE_UV_RUN_SUMMARY_JSON"] = json.dumps(
+        {
+            "summary_version": "1.1",
+            "quality_gate_failed": True,
+            "results": [{"dq_severity_counts": {"HIGH": 1}}],
+        }
+    )
 
     result = subprocess.run(
         ["bash", str(WORKFLOWS_DIR / "onboard_dataview.sh")],
@@ -492,6 +593,39 @@ def test_onboard_exits_2_on_quality_gate_breach(tmp_path: Path) -> None:
     calls = _read_calls(log_path)
     # Snapshot must NOT be saved on quality gate breach
     assert all("--snapshot" not in c for c in calls), "Must not save snapshot when quality gate is breached"
+    assert "severity=HIGH" in result.stdout
+    assert (tmp_path / "reports" / "dv_new_run_summary.json").exists()
+
+
+def test_onboard_suppresses_inner_success_stdout_on_quality_gate_breach(tmp_path: Path) -> None:
+    describe_json = '{"id":"dv_new"}'
+    responses: dict[str, tuple[int, str]] = {
+        "--validate-config": (0, ""),
+        "--describe-dataview": (0, describe_json),
+        "--fail-on-quality": (2, "SUCCESS: SDR generated for New View"),
+    }
+    env, _log_path = _base_env(tmp_path, responses)
+    env["DATA_VIEW_ID"] = "dv_new"
+    env["FAKE_UV_RUN_SUMMARY_JSON"] = json.dumps(
+        {
+            "summary_version": "1.1",
+            "quality_gate_failed": True,
+            "results": [{"dq_severity_counts": {"HIGH": 1}}],
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "onboard_dataview.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "SUCCESS: SDR generated" not in result.stdout
+    assert "SUCCESS: SDR generated" not in result.stderr
+    assert "severity=HIGH" in result.stdout
 
 
 def test_onboard_exits_1_when_data_view_id_not_set(tmp_path: Path) -> None:

--- a/tests/test_agent_workflows.py
+++ b/tests/test_agent_workflows.py
@@ -1,0 +1,695 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS_DIR = PROJECT_ROOT / "examples" / "agent-workflows"
+
+_WORKFLOW_SCRIPTS = ["_common.sh", "audit_and_report.sh", "onboard_dataview.sh", "quarterly_governance.sh"]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _install_fake_uv(tmp_path: Path, responses: dict[str, tuple[int, str]] | None = None) -> Path:
+    """Install a fake `uv` binary that records calls and returns canned responses.
+
+    *responses* maps argument-substring → (exit_code, stdout).
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+
+    # Build the response dispatch table as inline shell
+    dispatch_lines = []
+    for pattern, (code, out) in (responses or {}).items():
+        escaped_out = out.replace("'", "'\\''")
+        dispatch_lines.append(
+            f"if [[ \"$args\" == *{repr(pattern)}* ]]; then printf '%s\\n' '{escaped_out}'; exit {code}; fi"
+        )
+
+    dispatch_block = "\n".join(dispatch_lines)
+
+    fake_uv = bin_dir / "uv"
+    fake_uv.write_text(
+        textwrap.dedent(
+            rf"""\
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            args="$*"
+            printf '%s\n' "$args" >> "$FAKE_UV_LOG"
+
+            {dispatch_block}
+
+            exit "${{FAKE_UV_DEFAULT_EXIT:-0}}"
+            """
+        ),
+        encoding="utf-8",
+    )
+    fake_uv.chmod(0o755)
+    return fake_uv
+
+
+def _base_env(tmp_path: Path, responses: dict[str, tuple[int, str]] | None = None) -> tuple[dict[str, str], Path]:
+    log_path = tmp_path / "uv_calls.log"
+    log_path.write_text("", encoding="utf-8")
+    _install_fake_uv(tmp_path, responses)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "ORG_ID": "test-org",
+            "CLIENT_ID": "test-client",
+            "SECRET": "test-secret",
+            "SCOPES": "test-scopes",
+            "REPORT_DIR": str(tmp_path / "reports"),
+            "SNAPSHOT_DIR": str(tmp_path / "snapshots"),
+            "FAKE_UV_LOG": str(log_path),
+            "FAKE_UV_DEFAULT_EXIT": "0",
+            "PATH": f"{tmp_path / 'bin'}{os.pathsep}{env['PATH']}",
+        },
+    )
+    return env, log_path
+
+
+def _read_calls(log_path: Path) -> list[str]:
+    return log_path.read_text(encoding="utf-8").splitlines()
+
+
+# ---------------------------------------------------------------------------
+# File existence and permissions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("script_name", _WORKFLOW_SCRIPTS)
+def test_script_files_exist(script_name: str) -> None:
+    assert (WORKFLOWS_DIR / script_name).is_file(), f"{script_name} not found in {WORKFLOWS_DIR}"
+
+
+@pytest.mark.parametrize(
+    "script_name",
+    ["audit_and_report.sh", "onboard_dataview.sh", "quarterly_governance.sh"],
+)
+def test_scripts_are_executable(script_name: str) -> None:
+    path = WORKFLOWS_DIR / script_name
+    assert os.access(path, os.X_OK), f"{script_name} is not executable"
+
+
+# ---------------------------------------------------------------------------
+# _common.sh — sourcing and helper contract
+# ---------------------------------------------------------------------------
+
+
+def test_common_sh_sources_without_error(tmp_path: Path) -> None:
+    """Sourcing _common.sh in a minimal bash script must not produce errors."""
+    harness = tmp_path / "harness.sh"
+    harness.write_text(
+        textwrap.dedent(
+            f"""\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            # shellcheck source=/dev/null
+            source "{WORKFLOWS_DIR}/_common.sh"
+            echo "ok"
+            """
+        ),
+        encoding="utf-8",
+    )
+    harness.chmod(0o755)
+    result = subprocess.run(["bash", str(harness)], capture_output=True, text=True)
+    assert result.returncode == 0
+    assert "ok" in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("exit_code", "expected_rc", "expect_stderr"),
+    [
+        (0, 0, False),
+        (1, 1, True),
+        (2, 0, False),
+        (3, 0, False),
+        (130, 130, True),
+        (4, 1, True),   # synthetic — must be rejected
+        (5, 1, True),   # synthetic — must be rejected
+        (99, 1, True),  # unknown — must be rejected
+    ],
+)
+def test_common_handle_exit_code_behaviour(
+    tmp_path: Path, exit_code: int, expected_rc: int, expect_stderr: bool
+) -> None:
+    """handle_exit_code() must only pass 0, 1, 2, 3 and 130; all others exit 1."""
+    harness = tmp_path / "harness.sh"
+    harness.write_text(
+        textwrap.dedent(
+            f"""\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            # shellcheck source=/dev/null
+            source "{WORKFLOWS_DIR}/_common.sh"
+            handle_exit_code {exit_code} "test"
+            """
+        ),
+        encoding="utf-8",
+    )
+    harness.chmod(0o755)
+    result = subprocess.run(["bash", str(harness)], capture_output=True, text=True)
+    assert result.returncode == expected_rc
+    if expect_stderr:
+        assert result.stderr.strip() != ""
+
+
+def test_common_extract_dataview_ids(tmp_path: Path) -> None:
+    """extract_dataview_ids() must parse the real dataViews JSON shape."""
+    harness = tmp_path / "harness.sh"
+    harness.write_text(
+        textwrap.dedent(
+            f"""\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            # shellcheck source=/dev/null
+            source "{WORKFLOWS_DIR}/_common.sh"
+            JSON='{{"dataViews":[{{"id":"dv_abc"}},{{"id":"dv_xyz"}}]}}'
+            extract_dataview_ids "$JSON"
+            """
+        ),
+        encoding="utf-8",
+    )
+    harness.chmod(0o755)
+    result = subprocess.run(["bash", str(harness)], capture_output=True, text=True)
+    assert result.returncode == 0
+    assert "dv_abc" in result.stdout
+    assert "dv_xyz" in result.stdout
+
+
+def test_common_require_env_exits_when_unset(tmp_path: Path) -> None:
+    harness = tmp_path / "harness.sh"
+    harness.write_text(
+        textwrap.dedent(
+            f"""\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            unset MISSING_VAR || true
+            # shellcheck source=/dev/null
+            source "{WORKFLOWS_DIR}/_common.sh"
+            require_env MISSING_VAR
+            """
+        ),
+        encoding="utf-8",
+    )
+    harness.chmod(0o755)
+    result = subprocess.run(["bash", str(harness)], capture_output=True, text=True)
+    assert result.returncode == 1
+    assert "MISSING_VAR" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# audit_and_report.sh
+# ---------------------------------------------------------------------------
+
+
+def _audit_env(tmp_path: Path, **extra: str) -> tuple[dict[str, str], Path]:
+    discovery_json = '{"dataViews":[{"id":"dv_1"},{"id":"dv_2"}]}'
+    responses: dict[str, tuple[int, str]] = {
+        "--list-dataviews --agent-mode": (0, discovery_json),
+        "--org-report --agent-mode": (0, '{"status":"ok"}'),
+    }
+    env, log_path = _base_env(tmp_path, responses)
+    env.update(extra)
+    return env, log_path
+
+
+def test_audit_runs_to_completion(tmp_path: Path) -> None:
+    env, log_path = _audit_env(tmp_path)
+
+    result = subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "audit_and_report.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+
+
+def test_audit_calls_list_dataviews_with_agent_mode(tmp_path: Path) -> None:
+    env, log_path = _audit_env(tmp_path)
+
+    subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "audit_and_report.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    calls = _read_calls(log_path)
+    assert any("--list-dataviews" in c and "--agent-mode" in c for c in calls)
+
+
+def test_audit_calls_org_report_with_agent_mode(tmp_path: Path) -> None:
+    env, log_path = _audit_env(tmp_path)
+
+    subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "audit_and_report.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    calls = _read_calls(log_path)
+    assert any("--org-report" in c and "--agent-mode" in c for c in calls)
+
+
+def test_audit_first_run_creates_baseline_without_compare_with_prev(tmp_path: Path) -> None:
+    """On first run (no prior snapshots), must use --snapshot, not --compare-with-prev."""
+    # --list-snapshots returns empty list → first run
+    discovery_json = '{"dataViews":[{"id":"dv_1"}]}'
+    responses: dict[str, tuple[int, str]] = {
+        "--list-dataviews --agent-mode": (0, discovery_json),
+        "--list-snapshots": (0, '{"snapshots":[]}'),
+        "--org-report --agent-mode": (0, '{"status":"ok"}'),
+    }
+    env, log_path = _base_env(tmp_path, responses)
+
+    result = subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "audit_and_report.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    calls = _read_calls(log_path)
+
+    assert result.returncode == 0
+    # Must not call --compare-with-prev on first run
+    assert all("--compare-with-prev" not in c for c in calls), "Must not call --compare-with-prev on first run"
+    # Must create a baseline snapshot instead
+    assert any("--snapshot" in c and "dv_1" in c for c in calls), "Must create baseline snapshot on first run"
+
+
+def test_audit_subsequent_run_uses_compare_with_prev(tmp_path: Path) -> None:
+    """When prior snapshots exist, must use --compare-with-prev, not --snapshot."""
+    discovery_json = '{"dataViews":[{"id":"dv_1"}]}'
+    snapshots_json = '{"snapshots":[{"id":"snap_001"}]}'
+    responses: dict[str, tuple[int, str]] = {
+        "--list-dataviews --agent-mode": (0, discovery_json),
+        "--list-snapshots": (0, snapshots_json),
+        "--org-report --agent-mode": (0, '{"status":"ok"}'),
+    }
+    env, log_path = _base_env(tmp_path, responses)
+
+    result = subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "audit_and_report.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    calls = _read_calls(log_path)
+
+    assert result.returncode == 0
+    assert any("--compare-with-prev" in c for c in calls), "Must use --compare-with-prev when snapshots exist"
+
+
+def test_audit_never_combines_run_summary_json_with_output_dash(tmp_path: Path) -> None:
+    """Must never emit --run-summary-json - combined with --output -."""
+    env, log_path = _audit_env(tmp_path)
+
+    subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "audit_and_report.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    calls = _read_calls(log_path)
+    for call in calls:
+        assert not ("--run-summary-json -" in call and "--output -" in call), (
+            f"Invalid combination --run-summary-json - + --output - in: {call}"
+        )
+
+
+def test_audit_signal_exit_stops_workflow(tmp_path: Path) -> None:
+    """A signal exit from discovery must propagate and stop subsequent commands."""
+    discovery_json = '{"dataViews":[{"id":"dv_1"}]}'
+    responses: dict[str, tuple[int, str]] = {
+        "--list-dataviews --agent-mode": (130, discovery_json),
+    }
+    env, log_path = _base_env(tmp_path, responses)
+
+    result = subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "audit_and_report.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 130
+    calls = _read_calls(log_path)
+    # Org report must NOT have been called after signal exit
+    assert all("--org-report" not in c for c in calls)
+
+
+def test_audit_uses_ids_not_names(tmp_path: Path) -> None:
+    """Data view processing must use IDs from dataViews, not display names."""
+    # Discovery returns IDs only (no 'name' fields used in commands)
+    discovery_json = '{"dataViews":[{"id":"dv_abc123","name":"My View"}]}'
+    responses: dict[str, tuple[int, str]] = {
+        "--list-dataviews --agent-mode": (0, discovery_json),
+        "--org-report --agent-mode": (0, '{"status":"ok"}'),
+    }
+    env, log_path = _base_env(tmp_path, responses)
+
+    subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "audit_and_report.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    calls = _read_calls(log_path)
+    # Any per-DV call must use the ID, not the display name
+    dv_calls = [c for c in calls if "dv_abc123" in c or "My View" in c]
+    assert all("My View" not in c for c in dv_calls), "Must use IDs not display names"
+
+
+# ---------------------------------------------------------------------------
+# onboard_dataview.sh
+# ---------------------------------------------------------------------------
+
+
+def _onboard_env(tmp_path: Path, **extra: str) -> tuple[dict[str, str], Path]:
+    describe_json = '{"id":"dv_new","name":"New View"}'
+    sdr_json = '{"status":"ok","advisories":{"severity":"info"}}'
+    responses: dict[str, tuple[int, str]] = {
+        "--validate-config": (0, ""),
+        "--describe-dataview": (0, describe_json),
+        "--fail-on-quality": (0, sdr_json),
+    }
+    env, log_path = _base_env(tmp_path, responses)
+    env["DATA_VIEW_ID"] = "dv_new"
+    env.update(extra)
+    return env, log_path
+
+
+def test_onboard_runs_to_completion(tmp_path: Path) -> None:
+    env, log_path = _onboard_env(tmp_path)
+
+    result = subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "onboard_dataview.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+
+
+def test_onboard_calls_validate_config_first(tmp_path: Path) -> None:
+    env, log_path = _onboard_env(tmp_path)
+
+    subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "onboard_dataview.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    calls = _read_calls(log_path)
+    assert calls, "No calls were recorded"
+    assert "--validate-config" in calls[0], "validate-config must be first call"
+
+
+def test_onboard_calls_describe_dataview(tmp_path: Path) -> None:
+    env, log_path = _onboard_env(tmp_path)
+
+    subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "onboard_dataview.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    calls = _read_calls(log_path)
+    assert any("--describe-dataview" in c and "dv_new" in c for c in calls)
+
+
+def test_onboard_calls_sdr_with_agent_mode_and_quality_gate(tmp_path: Path) -> None:
+    env, log_path = _onboard_env(tmp_path)
+
+    subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "onboard_dataview.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    calls = _read_calls(log_path)
+    assert any(
+        "dv_new" in c and "--agent-mode" in c and "--fail-on-quality" in c
+        for c in calls
+    ), "SDR generation must use --agent-mode and --fail-on-quality"
+
+
+def test_onboard_saves_baseline_snapshot(tmp_path: Path) -> None:
+    env, log_path = _onboard_env(tmp_path)
+
+    subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "onboard_dataview.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    calls = _read_calls(log_path)
+    assert any("--snapshot" in c and "dv_new" in c for c in calls), "Must save baseline snapshot"
+
+
+def test_onboard_exits_2_on_quality_gate_breach(tmp_path: Path) -> None:
+    describe_json = '{"id":"dv_new"}'
+    sdr_json = '{"status":"quality_breach","advisories":{"severity":"high"}}'
+    responses: dict[str, tuple[int, str]] = {
+        "--validate-config": (0, ""),
+        "--describe-dataview": (0, describe_json),
+        "--fail-on-quality": (2, sdr_json),
+    }
+    env, log_path = _base_env(tmp_path, responses)
+    env["DATA_VIEW_ID"] = "dv_new"
+
+    result = subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "onboard_dataview.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 2
+    calls = _read_calls(log_path)
+    # Snapshot must NOT be saved on quality gate breach
+    assert all("--snapshot" not in c for c in calls), "Must not save snapshot when quality gate is breached"
+
+
+def test_onboard_exits_1_when_data_view_id_not_set(tmp_path: Path) -> None:
+    env, log_path = _base_env(tmp_path)
+    env.pop("DATA_VIEW_ID", None)
+
+    result = subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "onboard_dataview.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+    assert "DATA_VIEW_ID" in result.stderr
+
+
+def test_onboard_never_combines_run_summary_json_with_output_dash(tmp_path: Path) -> None:
+    env, log_path = _onboard_env(tmp_path)
+
+    subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "onboard_dataview.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    calls = _read_calls(log_path)
+    for call in calls:
+        assert not ("--run-summary-json -" in call and "--output -" in call)
+
+
+def test_onboard_signal_exit_stops_workflow(tmp_path: Path) -> None:
+    """Signal exit from validate-config must propagate and stop subsequent commands."""
+    responses: dict[str, tuple[int, str]] = {
+        "--validate-config": (130, ""),
+    }
+    env, log_path = _base_env(tmp_path, responses)
+    env["DATA_VIEW_ID"] = "dv_new"
+
+    result = subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "onboard_dataview.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    calls = _read_calls(log_path)
+    # No SDR generation after validate-config signal exit
+    assert all("--describe-dataview" not in c for c in calls)
+
+
+# ---------------------------------------------------------------------------
+# quarterly_governance.sh
+# ---------------------------------------------------------------------------
+
+
+def _governance_env(tmp_path: Path, org_exit: int = 0, **extra: str) -> tuple[dict[str, str], Path]:
+    org_json = '{"status":"ok","thresholds_exceeded":false}'
+    responses: dict[str, tuple[int, str]] = {
+        "--org-report": (org_exit, org_json),
+    }
+    env, log_path = _base_env(tmp_path, responses)
+    env.update(extra)
+    return env, log_path
+
+
+def test_governance_runs_to_completion(tmp_path: Path) -> None:
+    env, log_path = _governance_env(tmp_path)
+
+    result = subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "quarterly_governance.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+
+
+def test_governance_calls_org_report_with_trending_window(tmp_path: Path) -> None:
+    env, log_path = _governance_env(tmp_path, TRENDING_WINDOW="6")
+
+    subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "quarterly_governance.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    calls = _read_calls(log_path)
+    assert any("--org-report" in c and "--trending-window" in c and "6" in c for c in calls)
+
+
+def test_governance_uses_agent_mode_for_machine_readable_pass(tmp_path: Path) -> None:
+    env, log_path = _governance_env(tmp_path)
+
+    subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "quarterly_governance.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    calls = _read_calls(log_path)
+    assert any("--org-report" in c and "--agent-mode" in c for c in calls)
+
+
+def test_governance_uses_fail_on_threshold(tmp_path: Path) -> None:
+    env, log_path = _governance_env(tmp_path)
+
+    subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "quarterly_governance.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    calls = _read_calls(log_path)
+    assert any("--fail-on-threshold" in c for c in calls)
+
+
+def test_governance_generates_human_artifact_separately(tmp_path: Path) -> None:
+    """Markdown report must be a separate uv call from the machine-readable pass."""
+    env, log_path = _governance_env(tmp_path)
+
+    subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "quarterly_governance.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    calls = _read_calls(log_path)
+    org_calls = [c for c in calls if "--org-report" in c]
+    assert len(org_calls) >= 2, "Must have at least 2 org-report calls (machine + human)"
+    # One must use --agent-mode, one must use --format markdown
+    assert any("--agent-mode" in c for c in org_calls)
+    assert any("--format markdown" in c for c in org_calls)
+
+
+def test_governance_exits_2_when_threshold_exceeded(tmp_path: Path) -> None:
+    env, log_path = _governance_env(tmp_path, org_exit=2)
+
+    result = subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "quarterly_governance.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 2
+
+
+def test_governance_never_invents_exit_code_4_or_5(tmp_path: Path) -> None:
+    """Scripts must never exit with synthetic codes like 4 or 5."""
+    for org_exit in [0, 1, 2, 3]:
+        env, log_path = _governance_env(tmp_path, org_exit=org_exit)
+        result = subprocess.run(
+            ["bash", str(WORKFLOWS_DIR / "quarterly_governance.sh")],
+            cwd=PROJECT_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode not in (4, 5), (
+            f"Script must not emit exit code {result.returncode} for org_exit={org_exit}"
+        )
+
+
+def test_governance_signal_exit_stops_workflow(tmp_path: Path) -> None:
+    responses: dict[str, tuple[int, str]] = {
+        "--org-report": (130, ""),
+    }
+    env, log_path = _base_env(tmp_path, responses)
+
+    result = subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "quarterly_governance.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 130
+
+
+def test_governance_never_combines_run_summary_json_with_output_dash(tmp_path: Path) -> None:
+    env, log_path = _governance_env(tmp_path)
+
+    subprocess.run(
+        ["bash", str(WORKFLOWS_DIR / "quarterly_governance.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    calls = _read_calls(log_path)
+    for call in calls:
+        assert not ("--run-summary-json -" in call and "--output -" in call)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -758,6 +758,16 @@ class TestFastPathEntryPoint:
 
         assert _is_fast_path_flag(["prog", "--exit-codes", "--trending-window", "3"]) is None
 
+    def test_agent_mode_with_version_fast_path(self):
+        from cja_auto_sdr.__main__ import _is_fast_path_flag
+
+        assert _is_fast_path_flag(["prog", "--agent-mode", "--version"]) == "--version"
+
+    def test_agent_mode_with_completion_fast_path(self):
+        from cja_auto_sdr.__main__ import _is_fast_path_flag
+
+        assert _is_fast_path_flag(["prog", "--agent-mode", "--completion", "bash"]) == "--completion"
+
     def test_is_fast_path_flag_none_for_regular_args(self):
         from cja_auto_sdr.__main__ import _is_fast_path_flag
 

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -211,6 +211,15 @@ class TestCompletionFastPath:
         mock_generator_main.assert_not_called()
         assert "register-python-argcomplete" in capsys.readouterr().out
 
+    def test_agent_mode_with_completion(self):
+        """--agent-mode --completion bash should still work on fast path."""
+        from cja_auto_sdr.cli.parser import parse_arguments
+
+        # This tests that --agent-mode doesn't break completion
+        args = parse_arguments(["--agent-mode", "--completion", "bash"])
+        assert args.completion == "bash"
+        assert args.agent_mode is True
+
     def test_fast_path_missing_shell_falls_through_to_generator(self):
         """Invalid standalone completion requests must defer to argparse path."""
         from cja_auto_sdr import __main__ as entrypoint

--- a/tests/test_org_report.py
+++ b/tests/test_org_report.py
@@ -3134,6 +3134,59 @@ class TestOrgReportOutputHandling:
             assert '"report_type"' in captured.out
             assert '"org_id"' in captured.out
 
+    def test_console_output_to_stdout_emits_console_report(self, sample_result, capsys):
+        """--output - should still emit the console org-report payload."""
+        with (
+            patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "ok", {"org_id": "org_123"})),
+            patch("cja_auto_sdr.generator.cjapy.CJA", return_value=Mock()),
+            patch("cja_auto_sdr.generator.OrgComponentAnalyzer") as mock_analyzer,
+        ):
+            mock_analyzer.return_value.run_analysis.return_value = sample_result
+
+            success, _ = run_org_report(
+                config_file="config.json",
+                output_format="console",
+                output_path="-",
+                output_dir=".",
+                org_config=OrgReportConfig(),
+                profile=None,
+                quiet=True,
+            )
+
+            assert success is True
+            captured = capsys.readouterr()
+            assert "ORG-WIDE COMPONENT ANALYSIS REPORT: org_123" in captured.out
+            assert "SUMMARY" in captured.out
+            assert captured.err == ""
+
+    def test_org_stats_console_output_to_stdout_emits_stats_payload(self, sample_result, capsys):
+        """Console stdout should still render the org-stats payload."""
+        with (
+            patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "ok", {"org_id": "org_123"})),
+            patch("cja_auto_sdr.generator.cjapy.CJA", return_value=Mock()),
+            patch("cja_auto_sdr.generator.OrgComponentAnalyzer") as mock_analyzer,
+            patch("cja_auto_sdr.generator.build_org_step_summary", return_value="summary"),
+            patch("cja_auto_sdr.generator.append_github_step_summary"),
+        ):
+            mock_analyzer.return_value.run_analysis.return_value = sample_result
+
+            success, thresholds = run_org_report(
+                config_file="config.json",
+                output_format="console",
+                output_path="stdout",
+                output_dir=".",
+                org_config=OrgReportConfig(org_stats_only=True),
+                profile=None,
+                quiet=True,
+            )
+
+            assert success is True
+            assert thresholds is False
+            captured = capsys.readouterr()
+            assert "ORG STATS: org_123" in captured.out
+            assert "Data Views:" in captured.out
+            assert captured.err == ""
+
     def test_csv_output_to_stdout_errors(self, sample_result, capsys):
         """CSV org-report should error on stdout since it writes multiple files."""
         with (

--- a/tests/test_org_writer_compat_contracts.py
+++ b/tests/test_org_writer_compat_contracts.py
@@ -1065,3 +1065,46 @@ def test_legacy_json_writer_builder_patch_remains_visible_to_concurrent_legacy_c
     assert len(patched_calls) == 2
     assert json.loads(output_paths["thread"].read_text(encoding="utf-8"))["report_type"] == "patched:org_analysis"
     assert json.loads(output_paths["main"].read_text(encoding="utf-8"))["report_type"] == "patched:org_analysis"
+
+
+# ---------------------------------------------------------------------------
+# Advisories additive-compat contract
+# ---------------------------------------------------------------------------
+
+
+_EXPECTED_CORE_JSON_KEYS = frozenset(
+    [
+        "report_type",
+        "version",
+        "generated_at",
+        "org_id",
+        "parameters",
+        "summary",
+        "data_view_fetch_failures",
+        "distribution",
+        "data_views",
+        "component_index",
+        "similarity_pairs",
+        "clusters",
+        "recommendations",
+        "governance_violations",
+        "thresholds_exceeded",
+        "naming_audit",
+        "owner_summary",
+        "stale_components",
+    ]
+)
+
+
+def test_advisories_key_is_additive_does_not_remove_existing_keys(rich_org_report_result):
+    """Adding the advisories block must not drop any pre-existing top-level JSON keys."""
+    from cja_auto_sdr.org.writers.json import build_org_report_json_data
+
+    data = build_org_report_json_data(rich_org_report_result)
+
+    # All pre-existing keys must still be present
+    missing = _EXPECTED_CORE_JSON_KEYS - data.keys()
+    assert not missing, f"Keys removed after advisories injection: {missing}"
+
+    # The new key must also be present
+    assert "advisories" in data

--- a/tests/test_output_content_validation.py
+++ b/tests/test_output_content_validation.py
@@ -38,7 +38,7 @@ def rich_data_dict():
         "Metadata": pd.DataFrame(
             {
                 "Property": ["Generated At", "Data View ID", "Tool Version", "Total Metrics"],
-                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.4.9", 3],
+                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.5.0", 3],
             },
         ),
         "Data Quality": pd.DataFrame(
@@ -104,7 +104,7 @@ def rich_metadata_dict():
         "Generated At": "2025-01-15 10:30:00 PST",
         "Data View ID": "dv_content_test",
         "Data View Name": "Test DataView",
-        "Tool Version": "3.4.9",
+        "Tool Version": "3.5.0",
         "Metrics Count": "3",
         "Dimensions Count": "4",
     }
@@ -224,7 +224,7 @@ class TestJSONContentValidation:
             data = json.load(f)
 
         assert data["metadata"]["Data View ID"] == "dv_content_test"
-        assert data["metadata"]["Tool Version"] == "3.4.9"
+        assert data["metadata"]["Tool Version"] == "3.5.0"
 
     def test_json_metadata_preserves_partial_markers(self, tmp_path, rich_data_dict, rich_metadata_dict):
         logger = logging.getLogger("json_test")

--- a/tests/test_output_extraction_contracts.py
+++ b/tests/test_output_extraction_contracts.py
@@ -877,6 +877,7 @@ _DIFF_WRITER_SIGNATURES = {
         "use_color",
         "group_by_field",
         "group_by_field_limit",
+        "output_to_stdout",
     ],
 }
 
@@ -1130,3 +1131,47 @@ def test_trending_helper_signatures_via_package_root(func_name, expected_params)
     mod = importlib.import_module("cja_auto_sdr.org.writers")
     func = getattr(mod, func_name)
     assert list(signature(func).parameters) == expected_params
+
+
+# ---------------------------------------------------------------------------
+# output.diff.json — build_diff_json_data extraction contract
+# ---------------------------------------------------------------------------
+
+
+def test_build_diff_json_data_importable_from_output_diff_json():
+    """build_diff_json_data is importable from output.diff.json."""
+    from cja_auto_sdr.output.diff.json import build_diff_json_data
+
+    assert callable(build_diff_json_data)
+
+
+def test_build_diff_json_data_importable_from_output_diff():
+    """build_diff_json_data is importable from output.diff package root."""
+    from cja_auto_sdr.output.diff import build_diff_json_data
+
+    assert callable(build_diff_json_data)
+
+
+def test_build_diff_json_data_signature():
+    """build_diff_json_data must accept diff_result and changes_only."""
+    from cja_auto_sdr.output.diff.json import build_diff_json_data
+
+    params = list(signature(build_diff_json_data).parameters)
+    assert params == ["diff_result", "changes_only"]
+
+
+def test_build_diff_json_data_return_shape():
+    """build_diff_json_data must return a dict with required top-level keys."""
+    from cja_auto_sdr.output.diff.json import build_diff_json_data
+
+    data = build_diff_json_data(_make_diff_result())
+    required = {"metadata", "source", "target", "summary", "metric_diffs", "dimension_diffs", "advisories"}
+    assert required.issubset(set(data.keys()))
+
+
+def test_write_diff_output_accepts_output_to_stdout():
+    """write_diff_output signature must include output_to_stdout."""
+    from cja_auto_sdr.output.diff import write_diff_output
+
+    params = list(signature(write_diff_output).parameters)
+    assert "output_to_stdout" in params

--- a/tests/test_output_extraction_contracts.py
+++ b/tests/test_output_extraction_contracts.py
@@ -1175,3 +1175,35 @@ def test_write_diff_output_accepts_output_to_stdout():
 
     params = list(signature(write_diff_output).parameters)
     assert "output_to_stdout" in params
+
+
+# ---------------------------------------------------------------------------
+# Diff handler runtime_details contract
+# ---------------------------------------------------------------------------
+
+
+def test_diff_handler_runtime_details_contract():
+    """Diff command handlers must accept runtime_details: dict[str, Any] | None."""
+    from cja_auto_sdr.diff.commands import (
+        handle_compare_snapshots_command,
+        handle_diff_command,
+        handle_diff_snapshot_command,
+    )
+
+    for fn in (handle_diff_command, handle_diff_snapshot_command, handle_compare_snapshots_command):
+        params = signature(fn).parameters
+        assert "runtime_details" in params, f"{fn.__name__} missing runtime_details"
+        param = params["runtime_details"]
+        assert param.default is None, f"{fn.__name__}: runtime_details default must be None"
+
+
+def test_populate_diff_advisory_rollup_contract():
+    """_populate_diff_advisory_rollup must produce a dict with required rollup keys."""
+    from cja_auto_sdr.diff.commands import _populate_diff_advisory_rollup
+
+    result = _make_diff_result()
+    details: dict = {}
+    _populate_diff_advisory_rollup(details, result, changes_only=False)
+    rollup = details["advisory_rollup"]
+    required_keys = {"advisories_version", "severity", "summary", "types", "recommended_actions"}
+    assert required_keys.issubset(set(rollup.keys()))

--- a/tests/test_quality_policy_and_run_summary.py
+++ b/tests/test_quality_policy_and_run_summary.py
@@ -2169,7 +2169,13 @@ class TestOrgReportAdvisoryRollupRunSummaryContract:
         from cja_auto_sdr.generator import _merge_org_report_run_summary_details
         from cja_auto_sdr.org.models import OrgReportConfig
 
-        rollup = {"advisories_version": "1.0", "severity": "info", "summary": {}, "types": [], "recommended_actions": []}
+        rollup = {
+            "advisories_version": "1.0",
+            "severity": "info",
+            "summary": {},
+            "types": [],
+            "recommended_actions": [],
+        }
         run_state: dict = {"details": {}}
         _merge_org_report_run_summary_details(
             run_state,
@@ -2187,7 +2193,13 @@ class TestOrgReportAdvisoryRollupRunSummaryContract:
         from cja_auto_sdr.generator import _merge_org_report_run_summary_details
         from cja_auto_sdr.org.models import OrgReportConfig
 
-        rollup = {"advisories_version": "1.0", "severity": "info", "summary": {}, "types": [], "recommended_actions": []}
+        rollup = {
+            "advisories_version": "1.0",
+            "severity": "info",
+            "summary": {},
+            "types": [],
+            "recommended_actions": [],
+        }
         run_state: dict = {"details": {}}
         _merge_org_report_run_summary_details(
             run_state,
@@ -2214,7 +2226,10 @@ class TestDiffAdvisoryRollupRunSummaryContract:
         diff_result = DiffResult(
             summary=DiffSummary(),
             metadata_diff=MetadataDiff(
-                source_name="A", target_name="B", source_id="dv-a", target_id="dv-b",
+                source_name="A",
+                target_name="B",
+                source_id="dv-a",
+                target_id="dv-b",
             ),
             metric_diffs=[],
             dimension_diffs=[],
@@ -2265,7 +2280,10 @@ class TestDiffAdvisoryRollupRunSummaryContract:
         diff_result = DiffResult(
             summary=DiffSummary(metrics_removed=1),
             metadata_diff=MetadataDiff(
-                source_name="A", target_name="B", source_id="dv-a", target_id="dv-b",
+                source_name="A",
+                target_name="B",
+                source_id="dv-a",
+                target_id="dv-b",
             ),
             metric_diffs=[removed],
             dimension_diffs=[],

--- a/tests/test_quality_policy_and_run_summary.py
+++ b/tests/test_quality_policy_and_run_summary.py
@@ -2152,3 +2152,126 @@ class TestBuildOrgReportLockRunSummaryBlock:
             }
         )
         assert "loss_reason" not in block
+
+
+# ==================== advisory rollup in run-summary contract ====================
+
+
+class TestOrgReportAdvisoryRollupRunSummaryContract:
+    """Verify the advisory rollup integration with run-summary details."""
+
+    def test_summary_version_unchanged_with_advisory_rollup(self):
+        """Adding advisory_rollup must not alter the run-summary schema version."""
+        assert RUN_SUMMARY_SCHEMA_VERSION == "1.1"
+
+    def test_advisory_rollup_merged_via_details_key(self):
+        """Advisory rollup appears under details.advisories."""
+        from cja_auto_sdr.generator import _merge_org_report_run_summary_details
+        from cja_auto_sdr.org.models import OrgReportConfig
+
+        rollup = {"advisories_version": "1.0", "severity": "info", "summary": {}, "types": [], "recommended_actions": []}
+        run_state: dict = {"details": {}}
+        _merge_org_report_run_summary_details(
+            run_state,
+            success=True,
+            thresholds_exceeded=False,
+            fail_on_threshold=False,
+            lock_details={},
+            org_config=OrgReportConfig(),
+            advisory_rollup=rollup,
+        )
+        assert run_state["details"]["advisories"] is rollup
+
+    def test_existing_envelope_fields_survive_advisory_merge(self):
+        """Core run-summary envelope fields must not be lost when advisories are merged."""
+        from cja_auto_sdr.generator import _merge_org_report_run_summary_details
+        from cja_auto_sdr.org.models import OrgReportConfig
+
+        rollup = {"advisories_version": "1.0", "severity": "info", "summary": {}, "types": [], "recommended_actions": []}
+        run_state: dict = {"details": {}}
+        _merge_org_report_run_summary_details(
+            run_state,
+            success=True,
+            thresholds_exceeded=False,
+            fail_on_threshold=False,
+            lock_details={},
+            org_config=OrgReportConfig(),
+            advisory_rollup=rollup,
+        )
+        # Core fields must be present
+        assert "operation_success" in run_state["details"]
+        assert "execution_settings" in run_state["details"]
+
+
+class TestDiffAdvisoryRollupRunSummaryContract:
+    """Verify diff advisory rollup integration with run-summary details."""
+
+    def test_diff_advisory_rollup_merged_into_run_state(self):
+        """Advisory rollup from diff handler is merged under details.advisories."""
+        from cja_auto_sdr.diff.commands import _populate_diff_advisory_rollup
+        from cja_auto_sdr.diff.models import DiffResult, DiffSummary, MetadataDiff
+
+        diff_result = DiffResult(
+            summary=DiffSummary(),
+            metadata_diff=MetadataDiff(
+                source_name="A", target_name="B", source_id="dv-a", target_id="dv-b",
+            ),
+            metric_diffs=[],
+            dimension_diffs=[],
+        )
+        runtime_details: dict = {}
+        _populate_diff_advisory_rollup(runtime_details, diff_result, changes_only=False)
+
+        run_state: dict = {
+            "details": {
+                "operation_success": True,
+                "has_changes": False,
+                "warn_threshold_exit_code": None,
+            },
+        }
+        advisory_rollup = runtime_details.get("advisory_rollup")
+        if advisory_rollup is not None:
+            run_state["details"]["advisories"] = advisory_rollup
+
+        assert "advisories" in run_state["details"]
+        assert run_state["details"]["advisories"]["advisories_version"] == "1.0"
+        # Core fields preserved
+        assert run_state["details"]["operation_success"] is True
+        assert run_state["details"]["has_changes"] is False
+
+    def test_diff_advisory_rollup_not_merged_on_failure(self):
+        """When handler fails, runtime_details is empty and no advisories key appears."""
+        runtime_details: dict = {}
+        run_state: dict = {"details": {"operation_success": False}}
+
+        advisory_rollup = runtime_details.get("advisory_rollup")
+        if advisory_rollup is not None:
+            run_state["details"]["advisories"] = advisory_rollup
+
+        assert "advisories" not in run_state["details"]
+
+    def test_diff_advisory_rollup_severity_reflects_content(self):
+        """Breaking changes in diff should produce critical severity in rollup."""
+        from cja_auto_sdr.diff.commands import _populate_diff_advisory_rollup
+        from cja_auto_sdr.diff.models import (
+            ChangeType,
+            ComponentDiff,
+            DiffResult,
+            DiffSummary,
+            MetadataDiff,
+        )
+
+        removed = ComponentDiff(id="m1", name="Revenue", change_type=ChangeType.REMOVED)
+        diff_result = DiffResult(
+            summary=DiffSummary(metrics_removed=1),
+            metadata_diff=MetadataDiff(
+                source_name="A", target_name="B", source_id="dv-a", target_id="dv-b",
+            ),
+            metric_diffs=[removed],
+            dimension_diffs=[],
+        )
+        runtime_details: dict = {}
+        _populate_diff_advisory_rollup(runtime_details, diff_result, changes_only=False)
+        rollup = runtime_details["advisory_rollup"]
+        assert rollup["severity"] == "critical"
+        assert "breaking_changes" in rollup["types"]

--- a/tests/test_tool_manifests.py
+++ b/tests/test_tool_manifests.py
@@ -64,6 +64,49 @@ class TestToolManifests:
         if "fail_on_quality" in props:
             assert "INFO" in props["fail_on_quality"]["enum"]
 
+    def test_generate_manifest_includes_cli_format_aliases(self):
+        manifest = json.loads((TOOLS_DIR / "cja_sdr_generate.json").read_text())
+        fmt = manifest["parameters"]["properties"]["format"]
+
+        for value in ["all", "reports", "data", "ci"]:
+            assert value in fmt["enum"]
+        desc = fmt["description"].lower()
+        assert "reports" in desc
+        assert "data" in desc
+        assert "ci" in desc
+
+    def test_governance_threshold_types_match_cli(self):
+        manifest = json.loads((TOOLS_DIR / "cja_sdr_governance.json").read_text())
+        props = manifest["parameters"]["properties"]
+
+        duplicate_threshold = props["duplicate_threshold"]
+        assert duplicate_threshold["type"] == "integer"
+        assert duplicate_threshold["minimum"] == 0
+
+        isolated_threshold = props["isolated_threshold"]
+        assert isolated_threshold["type"] == "number"
+        assert isolated_threshold["minimum"] == 0.0
+        assert isolated_threshold["maximum"] == 1.0
+
+    def test_generate_manifest_quality_report_output_contract_matches_cli(self):
+        manifest = json.loads((TOOLS_DIR / "cja_sdr_generate.json").read_text())
+        props = manifest["parameters"]["properties"]
+
+        assert "output" in props
+        assert "output_dir" in props
+        output_desc = props["output"]["description"].lower()
+        assert "quality report" in output_desc
+        assert "stdout" in output_desc
+        assert "output_dir" in output_desc
+
+        output_dir_desc = props["output_dir"]["description"].lower()
+        assert "auto-named" in output_dir_desc
+        assert "quality report" in output_dir_desc
+
+        quality_report_desc = props["quality_report"]["description"].lower()
+        assert "standalone" in quality_report_desc
+        assert "without sdr files" in quality_report_desc
+
     def test_diff_snapshot_params_are_file_paths(self):
         manifest = json.loads((TOOLS_DIR / "cja_sdr_diff.json").read_text())
         props = manifest["parameters"]["properties"]
@@ -72,6 +115,54 @@ class TestToolManifests:
             if key in props:
                 desc = props[key].get("description", "")
                 assert "path" in desc.lower() or "file" in desc.lower(), f"{key} should be described as a file path"
+
+    def test_diff_manifest_limits_diff_output_to_inline_text_formats(self):
+        manifest = json.loads((TOOLS_DIR / "cja_sdr_diff.json").read_text())
+        props = manifest["parameters"]["properties"]
+
+        assert "output" in props
+        assert "diff_output" in props
+        assert "output_dir" in props
+        assert "format_pr_comment" in props
+        assert "include_inventory" not in props
+
+        format_enum = props["format"]["enum"]
+        assert "pr_comment" not in format_enum
+
+        output_desc = props["output"]["description"].lower()
+        assert "stdout" in output_desc
+        assert "diff_output" in output_desc
+        assert "json" in output_desc
+        assert "format_pr_comment" in output_desc
+
+        diff_output_desc = props["diff_output"]["description"].lower()
+        assert "console" in diff_output_desc
+        assert "format_pr_comment" in diff_output_desc
+        assert "json" in diff_output_desc
+        assert "output_dir" in diff_output_desc
+
+        output_dir_desc = props["output_dir"]["description"].lower()
+        assert "json" in output_dir_desc
+        assert "markdown" in output_dir_desc
+
+        pr_comment_desc = props["format_pr_comment"]["description"].lower()
+        assert "--format-pr-comment" in pr_comment_desc
+        assert "markdown" in pr_comment_desc
+
+    def test_governance_manifest_describes_output_shape_by_format(self):
+        manifest = json.loads((TOOLS_DIR / "cja_sdr_governance.json").read_text())
+        props = manifest["parameters"]["properties"]
+
+        output_desc = props["output"]["description"].lower()
+        assert "single file" in output_desc
+        assert "csv" in output_desc
+        assert "multiple csv files" in output_desc
+        assert "console" in output_desc
+
+        output_dir_desc = props["output_dir"]["description"].lower()
+        assert "auto-named" in output_dir_desc
+        assert "csv" in output_dir_desc
+        assert "directory" in output_dir_desc
 
     def test_no_show_config_in_manifests(self):
         for name in REQUIRED_MANIFESTS:
@@ -88,6 +179,13 @@ class TestToolManifests:
             "orchestrator",
             "applicability",
             "preflight",
+            "quality_report",
+            "output_dir",
+            "diff_output",
+            "format_pr_comment",
+            "reports",
+            "data",
+            "ci",
         ]
         for topic in required_topics:
             assert topic.lower() in content.lower(), f"README missing topic: {topic}"

--- a/tests/test_tool_manifests.py
+++ b/tests/test_tool_manifests.py
@@ -127,6 +127,15 @@ class TestToolManifests:
                 desc = props[key].get("description", "")
                 assert "path" in desc.lower() or "file" in desc.lower(), f"{key} should be described as a file path"
 
+    def test_diff_manifest_snapshot_param_matches_diff_snapshot_baseline_contract(self):
+        manifest = json.loads((TOOLS_DIR / "cja_sdr_diff.json").read_text())
+        snapshot_desc = manifest["parameters"]["properties"]["snapshot"]["description"].lower()
+
+        assert "existing" in snapshot_desc
+        assert "baseline" in snapshot_desc
+        assert "diff_snapshot" in snapshot_desc
+        assert "auto_snapshot" in snapshot_desc
+
     def test_diff_manifest_limits_diff_output_to_inline_text_formats(self):
         manifest = json.loads((TOOLS_DIR / "cja_sdr_diff.json").read_text())
         props = manifest["parameters"]["properties"]
@@ -188,6 +197,15 @@ class TestToolManifests:
             manifest = json.loads((TOOLS_DIR / name).read_text())
             props = manifest["parameters"]["properties"]
             assert "show_config" not in props, f"show_config should not be in {name}"
+
+    def test_config_file_manifest_defaults_match_cli(self):
+        for name in ["cja_sdr_config.json", "cja_sdr_generate.json"]:
+            manifest = json.loads((TOOLS_DIR / name).read_text())
+            config_desc = manifest["parameters"]["properties"]["config_file"]["description"].lower()
+
+            assert "config.json" in config_desc
+            assert "working directory" in config_desc
+            assert "~/.cja_auto_sdr/config.json" not in config_desc
 
     def test_readme_covers_required_topics(self):
         content = (TOOLS_DIR / "README.md").read_text()

--- a/tests/test_tool_manifests.py
+++ b/tests/test_tool_manifests.py
@@ -164,6 +164,12 @@ class TestToolManifests:
         assert "csv" in output_dir_desc
         assert "directory" in output_dir_desc
 
+    def test_governance_manifest_trending_window_uses_snapshot_count_not_days(self):
+        manifest = json.loads((TOOLS_DIR / "cja_sdr_governance.json").read_text())
+        desc = manifest["parameters"]["properties"]["trending_window"]["description"].lower()
+        assert "snapshot" in desc
+        assert "days" not in desc
+
     def test_no_show_config_in_manifests(self):
         for name in REQUIRED_MANIFESTS:
             manifest = json.loads((TOOLS_DIR / name).read_text())

--- a/tests/test_tool_manifests.py
+++ b/tests/test_tool_manifests.py
@@ -71,8 +71,7 @@ class TestToolManifests:
         for key in ["compare_snapshots_source", "compare_snapshots_target", "snapshot"]:
             if key in props:
                 desc = props[key].get("description", "")
-                assert "path" in desc.lower() or "file" in desc.lower(), \
-                    f"{key} should be described as a file path"
+                assert "path" in desc.lower() or "file" in desc.lower(), f"{key} should be described as a file path"
 
     def test_no_show_config_in_manifests(self):
         for name in REQUIRED_MANIFESTS:
@@ -83,8 +82,12 @@ class TestToolManifests:
     def test_readme_covers_required_topics(self):
         content = (TOOLS_DIR / "README.md").read_text()
         required_topics = [
-            "agent_mode", "stdout", "run-summary-json",
-            "orchestrator", "applicability", "preflight",
+            "agent_mode",
+            "stdout",
+            "run-summary-json",
+            "orchestrator",
+            "applicability",
+            "preflight",
         ]
         for topic in required_topics:
             assert topic.lower() in content.lower(), f"README missing topic: {topic}"

--- a/tests/test_tool_manifests.py
+++ b/tests/test_tool_manifests.py
@@ -1,0 +1,113 @@
+# tests/test_tool_manifests.py
+"""Tests for tools/ JSON tool manifests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+TOOLS_DIR = Path(__file__).resolve().parent.parent / "tools"
+
+REQUIRED_MANIFESTS = [
+    "cja_sdr_generate.json",
+    "cja_sdr_discover.json",
+    "cja_sdr_config.json",
+    "cja_sdr_diff.json",
+    "cja_sdr_governance.json",
+]
+
+REQUIRED_TOP_KEYS = {"name", "description", "parameters"}
+
+
+class TestToolManifests:
+    """Validate tool manifest structure and content."""
+
+    def test_readme_exists(self):
+        assert (TOOLS_DIR / "README.md").exists()
+
+    @pytest.fixture(params=REQUIRED_MANIFESTS)
+    def manifest(self, request):
+        path = TOOLS_DIR / request.param
+        assert path.exists(), f"Missing manifest: {request.param}"
+        return json.loads(path.read_text())
+
+    @pytest.fixture(params=REQUIRED_MANIFESTS)
+    def manifest_name(self, request):
+        return request.param
+
+    def test_manifest_is_valid_json(self, manifest):
+        assert isinstance(manifest, dict)
+
+    def test_manifest_has_required_keys(self, manifest):
+        for key in REQUIRED_TOP_KEYS:
+            assert key in manifest, f"Missing key: {key}"
+
+    def test_parameters_type_is_object(self, manifest):
+        assert manifest["parameters"]["type"] == "object"
+
+    def test_parameters_have_properties(self, manifest):
+        assert "properties" in manifest["parameters"]
+
+    def test_generate_manifest_quality_report_is_format_enum(self):
+        manifest = json.loads((TOOLS_DIR / "cja_sdr_generate.json").read_text())
+        props = manifest["parameters"]["properties"]
+        if "quality_report" in props:
+            assert "enum" in props["quality_report"]
+            assert "json" in props["quality_report"]["enum"]
+            assert "csv" in props["quality_report"]["enum"]
+
+    def test_generate_manifest_fail_on_quality_includes_info(self):
+        manifest = json.loads((TOOLS_DIR / "cja_sdr_generate.json").read_text())
+        props = manifest["parameters"]["properties"]
+        if "fail_on_quality" in props:
+            assert "INFO" in props["fail_on_quality"]["enum"]
+
+    def test_diff_snapshot_params_are_file_paths(self):
+        manifest = json.loads((TOOLS_DIR / "cja_sdr_diff.json").read_text())
+        props = manifest["parameters"]["properties"]
+        # snapshot-related params should indicate file paths
+        for key in ["compare_snapshots_source", "compare_snapshots_target", "snapshot"]:
+            if key in props:
+                desc = props[key].get("description", "")
+                assert "path" in desc.lower() or "file" in desc.lower(), \
+                    f"{key} should be described as a file path"
+
+    def test_no_show_config_in_manifests(self):
+        for name in REQUIRED_MANIFESTS:
+            manifest = json.loads((TOOLS_DIR / name).read_text())
+            props = manifest["parameters"]["properties"]
+            assert "show_config" not in props, f"show_config should not be in {name}"
+
+    def test_readme_covers_required_topics(self):
+        content = (TOOLS_DIR / "README.md").read_text()
+        required_topics = [
+            "agent_mode", "stdout", "run-summary-json",
+            "orchestrator", "applicability", "preflight",
+        ]
+        for topic in required_topics:
+            assert topic.lower() in content.lower(), f"README missing topic: {topic}"
+
+    def test_golden_shape_generate(self):
+        manifest = json.loads((TOOLS_DIR / "cja_sdr_generate.json").read_text())
+        assert manifest["name"] == "cja_sdr_generate"
+        assert "parameters" in manifest
+        props = manifest["parameters"]["properties"]
+        assert "data_view_id" in props
+
+    def test_golden_shape_discover(self):
+        manifest = json.loads((TOOLS_DIR / "cja_sdr_discover.json").read_text())
+        assert manifest["name"] == "cja_sdr_discover"
+
+    def test_golden_shape_config(self):
+        manifest = json.loads((TOOLS_DIR / "cja_sdr_config.json").read_text())
+        assert manifest["name"] == "cja_sdr_config"
+
+    def test_golden_shape_diff(self):
+        manifest = json.loads((TOOLS_DIR / "cja_sdr_diff.json").read_text())
+        assert manifest["name"] == "cja_sdr_diff"
+
+    def test_golden_shape_governance(self):
+        manifest = json.loads((TOOLS_DIR / "cja_sdr_governance.json").read_text())
+        assert manifest["name"] == "cja_sdr_governance"

--- a/tests/test_tool_manifests.py
+++ b/tests/test_tool_manifests.py
@@ -88,6 +88,17 @@ class TestToolManifests:
         assert isolated_threshold["minimum"] == 0.0
         assert isolated_threshold["maximum"] == 1.0
 
+    def test_discover_manifest_formats_match_cli(self):
+        manifest = json.loads((TOOLS_DIR / "cja_sdr_discover.json").read_text())
+        fmt = manifest["parameters"]["properties"]["format"]
+
+        assert set(fmt["enum"]) == {"console", "json", "csv"}
+        assert "table" not in fmt["enum"]
+
+        desc = fmt["description"].lower()
+        assert "console" in desc
+        assert "table" not in desc
+
     def test_generate_manifest_quality_report_output_contract_matches_cli(self):
         manifest = json.loads((TOOLS_DIR / "cja_sdr_generate.json").read_text())
         props = manifest["parameters"]["properties"]
@@ -166,7 +177,9 @@ class TestToolManifests:
 
     def test_governance_manifest_trending_window_uses_snapshot_count_not_days(self):
         manifest = json.loads((TOOLS_DIR / "cja_sdr_governance.json").read_text())
-        desc = manifest["parameters"]["properties"]["trending_window"]["description"].lower()
+        trending_window = manifest["parameters"]["properties"]["trending_window"]
+        desc = trending_window["description"].lower()
+        assert trending_window["minimum"] == 2
         assert "snapshot" in desc
         assert "days" not in desc
 
@@ -189,6 +202,7 @@ class TestToolManifests:
             "output_dir",
             "diff_output",
             "format_pr_comment",
+            "generic wrapper",
             "reports",
             "data",
             "ci",

--- a/tests/test_ux_features.py
+++ b/tests/test_ux_features.py
@@ -344,11 +344,11 @@ class TestCombinedFeatures:
 class TestVersionUpdated:
     """Test that version is correct"""
 
-    def test_version_is_3_4_9(self):
-        """Test that version is 3.4.9"""
+    def test_version_is_3_5_0(self):
+        """Test that version is 3.5.0"""
         from cja_auto_sdr.generator import __version__
 
-        assert __version__ == "3.4.9"
+        assert __version__ == "3.5.0"
 
 
 class TestFormatAutoDetection:

--- a/tools/README.md
+++ b/tools/README.md
@@ -147,6 +147,26 @@ For a standalone quality-report-only flow, set `quality_report` to `json` or `cs
 
 ---
 
+## Example: Generic Wrapper Construction
+
+For a non-LLM wrapper that reads these manifests and shells out to the CLI:
+
+1. Load the manifest JSON for the target command family.
+2. Validate the caller payload against `parameters.properties` and any documented command-specific applicability rules.
+3. Convert `snake_case` parameter names to CLI flags (`run_summary_json` → `--run-summary-json`).
+4. Emit booleans as presence/absence flags, not string values (`agent_mode: true` → `--agent-mode`).
+5. Preserve exact IDs and snapshot file paths as documented instead of guessing by name.
+6. Execute `uv run cja_auto_sdr ...` and consume stdout/stderr according to the command family's documented output contract.
+
+Minimal example:
+
+```text
+payload = {"command": "list_dataviews", "agent_mode": true, "format": "json"}
+argv = ["uv", "run", "cja_auto_sdr", "--list-dataviews", "--agent-mode", "--format", "json"]
+```
+
+---
+
 ## Notes for Manifest Consumers
 
 - `show_config` (interactive config display) is intentionally excluded from all manifests — it is not suitable for automated use.

--- a/tools/README.md
+++ b/tools/README.md
@@ -18,31 +18,36 @@ This directory contains OpenAI-style JSON function definitions (tool manifests) 
 
 Not every manifest parameter is valid for every command within a family. The `command` enum in each manifest determines which other parameters are applicable:
 
+- **`cja_sdr_generate`**: `data_view_id` is always required. `format` accepts the direct formats plus the CLI aliases `all`, `reports`, `data`, and `ci`. Main SDR artifacts still use `output_dir` auto-naming. Standalone `quality_report` mode additionally honors `output` for stdout or a caller-chosen file path, and falls back to `output_dir` for auto-named report files when `output` is omitted.
 - **`cja_sdr_discover`**: `data_view_id` is required only for `describe_dataview`, `list_metrics`, `list_dimensions`, `list_segments`, `list_calculated_metrics`. It is unused for `list_dataviews`, `list_connections`, `list_datasets`.
-- **`cja_sdr_diff`**: `source`/`target` apply to `diff`. `compare_snapshots_source`/`compare_snapshots_target` apply to `compare_snapshots`. `snapshot` applies to `diff_snapshot`. `compare_with_prev` requires only a data view ID (passed as `source`).
+- **`cja_sdr_diff`**: `source`/`target` apply to `diff`. `compare_snapshots_source`/`compare_snapshots_target` apply to `compare_snapshots`. `snapshot` applies to `diff_snapshot`. `compare_with_prev` requires only a data view ID (passed as `source`). `output` is for stdout JSON only. `diff_output` is limited to inline-text output such as `console` or `format_pr_comment: true`; file-writing formats (`json`, `markdown`, `html`, `excel`, `csv`) create auto-named artifacts under `output_dir`.
+- **`cja_sdr_governance`**: `duplicate_threshold` is an integer count of high-similarity pairs. `isolated_threshold` is a `0.0-1.0` percentage. `output` can target stdout or a named location, but the shape depends on `format`: JSON/Excel/Markdown/HTML create a single file, CSV expands to a directory of multiple files, and console ignores named file paths. `output_dir` controls auto-named artifacts.
 - **`cja_sdr_config`**: `config_json` applies only to `config_status`.
 
 ---
 
 ## Agent Mode (`agent_mode`)
 
-All generation and reporting tools accept an `agent_mode` boolean. When `true`:
+`agent_mode` is a wrapper convenience that maps to the CLI's `--agent-mode` preset:
 
-- Banners, progress bars, and human-readable noise are suppressed.
-- Structured JSON is emitted to **stdout** (rather than formatted for a terminal).
-- Errors are written to **stderr** as JSON objects with `error`, `code`, and `details` fields.
+```text
+--format json --output - --log-format json
+```
 
-**Always set `agent_mode: true` in automated pipelines.**
+Important caveats:
 
-CLI mapping: `agent_mode: true` → `--agent-mode` flag.
+- It expands to the repo's real CLI contract; it is not an independent execution mode.
+- Explicit manifest parameters still win over the preset.
+- Command-family behavior still follows the underlying CLI implementation. Discovery, diff, and org-report flows honor stdout JSON directly. Single-SDR generation still writes auto-named SDR artifacts under `output_dir`, while standalone `quality_report` mode continues to honor `output`/`output_dir`.
 
 ---
 
 ## stdout vs. File Output
 
-- When `output` is omitted, the tool writes to **stdout**. Combine with `agent_mode: true` and `format: "json"` to receive structured, parseable output directly from the tool call.
-- When `output` is provided, the file is written to that path and a confirmation summary is emitted to stdout.
-- Use `run_summary_json` to always capture a machine-readable run summary at a known file path, regardless of where primary output goes.
+- `cja_sdr_generate`: main SDR artifacts use `output_dir` auto-naming. Standalone `quality_report` mode supports `output: "-"` / `output: "stdout"` for JSON or CSV stdout, a caller-chosen file path in `output`, or an auto-named report under `output_dir`.
+- `cja_sdr_diff`: use `output: "-"` or `output: "stdout"` for JSON stdout. `diff_output` is only for inline-text output such as `console` or `format_pr_comment: true`; JSON/Markdown/HTML/Excel/CSV file outputs remain auto-named under `output_dir`.
+- `cja_sdr_governance`: use `output: "-"` or `output: "stdout"` for supported stdout flows. For named outputs, JSON/Excel/Markdown/HTML create a single file, CSV creates a directory of multiple files, and console ignores named file paths. Use `output_dir` for auto-named artifacts.
+- Use `run_summary_json` to capture a stable machine-readable completion record at a known path regardless of primary output behavior.
 
 ---
 
@@ -130,13 +135,15 @@ A typical agent workflow for generating a governed SDR:
     "data_view_id": "dv_abc123xyz",
     "format": "json",
     "agent_mode": true,
-    "quality_report": "json",
+    "output_dir": "/tmp/reports",
     "fail_on_quality": "HIGH",
     "run_summary_json": "/tmp/run_summary.json",
     "profile": "prod"
   }
 }
 ```
+
+For a standalone quality-report-only flow, set `quality_report` to `json` or `csv` and use `output` for stdout or a stable report path.
 
 ---
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,148 @@
+# CJA Auto SDR — Tool Manifests
+
+This directory contains OpenAI-style JSON function definitions (tool manifests) for integrating `cja_auto_sdr` into agent frameworks (OpenAI function calling, Anthropic tool use, LangChain, etc.).
+
+## Manifest Overview
+
+| File | Tool Name | Purpose |
+|------|-----------|---------|
+| `cja_sdr_generate.json` | `cja_sdr_generate` | Generate an SDR document for a single data view |
+| `cja_sdr_discover.json` | `cja_sdr_discover` | Discover and inspect CJA resources (data views, connections, datasets) |
+| `cja_sdr_config.json` | `cja_sdr_config` | Configuration preflight and status checks |
+| `cja_sdr_diff.json` | `cja_sdr_diff` | Compare data view snapshots and detect schema drift |
+| `cja_sdr_governance.json` | `cja_sdr_governance` | Org-wide governance reporting and drift detection |
+
+---
+
+## Command-Family Applicability
+
+Not every manifest parameter is valid for every command within a family. The `command` enum in each manifest determines which other parameters are applicable:
+
+- **`cja_sdr_discover`**: `data_view_id` is required only for `describe_dataview`, `list_metrics`, `list_dimensions`, `list_segments`, `list_calculated_metrics`. It is unused for `list_dataviews`, `list_connections`, `list_datasets`.
+- **`cja_sdr_diff`**: `source`/`target` apply to `diff`. `compare_snapshots_source`/`compare_snapshots_target` apply to `compare_snapshots`. `snapshot` applies to `diff_snapshot`. `compare_with_prev` requires only a data view ID (passed as `source`).
+- **`cja_sdr_config`**: `config_json` applies only to `config_status`.
+
+---
+
+## Agent Mode (`agent_mode`)
+
+All generation and reporting tools accept an `agent_mode` boolean. When `true`:
+
+- Banners, progress bars, and human-readable noise are suppressed.
+- Structured JSON is emitted to **stdout** (rather than formatted for a terminal).
+- Errors are written to **stderr** as JSON objects with `error`, `code`, and `details` fields.
+
+**Always set `agent_mode: true` in automated pipelines.**
+
+CLI mapping: `agent_mode: true` → `--agent-mode` flag.
+
+---
+
+## stdout vs. File Output
+
+- When `output` is omitted, the tool writes to **stdout**. Combine with `agent_mode: true` and `format: "json"` to receive structured, parseable output directly from the tool call.
+- When `output` is provided, the file is written to that path and a confirmation summary is emitted to stdout.
+- Use `run_summary_json` to always capture a machine-readable run summary at a known file path, regardless of where primary output goes.
+
+---
+
+## `run-summary-json` Usage
+
+The `run_summary_json` parameter (CLI: `--run-summary-json <path>`) writes a JSON file after the command completes containing:
+
+```json
+{
+  "exit_code": 0,
+  "duration_seconds": 4.2,
+  "data_view_id": "dv_abc123",
+  "component_counts": { "metrics": 42, "dimensions": 118 },
+  "quality_issues": 3,
+  "timestamp": "2026-03-28T10:00:00Z"
+}
+```
+
+This is the recommended integration point for orchestrators and CI systems that need structured outcome data without parsing stdout.
+
+---
+
+## Config Preflight Flows
+
+Before running generation or governance commands in an automated pipeline, use `cja_sdr_config` to verify connectivity:
+
+1. Call `cja_sdr_config` with `command: "validate_config"` and the target `profile`.
+2. If it returns a non-zero exit code, abort and surface the error — credentials or connectivity are not ready.
+3. Optionally call `config_status` with `config_json: true` to log the effective configuration for audit purposes.
+4. Proceed with `cja_sdr_generate` or `cja_sdr_governance`.
+
+The `--validate-config` CLI flag performs a lightweight credential resolution and API ping — it does not generate any SDR output.
+
+---
+
+## `scripts/orchestrator.py` Scope
+
+`scripts/orchestrator.py` is a **subprocess-based orchestration helper** for programmatic automation from Python. It is distinct from agent tool calling:
+
+- It manages subprocess invocations of `cja_auto_sdr` CLI commands.
+- It is appropriate for batch pipelines, CI scripts, and Python-native orchestration.
+- For LLM agent frameworks, prefer the tool manifests in this directory over direct subprocess invocation.
+
+The tool manifests here complement `orchestrator.py` — they describe the *interface*, while `orchestrator.py` handles *subprocess execution mechanics*.
+
+---
+
+## Exact-ID Guidance
+
+All data view IDs (`data_view_id`, `source`, `target`) must be **exact CJA data view IDs**, not display names. Data view IDs begin with `dv_` followed by an alphanumeric string.
+
+Use `cja_sdr_discover` with `command: "list_dataviews"` to enumerate available data view IDs before calling generation or diff commands.
+
+---
+
+## Example: Tool Calling Sequence
+
+A typical agent workflow for generating a governed SDR:
+
+```json
+// Step 1: Preflight — validate config
+{
+  "tool": "cja_sdr_config",
+  "parameters": {
+    "command": "validate_config",
+    "profile": "prod"
+  }
+}
+
+// Step 2: Discovery — find the right data view
+{
+  "tool": "cja_sdr_discover",
+  "parameters": {
+    "command": "list_dataviews",
+    "format": "json",
+    "agent_mode": true,
+    "profile": "prod"
+  }
+}
+
+// Step 3: Generate SDR with quality gate
+{
+  "tool": "cja_sdr_generate",
+  "parameters": {
+    "data_view_id": "dv_abc123xyz",
+    "format": "json",
+    "agent_mode": true,
+    "quality_report": "json",
+    "fail_on_quality": "HIGH",
+    "run_summary_json": "/tmp/run_summary.json",
+    "profile": "prod"
+  }
+}
+```
+
+---
+
+## Notes for Manifest Consumers
+
+- `show_config` (interactive config display) is intentionally excluded from all manifests — it is not suitable for automated use.
+- All `enum` values mirror the exact CLI flag values (e.g. `"INFO"`, `"LOW"` for `fail_on_quality`).
+- Boolean parameters map to presence/absence of the corresponding CLI flag (e.g. `agent_mode: true` → `--agent-mode`).
+- Parameter names use `snake_case`; CLI flags use `kebab-case` (e.g. `run_summary_json` → `--run-summary-json`).

--- a/tools/cja_sdr_config.json
+++ b/tools/cja_sdr_config.json
@@ -1,0 +1,27 @@
+{
+  "name": "cja_sdr_config",
+  "description": "Configuration preflight and status checks for cja_auto_sdr. Use 'validate_config' to verify credentials and connectivity before running generation or governance commands. Use 'config_status' to inspect current effective configuration. These are lightweight, read-only operations suitable for agent preflight checks.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "command": {
+        "type": "string",
+        "enum": ["validate_config", "config_status"],
+        "description": "Config command to run. 'validate_config' tests credential resolution and API connectivity. 'config_status' displays the effective configuration for the selected profile."
+      },
+      "config_json": {
+        "type": "boolean",
+        "description": "When true, emit config_status output as JSON (applies to config_status command only). Useful for agents parsing configuration programmatically."
+      },
+      "config_file": {
+        "type": "string",
+        "description": "Path to a custom config file. Overrides the default ~/.cja_auto_sdr/config.json."
+      },
+      "profile": {
+        "type": "string",
+        "description": "Named credential profile to validate or inspect. Defaults to the default profile."
+      }
+    },
+    "required": ["command"]
+  }
+}

--- a/tools/cja_sdr_config.json
+++ b/tools/cja_sdr_config.json
@@ -15,7 +15,7 @@
       },
       "config_file": {
         "type": "string",
-        "description": "Path to a custom config file. Overrides the default ~/.cja_auto_sdr/config.json."
+        "description": "Path to a custom config file. Overrides the default config.json in the working directory."
       },
       "profile": {
         "type": "string",

--- a/tools/cja_sdr_diff.json
+++ b/tools/cja_sdr_diff.json
@@ -27,7 +27,7 @@
       },
       "snapshot": {
         "type": "string",
-        "description": "File path where the new snapshot will be written (for diff_snapshot command) or the snapshot file path used as a reference."
+        "description": "File path to an existing baseline snapshot JSON file for the 'diff_snapshot' command. New snapshots are only written via auto_snapshot into snapshot_dir."
       },
       "format": {
         "type": "string",

--- a/tools/cja_sdr_diff.json
+++ b/tools/cja_sdr_diff.json
@@ -7,7 +7,7 @@
       "command": {
         "type": "string",
         "enum": ["diff", "diff_snapshot", "compare_with_prev", "compare_snapshots"],
-        "description": "Diff command to run. 'diff' compares two live data views (source and target required). 'diff_snapshot' captures a new snapshot for a data view. 'compare_with_prev' diffs a data view against its previous snapshot. 'compare_snapshots' diffs two snapshot files on disk (compare_snapshots_source and compare_snapshots_target required)."
+        "description": "Diff command to run. 'diff' compares two live data views (source and target required). 'diff_snapshot' compares a live data view (source) against a snapshot file (snapshot). 'compare_with_prev' diffs a data view against its previous snapshot. 'compare_snapshots' diffs two snapshot files on disk (compare_snapshots_source and compare_snapshots_target required)."
       },
       "source": {
         "type": "string",
@@ -31,12 +31,24 @@
       },
       "format": {
         "type": "string",
-        "enum": ["console", "json", "csv", "html", "markdown", "excel", "pr_comment"],
-        "description": "Output format for the diff report. Use 'json' for agent/machine-readable output. Use 'pr_comment' to generate GitHub PR comment markdown."
+        "enum": ["console", "json", "csv", "html", "markdown", "excel"],
+        "description": "Output format for the diff report. Use 'json' for agent/machine-readable output."
       },
       "output": {
         "type": "string",
-        "description": "File path to write the diff report to. Omit to receive output on stdout."
+        "description": "Use '-' or 'stdout' to emit JSON diff output on stdout. For console output or when format_pr_comment is true, use diff_output to capture the rendered text in a named file. File-writing formats ('json', 'markdown', 'html', 'excel', 'csv') create auto-named artifacts under output_dir."
+      },
+      "diff_output": {
+        "type": "string",
+        "description": "Named file path for inline-text diff output only. Currently applies to 'console' output and to PR-comment mode when format_pr_comment is true; JSON, Markdown, HTML, Excel, and CSV formats ignore this path and write auto-named artifacts under output_dir."
+      },
+      "output_dir": {
+        "type": "string",
+        "description": "Directory where file-writing diff formats ('json', 'markdown', 'html', 'excel', 'csv') create auto-named artifacts."
+      },
+      "format_pr_comment": {
+        "type": "boolean",
+        "description": "When true, emit GitHub/GitLab PR comment markdown via the CLI's --format-pr-comment flag instead of the regular diff format."
       },
       "agent_mode": {
         "type": "boolean",
@@ -45,10 +57,6 @@
       "changes_only": {
         "type": "boolean",
         "description": "When true, omit unchanged components from the diff output. Reduces noise for large data views with few changes."
-      },
-      "include_inventory": {
-        "type": "boolean",
-        "description": "Include full component inventory in the diff output, not just changed items."
       },
       "profile": {
         "type": "string",

--- a/tools/cja_sdr_diff.json
+++ b/tools/cja_sdr_diff.json
@@ -1,0 +1,64 @@
+{
+  "name": "cja_sdr_diff",
+  "description": "Compare CJA data view snapshots to detect schema drift, additions, removals, and modifications over time. Supports direct data view comparison, snapshot-based diff, previous-snapshot comparison, and comparing two snapshot files on disk.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "command": {
+        "type": "string",
+        "enum": ["diff", "diff_snapshot", "compare_with_prev", "compare_snapshots"],
+        "description": "Diff command to run. 'diff' compares two live data views (source and target required). 'diff_snapshot' captures a new snapshot for a data view. 'compare_with_prev' diffs a data view against its previous snapshot. 'compare_snapshots' diffs two snapshot files on disk (compare_snapshots_source and compare_snapshots_target required)."
+      },
+      "source": {
+        "type": "string",
+        "description": "Source data view ID for the 'diff' command (the baseline / older side)."
+      },
+      "target": {
+        "type": "string",
+        "description": "Target data view ID for the 'diff' command (the current / newer side)."
+      },
+      "compare_snapshots_source": {
+        "type": "string",
+        "description": "File path to the source (older) snapshot JSON file for the 'compare_snapshots' command."
+      },
+      "compare_snapshots_target": {
+        "type": "string",
+        "description": "File path to the target (newer) snapshot JSON file for the 'compare_snapshots' command."
+      },
+      "snapshot": {
+        "type": "string",
+        "description": "File path where the new snapshot will be written (for diff_snapshot command) or the snapshot file path used as a reference."
+      },
+      "format": {
+        "type": "string",
+        "enum": ["console", "json", "csv", "html", "markdown", "excel", "pr_comment"],
+        "description": "Output format for the diff report. Use 'json' for agent/machine-readable output. Use 'pr_comment' to generate GitHub PR comment markdown."
+      },
+      "output": {
+        "type": "string",
+        "description": "File path to write the diff report to. Omit to receive output on stdout."
+      },
+      "agent_mode": {
+        "type": "boolean",
+        "description": "Enable agent mode: suppresses banners, emits structured JSON to stdout. Recommended for programmatic diff consumption."
+      },
+      "changes_only": {
+        "type": "boolean",
+        "description": "When true, omit unchanged components from the diff output. Reduces noise for large data views with few changes."
+      },
+      "include_inventory": {
+        "type": "boolean",
+        "description": "Include full component inventory in the diff output, not just changed items."
+      },
+      "profile": {
+        "type": "string",
+        "description": "Named credential profile to use. Defaults to the default profile."
+      },
+      "run_summary_json": {
+        "type": "string",
+        "description": "File path to write a machine-readable run summary JSON (timing, change counts, exit code) after the diff completes."
+      }
+    },
+    "required": ["command"]
+  }
+}

--- a/tools/cja_sdr_discover.json
+++ b/tools/cja_sdr_discover.json
@@ -1,0 +1,45 @@
+{
+  "name": "cja_sdr_discover",
+  "description": "Discover and inspect Adobe CJA resources: list data views, connections, datasets, or inspect a specific data view's metrics, dimensions, segments, and calculated metrics. Use this tool before cja_sdr_generate to find valid data_view_id values.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "command": {
+        "type": "string",
+        "enum": [
+          "list_dataviews",
+          "list_connections",
+          "list_datasets",
+          "describe_dataview",
+          "list_metrics",
+          "list_dimensions",
+          "list_segments",
+          "list_calculated_metrics"
+        ],
+        "description": "Discovery command to run. Use 'list_dataviews' first to enumerate available data view IDs. Use 'describe_dataview' or the list_* commands with data_view_id to inspect a specific data view."
+      },
+      "data_view_id": {
+        "type": "string",
+        "description": "Data view ID required for inspection commands: describe_dataview, list_metrics, list_dimensions, list_segments, list_calculated_metrics."
+      },
+      "format": {
+        "type": "string",
+        "enum": ["json", "csv", "table"],
+        "description": "Output format. Use 'json' for agent/programmatic consumption. Defaults to 'table' for human-readable console output."
+      },
+      "output": {
+        "type": "string",
+        "description": "File path to write discovery output to. Omit to receive output on stdout."
+      },
+      "agent_mode": {
+        "type": "boolean",
+        "description": "Enable agent mode: suppresses banners, emits clean JSON to stdout. Recommended for programmatic use."
+      },
+      "profile": {
+        "type": "string",
+        "description": "Named credential profile to use. Defaults to the default profile."
+      }
+    },
+    "required": ["command"]
+  }
+}

--- a/tools/cja_sdr_discover.json
+++ b/tools/cja_sdr_discover.json
@@ -24,8 +24,8 @@
       },
       "format": {
         "type": "string",
-        "enum": ["json", "csv", "table"],
-        "description": "Output format. Use 'json' for agent/programmatic consumption. Defaults to 'table' for human-readable console output."
+        "enum": ["console", "json", "csv"],
+        "description": "Output format. Use 'json' for agent/programmatic consumption. Defaults to 'console' for human-readable output."
       },
       "output": {
         "type": "string",

--- a/tools/cja_sdr_generate.json
+++ b/tools/cja_sdr_generate.json
@@ -1,6 +1,6 @@
 {
   "name": "cja_sdr_generate",
-  "description": "Generate a Solution Design Reference (SDR) document for a single Adobe Customer Journey Analytics data view. Produces structured output describing all metrics, dimensions, segments, and calculated metrics in the data view. Use --agent-mode to get machine-readable JSON on stdout.",
+  "description": "Generate a Solution Design Reference (SDR) document for a single Adobe Customer Journey Analytics data view. Produces SDR artifacts describing metrics, dimensions, segments, and calculated metrics. Single-SDR generation writes auto-named artifacts under output_dir; standalone quality_report output still honors output/output_dir, and run_summary_json provides stable machine-readable completion metadata.",
   "parameters": {
     "type": "object",
     "properties": {
@@ -10,21 +10,25 @@
       },
       "format": {
         "type": "string",
-        "enum": ["excel", "csv", "json", "html", "markdown"],
-        "description": "Output format for the SDR document. Defaults to 'excel' when writing to file; use 'json' with agent_mode for machine-readable output."
+        "enum": ["excel", "csv", "json", "html", "markdown", "all", "reports", "data", "ci"],
+        "description": "Output format for the SDR artifact. Supports direct formats plus aliases: 'all' (all formats + console), 'reports' (excel + markdown), 'data' (csv + json), and 'ci' (json + markdown). JSON is recommended for machine-readable downstream processing."
       },
       "output": {
         "type": "string",
-        "description": "File path to write the SDR output to. If omitted, output goes to stdout (combine with agent_mode and format=json for structured output)."
+        "description": "Optional destination for standalone quality reports (quality_report only). Use '-' or 'stdout' for JSON/CSV stdout, or provide a file path for a stable report artifact. SDR artifacts themselves still use output_dir auto-naming."
+      },
+      "output_dir": {
+        "type": "string",
+        "description": "Directory where generated SDR artifacts are written. Also used as the fallback location for auto-named standalone quality reports when output is omitted."
       },
       "agent_mode": {
         "type": "boolean",
-        "description": "Enable agent mode: suppresses banners and progress noise, emits structured JSON to stdout. Strongly recommended for programmatic use."
+        "description": "Wrapper convenience that maps to the CLI's --agent-mode preset. In current single-SDR generation, it selects machine-friendly defaults but artifacts still land under output_dir auto-naming."
       },
       "quality_report": {
         "type": "string",
         "enum": ["json", "csv"],
-        "description": "Emit a data quality report in the specified format alongside the SDR. 'json' is recommended for agent consumers."
+        "description": "Generate a standalone data quality report only in the specified format ('json' or 'csv') without SDR files. Use output/output_dir to control where the report is written."
       },
       "fail_on_quality": {
         "type": "string",

--- a/tools/cja_sdr_generate.json
+++ b/tools/cja_sdr_generate.json
@@ -1,0 +1,71 @@
+{
+  "name": "cja_sdr_generate",
+  "description": "Generate a Solution Design Reference (SDR) document for a single Adobe Customer Journey Analytics data view. Produces structured output describing all metrics, dimensions, segments, and calculated metrics in the data view. Use --agent-mode to get machine-readable JSON on stdout.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "data_view_id": {
+        "type": "string",
+        "description": "The Adobe CJA data view ID to generate the SDR for (e.g. 'dv_abc123xyz'). Required."
+      },
+      "format": {
+        "type": "string",
+        "enum": ["excel", "csv", "json", "html", "markdown"],
+        "description": "Output format for the SDR document. Defaults to 'excel' when writing to file; use 'json' with agent_mode for machine-readable output."
+      },
+      "output": {
+        "type": "string",
+        "description": "File path to write the SDR output to. If omitted, output goes to stdout (combine with agent_mode and format=json for structured output)."
+      },
+      "agent_mode": {
+        "type": "boolean",
+        "description": "Enable agent mode: suppresses banners and progress noise, emits structured JSON to stdout. Strongly recommended for programmatic use."
+      },
+      "quality_report": {
+        "type": "string",
+        "enum": ["json", "csv"],
+        "description": "Emit a data quality report in the specified format alongside the SDR. 'json' is recommended for agent consumers."
+      },
+      "fail_on_quality": {
+        "type": "string",
+        "enum": ["INFO", "LOW", "MEDIUM", "HIGH", "CRITICAL"],
+        "description": "Fail (non-zero exit) if any quality issue at or above this severity level is found. Use 'HIGH' or 'CRITICAL' for gating pipelines."
+      },
+      "max_issues": {
+        "type": "integer",
+        "description": "Maximum number of quality issues allowed before failing. Only relevant when fail_on_quality is set.",
+        "minimum": 0
+      },
+      "snapshot": {
+        "type": "string",
+        "description": "File path to write a JSON snapshot of this SDR for later diff comparison."
+      },
+      "snapshot_dir": {
+        "type": "string",
+        "description": "Directory path where auto-generated snapshots are stored. Used with auto_snapshot."
+      },
+      "auto_snapshot": {
+        "type": "boolean",
+        "description": "Automatically save a timestamped snapshot to snapshot_dir after generation."
+      },
+      "profile": {
+        "type": "string",
+        "description": "Named credential profile to use (as configured via --config). Defaults to the default profile."
+      },
+      "config_file": {
+        "type": "string",
+        "description": "Path to a custom config file (overrides the default ~/.cja_auto_sdr/config.json)."
+      },
+      "run_summary_json": {
+        "type": "string",
+        "description": "File path to write a machine-readable run summary JSON (timing, counts, exit code). Useful for CI and orchestrator integration."
+      },
+      "log_format": {
+        "type": "string",
+        "enum": ["text", "json"],
+        "description": "Log output format. Use 'json' when ingesting logs programmatically."
+      }
+    },
+    "required": ["data_view_id"]
+  }
+}

--- a/tools/cja_sdr_generate.json
+++ b/tools/cja_sdr_generate.json
@@ -58,7 +58,7 @@
       },
       "config_file": {
         "type": "string",
-        "description": "Path to a custom config file (overrides the default ~/.cja_auto_sdr/config.json)."
+        "description": "Path to a custom config file (overrides the default config.json in the working directory)."
       },
       "run_summary_json": {
         "type": "string",

--- a/tools/cja_sdr_governance.json
+++ b/tools/cja_sdr_governance.json
@@ -10,15 +10,15 @@
         "minimum": 1
       },
       "duplicate_threshold": {
-        "type": "number",
-        "description": "Similarity score threshold (0.0–1.0) above which two components are flagged as potential duplicates.",
-        "minimum": 0.0,
-        "maximum": 1.0
+        "type": "integer",
+        "description": "Maximum allowed count of high-similarity component pairs (>=90%). Use with fail_on_threshold for CI governance gates.",
+        "minimum": 0
       },
       "isolated_threshold": {
-        "type": "integer",
-        "description": "Number of data views a component must appear in to avoid being flagged as isolated/unused.",
-        "minimum": 1
+        "type": "number",
+        "description": "Maximum isolated component percentage (0.0-1.0). Use with fail_on_threshold for CI governance gates.",
+        "minimum": 0.0,
+        "maximum": 1.0
       },
       "fail_on_threshold": {
         "type": "boolean",
@@ -31,7 +31,11 @@
       },
       "output": {
         "type": "string",
-        "description": "File path to write the org report to. Omit to receive output on stdout."
+        "description": "Use '-' or 'stdout' to emit supported stdout formats. For named outputs, JSON/Excel/Markdown/HTML write a single file, CSV treats the path as a directory/base path for multiple CSV files, and console ignores file paths."
+      },
+      "output_dir": {
+        "type": "string",
+        "description": "Directory where auto-named org-report artifacts are written when output is omitted. Auto-named CSV output creates a directory of multiple CSV files beneath this location."
       },
       "agent_mode": {
         "type": "boolean",

--- a/tools/cja_sdr_governance.json
+++ b/tools/cja_sdr_governance.json
@@ -1,0 +1,72 @@
+{
+  "name": "cja_sdr_governance",
+  "description": "Run an org-wide governance report across all Adobe CJA data views. Identifies duplicate components, isolated/unused metrics and dimensions, schema drift over time, and cross-data-view patterns. Use for periodic governance audits, drift detection, and automated quality gates.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "trending_window": {
+        "type": "integer",
+        "description": "Number of days to include in drift detection trending analysis. Higher values show longer-term trends.",
+        "minimum": 1
+      },
+      "duplicate_threshold": {
+        "type": "number",
+        "description": "Similarity score threshold (0.0–1.0) above which two components are flagged as potential duplicates.",
+        "minimum": 0.0,
+        "maximum": 1.0
+      },
+      "isolated_threshold": {
+        "type": "integer",
+        "description": "Number of data views a component must appear in to avoid being flagged as isolated/unused.",
+        "minimum": 1
+      },
+      "fail_on_threshold": {
+        "type": "boolean",
+        "description": "Exit with a non-zero code if any governance threshold (duplicate or isolated) is exceeded. Useful for CI pipeline gating."
+      },
+      "format": {
+        "type": "string",
+        "enum": ["console", "json", "csv", "html", "markdown", "excel"],
+        "description": "Output format for the org report. Use 'json' for agent/machine-readable output."
+      },
+      "output": {
+        "type": "string",
+        "description": "File path to write the org report to. Omit to receive output on stdout."
+      },
+      "agent_mode": {
+        "type": "boolean",
+        "description": "Enable agent mode: suppresses banners and progress noise, emits structured JSON to stdout. Recommended for programmatic consumption."
+      },
+      "profile": {
+        "type": "string",
+        "description": "Named credential profile to use. Defaults to the default profile."
+      },
+      "run_summary_json": {
+        "type": "string",
+        "description": "File path to write a machine-readable run summary JSON (timing, issue counts, exit code) after the report completes."
+      },
+      "include_names": {
+        "type": "boolean",
+        "description": "Include human-readable component names alongside IDs in the org report output."
+      },
+      "skip_similarity": {
+        "type": "boolean",
+        "description": "Skip the similarity/duplicate detection pass. Speeds up the report when duplicate analysis is not needed."
+      },
+      "filter_pattern": {
+        "type": "string",
+        "description": "Regex or glob pattern to include only matching data views in the org report."
+      },
+      "exclude_pattern": {
+        "type": "string",
+        "description": "Regex or glob pattern to exclude matching data views from the org report."
+      },
+      "limit": {
+        "type": "integer",
+        "description": "Maximum number of data views to process. Useful for testing or sampling large orgs.",
+        "minimum": 1
+      }
+    },
+    "required": []
+  }
+}

--- a/tools/cja_sdr_governance.json
+++ b/tools/cja_sdr_governance.json
@@ -6,7 +6,7 @@
     "properties": {
       "trending_window": {
         "type": "integer",
-        "description": "Number of days to include in drift detection trending analysis. Higher values show longer-term trends.",
+        "description": "Number of cached org-report snapshots to include in drift detection trending analysis. Higher values compare across a longer snapshot history.",
         "minimum": 1
       },
       "duplicate_threshold": {

--- a/tools/cja_sdr_governance.json
+++ b/tools/cja_sdr_governance.json
@@ -6,8 +6,8 @@
     "properties": {
       "trending_window": {
         "type": "integer",
-        "description": "Number of cached org-report snapshots to include in drift detection trending analysis. Higher values compare across a longer snapshot history.",
-        "minimum": 1
+        "description": "Number of cached org-report snapshots to include in drift detection trending analysis. Must be at least 2 because drift compares across snapshot history. Higher values compare across a longer snapshot history.",
+        "minimum": 2
       },
       "duplicate_threshold": {
         "type": "integer",


### PR DESCRIPTION
## Summary

- **`--agent-mode` CLI preset** — defaults to `--format json --output - --log-format json` for agent-friendly invocation, with explicit-override detection and fast-path compatibility
- **JSON `advisories` block** — derived convenience layer in org-report and diff output with versioned schema (`advisories_version: "1.0"`), severity rollups, and a documented `recommended_actions` registry
- **Run-summary advisory rollups** — compact `details.advisories` in `--run-summary-json` for both org-report and diff modes
- **`tools/` JSON tool manifests** — 5 function-calling definitions (generate, discover, config, diff, governance) with README covering applicability and usage
- **`docs/agent-playbooks/`** — 5 cross-agent task playbooks (sdr-auditor, diff-reviewer, onboarding-guide, quality-monitor, snapshot-manager) with structural validation tests
- **`examples/agent-workflows/`** — 3 behavior-tested shell workflows (audit_and_report, onboard_dataview, quarterly_governance) with shared `_common.sh` helpers and v3.5.0 contract alignment
- **`sample_outputs/agent/`** — representative contract fixtures for machine-readable payloads
- **Diff JSON builder extraction** — `build_diff_json_data()` as shared public seam with stdout JSON support across all diff-family commands
- **Contract alignment fixes** — agent-mode defaults, diff stdout alias, org-report console output, advisory action registry, and quiet-flag recomputation after output resolution
- **Documentation** — Agent Integration section in `AGENTS.md`, expanded `AGENT_AUTOMATION.md` with advisories registry and decision matrix, CLI/quick reference updates, fixed inspection command forms

## Stats

- 31 commits across feature, fix, refactor, docs, style, and chore categories
- 67 files changed, 7,016 insertions, 229 deletions
- 7,590 tests collected (7,589 passed, 1 skipped), up from 7,294
- 95% coverage gate maintained
- Ruff lint clean

## Test plan

- [x] Full test suite passes locally (`uv run pytest tests/ -x -q`) — 7,589 passed, 1 skipped in 86s
- [x] Ruff lint clean (`uv run ruff check src/ tests/`) — all checks passed
- [x] Ruff format clean (`uv run ruff format --check src/ tests/`) — 241 files formatted
- [x] Version sync check passes (`uv run python scripts/check_version_sync.py`) — all references match 3.5.0
- [x] Test counts synced (`uv run python scripts/update_test_counts.py --check`) — README.md and tests/README.md current
- [x] CI passes (tests, lint, version-sync, test-counts workflows)
- [x] `--agent-mode` resolves correctly on all command families — 57 agent-mode tests pass
- [x] Diff JSON stdout works end-to-end with `--agent-mode` — 722 diff tests pass
- [x] Advisory rollups appear in `--run-summary-json` output — 223 run-summary tests pass
- [x] Tool manifests validate as JSON with correct schemas — 44 manifest tests pass
- [x] Playbook and workflow tests pass — 109 playbook/workflow tests pass
- [x] Agent contract alignment verified across all command families — v3.5.0 spec conformance