### PR TITLE
v3.5.3 timing hardening and logging cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable changes to the CJA SDR Generator project will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.3] — 2026-04-01
+
+### Changed
+- Replaced wall-clock `time.time()` with `time.monotonic()` / `time.perf_counter()` for all in-process elapsed-time, cooldown, and TTL bookkeeping in circuit breaker, API tuner, validation caches, performance tracker, batch processor, CLI execution, and org analyzer.
+- Converted eager f-string logging to lazy `%s`-style interpolation across hot-path runtime modules outside `generator.py` (`api/`, `core/`, `pipeline/`, `org/`).
+- Extracted shared `_unique_error_key()` helper for cache fallback key generation using monotonic nanosecond resolution.
+- Added one-shot guard for legacy temp-file cleanup in `_config_from_env()` to avoid repeated `/tmp` scans.
+
 ## [3.5.2] — 2026-03-31
 
 ### Security

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,8 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Package manager: **uv**
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
-- Current version: v3.5.2
-- Tests: **7,661** across 129 files at **95% coverage gate**
+- Current version: v3.5.3
+- Tests: **7,662** across 129 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)
 

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (7,662+ tests)
+├── tests/                     # Test suite (7,665+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (7,665+ tests)
+├── tests/                     # Test suite (7,666+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (7,661+ tests)
+├── tests/                     # Test suite (7,662+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -924,7 +924,7 @@ cja_auto_sdr --list-dataviews --log-level DEBUG
 At launch, the tool logs diagnostic lines containing the tool version, Python version, platform, active log level, inferred run mode (batch, single, or discovery), and dependency versions. These appear automatically at `INFO` level and are useful for troubleshooting environment issues in CI/CD logs or support requests:
 
 ```text
-CJA SDR Generator v3.5.2 | Python 3.14.2 | darwin | log_level=INFO | mode=single
+CJA SDR Generator v3.5.3 | Python 3.14.2 | darwin | log_level=INFO | mode=single
 Dependencies: cjapy=0.2.4.post3, pandas=2.3.3, numpy=2.2.1, xlsxwriter=3.2.9, tqdm=4.67.0
 ```
 

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -203,7 +203,7 @@ This command:
 
 ```bash
 $ uv run cja_auto_sdr -V
-cja_auto_sdr 3.5.2
+cja_auto_sdr 3.5.3
 ```
 
 > **Important:** All commands in this guide assume you're in the `cja_auto_sdr` directory. If you see "command not found", make sure you're in the right directory and have run `uv sync`.

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Quick Reference Card
 
-Single-page command cheat sheet for CJA SDR Generator v3.5.2.
+Single-page command cheat sheet for CJA SDR Generator v3.5.3.
 
 ## Four Main Modes
 

--- a/src/cja_auto_sdr/api/cache.py
+++ b/src/cja_auto_sdr/api/cache.py
@@ -3,6 +3,7 @@
 import atexit
 import contextlib
 import hashlib
+import itertools
 import logging
 import multiprocessing
 import threading
@@ -14,10 +15,25 @@ import pandas as pd
 
 from cja_auto_sdr.core.constants import CACHE_KEY_HASH_LENGTH
 
+_ERROR_KEY_COUNTER = itertools.count()
+
 
 def _unique_error_key() -> str:
     """Return a unique cache key that forces a miss on key-generation failure."""
-    return f"error:{time.monotonic_ns()}"
+    return (
+        f"error:{time.monotonic_ns()}:"
+        f"{multiprocessing.current_process().pid}:{threading.get_ident()}:{next(_ERROR_KEY_COUNTER)}"
+    )
+
+
+def _local_cache_clock() -> float:
+    """Return a monotonic clock for in-process cache bookkeeping."""
+    return time.monotonic()
+
+
+def _shared_cache_clock() -> float:
+    """Return a monotonic clock for same-host Manager-backed cache state."""
+    return time.monotonic()
 
 
 def _validate_cache_params(max_size: int, ttl_seconds: int) -> None:
@@ -146,7 +162,7 @@ class ValidationCache:
             cached_issues, timestamp = self._cache[cache_key]
 
             # Check TTL expiration
-            age = time.monotonic() - timestamp
+            age = _local_cache_clock() - timestamp
             if age > self.ttl_seconds:
                 if debug_enabled:
                     self.logger.debug("Cache EXPIRED: %s (age: %.1fs)", item_type, age)
@@ -187,7 +203,7 @@ class ValidationCache:
         debug_enabled = self.logger.isEnabledFor(logging.DEBUG)
 
         with self._lock:
-            now = time.monotonic()
+            now = _local_cache_clock()
 
             if cache_key not in self._cache:
                 self._ensure_capacity_for_new_entry(now, debug_enabled)
@@ -433,14 +449,14 @@ class SharedValidationCache:
             cached_issues, timestamp = cached_data
 
             # Check TTL expiration
-            age = time.monotonic() - timestamp
+            age = _shared_cache_clock() - timestamp
             if age > self.ttl_seconds:
                 self._remove_entry(cache_key)
                 self._stats["misses"] = self._stats.get("misses", 0) + 1
                 return None, cache_key
 
             # Cache hit - update access time and stats
-            self._access_times[cache_key] = time.monotonic()
+            self._access_times[cache_key] = _shared_cache_clock()
             self._stats["hits"] = self._stats.get("hits", 0) + 1
 
             # Return copy to prevent mutation
@@ -528,7 +544,7 @@ class SharedValidationCache:
             cache_key = self._generate_cache_key(df, item_type, required_fields, critical_fields)
 
         with self._lock:
-            now = time.monotonic()
+            now = _shared_cache_clock()
 
             if cache_key not in self._cache:
                 self._ensure_capacity_for_new_entry(now)
@@ -547,7 +563,7 @@ class SharedValidationCache:
             self._access_times.clear()
             return False
 
-        current_time = now if now is not None else time.monotonic()
+        current_time = now if now is not None else _shared_cache_clock()
         if not access_times_reconciled:
             self._reconcile_access_times(current_time)
 

--- a/src/cja_auto_sdr/api/cache.py
+++ b/src/cja_auto_sdr/api/cache.py
@@ -15,6 +15,11 @@ import pandas as pd
 from cja_auto_sdr.core.constants import CACHE_KEY_HASH_LENGTH
 
 
+def _unique_error_key() -> str:
+    """Return a unique cache key that forces a miss on key-generation failure."""
+    return f"error:{time.monotonic_ns()}"
+
+
 def _validate_cache_params(max_size: int, ttl_seconds: int) -> None:
     """Validate cache initialization parameters."""
     if max_size < 1:
@@ -67,7 +72,7 @@ class ValidationCache:
         self._misses = 0
         self._evictions = 0
 
-        self.logger.debug(f"ValidationCache initialized: max_size={max_size}, ttl={ttl_seconds}s")
+        self.logger.debug("ValidationCache initialized: max_size=%s, ttl=%ss", max_size, ttl_seconds)
 
     def _generate_cache_key(
         self,
@@ -108,9 +113,9 @@ class ValidationCache:
             return f"{item_type}:{df_hash}:{config_hash}"
 
         except (TypeError, KeyError, ValueError) as e:
-            self.logger.warning(f"Error generating cache key: {e}. Cache disabled for this call.")
+            self.logger.warning("Error generating cache key: %s. Cache disabled for this call.", e)
             # Return unique key to force cache miss
-            return f"error:{time.time()}"
+            return _unique_error_key()
 
     def get(
         self,
@@ -135,16 +140,16 @@ class ValidationCache:
             if cache_key not in self._cache:
                 self._misses += 1
                 if debug_enabled:
-                    self.logger.debug(f"Cache MISS: {item_type} (key: {cache_key[:20]}...)")
+                    self.logger.debug("Cache MISS: %s (key: %s...)", item_type, cache_key[:20])
                 return None, cache_key
 
             cached_issues, timestamp = self._cache[cache_key]
 
             # Check TTL expiration
-            age = time.time() - timestamp
+            age = time.monotonic() - timestamp
             if age > self.ttl_seconds:
                 if debug_enabled:
-                    self.logger.debug(f"Cache EXPIRED: {item_type} (age: {age:.1f}s)")
+                    self.logger.debug("Cache EXPIRED: %s (age: %.1fs)", item_type, age)
                 del self._cache[cache_key]
                 self._misses += 1
                 return None, cache_key
@@ -153,7 +158,7 @@ class ValidationCache:
             self._cache.move_to_end(cache_key)
             self._hits += 1
             if debug_enabled:
-                self.logger.debug(f"Cache HIT: {item_type} ({len(cached_issues)} issues)")
+                self.logger.debug("Cache HIT: %s (%s issues)", item_type, len(cached_issues))
 
             # Return deep copy to prevent mutation of cached data
             return [issue.copy() for issue in cached_issues], cache_key
@@ -182,7 +187,7 @@ class ValidationCache:
         debug_enabled = self.logger.isEnabledFor(logging.DEBUG)
 
         with self._lock:
-            now = time.time()
+            now = time.monotonic()
 
             if cache_key not in self._cache:
                 self._ensure_capacity_for_new_entry(now, debug_enabled)
@@ -195,7 +200,7 @@ class ValidationCache:
             self._cache.move_to_end(cache_key)
 
             if debug_enabled:
-                self.logger.debug(f"Cache STORE: {item_type} ({len(issues)} issues)")
+                self.logger.debug("Cache STORE: %s (%s issues)", item_type, len(issues))
 
     def _ensure_capacity_for_new_entry(self, now: float, debug_enabled: bool = False) -> None:
         """Make room for one new entry when capacity pressure exists (must be called within lock)."""
@@ -224,7 +229,7 @@ class ValidationCache:
             del self._cache[key]
 
         if expired_keys and debug_enabled:
-            self.logger.debug(f"Cache PRUNE: removed {len(expired_keys)} expired entries")
+            self.logger.debug("Cache PRUNE: removed %s expired entries", len(expired_keys))
 
         return len(expired_keys)
 
@@ -242,7 +247,7 @@ class ValidationCache:
         self._evictions += 1
 
         if debug_enabled:
-            self.logger.debug(f"Cache EVICT: LRU entry removed (total evictions: {self._evictions})")
+            self.logger.debug("Cache EVICT: LRU entry removed (total evictions: %s)", self._evictions)
 
     def get_statistics(self) -> dict[str, Any]:
         """
@@ -287,13 +292,16 @@ class ValidationCache:
         estimated_time_saved = stats["hits"] * 0.049  # 49ms saved per hit
 
         self.logger.info(
-            f"Cache Statistics: {stats['hits']}/{stats['total_requests']} hits ({stats['hit_rate']:.1f}% hit rate)",
+            "Cache Statistics: %s/%s hits (%.1f%% hit rate)",
+            stats["hits"],
+            stats["total_requests"],
+            stats["hit_rate"],
         )
-        self.logger.info(f"  - Cache size: {stats['size']}/{stats['max_size']} entries")
+        self.logger.info("  - Cache size: %s/%s entries", stats["size"], stats["max_size"])
         if stats["evictions"] > 0:
-            self.logger.info(f"  - Evictions: {stats['evictions']}")
+            self.logger.info("  - Evictions: %s", stats["evictions"])
         if estimated_time_saved > 0.1:
-            self.logger.info(f"  - Estimated time saved: {estimated_time_saved:.2f}s")
+            self.logger.info("  - Estimated time saved: %.2fs", estimated_time_saved)
 
 
 class SharedValidationCache:
@@ -388,9 +396,9 @@ class SharedValidationCache:
             return f"{item_type}:{df_hash}:{config_hash}"
 
         except (TypeError, KeyError, ValueError) as e:
-            self.logger.warning(f"Error generating cache key: {e}. Cache disabled for this call.")
+            self.logger.warning("Error generating cache key: %s. Cache disabled for this call.", e)
             # Return unique key to force cache miss
-            return f"error:{time.time()}"
+            return _unique_error_key()
 
     def get(
         self,
@@ -425,14 +433,14 @@ class SharedValidationCache:
             cached_issues, timestamp = cached_data
 
             # Check TTL expiration
-            age = time.time() - timestamp
+            age = time.monotonic() - timestamp
             if age > self.ttl_seconds:
                 self._remove_entry(cache_key)
                 self._stats["misses"] = self._stats.get("misses", 0) + 1
                 return None, cache_key
 
             # Cache hit - update access time and stats
-            self._access_times[cache_key] = time.time()
+            self._access_times[cache_key] = time.monotonic()
             self._stats["hits"] = self._stats.get("hits", 0) + 1
 
             # Return copy to prevent mutation
@@ -520,7 +528,7 @@ class SharedValidationCache:
             cache_key = self._generate_cache_key(df, item_type, required_fields, critical_fields)
 
         with self._lock:
-            now = time.time()
+            now = time.monotonic()
 
             if cache_key not in self._cache:
                 self._ensure_capacity_for_new_entry(now)
@@ -539,7 +547,7 @@ class SharedValidationCache:
             self._access_times.clear()
             return False
 
-        current_time = now if now is not None else time.time()
+        current_time = now if now is not None else time.monotonic()
         if not access_times_reconciled:
             self._reconcile_access_times(current_time)
 

--- a/src/cja_auto_sdr/api/client.py
+++ b/src/cja_auto_sdr/api/client.py
@@ -29,7 +29,7 @@ from cja_auto_sdr.core.exceptions import (
 _LEGACY_TEMP_CONFIG_PREFIXES = ("cja_env_config_", "cja_profile_test_")
 _LEGACY_TEMP_CONFIG_SUFFIX = ".json"
 _LEGACY_TEMP_CONFIG_MAX_AGE_SECONDS = 3600.0
-_temp_cleanup_done = False
+_temp_cleanup_next_check_monotonic = 0.0
 CredentialConfigValue = str | Sequence[str] | None
 
 
@@ -54,10 +54,15 @@ def _bootstrap_dotenv(logger: logging.Logger) -> None:
         logger.debug("Failed to load .env via python-dotenv: %s", e)
 
 
-def _cleanup_stale_temp_configs(logger: logging.Logger) -> None:
-    """Remove leftover temp credential files from older releases."""
+def _cleanup_stale_temp_configs(logger: logging.Logger) -> float:
+    """Remove leftover temp credential files from older releases.
+
+    Returns the number of seconds to wait before the next cleanup scan.
+    """
     temp_dir = Path(tempfile.gettempdir())
     now = time.time()
+    next_scan_in = _LEGACY_TEMP_CONFIG_MAX_AGE_SECONDS
+    retry_immediately = False
 
     try:
         candidates = set()
@@ -65,7 +70,7 @@ def _cleanup_stale_temp_configs(logger: logging.Logger) -> None:
             candidates.update(temp_dir.glob(f"{prefix}*{_LEGACY_TEMP_CONFIG_SUFFIX}"))
     except OSError as e:
         logger.debug("Failed to scan temp directory for stale config files: %s", e)
-        return
+        return 0.0
 
     removed = 0
     for candidate in candidates:
@@ -74,15 +79,20 @@ def _cleanup_stale_temp_configs(logger: logging.Logger) -> None:
         except OSError:
             continue
         if age_seconds < _LEGACY_TEMP_CONFIG_MAX_AGE_SECONDS:
+            next_scan_in = min(next_scan_in, _LEGACY_TEMP_CONFIG_MAX_AGE_SECONDS - age_seconds)
             continue
         try:
             candidate.unlink()
         except OSError:
+            retry_immediately = True
             continue
         removed += 1
 
     if removed:
         logger.debug("Removed %s stale temp credential file(s) from previous runs", removed)
+    if retry_immediately:
+        return 0.0
+    return max(0.0, next_scan_in)
 
 
 def _build_cjapy_config_kwargs(credentials: Mapping[str, CredentialConfigValue]) -> dict[str, str | None]:
@@ -109,10 +119,11 @@ def _config_from_env(credentials: dict[str, str], logger: logging.Logger):
         credentials: Dictionary of credentials from environment
         logger: Logger instance
     """
-    global _temp_cleanup_done  # noqa: PLW0603
-    if not _temp_cleanup_done:
-        _cleanup_stale_temp_configs(logger)
-        _temp_cleanup_done = True
+    global _temp_cleanup_next_check_monotonic  # noqa: PLW0603
+    now = time.monotonic()
+    if now >= _temp_cleanup_next_check_monotonic:
+        next_scan_in = _cleanup_stale_temp_configs(logger)
+        _temp_cleanup_next_check_monotonic = now + max(0.0, next_scan_in)
     cjapy.configure(**_build_cjapy_config_kwargs(credentials))
     logger.debug("Configured cjapy directly from in-memory credentials")
 

--- a/src/cja_auto_sdr/api/client.py
+++ b/src/cja_auto_sdr/api/client.py
@@ -29,6 +29,7 @@ from cja_auto_sdr.core.exceptions import (
 _LEGACY_TEMP_CONFIG_PREFIXES = ("cja_env_config_", "cja_profile_test_")
 _LEGACY_TEMP_CONFIG_SUFFIX = ".json"
 _LEGACY_TEMP_CONFIG_MAX_AGE_SECONDS = 3600.0
+_temp_cleanup_done = False
 CredentialConfigValue = str | Sequence[str] | None
 
 
@@ -40,7 +41,7 @@ def _bootstrap_dotenv(logger: logging.Logger) -> None:
         logger.debug("python-dotenv not installed (.env files will not be auto-loaded)")
         return
     except RECOVERABLE_DOTENV_BOOTSTRAP_EXCEPTIONS as e:
-        logger.debug(f"Failed to import python-dotenv for .env auto-loading: {e}")
+        logger.debug("Failed to import python-dotenv for .env auto-loading: %s", e)
         return
 
     try:
@@ -50,7 +51,7 @@ def _bootstrap_dotenv(logger: logging.Logger) -> None:
         else:
             logger.debug(".env file not found (python-dotenv available but no .env file)")
     except RECOVERABLE_DOTENV_BOOTSTRAP_EXCEPTIONS as e:
-        logger.debug(f"Failed to load .env via python-dotenv: {e}")
+        logger.debug("Failed to load .env via python-dotenv: %s", e)
 
 
 def _cleanup_stale_temp_configs(logger: logging.Logger) -> None:
@@ -63,7 +64,7 @@ def _cleanup_stale_temp_configs(logger: logging.Logger) -> None:
         for prefix in _LEGACY_TEMP_CONFIG_PREFIXES:
             candidates.update(temp_dir.glob(f"{prefix}*{_LEGACY_TEMP_CONFIG_SUFFIX}"))
     except OSError as e:
-        logger.debug(f"Failed to scan temp directory for stale config files: {e}")
+        logger.debug("Failed to scan temp directory for stale config files: %s", e)
         return
 
     removed = 0
@@ -81,7 +82,7 @@ def _cleanup_stale_temp_configs(logger: logging.Logger) -> None:
         removed += 1
 
     if removed:
-        logger.debug(f"Removed {removed} stale temp credential file(s) from previous runs")
+        logger.debug("Removed %s stale temp credential file(s) from previous runs", removed)
 
 
 def _build_cjapy_config_kwargs(credentials: Mapping[str, CredentialConfigValue]) -> dict[str, str | None]:
@@ -108,7 +109,10 @@ def _config_from_env(credentials: dict[str, str], logger: logging.Logger):
         credentials: Dictionary of credentials from environment
         logger: Logger instance
     """
-    _cleanup_stale_temp_configs(logger)
+    global _temp_cleanup_done  # noqa: PLW0603
+    if not _temp_cleanup_done:
+        _cleanup_stale_temp_configs(logger)
+        _temp_cleanup_done = True
     cjapy.configure(**_build_cjapy_config_kwargs(credentials))
     logger.debug("Configured cjapy directly from in-memory credentials")
 
@@ -181,10 +185,10 @@ def configure_cjapy(
         return True, display_source, credentials
 
     except CredentialSourceError as e:
-        logger.error(f"Credential error: {e}")
+        logger.error("Credential error: %s", e)
         return False, str(e), None
     except (ProfileNotFoundError, ProfileConfigError) as e:
-        logger.error(f"Profile error: {e}")
+        logger.error("Profile error: %s", e)
         return False, f"Profile error: {e}", None
 
 
@@ -231,14 +235,14 @@ def initialize_cja(
         resolver = CredentialResolver(logger)
         try:
             credentials, source = resolver.resolve(profile=active_profile, config_file=config_file)
-            logger.info(f"Credentials loaded from: {source}")
+            logger.info("Credentials loaded from: %s", source)
         except CredentialSourceError as e:
             logger.critical("=" * BANNER_WIDTH)
             logger.critical("CREDENTIAL LOADING FAILED")
             logger.critical("=" * BANNER_WIDTH)
             logger.critical(str(e))
             if e.reason:
-                logger.critical(f"Reason: {e.reason}")
+                logger.critical("Reason: %s", e.reason)
             if e.details:
                 logger.critical(e.details)
             logger.critical("")
@@ -251,11 +255,11 @@ def initialize_cja(
         # Configure cjapy with resolved credentials
         if source.startswith("config:"):
             # Config file - use cjapy's native loading
-            logger.info(f"Loading CJA configuration from {config_file}...")
+            logger.info("Loading CJA configuration from %s...", config_file)
             cjapy.importConfigFile(config_file)
         else:
             # Profile or environment credentials go through direct in-memory configuration.
-            logger.info(f"Loading CJA configuration from {source}...")
+            logger.info("Loading CJA configuration from %s...", source)
             _config_from_env(credentials, logger)
 
         logger.info("Configuration loaded successfully")
@@ -276,12 +280,13 @@ def initialize_cja(
             )
             if test_call is not None:
                 logger.info(
-                    f"\u2713 API connection successful! Found {len(test_call) if hasattr(test_call, '__len__') else 'multiple'} data view(s)",
+                    "\u2713 API connection successful! Found %s data view(s)",
+                    len(test_call) if hasattr(test_call, "__len__") else "multiple",
                 )
             else:
                 logger.warning("API connection test returned None - connection may be unstable")
         except RECOVERABLE_CONNECTION_TEST_EXCEPTIONS as test_error:
-            logger.warning(f"Could not verify connection with test call: {test_error!s}")
+            logger.warning("Could not verify connection with test call: %s", test_error)
             logger.warning("Proceeding anyway - errors may occur during data fetching")
 
         logger.info("CJA initialization complete")
@@ -291,8 +296,8 @@ def initialize_cja(
         logger.critical("=" * BANNER_WIDTH)
         logger.critical("CONFIGURATION FILE ERROR")
         logger.critical("=" * BANNER_WIDTH)
-        logger.critical(f"Config file not found: {config_file}")
-        logger.critical(f"Current working directory: {Path.cwd()}")
+        logger.critical("Config file not found: %s", config_file)
+        logger.critical("Current working directory: %s", Path.cwd())
         logger.critical("Please ensure the configuration file exists in the correct location")
         return None
 
@@ -300,7 +305,7 @@ def initialize_cja(
         logger.critical("=" * BANNER_WIDTH)
         logger.critical("DEPENDENCY ERROR")
         logger.critical("=" * BANNER_WIDTH)
-        logger.critical(f"Failed to import cjapy module: {e!s}")
+        logger.critical("Failed to import cjapy module: %s", e)
         logger.critical("Please ensure cjapy is installed: pip install cjapy")
         return None
 
@@ -308,7 +313,7 @@ def initialize_cja(
         logger.critical("=" * BANNER_WIDTH)
         logger.critical("CJA CONFIGURATION ERROR")
         logger.critical("=" * BANNER_WIDTH)
-        logger.critical(f"Configuration error: {e!s}")
+        logger.critical("Configuration error: %s", e)
         logger.critical("This usually indicates an issue with the authentication credentials")
         logger.critical("Please verify all fields in your configuration file are correct")
         return None
@@ -317,7 +322,7 @@ def initialize_cja(
         logger.critical("=" * BANNER_WIDTH)
         logger.critical("PERMISSION ERROR")
         logger.critical("=" * BANNER_WIDTH)
-        logger.critical(f"Cannot read configuration file: {e!s}")
+        logger.critical("Cannot read configuration file: %s", e)
         logger.critical("Please check file permissions")
         return None
 
@@ -325,8 +330,8 @@ def initialize_cja(
         logger.critical("=" * BANNER_WIDTH)
         logger.critical("CJA INITIALIZATION FAILED")
         logger.critical("=" * BANNER_WIDTH)
-        logger.critical(f"Unexpected error: {e!s}")
-        logger.critical(f"Error type: {type(e).__name__}")
+        logger.critical("Unexpected error: %s", e)
+        logger.critical("Error type: %s", type(e).__name__)
         logger.exception("Full error details:")
         logger.critical("")
         logger.critical("Troubleshooting steps:")

--- a/src/cja_auto_sdr/api/fetch.py
+++ b/src/cja_auto_sdr/api/fetch.py
@@ -163,13 +163,13 @@ class ParallelAPIFetcher:
                             detail = task_status.error_message or task_status.reason or "unknown failure"
                             errors[task_name] = detail
                             pbar.set_postfix_str(f"\u2717 {task_name}", refresh=True)
-                            self.logger.error(f"\u2717 {task_name.capitalize()} fetch failed: {detail}")
+                            self.logger.error("\u2717 %s fetch failed: %s", task_name.capitalize(), detail)
                         elif task_status is not None and task_status.status == "empty":
                             pbar.set_postfix_str(f"\u2205 {task_name}", refresh=True)
-                            self.logger.warning(f"\u2205 {task_name.capitalize()} fetch returned no components")
+                            self.logger.warning("\u2205 %s fetch returned no components", task_name.capitalize())
                         else:
                             pbar.set_postfix_str(f"\u2713 {task_name}", refresh=True)
-                            self.logger.info(f"\u2713 {task_name.capitalize()} fetch completed")
+                            self.logger.info("\u2713 %s fetch completed", task_name.capitalize())
                     except Exception as e:  # Intentional: per-task boundary for heterogeneous worker failures
                         errors[task_name] = str(e)
                         self._record_fetch_status(
@@ -179,17 +179,17 @@ class ParallelAPIFetcher:
                             error_message=str(e),
                         )
                         pbar.set_postfix_str(f"\u2717 {task_name}", refresh=True)
-                        self.logger.error(f"\u2717 {task_name.capitalize()} fetch failed: {e}")
+                        self.logger.error("\u2717 %s fetch failed: %s", task_name.capitalize(), e)
                     pbar.update(1)
 
         self.perf_tracker.end("Parallel API Fetch")
 
         # Log summary
         success_count = sum(1 for status in self.get_fetch_statuses().values() if status.status == "success")
-        self.logger.info(f"Parallel fetch complete: {success_count}/3 successful")
+        self.logger.info("Parallel fetch complete: %s/3 successful", success_count)
 
         if errors:
-            self.logger.warning(f"Errors encountered: {list(errors.keys())}")
+            self.logger.warning("Errors encountered: %s", list(errors.keys()))
 
         # Return results with proper None checking for DataFrames
         metrics_result = results.get("metrics")
@@ -235,7 +235,7 @@ class ParallelAPIFetcher:
     def _fetch_metrics(self, data_view_id: str) -> pd.DataFrame:
         """Fetch metrics with error handling and retry"""
         try:
-            self.logger.debug(f"Fetching metrics for {data_view_id}")
+            self.logger.debug("Fetching metrics for %s", data_view_id)
 
             # Use retry for transient network errors with circuit breaker support
             metrics = self._timed_api_call(
@@ -251,12 +251,12 @@ class ParallelAPIFetcher:
                 self._record_fetch_status("metrics", "empty", reason="empty_response", item_count=0)
                 return pd.DataFrame()
 
-            self.logger.info(f"Successfully fetched {len(metrics)} metrics")
+            self.logger.info("Successfully fetched %s metrics", len(metrics))
             self._record_fetch_status("metrics", "success", item_count=len(metrics))
             return metrics
 
         except CircuitBreakerOpen as e:
-            self.logger.warning(f"Circuit breaker open for metrics fetch: {e.message}")
+            self.logger.warning("Circuit breaker open for metrics fetch: %s", e.message)
             self._record_fetch_status(
                 "metrics",
                 "failed",
@@ -265,7 +265,7 @@ class ParallelAPIFetcher:
             )
             return pd.DataFrame()
         except AttributeError as e:
-            self.logger.error(f"API method error - getMetrics may not be available: {e!s}")
+            self.logger.error("API method error - getMetrics may not be available: %s", e)
             self._record_fetch_status(
                 "metrics",
                 "failed",
@@ -274,14 +274,14 @@ class ParallelAPIFetcher:
             )
             return pd.DataFrame()
         except Exception as e:  # Intentional: preserve resilient fallback-to-empty contract for metrics fetch
-            self.logger.error(f"Failed to fetch metrics: {e!s}")
+            self.logger.error("Failed to fetch metrics: %s", e)
             self._record_fetch_status("metrics", "failed", reason="exception", error_message=str(e))
             return pd.DataFrame()
 
     def _fetch_dimensions(self, data_view_id: str) -> pd.DataFrame:
         """Fetch dimensions with error handling and retry"""
         try:
-            self.logger.debug(f"Fetching dimensions for {data_view_id}")
+            self.logger.debug("Fetching dimensions for %s", data_view_id)
 
             # Use retry for transient network errors with circuit breaker support
             dimensions = self._timed_api_call(
@@ -297,12 +297,12 @@ class ParallelAPIFetcher:
                 self._record_fetch_status("dimensions", "empty", reason="empty_response", item_count=0)
                 return pd.DataFrame()
 
-            self.logger.info(f"Successfully fetched {len(dimensions)} dimensions")
+            self.logger.info("Successfully fetched %s dimensions", len(dimensions))
             self._record_fetch_status("dimensions", "success", item_count=len(dimensions))
             return dimensions
 
         except CircuitBreakerOpen as e:
-            self.logger.warning(f"Circuit breaker open for dimensions fetch: {e.message}")
+            self.logger.warning("Circuit breaker open for dimensions fetch: %s", e.message)
             self._record_fetch_status(
                 "dimensions",
                 "failed",
@@ -311,7 +311,7 @@ class ParallelAPIFetcher:
             )
             return pd.DataFrame()
         except AttributeError as e:
-            self.logger.error(f"API method error - getDimensions may not be available: {e!s}")
+            self.logger.error("API method error - getDimensions may not be available: %s", e)
             self._record_fetch_status(
                 "dimensions",
                 "failed",
@@ -320,14 +320,14 @@ class ParallelAPIFetcher:
             )
             return pd.DataFrame()
         except Exception as e:  # Intentional: preserve resilient fallback-to-empty contract for dimensions fetch
-            self.logger.error(f"Failed to fetch dimensions: {e!s}")
+            self.logger.error("Failed to fetch dimensions: %s", e)
             self._record_fetch_status("dimensions", "failed", reason="exception", error_message=str(e))
             return pd.DataFrame()
 
     def _fetch_dataview_info(self, data_view_id: str) -> dict:
         """Fetch data view information with error handling and retry"""
         try:
-            self.logger.debug(f"Fetching data view information for {data_view_id}")
+            self.logger.debug("Fetching data view information for %s", data_view_id)
 
             # Use retry for transient network errors with circuit breaker support
             lookup_data = self._timed_api_call(self.cja.getDataView, data_view_id, operation_name="getDataView")
@@ -353,12 +353,12 @@ class ParallelAPIFetcher:
                 )
 
             validated_payload = assessment.payload or {}
-            self.logger.info(f"Successfully fetched data view info: {validated_payload.get('name', 'Unknown')}")
+            self.logger.info("Successfully fetched data view info: %s", validated_payload.get("name", "Unknown"))
             self._record_fetch_status("dataview", "success")
             return validated_payload
 
         except CircuitBreakerOpen as e:
-            self.logger.warning(f"Circuit breaker open for data view fetch: {e.message}")
+            self.logger.warning("Circuit breaker open for data view fetch: %s", e.message)
             self._record_fetch_status(
                 "dataview",
                 "failed",
@@ -372,7 +372,7 @@ class ParallelAPIFetcher:
                 circuit_breaker_open=True,
             )
         except Exception as e:  # Intentional: preserve resilient lookup-failure payload contract
-            self.logger.error(f"Failed to fetch data view information: {e!s}")
+            self.logger.error("Failed to fetch data view information: %s", e)
             self._record_fetch_status("dataview", "failed", reason="exception", error_message=str(e))
             return self._build_lookup_failure_payload(
                 data_view_id,

--- a/src/cja_auto_sdr/api/quality.py
+++ b/src/cja_auto_sdr/api/quality.py
@@ -57,25 +57,25 @@ class DataQualityChecker:
         # Conditional logging based on log level for performance
         # Only log individual issues in DEBUG mode
         if self.logger.isEnabledFor(logging.DEBUG):
-            self.logger.debug(f"DQ Issue [{severity}] - {item_type}: {description}")
+            self.logger.debug("DQ Issue [%s] - %s: %s", severity, item_type, description)
         elif (
             self.log_high_severity_issues
             and severity in ["CRITICAL", "HIGH"]
             and self.logger.isEnabledFor(logging.WARNING)
         ):
             # In non-DEBUG modes, only log CRITICAL/HIGH severity issues
-            self.logger.warning(f"DQ Issue [{severity}] - {item_type}: {description}")
+            self.logger.warning("DQ Issue [%s] - %s: %s", severity, item_type, description)
         return issue
 
     def check_duplicates(self, df: pd.DataFrame, item_type: str):
         """Check for duplicate names in metrics or dimensions"""
         try:
             if df.empty:
-                self.logger.info(f"Skipping duplicate check for empty {item_type} dataframe")
+                self.logger.info("Skipping duplicate check for empty %s dataframe", item_type)
                 return
 
             if "name" not in df.columns:
-                self.logger.warning(f"'name' column not found in {item_type}. Skipping duplicate check.")
+                self.logger.warning("'name' column not found in %s. Skipping duplicate check.", item_type)
                 return
 
             duplicates = df["name"].value_counts()
@@ -97,7 +97,7 @@ class DataQualityChecker:
         """Validate that required fields are present"""
         try:
             if df.empty:
-                self.logger.info(f"Skipping required fields check for empty {item_type} dataframe")
+                self.logger.info("Skipping required fields check for empty %s dataframe", item_type)
                 return
 
             missing_fields = [field for field in required_fields if field not in df.columns]
@@ -118,7 +118,7 @@ class DataQualityChecker:
         """Check for null values in critical fields"""
         try:
             if df.empty:
-                self.logger.info(f"Skipping null value check for empty {item_type} dataframe")
+                self.logger.info("Skipping null value check for empty %s dataframe", item_type)
                 return
 
             for field in critical_fields:
@@ -141,11 +141,11 @@ class DataQualityChecker:
         """Check for items without descriptions"""
         try:
             if df.empty:
-                self.logger.info(f"Skipping description check for empty {item_type} dataframe")
+                self.logger.info("Skipping description check for empty %s dataframe", item_type)
                 return
 
             if "description" not in df.columns:
-                self.logger.info(f"'description' column not found in {item_type}")
+                self.logger.info("'description' column not found in %s", item_type)
                 return
 
             missing_desc = df[df["description"].isna() | (df["description"] == "")]
@@ -183,11 +183,11 @@ class DataQualityChecker:
         """Check for missing or invalid IDs"""
         try:
             if df.empty:
-                self.logger.info(f"Skipping ID validity check for empty {item_type} dataframe")
+                self.logger.info("Skipping ID validity check for empty %s dataframe", item_type)
                 return
 
             if "id" not in df.columns:
-                self.logger.warning(f"'id' column not found in {item_type}")
+                self.logger.warning("'id' column not found in %s", item_type)
                 return
 
             missing_ids = df[df["id"].isna() | (df["id"] == "")]
@@ -250,7 +250,7 @@ class DataQualityChecker:
                 if cached_issues is not None:
                     with self._issues_lock:
                         self.issues.extend(cached_issues)
-                    self.logger.debug(f"Using cached validation results for {item_type}")
+                    self.logger.debug("Using cached validation results for %s", item_type)
                     return
 
             # Check 1: Empty DataFrame (quick exit)
@@ -333,7 +333,7 @@ class DataQualityChecker:
                     )
 
             if self.logger.isEnabledFor(logging.DEBUG):
-                self.logger.debug(f"Optimized validation complete for {item_type}: {len(df)} items checked")
+                self.logger.debug("Optimized validation complete for %s: %s items checked", item_type, len(df))
 
             if self.validation_cache is not None:
                 self.validation_cache.put(df, item_type, required_fields, critical_fields, local_issues, cache_key)
@@ -388,14 +388,14 @@ class DataQualityChecker:
                         try:
                             future.result()
                             pbar.set_postfix_str(f"\u2713 {task_name}", refresh=True)
-                            self.logger.debug(f"\u2713 {task_name.capitalize()} validation completed")
+                            self.logger.debug("\u2713 %s validation completed", task_name.capitalize())
                         except Exception as e:  # Intentional: Future result collection must handle any worker exception
                             pbar.set_postfix_str(f"\u2717 {task_name}", refresh=True)
-                            self.logger.error(f"\u2717 {task_name.capitalize()} validation failed: {e}")
+                            self.logger.error("\u2717 %s validation failed: %s", task_name.capitalize(), e)
                             self.logger.exception("Full error details:")
                         pbar.update(1)
 
-            self.logger.info(f"Parallel validation complete. Found {len(self.issues)} issue(s)")
+            self.logger.info("Parallel validation complete. Found %s issue(s)", len(self.issues))
 
         except Exception as e:  # Intentional: Parallel executor boundary; thread pool can surface heterogeneous errors
             self.logger.error(_format_error_msg("in parallel validation", error=e))
@@ -439,7 +439,7 @@ class DataQualityChecker:
 
             # Limit to top N issues if max_issues > 0
             if max_issues > 0 and len(df) > max_issues:
-                self.logger.info(f"Limiting data quality issues to top {max_issues} (of {len(df)} total)")
+                self.logger.info("Limiting data quality issues to top %s (of %s total)", max_issues, len(df))
                 df = df.head(max_issues)
 
             return df
@@ -470,12 +470,12 @@ class DataQualityChecker:
             sev = issue["Severity"]
             severity_counts[sev] = severity_counts.get(sev, 0) + 1
 
-        self.logger.info(f"Data quality validation complete: {len(self.issues)} issue(s) found")
+        self.logger.info("Data quality validation complete: %s issue(s) found", len(self.issues))
 
         if self.logger.isEnabledFor(logging.INFO):
             for sev in ["CRITICAL", "HIGH", "MEDIUM", "LOW"]:
                 if sev in severity_counts:
-                    self.logger.info(f"  {sev}: {severity_counts[sev]}")
+                    self.logger.info("  %s: %s", sev, severity_counts[sev])
         elif self.logger.isEnabledFor(logging.WARNING):
             # Minimal warning-level telemetry for production mode.
             high_severity = {
@@ -483,4 +483,4 @@ class DataQualityChecker:
             }
             if high_severity:
                 details = ", ".join(f"{sev}: {count}" for sev, count in high_severity.items())
-                self.logger.warning(f"Data quality high-severity summary: {details}")
+                self.logger.warning("Data quality high-severity summary: %s", details)

--- a/src/cja_auto_sdr/api/resilience.py
+++ b/src/cja_auto_sdr/api/resilience.py
@@ -536,7 +536,7 @@ class CircuitBreaker:
         self._failure_count = 0
         self._success_count = 0
         self._last_failure_time: float | None = None
-        self._last_state_change_time = time.time()
+        self._last_state_change_time = time.monotonic()
         self._lock = threading.Lock()
 
         # Statistics
@@ -571,7 +571,7 @@ class CircuitBreaker:
             if self._state == CircuitState.OPEN:
                 # Check if timeout has elapsed for recovery attempt
                 if self._last_failure_time is not None:
-                    elapsed = time.time() - self._last_failure_time
+                    elapsed = time.monotonic() - self._last_failure_time
                     if elapsed >= self.config.timeout_seconds:
                         self._transition_to(CircuitState.HALF_OPEN)
                         return True
@@ -617,7 +617,7 @@ class CircuitBreaker:
         with self._lock:
             self._failure_count += 1
             self._total_failures += 1
-            self._last_failure_time = time.time()
+            self._last_failure_time = time.monotonic()
 
             if self._state == CircuitState.CLOSED:
                 if self._failure_count >= self.config.failure_threshold:
@@ -637,7 +637,7 @@ class CircuitBreaker:
         """
         old_state = self._state
         self._state = new_state
-        self._last_state_change_time = time.time()
+        self._last_state_change_time = time.monotonic()
 
         if old_state != new_state:
             emit_diagnostic(
@@ -658,11 +658,11 @@ class CircuitBreaker:
             Dict with state, counts, and timing information
         """
         with self._lock:
-            time_in_state = time.time() - self._last_state_change_time
+            time_in_state = time.monotonic() - self._last_state_change_time
             time_until_retry = 0.0
 
             if self._state == CircuitState.OPEN and self._last_failure_time is not None:
-                time_until_retry = max(0.0, self.config.timeout_seconds - (time.time() - self._last_failure_time))
+                time_until_retry = max(0.0, self.config.timeout_seconds - (time.monotonic() - self._last_failure_time))
 
             return {
                 "state": self._state.value,
@@ -683,7 +683,7 @@ class CircuitBreaker:
             self._failure_count = 0
             self._success_count = 0
             self._last_failure_time = None
-            self._last_state_change_time = time.time()
+            self._last_state_change_time = time.monotonic()
             self.logger.debug("Circuit breaker reset to CLOSED state")
 
     def __call__(self, func: Callable[..., T]) -> Callable[..., T]:
@@ -769,11 +769,11 @@ def retry_with_backoff(
                     result = func(*args, **kwargs)
                     # Log success after retry
                     if attempt > 0:
-                        _logger.info(f"✓ {func.__name__} succeeded on attempt {attempt + 1}/{_max_retries + 1}")
+                        _logger.info("✓ %s succeeded on attempt %s/%s", func.__name__, attempt + 1, _max_retries + 1)
                     return result
                 except _retryable_exceptions as e:
                     if attempt == _max_retries:
-                        _logger.error(f"All {_max_retries + 1} attempts failed for {func.__name__}")
+                        _logger.error("All %s attempts failed for %s", _max_retries + 1, func.__name__)
 
                         # Provide enhanced error message based on exception type
                         if isinstance(e, RetryableHTTPError):
@@ -788,7 +788,7 @@ def retry_with_backoff(
                             error_msg = ErrorMessageHelper.get_network_error_message(e, operation=func.__name__)
                             _logger.error("\n" + error_msg)
                         else:  # pragma: no cover — RETRYABLE_EXCEPTIONS exhausted above
-                            _logger.error(f"Error: {e!s}")
+                            _logger.error("Error: %s", e)
                             _logger.error(
                                 "Troubleshooting: Check network connectivity, verify API credentials, or try again later",
                             )
@@ -802,15 +802,19 @@ def retry_with_backoff(
                         delay = delay * random.uniform(*RETRY_JITTER_RANGE)
 
                     _logger.warning(
-                        f"⚠ {func.__name__} attempt {attempt + 1}/{_max_retries + 1} failed: {e!s}. "
-                        f"Retrying in {delay:.1f}s...",
+                        "⚠ %s attempt %s/%s failed: %s. Retrying in %.1fs...",
+                        func.__name__,
+                        attempt + 1,
+                        _max_retries + 1,
+                        e,
+                        delay,
                     )
                     time.sleep(delay)
                 except (
                     Exception
                 ) as e:  # Intentional: Retry loop must catch all to distinguish retryable vs non-retryable
                     # Non-retryable exception, raise immediately
-                    _logger.error(f"{func.__name__} failed with non-retryable error: {e!s}")
+                    _logger.error("%s failed with non-retryable error: %s", func.__name__, e)
                     raise
 
             # Defensive guard: should be unreachable since the last attempt
@@ -896,7 +900,7 @@ def make_api_call_with_retry[T](
 
             # Log success after retry
             if attempt > 0:
-                _logger.info(f"✓ {operation_name} succeeded on attempt {attempt + 1}/{max_retries + 1}")
+                _logger.info("✓ %s succeeded on attempt %s/%s", operation_name, attempt + 1, max_retries + 1)
 
             # Record success to circuit breaker
             if circuit_breaker is not None:
@@ -907,7 +911,7 @@ def make_api_call_with_retry[T](
             last_exception = e
 
             if attempt == max_retries:
-                _logger.error(f"All {max_retries + 1} attempts failed for {operation_name}")
+                _logger.error("All %s attempts failed for %s", max_retries + 1, operation_name)
 
                 # Provide enhanced error message based on exception type
                 if isinstance(e, RetryableHTTPError):
@@ -919,7 +923,7 @@ def make_api_call_with_retry[T](
                     error_msg = ErrorMessageHelper.get_network_error_message(e, operation=operation_name)
                     _logger.error("\n" + error_msg)
                 else:  # pragma: no cover — RETRYABLE_EXCEPTIONS exhausted above
-                    _logger.error(f"Error: {e!s}")
+                    _logger.error("Error: %s", e)
                     _logger.error(
                         "Troubleshooting: Check network connectivity, verify API credentials, or try again later",
                     )
@@ -934,12 +938,17 @@ def make_api_call_with_retry[T](
                 delay = delay * random.uniform(*RETRY_JITTER_RANGE)
 
             _logger.warning(
-                f"⚠ {operation_name} attempt {attempt + 1}/{max_retries + 1} failed: {e!s}. Retrying in {delay:.1f}s...",
+                "⚠ %s attempt %s/%s failed: %s. Retrying in %.1fs...",
+                operation_name,
+                attempt + 1,
+                max_retries + 1,
+                e,
+                delay,
             )
             time.sleep(delay)
         except Exception as e:  # Intentional: Retry loop must catch all to distinguish retryable vs non-retryable
             # Non-retryable exception
-            _logger.error(f"{operation_name} failed with non-retryable error: {e!s}")
+            _logger.error("%s failed with non-retryable error: %s", operation_name, e)
             # Record failure to circuit breaker
             if circuit_breaker is not None:
                 circuit_breaker.record_failure(e)

--- a/src/cja_auto_sdr/api/tuning.py
+++ b/src/cja_auto_sdr/api/tuning.py
@@ -127,7 +127,10 @@ class APIWorkerTuner:
                     self._scale_ups += 1
                     self.logger.info(
                         "API tuner: scaling UP %s \u2192 %s workers (avg response: %.0fms < %sms threshold)",
-                        self._current_workers, new_workers, avg_time, self.config.scale_up_threshold_ms,
+                        self._current_workers,
+                        new_workers,
+                        avg_time,
+                        self.config.scale_up_threshold_ms,
                     )
 
             elif avg_time > self.config.scale_down_threshold_ms and self._current_workers > self.config.min_workers:
@@ -136,7 +139,10 @@ class APIWorkerTuner:
                 self._scale_downs += 1
                 self.logger.info(
                     "API tuner: scaling DOWN %s \u2192 %s workers (avg response: %.0fms > %sms threshold)",
-                    self._current_workers, new_workers, avg_time, self.config.scale_down_threshold_ms,
+                    self._current_workers,
+                    new_workers,
+                    avg_time,
+                    self.config.scale_down_threshold_ms,
                 )
 
             if new_workers is not None:

--- a/src/cja_auto_sdr/api/tuning.py
+++ b/src/cja_auto_sdr/api/tuning.py
@@ -110,7 +110,7 @@ class APIWorkerTuner:
                 return None
 
             # Check cooldown period
-            now = time.time()
+            now = time.monotonic()
             if now - self._last_adjustment_time < self.config.cooldown_seconds:
                 return None
 
@@ -126,8 +126,8 @@ class APIWorkerTuner:
                     new_workers = self._current_workers + 1
                     self._scale_ups += 1
                     self.logger.info(
-                        f"API tuner: scaling UP {self._current_workers} \u2192 {new_workers} workers "
-                        f"(avg response: {avg_time:.0f}ms < {self.config.scale_up_threshold_ms}ms threshold)",
+                        "API tuner: scaling UP %s \u2192 %s workers (avg response: %.0fms < %sms threshold)",
+                        self._current_workers, new_workers, avg_time, self.config.scale_up_threshold_ms,
                     )
 
             elif avg_time > self.config.scale_down_threshold_ms and self._current_workers > self.config.min_workers:
@@ -135,8 +135,8 @@ class APIWorkerTuner:
                 new_workers = self._current_workers - 1
                 self._scale_downs += 1
                 self.logger.info(
-                    f"API tuner: scaling DOWN {self._current_workers} \u2192 {new_workers} workers "
-                    f"(avg response: {avg_time:.0f}ms > {self.config.scale_down_threshold_ms}ms threshold)",
+                    "API tuner: scaling DOWN %s \u2192 %s workers (avg response: %.0fms > %sms threshold)",
+                    self._current_workers, new_workers, avg_time, self.config.scale_down_threshold_ms,
                 )
 
             if new_workers is not None:
@@ -180,4 +180,4 @@ class APIWorkerTuner:
                 self._current_workers = max(self.config.min_workers, min(workers, self.config.max_workers))
             self._response_times.clear()
             self._last_adjustment_time = 0.0
-            self.logger.debug(f"API tuner reset (workers: {self._current_workers})")
+            self.logger.debug("API tuner reset (workers: %s)", self._current_workers)

--- a/src/cja_auto_sdr/api/tuning.py
+++ b/src/cja_auto_sdr/api/tuning.py
@@ -66,7 +66,7 @@ class APIWorkerTuner:
 
         # Rolling window of response times
         self._response_times: list[float] = []
-        self._last_adjustment_time = 0.0
+        self._last_adjustment_time: float | None = None
 
         # Thread safety
         self._lock = threading.Lock()
@@ -111,7 +111,10 @@ class APIWorkerTuner:
 
             # Check cooldown period
             now = time.monotonic()
-            if now - self._last_adjustment_time < self.config.cooldown_seconds:
+            if (
+                self._last_adjustment_time is not None
+                and now - self._last_adjustment_time < self.config.cooldown_seconds
+            ):
                 return None
 
             # Calculate average response time
@@ -185,5 +188,5 @@ class APIWorkerTuner:
             if workers is not None:
                 self._current_workers = max(self.config.min_workers, min(workers, self.config.max_workers))
             self._response_times.clear()
-            self._last_adjustment_time = 0.0
+            self._last_adjustment_time = None
             self.logger.debug("API tuner reset (workers: %s)", self._current_workers)

--- a/src/cja_auto_sdr/cli/execution.py
+++ b/src/cja_auto_sdr/cli/execution.py
@@ -314,7 +314,7 @@ def prepare_sdr_execution_context(
             )
         sys.exit(1)
 
-    processing_start_time = time.time()
+    processing_start_time = time.monotonic()
 
     api_tuning_config = None
     if getattr(args, "api_auto_tune", False):
@@ -452,7 +452,7 @@ def _run_quality_report_mode(
                 break
 
     if not args.quiet:
-        total_runtime = time.time() - processing_start_time
+        total_runtime = time.monotonic() - processing_start_time
         print()
         print(generator.ConsoleColors.bold(f"Total runtime: {total_runtime:.1f}s"))
 
@@ -534,7 +534,7 @@ def _run_batch_mode(
     successful_results = list(results.get("successful", []))
     processed_results = successful_results + list(results.get("failed", []))
 
-    total_runtime = time.time() - processing_start_time
+    total_runtime = time.monotonic() - processing_start_time
     print()
     print(generator.ConsoleColors.bold(f"Total runtime: {total_runtime:.1f}s"))
 
@@ -730,7 +730,7 @@ def _run_single_mode(
     )
     processed_results = [result]
 
-    total_runtime = time.time() - processing_start_time
+    total_runtime = time.monotonic() - processing_start_time
     print()
     if result.success:
         successful_results = [result]

--- a/src/cja_auto_sdr/core/logging.py
+++ b/src/cja_auto_sdr/core/logging.py
@@ -668,12 +668,14 @@ def setup_logging(
 
     if logger.isEnabledFor(logging.INFO):
         if log_file is not None:
-            logger.info(f"Logging initialized. Log file: {log_file}")
+            logger.info("Logging initialized. Log file: %s", log_file)
         else:
             logger.info("Logging initialized. Console output only.")
-        logger.info(f"CJA SDR Generator version: {__version__}", extra={"sdr_version": __version__})
+        logger.info("CJA SDR Generator version: %s", __version__, extra={"sdr_version": __version__})
         logger.info(
-            f"Python {sys.version.split()[0]} on {sys.platform}",
+            "Python %s on %s",
+            sys.version.split()[0],
+            sys.platform,
             extra={"python_version": sys.version.split()[0], "platform": sys.platform},
         )
         try:
@@ -682,9 +684,9 @@ def setup_logging(
             dep_versions = dict.fromkeys(_CORE_DEPENDENCIES, "?")
             logger.debug("Failed to resolve dependency versions for startup logging", exc_info=True)
         dep_summary = ", ".join(f"{pkg}={ver}" for pkg, ver in dep_versions.items())
-        logger.info(f"Dependencies: {dep_summary}", extra={"dependency_versions": dep_versions})
-        logger.info(f"Log level: {log_level.upper()}", extra={"log_level": log_level.upper()})
-        logger.info(f"Run mode: {_infer_run_mode(data_view_id, batch_mode)}")
+        logger.info("Dependencies: %s", dep_summary, extra={"dependency_versions": dep_versions})
+        logger.info("Log level: %s", log_level.upper(), extra={"log_level": log_level.upper()})
+        logger.info("Run mode: %s", _infer_run_mode(data_view_id, batch_mode))
 
     # Flush handlers to ensure log file is not empty even on early exit
     for handler in logging.root.handlers:

--- a/src/cja_auto_sdr/core/perf.py
+++ b/src/cja_auto_sdr/core/perf.py
@@ -18,12 +18,12 @@ class PerformanceTracker:
 
     def start(self, operation_name: str):
         """Start timing an operation"""
-        self.start_times[operation_name] = time.time()
+        self.start_times[operation_name] = time.perf_counter()
 
     def end(self, operation_name: str):
         """End timing an operation"""
         if operation_name in self.start_times:
-            duration = time.time() - self.start_times[operation_name]
+            duration = time.perf_counter() - self.start_times[operation_name]
             if len(self.metrics) >= self.MAX_METRICS:
                 # Drop oldest entry to prevent unbounded growth
                 oldest = next(iter(self.metrics))
@@ -32,7 +32,7 @@ class PerformanceTracker:
 
             # Log individual operations only in DEBUG mode for performance
             if self.logger.isEnabledFor(logging.DEBUG):
-                self.logger.debug(f"\u23f1\ufe0f  {operation_name} completed in {duration:.2f}s")
+                self.logger.debug("\u23f1\ufe0f  %s completed in %.2fs", operation_name, duration)
 
             del self.start_times[operation_name]
 
@@ -60,15 +60,15 @@ class PerformanceTracker:
             self.logger.info("=" * BANNER_WIDTH)
             self.logger.info("VALIDATION CACHE STATISTICS")
             self.logger.info("=" * BANNER_WIDTH)
-            self.logger.info(f"Cache Hits:        {stats['hits']}")
-            self.logger.info(f"Cache Misses:      {stats['misses']}")
-            self.logger.info(f"Hit Rate:          {stats['hit_rate']:.1f}%")
-            self.logger.info(f"Cache Size:        {stats['size']}/{stats['max_size']}")
-            self.logger.info(f"Evictions:         {stats['evictions']}")
+            self.logger.info("Cache Hits:        %s", stats["hits"])
+            self.logger.info("Cache Misses:      %s", stats["misses"])
+            self.logger.info("Hit Rate:          %.1f%%", stats["hit_rate"])
+            self.logger.info("Cache Size:        %s/%s", stats["size"], stats["max_size"])
+            self.logger.info("Evictions:         %s", stats["evictions"])
 
             if stats["hits"] > 0:
                 # Assume average validation takes 50ms, cache lookup takes 1ms
                 time_saved = stats["hits"] * 0.049  # 49ms saved per hit
-                self.logger.info(f"Estimated Time Saved: {time_saved:.2f}s")
+                self.logger.info("Estimated Time Saved: %.2fs", time_saved)
 
             self.logger.info("=" * BANNER_WIDTH)

--- a/src/cja_auto_sdr/core/version.py
+++ b/src/cja_auto_sdr/core/version.py
@@ -1,3 +1,3 @@
 """Version information for CJA Auto SDR."""
 
-__version__ = "3.5.2"
+__version__ = "3.5.3"

--- a/src/cja_auto_sdr/org/analyzer.py
+++ b/src/cja_auto_sdr/org/analyzer.py
@@ -596,7 +596,9 @@ class OrgComponentAnalyzer:
             if pattern:
                 before = len(filtered)
                 filtered = [dv for dv in filtered if not pattern.search(dv.get("name", ""))]
-                self.logger.info("Exclude '%s' removed %s data views", self.config.exclude_pattern, before - len(filtered))
+                self.logger.info(
+                    "Exclude '%s' removed %s data views", self.config.exclude_pattern, before - len(filtered)
+                )
 
         # Track total available before sampling/limiting
         total_available = len(filtered)

--- a/src/cja_auto_sdr/org/analyzer.py
+++ b/src/cja_auto_sdr/org/analyzer.py
@@ -369,7 +369,7 @@ class OrgComponentAnalyzer:
 
     def _run_analysis_impl(self) -> OrgReportResult:
         """Internal implementation of org-wide analysis (called within lock)."""
-        start_time = time.time()
+        start_time = time.monotonic()
         timestamp = datetime.now(UTC).isoformat()
         self._assert_lock_healthy()
 
@@ -389,15 +389,15 @@ class OrgComponentAnalyzer:
                 distribution=ComponentDistribution(),
                 similarity_pairs=None,
                 recommendations=[],
-                duration=time.time() - start_time,
+                duration=time.monotonic() - start_time,
                 is_sampled=is_sampled,
                 total_available_data_views=total_available,
             )
 
         if is_sampled:
-            self.logger.info(f"Sampled {len(data_views)} from {total_available} available data views")
+            self.logger.info("Sampled %s from %s available data views", len(data_views), total_available)
         else:
-            self.logger.info(f"Found {len(data_views)} data views to analyze")
+            self.logger.info("Found %s data views to analyze", len(data_views))
 
         # 2. Fetch components for each data view in parallel
         self.logger.info("Fetching components from all data views...")
@@ -408,7 +408,7 @@ class OrgComponentAnalyzer:
         self.logger.info("Building component index...")
         component_index = self._build_component_index(summaries)
         self._assert_lock_healthy()
-        self.logger.info(f"Indexed {len(component_index)} unique components")
+        self.logger.info("Indexed %s unique components", len(component_index))
 
         # 3.5. Check memory warning
         self._check_memory_warning(component_index)
@@ -447,7 +447,7 @@ class OrgComponentAnalyzer:
             self.logger.info("Computing similarity matrix...")
             similarity_pairs = self._compute_similarity_matrix(summaries, precomputed=pairwise_data)
             effective_threshold = effective_governance_overlap_threshold(self.config.overlap_threshold)
-            self.logger.info(f"Found {len(similarity_pairs)} pairs above threshold (>= {effective_threshold})")
+            self.logger.info("Found %s pairs above threshold (>= %s)", len(similarity_pairs), effective_threshold)
         elif self.config.org_stats_only:
             self.logger.info("Skipping similarity matrix (--org-stats mode)")
         elif self.config.skip_similarity:
@@ -459,7 +459,7 @@ class OrgComponentAnalyzer:
             self.logger.info("Computing data view clusters...")
             clusters = self._compute_clusters(summaries, precomputed=pairwise_data)
             if clusters:
-                self.logger.info(f"Found {len(clusters)} clusters")
+                self.logger.info("Found %s clusters", len(clusters))
 
         # 7. Generate recommendations
         self.logger.info("Generating recommendations...")
@@ -477,7 +477,7 @@ class OrgComponentAnalyzer:
                 len(component_index),
             )
             if thresholds_exceeded:
-                self.logger.warning(f"Governance thresholds exceeded: {len(governance_violations)} violation(s)")
+                self.logger.warning("Governance thresholds exceeded: %s violation(s)", len(governance_violations))
         self._assert_lock_healthy()
 
         # 9. Naming audit (Feature 3)
@@ -502,11 +502,11 @@ class OrgComponentAnalyzer:
             self.logger.info("Detecting stale components...")
             stale_components = self._detect_stale_components(component_index)
             if stale_components:
-                self.logger.info(f"Found {len(stale_components)} components with stale naming patterns")
+                self.logger.info("Found %s components with stale naming patterns", len(stale_components))
         self._assert_lock_healthy()
 
-        duration = time.time() - start_time
-        self.logger.info(f"Analysis complete in {duration:.2f}s")
+        duration = time.monotonic() - start_time
+        self.logger.info("Analysis complete in %.2fs", duration)
 
         return OrgReportResult(
             timestamp=timestamp,
@@ -556,7 +556,7 @@ class OrgComponentAnalyzer:
         try:
             return re.compile(pattern, re.IGNORECASE)
         except re.error as e:
-            self.logger.warning(f"Invalid {name} pattern: {e}")
+            self.logger.warning("Invalid %s pattern: %s", name, e)
             return None
 
     def _list_and_filter_data_views(self) -> tuple[list[dict[str, Any]], bool, int]:
@@ -571,7 +571,7 @@ class OrgComponentAnalyzer:
         try:
             all_data_views = self.cja.getDataViews()
         except Exception as e:  # Intentional: API boundary, return empty result to preserve command resilience.
-            self.logger.error(f"Failed to list data views: {e}")
+            self.logger.error("Failed to list data views: %s", e)
             return [], False, 0
 
         if all_data_views is None or len(all_data_views) == 0:
@@ -588,7 +588,7 @@ class OrgComponentAnalyzer:
             pattern = self._validate_regex_pattern(self.config.filter_pattern, "filter")
             if pattern:
                 filtered = [dv for dv in filtered if pattern.search(dv.get("name", ""))]
-                self.logger.info(f"Filter '{self.config.filter_pattern}' matched {len(filtered)} data views")
+                self.logger.info("Filter '%s' matched %s data views", self.config.filter_pattern, len(filtered))
 
         # Apply exclude filter
         if self.config.exclude_pattern:
@@ -596,7 +596,7 @@ class OrgComponentAnalyzer:
             if pattern:
                 before = len(filtered)
                 filtered = [dv for dv in filtered if not pattern.search(dv.get("name", ""))]
-                self.logger.info(f"Exclude '{self.config.exclude_pattern}' removed {before - len(filtered)} data views")
+                self.logger.info("Exclude '%s' removed %s data views", self.config.exclude_pattern, before - len(filtered))
 
         # Track total available before sampling/limiting
         total_available = len(filtered)
@@ -610,11 +610,11 @@ class OrgComponentAnalyzer:
                 random.seed(self.config.sample_seed)
                 filtered = random.sample(filtered, self.config.sample_size)
             is_sampled = True
-            self.logger.info(f"Sampled {len(filtered)} data views (seed={self.config.sample_seed})")
+            self.logger.info("Sampled %s data views (seed=%s)", len(filtered), self.config.sample_seed)
 
         # Apply limit (after sampling)
         if self.config.limit and len(filtered) > self.config.limit:
-            self.logger.info(f"Limiting to first {self.config.limit} data views")
+            self.logger.info("Limiting to first %s data views", self.config.limit)
             filtered = filtered[: self.config.limit]
 
         return filtered, is_sampled, total_available
@@ -713,7 +713,7 @@ class OrgComponentAnalyzer:
                         to_fetch.append(dv)
 
                 if cache_hits > 0:
-                    self.logger.info(f"Cache: {cache_hits} hits, {len(to_fetch)} to fetch")
+                    self.logger.info("Cache: %s hits, %s to fetch", cache_hits, len(to_fetch))
         else:
             to_fetch = data_views
 
@@ -823,7 +823,7 @@ class OrgComponentAnalyzer:
         """
         dv_id = dv.get("id", "")
         dv_name = dv.get("name", "Unknown")
-        start_time = time.time()
+        start_time = time.monotonic()
 
         try:
             cja = self._get_thread_client()
@@ -942,7 +942,7 @@ class OrgComponentAnalyzer:
                 metric_count=len(metric_ids),
                 dimension_count=len(dimension_ids),
                 status=dv.get("status", "active"),
-                fetch_duration=time.time() - start_time,
+                fetch_duration=time.monotonic() - start_time,
                 metric_names=metric_names,
                 dimension_names=dimension_names,
                 standard_metric_count=standard_metric_count,
@@ -963,7 +963,7 @@ class OrgComponentAnalyzer:
                 data_view_id=dv_id,
                 data_view_name=dv_name,
                 error=error_msg,
-                fetch_duration=time.time() - start_time,
+                fetch_duration=time.monotonic() - start_time,
             )
 
     def _build_component_index(self, summaries: list[DataViewSummary]) -> dict[str, ComponentInfo]:
@@ -1289,7 +1289,7 @@ class OrgComponentAnalyzer:
         try:
             Z = linkage(condensed_dist, method=self.config.cluster_method)
         except Exception as e:  # Intentional: clustering is optional and should never fail the full org report.
-            self.logger.warning(f"Clustering failed: {e}")
+            self.logger.warning("Clustering failed: %s", e)
             return None
 
         # Determine optimal number of clusters using silhouette or fixed threshold

--- a/src/cja_auto_sdr/pipeline/batch.py
+++ b/src/cja_auto_sdr/pipeline/batch.py
@@ -130,12 +130,12 @@ class BatchProcessor:
         self.batch_id = str(uuid.uuid4())[:8]
         base_logger = generator.setup_logging(batch_mode=True, log_level=self.log_level, log_format=self.log_format)
         self.logger = generator.with_log_context(base_logger, run_mode="batch", batch_id=self.batch_id)
-        self.logger.info(f"Batch ID: {self.batch_id}")
+        self.logger.info("Batch ID: %s", self.batch_id)
 
         self._shared_cache = None
         if self.shared_cache_enabled and self.enable_cache and not self.skip_validation:
             self._shared_cache = generator.SharedValidationCache(max_size=self.cache_size, ttl_seconds=self.cache_ttl)
-            self.logger.info(f"[{self.batch_id}] Shared validation cache enabled (max_size={self.cache_size})")
+            self.logger.info("[%s] Shared validation cache enabled (max_size=%s)", self.batch_id, self.cache_size)
 
         try:
             Path(self.output_dir).mkdir(parents=True, exist_ok=True)
@@ -155,16 +155,16 @@ class BatchProcessor:
         generator = _generator_module()
 
         self.logger.info("=" * generator.BANNER_WIDTH)
-        self.logger.info(f"[{self.batch_id}] BATCH PROCESSING START")
+        self.logger.info("[%s] BATCH PROCESSING START", self.batch_id)
         self.logger.info("=" * generator.BANNER_WIDTH)
-        self.logger.info(f"[{self.batch_id}] Data views to process: {len(data_view_ids)}")
-        self.logger.info(f"[{self.batch_id}] Parallel workers: {self.workers}")
-        self.logger.info(f"[{self.batch_id}] Continue on error: {self.continue_on_error}")
-        self.logger.info(f"[{self.batch_id}] Output directory: {self.output_dir}")
-        self.logger.info(f"[{self.batch_id}] Output format: {self.output_format}")
+        self.logger.info("[%s] Data views to process: %s", self.batch_id, len(data_view_ids))
+        self.logger.info("[%s] Parallel workers: %s", self.batch_id, self.workers)
+        self.logger.info("[%s] Continue on error: %s", self.batch_id, self.continue_on_error)
+        self.logger.info("[%s] Output directory: %s", self.batch_id, self.output_dir)
+        self.logger.info("[%s] Output format: %s", self.batch_id, self.output_format)
         self.logger.info("=" * generator.BANNER_WIDTH)
 
-        batch_start_time = time.time()
+        batch_start_time = time.monotonic()
         results = {"successful": [], "failed": [], "total": len(data_view_ids), "total_duration": 0}
 
         worker_args = [
@@ -223,29 +223,30 @@ class BatchProcessor:
                             if result.success:
                                 results["successful"].append(result)
                                 pbar.set_postfix_str(f"✓ {dv_id[:20]}", refresh=True)
-                                self.logger.info(f"[{self.batch_id}] ✓ {dv_id}: SUCCESS ({result.duration:.1f}s)")
+                                self.logger.info("[%s] ✓ %s: SUCCESS (%.1fs)", self.batch_id, dv_id, result.duration)
                             else:
                                 results["failed"].append(result)
                                 pbar.set_postfix_str(f"✗ {dv_id[:20]}", refresh=True)
-                                self.logger.error(f"[{self.batch_id}] ✗ {dv_id}: FAILED - {result.error_message}")
+                                self.logger.error("[%s] ✗ %s: FAILED - %s", self.batch_id, dv_id, result.error_message)
 
                                 if not self.continue_on_error:
                                     self.logger.warning(
-                                        f"[{self.batch_id}] Stopping batch processing due to error (use --continue-on-error to continue)",
+                                        "[%s] Stopping batch processing due to error (use --continue-on-error to continue)",
+                                        self.batch_id,
                                     )
                                     for pending in future_to_dv:
                                         pending.cancel()
                                     break
 
                         except (KeyboardInterrupt, SystemExit):
-                            self.logger.warning(f"[{self.batch_id}] Interrupted - cancelling remaining tasks...")
+                            self.logger.warning("[%s] Interrupted - cancelling remaining tasks...", self.batch_id)
                             for pending in future_to_dv:
                                 pending.cancel()
                             raise
                         except Exception as e:  # Intentional: batch worker resilience boundary
                             is_expected = isinstance(e, generator.RECOVERABLE_BATCH_WORKER_EXCEPTIONS)
                             prefix = "EXCEPTION" if is_expected else "UNEXPECTED EXCEPTION"
-                            self.logger.error(f"[{self.batch_id}] ✗ {dv_id}: {prefix} - {e!s}")
+                            self.logger.error("[%s] ✗ %s: %s - %s", self.batch_id, dv_id, prefix, e)
                             if not is_expected:
                                 self.logger.debug("Unexpected batch worker error", exc_info=True)
                             results["failed"].append(
@@ -261,7 +262,7 @@ class BatchProcessor:
                             )
 
                             if not self.continue_on_error:
-                                self.logger.warning(f"[{self.batch_id}] Stopping batch processing due to error")
+                                self.logger.warning("[%s] Stopping batch processing due to error", self.batch_id)
                                 for pending in future_to_dv:
                                     pending.cancel()
                                 break
@@ -271,8 +272,11 @@ class BatchProcessor:
             if self._shared_cache is not None:
                 cache_stats = self._shared_cache.get_statistics()
                 self.logger.info(
-                    f"[{self.batch_id}] Shared cache stats: {cache_stats['hits']} hits, "
-                    f"{cache_stats['misses']} misses ({cache_stats['hit_rate']:.1f}% hit rate)",
+                    "[%s] Shared cache stats: %s hits, %s misses (%.1f%% hit rate)",
+                    self.batch_id,
+                    cache_stats["hits"],
+                    cache_stats["misses"],
+                    cache_stats["hit_rate"],
                 )
                 emit_diagnostic(
                     self.logger,
@@ -287,7 +291,7 @@ class BatchProcessor:
                 self._shared_cache.shutdown()
                 self._shared_cache = None
 
-        results["total_duration"] = time.time() - batch_start_time
+        results["total_duration"] = time.monotonic() - batch_start_time
         self.print_summary(results)
         return results
 
@@ -306,18 +310,18 @@ class BatchProcessor:
 
         self.logger.info("")
         self.logger.info("=" * generator.BANNER_WIDTH)
-        self.logger.info(f"[{self.batch_id}] BATCH PROCESSING SUMMARY")
+        self.logger.info("[%s] BATCH PROCESSING SUMMARY", self.batch_id)
         self.logger.info("=" * generator.BANNER_WIDTH)
-        self.logger.info(f"[{self.batch_id}] Total data views: {total}")
-        self.logger.info(f"[{self.batch_id}] Successful: {successful_count}")
-        self.logger.info(f"[{self.batch_id}] Failed: {failed_count}")
-        self.logger.info(f"[{self.batch_id}] Success rate: {success_rate:.1f}%")
-        self.logger.info(f"[{self.batch_id}] Total output size: {total_size_formatted}")
-        self.logger.info(f"[{self.batch_id}] Total duration: {total_duration:.1f}s")
-        self.logger.info(f"[{self.batch_id}] Average per data view: {avg_duration:.1f}s")
+        self.logger.info("[%s] Total data views: %s", self.batch_id, total)
+        self.logger.info("[%s] Successful: %s", self.batch_id, successful_count)
+        self.logger.info("[%s] Failed: %s", self.batch_id, failed_count)
+        self.logger.info("[%s] Success rate: %.1f%%", self.batch_id, success_rate)
+        self.logger.info("[%s] Total output size: %s", self.batch_id, total_size_formatted)
+        self.logger.info("[%s] Total duration: %.1fs", self.batch_id, total_duration)
+        self.logger.info("[%s] Average per data view: %.1fs", self.batch_id, avg_duration)
         if total_duration > 0:
             throughput = total / total_duration
-            self.logger.info(f"[{self.batch_id}] Throughput: {throughput:.2f} views/second")
+            self.logger.info("[%s] Throughput: %.2f views/second", self.batch_id, throughput)
         self.logger.info("=" * generator.BANNER_WIDTH)
 
         print()
@@ -348,7 +352,11 @@ class BatchProcessor:
                 line = f"  {result.data_view_id:20s}  {result.data_view_name:30s}  {size_str:>10s}  {result.duration:5.1f}s"
                 print(generator.ConsoleColors.success("  ✓") + line[3:])
                 self.logger.info(
-                    f"  ✓ {result.data_view_id:20s}  {result.data_view_name:30s}  {size_str:>10s}  {result.duration:5.1f}s",
+                    "  ✓ %-20s  %-30s  %10s  %5.1fs",
+                    result.data_view_id,
+                    result.data_view_name,
+                    size_str,
+                    result.duration,
                 )
             print()
             self.logger.info("")
@@ -359,7 +367,7 @@ class BatchProcessor:
             for result in results["failed"]:
                 line = f"  {result.data_view_id:20s}  {result.error_message}"
                 print(generator.ConsoleColors.error("  ✗") + line[3:])
-                self.logger.info(f"  ✗ {result.data_view_id:20s}  {result.error_message}")
+                self.logger.info("  ✗ %-20s  %s", result.data_view_id, result.error_message)
             print()
             self.logger.info("")
 
@@ -370,5 +378,5 @@ class BatchProcessor:
             throughput = (total / total_duration) * 60
             print(f"Throughput: {throughput:.1f} data views per minute")
             print("=" * generator.BANNER_WIDTH)
-            self.logger.info(f"Throughput: {throughput:.1f} data views per minute")
+            self.logger.info("Throughput: %.1f data views per minute", throughput)
             self.logger.info("=" * generator.BANNER_WIDTH)

--- a/tests/README.md
+++ b/tests/README.md
@@ -141,7 +141,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 7,662 comprehensive tests**
+**Total: 7,665 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -150,16 +150,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,556 | 123 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,559 | 123 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 7 | 1 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **7,662** | **129** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **7,665** | **129** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,549 | 122 | `-m "unit and not slow"` |
+| `test-unit` | 7,552 | 122 | `-m "unit and not slow"` |
 | `test-integration` | 103 | 6 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -186,7 +186,7 @@ tests/
 | `test_utils.py` | 50 | Utility functions and helpers |
 | `test_excel_formatting.py` | 28 | Excel sheet formatting and styling |
 | `test_parallel_api_fetcher.py` | 35 | Parallel API data fetching |
-| `test_api_tuning.py` | 24 | API worker auto-tuning |
+| `test_api_tuning.py` | 25 | API worker auto-tuning |
 | `test_error_messages.py` | 23 | Enhanced error messages and guidance |
 | `test_explain_exit_code.py` | 44 | --explain-exit-code shared explainer, parser, fast-path, and run-summary behavior |
 | `test_circuit_breaker.py` | 25 | Circuit breaker pattern |
@@ -196,7 +196,7 @@ tests/
 | `test_process_single_dataview.py` | 44 | End-to-end single data view processing |
 | `test_optimized_validation.py` | 16 | Optimized data quality validation |
 | `test_name_resolution.py` | 24 | Data view name to ID resolution |
-| `test_shared_cache.py` | 26 | Shared validation cache |
+| `test_shared_cache.py` | 28 | Shared validation cache |
 | `test_logging_optimization.py` | 17 | Logging performance optimizations |
 | `test_env_credentials.py` | 15 | Environment variable credentials |
 | `test_dry_run.py` | 15 | Dry-run mode functionality |
@@ -298,7 +298,7 @@ tests/
 | `test_agent_workflows.py` | 69 | Agent workflow shell script validation tests |
 | `test_manifest_agent_contract.py` | 16 | Manifest vs runtime capability drift tests |
 | `test_tool_manifests.py` | 40 | Tool manifest schema and content tests |
-| **Total** | **7,662** | **Collected via pytest --collect-only** |
+| **Total** | **7,665** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -756,13 +756,13 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (7,662 tests total)
+- [x] Comprehensive test coverage (7,665 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 78 tests
-- [x] API worker auto-tuning tests (test_api_tuning.py) - 24 tests
+- [x] API worker auto-tuning tests (test_api_tuning.py) - 25 tests
 - [x] Circuit breaker pattern tests (test_circuit_breaker.py) - 25 tests
-- [x] Shared validation cache tests (test_shared_cache.py) - 26 tests
+- [x] Shared validation cache tests (test_shared_cache.py) - 28 tests
 - [x] Calculated metrics inventory tests (test_calculated_metrics_inventory.py) - 366 tests
 - [x] Segments inventory tests (test_segments_inventory.py) - 48 tests
 - [x] Derived fields inventory tests (test_derived_inventory.py) - 62 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -141,7 +141,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 7,661 comprehensive tests**
+**Total: 7,662 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -150,16 +150,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,555 | 123 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,556 | 123 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 7 | 1 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **7,661** | **129** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **7,662** | **129** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,548 | 122 | `-m "unit and not slow"` |
+| `test-unit` | 7,549 | 122 | `-m "unit and not slow"` |
 | `test-integration` | 103 | 6 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -215,7 +215,7 @@ tests/
 | `test_main_entry_points.py` | 43 | main() and _main_impl() entry points, dispatch, run_state, run summary |
 | `test_quality_policy_and_run_summary.py` | 169 | Quality policy functions and run summary/status inference |
 | `test_e2e_integration.py` | 16 | End-to-end integration tests with real pipeline, mocked API boundary |
-| `test_api_client.py` | 29 | API client exception paths and error handling |
+| `test_api_client.py` | 30 | API client exception paths and error handling |
 | `test_config_validation.py` | 55 | Configuration validation logic |
 | `test_credentials.py` | 73 | Credential resolution and source selection |
 | `test_perf.py` | 7 | Performance utilities (cache eviction, statistics) |
@@ -298,7 +298,7 @@ tests/
 | `test_agent_workflows.py` | 69 | Agent workflow shell script validation tests |
 | `test_manifest_agent_contract.py` | 16 | Manifest vs runtime capability drift tests |
 | `test_tool_manifests.py` | 40 | Tool manifest schema and content tests |
-| **Total** | **7,661** | **Collected via pytest --collect-only** |
+| **Total** | **7,662** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -756,7 +756,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (7,661 tests total)
+- [x] Comprehensive test coverage (7,662 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 78 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -141,7 +141,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 7,665 comprehensive tests**
+**Total: 7,666 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -150,16 +150,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,559 | 123 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,560 | 123 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 7 | 1 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **7,665** | **129** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **7,666** | **129** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,552 | 122 | `-m "unit and not slow"` |
+| `test-unit` | 7,553 | 122 | `-m "unit and not slow"` |
 | `test-integration` | 103 | 6 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -215,7 +215,7 @@ tests/
 | `test_main_entry_points.py` | 43 | main() and _main_impl() entry points, dispatch, run_state, run summary |
 | `test_quality_policy_and_run_summary.py` | 169 | Quality policy functions and run summary/status inference |
 | `test_e2e_integration.py` | 16 | End-to-end integration tests with real pipeline, mocked API boundary |
-| `test_api_client.py` | 30 | API client exception paths and error handling |
+| `test_api_client.py` | 31 | API client exception paths and error handling |
 | `test_config_validation.py` | 55 | Configuration validation logic |
 | `test_credentials.py` | 73 | Credential resolution and source selection |
 | `test_perf.py` | 7 | Performance utilities (cache eviction, statistics) |
@@ -298,7 +298,7 @@ tests/
 | `test_agent_workflows.py` | 69 | Agent workflow shell script validation tests |
 | `test_manifest_agent_contract.py` | 16 | Manifest vs runtime capability drift tests |
 | `test_tool_manifests.py` | 40 | Tool manifest schema and content tests |
-| **Total** | **7,665** | **Collected via pytest --collect-only** |
+| **Total** | **7,666** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -756,7 +756,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (7,665 tests total)
+- [x] Comprehensive test coverage (7,666 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 78 tests

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -23,6 +23,7 @@ import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+import cja_auto_sdr.api.client as _client_module
 from cja_auto_sdr.api.client import (
     _bootstrap_dotenv,
     _config_from_env,
@@ -34,6 +35,12 @@ from cja_auto_sdr.core.exceptions import (
     ProfileConfigError,
     ProfileNotFoundError,
 )
+
+
+@pytest.fixture(autouse=True)
+def _reset_temp_cleanup_guard():
+    """Reset the one-shot temp-cleanup guard between tests."""
+    _client_module._temp_cleanup_done = False
 
 
 @pytest.fixture
@@ -181,7 +188,7 @@ class TestConfigFromEnvCleanup:
         _config_from_env(credentials, mock_logger)
 
         assert not stale_file.exists()
-        assert any("Removed 1 stale temp credential file" in str(call) for call in mock_logger.debug.call_args_list)
+        mock_logger.debug.assert_any_call("Removed %s stale temp credential file(s) from previous runs", 1)
 
     @patch("cja_auto_sdr.api.client.cjapy")
     @patch("cja_auto_sdr.api.client.tempfile.gettempdir")
@@ -202,7 +209,7 @@ class TestConfigFromEnvCleanup:
         _config_from_env(credentials, mock_logger)
 
         assert not stale_file.exists()
-        assert any("Removed 1 stale temp credential file" in str(call) for call in mock_logger.debug.call_args_list)
+        mock_logger.debug.assert_any_call("Removed %s stale temp credential file(s) from previous runs", 1)
 
     @patch("cja_auto_sdr.api.client.cjapy")
     @patch("cja_auto_sdr.api.client.tempfile.gettempdir")
@@ -216,6 +223,18 @@ class TestConfigFromEnvCleanup:
         _config_from_env(credentials, mock_logger)
 
         assert recent_file.exists()
+
+    @patch("cja_auto_sdr.api.client.cjapy")
+    @patch("cja_auto_sdr.api.client._cleanup_stale_temp_configs")
+    def test_stale_cleanup_runs_only_once_per_process(self, mock_cleanup, mock_cjapy, mock_logger):
+        """The temp-directory scan should happen at most once per process."""
+        credentials = {"org_id": "test@AdobeOrg", "client_id": "x", "secret": "y"}
+
+        _config_from_env(credentials, mock_logger)
+        _config_from_env(credentials, mock_logger)
+        _config_from_env(credentials, mock_logger)
+
+        mock_cleanup.assert_called_once_with(mock_logger)
 
 
 # ==================== configure_cjapy default logger (lines 96-97) ====================

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -39,8 +39,8 @@ from cja_auto_sdr.core.exceptions import (
 
 @pytest.fixture(autouse=True)
 def _reset_temp_cleanup_guard():
-    """Reset the one-shot temp-cleanup guard between tests."""
-    _client_module._temp_cleanup_done = False
+    """Reset temp-cleanup scheduling state between tests."""
+    _client_module._temp_cleanup_next_check_monotonic = 0.0
 
 
 @pytest.fixture
@@ -226,15 +226,61 @@ class TestConfigFromEnvCleanup:
 
     @patch("cja_auto_sdr.api.client.cjapy")
     @patch("cja_auto_sdr.api.client._cleanup_stale_temp_configs")
-    def test_stale_cleanup_runs_only_once_per_process(self, mock_cleanup, mock_cjapy, mock_logger):
-        """The temp-directory scan should happen at most once per process."""
+    def test_stale_cleanup_is_throttled_until_due(self, mock_cleanup, mock_cjapy, mock_logger):
+        """The temp-directory scan should only rerun once the scheduled recheck time arrives."""
         credentials = {"org_id": "test@AdobeOrg", "client_id": "x", "secret": "y"}
+        mock_cleanup.side_effect = [30.0, 30.0]
 
-        _config_from_env(credentials, mock_logger)
-        _config_from_env(credentials, mock_logger)
-        _config_from_env(credentials, mock_logger)
+        with patch("cja_auto_sdr.api.client.time.monotonic", side_effect=[100.0, 110.0, 131.0]):
+            _config_from_env(credentials, mock_logger)
+            _config_from_env(credentials, mock_logger)
+            _config_from_env(credentials, mock_logger)
 
-        mock_cleanup.assert_called_once_with(mock_logger)
+        assert mock_cjapy.configure.call_count == 3
+        assert mock_cleanup.call_count == 2
+        mock_cleanup.assert_any_call(mock_logger)
+
+    @patch("cja_auto_sdr.api.client.cjapy")
+    @patch("cja_auto_sdr.api.client.tempfile.gettempdir")
+    def test_recent_temp_configs_are_removed_after_scheduled_recheck(
+        self,
+        mock_gettempdir,
+        mock_cjapy,
+        mock_logger,
+        tmp_path,
+    ):
+        """Legacy temp files skipped while recent should be deleted once they later become stale."""
+        mock_gettempdir.return_value = str(tmp_path)
+        credentials = {"org_id": "test@AdobeOrg", "client_id": "x", "secret": "y"}
+        recent_file = tmp_path / "cja_env_config_recent.json"
+        current_times = {"wall": 10_000.0, "mono": 100.0}
+        recent_file.write_text("{}", encoding="utf-8")
+        os.utime(
+            recent_file,
+            (
+                current_times["wall"] - (_client_module._LEGACY_TEMP_CONFIG_MAX_AGE_SECONDS - 10.0),
+                current_times["wall"] - (_client_module._LEGACY_TEMP_CONFIG_MAX_AGE_SECONDS - 10.0),
+            ),
+        )
+
+        with (
+            patch("cja_auto_sdr.api.client.time.time", side_effect=lambda: current_times["wall"]),
+            patch("cja_auto_sdr.api.client.time.monotonic", side_effect=lambda: current_times["mono"]),
+        ):
+            _config_from_env(credentials, mock_logger)
+            assert recent_file.exists()
+
+            current_times["wall"] += 5.0
+            current_times["mono"] += 5.0
+            _config_from_env(credentials, mock_logger)
+            assert recent_file.exists()
+
+            current_times["wall"] += 6.0
+            current_times["mono"] += 6.0
+            _config_from_env(credentials, mock_logger)
+
+        assert not recent_file.exists()
+        assert mock_cjapy.configure.call_count == 3
 
 
 # ==================== configure_cjapy default logger (lines 96-97) ====================

--- a/tests/test_api_tuning.py
+++ b/tests/test_api_tuning.py
@@ -13,8 +13,8 @@ Validates that APIWorkerTuner:
 
 import os
 import sys
-import time
 from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import patch
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from cja_auto_sdr.generator import APITuningConfig, APIWorkerTuner
@@ -194,7 +194,7 @@ class TestAPIWorkerTunerCooldown:
         assert tuner.current_workers == 4  # No change due to cooldown
 
     def test_allows_adjustment_after_cooldown(self):
-        """Should allow adjustment after cooldown expires"""
+        """Should allow adjustment after cooldown expires (deterministic, no sleep)"""
         config = APITuningConfig(
             min_workers=1,
             max_workers=10,
@@ -202,20 +202,46 @@ class TestAPIWorkerTunerCooldown:
             sample_window=3,
             cooldown_seconds=0.1,  # 100ms cooldown
         )
-        tuner = APIWorkerTuner(config=config, initial_workers=3)
+        fake_now = [100.0]
 
-        # First adjustment
-        for i in range(3):
-            tuner.record_response_time(50)
+        with patch("cja_auto_sdr.api.tuning.time.monotonic", side_effect=lambda: fake_now[0]):
+            tuner = APIWorkerTuner(config=config, initial_workers=3)
+
+            # First adjustment
+            for _ in range(3):
+                tuner.record_response_time(50)
+            assert tuner.current_workers == 4
+
+            # Still cooling down
+            fake_now[0] += 0.05
+            for _ in range(3):
+                tuner.record_response_time(50)
+            assert tuner.current_workers == 4
+
+            # Cooldown elapsed
+            fake_now[0] += 0.1
+            for _ in range(3):
+                tuner.record_response_time(50)
+            assert tuner.current_workers == 5
+
+    def test_first_adjustment_bypasses_cooldown_sentinel(self):
+        """The first adjustment should not be blocked when monotonic starts below cooldown."""
+        config = APITuningConfig(
+            min_workers=1,
+            max_workers=10,
+            scale_up_threshold_ms=200,
+            sample_window=3,
+            cooldown_seconds=10.0,
+        )
+
+        with patch("cja_auto_sdr.api.tuning.time.monotonic", return_value=5.0):
+            tuner = APIWorkerTuner(config=config, initial_workers=3)
+
+            for _ in range(3):
+                result = tuner.record_response_time(50)
+
+        assert result == 4
         assert tuner.current_workers == 4
-
-        # Wait for cooldown
-        time.sleep(0.15)
-
-        # Should allow second adjustment
-        for i in range(3):
-            tuner.record_response_time(50)
-        assert tuner.current_workers == 5
 
 
 class TestAPIWorkerTunerStatistics:

--- a/tests/test_cache_edge_cases.py
+++ b/tests/test_cache_edge_cases.py
@@ -105,15 +105,17 @@ class TestErrorPathKeyGeneration:
             patch.object(cache.logger, "warning"),
             patch(
                 "cja_auto_sdr.api.cache.time.monotonic_ns",
-                side_effect=[1_000_000_000, 1_500_000_000],
+                return_value=1_000_000_000,
             ) as mock_ns,
         ):
             key1 = cache._generate_cache_key("not_a_dataframe", "Metrics", ["id"], ["id"])
             key2 = cache._generate_cache_key("not_a_dataframe", "Metrics", ["id"], ["id"])
-        # Error-path keys intentionally embed a monotonic nanosecond timestamp
-        # so failures cannot collide and accidentally turn into cache hits.
-        assert key1 == "error:1000000000"
-        assert key2 == "error:1500000000"
+        # Error-path keys intentionally include a monotonic timestamp plus
+        # extra uniqueness so repeated failures cannot accidentally collide
+        # into cache hits even if the clock reading repeats.
+        assert key1.startswith("error:1000000000:")
+        assert key2.startswith("error:1000000000:")
+        assert key1 != key2
         assert mock_ns.call_count == 2
 
 

--- a/tests/test_cache_edge_cases.py
+++ b/tests/test_cache_edge_cases.py
@@ -104,17 +104,17 @@ class TestErrorPathKeyGeneration:
         with (
             patch.object(cache.logger, "warning"),
             patch(
-                "cja_auto_sdr.api.cache.time.time",
-                side_effect=[1000.0, 1000.5],
-            ) as mock_time,
+                "cja_auto_sdr.api.cache.time.monotonic_ns",
+                side_effect=[1_000_000_000, 1_500_000_000],
+            ) as mock_ns,
         ):
             key1 = cache._generate_cache_key("not_a_dataframe", "Metrics", ["id"], ["id"])
             key2 = cache._generate_cache_key("not_a_dataframe", "Metrics", ["id"], ["id"])
-        # Error-path keys intentionally embed the current timestamp so failures
-        # cannot collide and accidentally turn into cache hits.
-        assert key1 == "error:1000.0"
-        assert key2 == "error:1000.5"
-        assert mock_time.call_count == 2
+        # Error-path keys intentionally embed a monotonic nanosecond timestamp
+        # so failures cannot collide and accidentally turn into cache hits.
+        assert key1 == "error:1000000000"
+        assert key2 == "error:1500000000"
+        assert mock_ns.call_count == 2
 
 
 # ==================== TTL Boundary ====================
@@ -129,12 +129,12 @@ class TestTTLBoundary:
         cache.put(df, "Metrics", ["id"], ["id"], [{"test": "issue"}])
 
         key = cache._generate_cache_key(df, "Metrics", ["id"], ["id"])
-        now = time.time()
+        now = time.monotonic()
         with cache._lock:
             issues, _ts = cache._cache[key]
             cache._cache[key] = (issues, now - 9.999)  # TTL - epsilon
 
-        with patch("cja_auto_sdr.api.cache.time.time", return_value=now):
+        with patch("cja_auto_sdr.api.cache.time.monotonic", return_value=now):
             result, _key = cache.get(df, "Metrics", ["id"], ["id"])
             assert result is not None
 
@@ -144,12 +144,12 @@ class TestTTLBoundary:
         cache.put(df, "Metrics", ["id"], ["id"], [{"test": "issue"}])
 
         key = cache._generate_cache_key(df, "Metrics", ["id"], ["id"])
-        now = time.time()
+        now = time.monotonic()
         with cache._lock:
             issues, _ts = cache._cache[key]
             cache._cache[key] = (issues, now - 10.001)  # TTL + epsilon
 
-        with patch("cja_auto_sdr.api.cache.time.time", return_value=now):
+        with patch("cja_auto_sdr.api.cache.time.monotonic", return_value=now):
             result, _key = cache.get(df, "Metrics", ["id"], ["id"])
             assert result is None
 
@@ -161,13 +161,13 @@ class TestTTLBoundary:
 
         # Set timestamp to exactly TTL age
         key = cache._generate_cache_key(df, "Metrics", ["id"], ["id"])
-        now = time.time()
+        now = time.monotonic()
         with cache._lock:
             issues, _ts = cache._cache[key]
             cache._cache[key] = (issues, now - 10)  # Exactly at TTL boundary
 
-        # Patch time.time to return consistent value for the comparison
-        with patch("cja_auto_sdr.api.cache.time.time", return_value=now):
+        # Patch time.monotonic to return consistent value for the comparison
+        with patch("cja_auto_sdr.api.cache.time.monotonic", return_value=now):
             result, _key = cache.get(df, "Metrics", ["id"], ["id"])
             # age == ttl_seconds → NOT expired (uses > not >=)
             assert result is not None

--- a/tests/test_org_report.py
+++ b/tests/test_org_report.py
@@ -1406,7 +1406,11 @@ class TestOrgComponentAnalyzer:
         ):
             analyzer.run_analysis()
 
-        assert any("pairs above threshold (>= 0.9)" in str(call.args[0]) for call in mock_logger.info.call_args_list)
+        assert any(
+            "pairs above threshold" in str(call.args[0]) and 0.9 in call.args[1:]
+            for call in mock_logger.info.call_args_list
+            if call.args
+        )
 
     def test_similarity_includes_exact_ninety_percent(self, mock_cja, mock_logger):
         """Test exact 0.9 similarity is included when overlap threshold is higher"""

--- a/tests/test_org_report.py
+++ b/tests/test_org_report.py
@@ -264,12 +264,12 @@ class TestOrgReportLock:
             )
             proc.start()
 
-            deadline = time.time() + 3
+            deadline = time.time() + 5
             while _read_signal(ready_file) is None and time.time() < deadline:
                 time.sleep(0.02)
 
             assert _read_signal(ready_file) == "1"
-            proc.join(timeout=3)
+            proc.join(timeout=5)
             assert not proc.is_alive()
 
             recovered = OrgReportLock("test_org@AdobeOrg", lock_dir=Path(tmpdir))

--- a/tests/test_output_content_validation.py
+++ b/tests/test_output_content_validation.py
@@ -38,7 +38,7 @@ def rich_data_dict():
         "Metadata": pd.DataFrame(
             {
                 "Property": ["Generated At", "Data View ID", "Tool Version", "Total Metrics"],
-                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.5.2", 3],
+                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.5.3", 3],
             },
         ),
         "Data Quality": pd.DataFrame(
@@ -104,7 +104,7 @@ def rich_metadata_dict():
         "Generated At": "2025-01-15 10:30:00 PST",
         "Data View ID": "dv_content_test",
         "Data View Name": "Test DataView",
-        "Tool Version": "3.5.2",
+        "Tool Version": "3.5.3",
         "Metrics Count": "3",
         "Dimensions Count": "4",
     }
@@ -224,7 +224,7 @@ class TestJSONContentValidation:
             data = json.load(f)
 
         assert data["metadata"]["Data View ID"] == "dv_content_test"
-        assert data["metadata"]["Tool Version"] == "3.5.2"
+        assert data["metadata"]["Tool Version"] == "3.5.3"
 
     def test_json_metadata_preserves_partial_markers(self, tmp_path, rich_data_dict, rich_metadata_dict):
         logger = logging.getLogger("json_test")

--- a/tests/test_shared_cache.py
+++ b/tests/test_shared_cache.py
@@ -292,11 +292,12 @@ class TestSharedValidationCacheEviction:
         """Reconciliation should be skipped if expiration pruning already frees capacity."""
         fake_now = [1000000.0]
 
-        def mock_time():
+        def mock_monotonic():
             return fake_now[0]
 
         with patch("cja_auto_sdr.api.cache.time") as mock_time_module:
-            mock_time_module.time = mock_time
+            mock_time_module.monotonic = mock_monotonic
+            mock_time_module.monotonic_ns = lambda: int(fake_now[0] * 1e9)
             cache = SharedValidationCache(max_size=2, ttl_seconds=1)
 
             try:

--- a/tests/test_shared_cache.py
+++ b/tests/test_shared_cache.py
@@ -11,7 +11,6 @@ Validates that SharedValidationCache:
 8. Properly shuts down Manager resources
 """
 
-import time
 from concurrent.futures import ProcessPoolExecutor
 from unittest.mock import patch
 
@@ -31,6 +30,16 @@ def _shared_cache_processpool_worker(cache):
             cache.put(df, "Metrics", ["id"], ["id"], [{"source": "worker"}], cache_key)
             result, _ = cache.get(df, "Metrics", ["id"], ["id"])
         return {"status": "ok", "result": result, "stats": cache.get_statistics()}
+    except Exception as exc:
+        return {"status": "error", "error": f"{type(exc).__name__}: {exc}"}
+
+
+def _shared_cache_touch_worker(cache, item_id):
+    """Worker helper that touches a cached key to refresh its shared recency."""
+    df = pd.DataFrame({"id": [item_id]})
+    try:
+        result, _ = cache.get(df, "Metrics", ["id"], ["id"])
+        return {"status": "ok", "hit": result is not None, "stats": cache.get_statistics()}
     except Exception as exc:
         return {"status": "error", "error": f"{type(exc).__name__}: {exc}"}
 
@@ -258,6 +267,56 @@ class TestSharedValidationCacheEviction:
 
         cache.shutdown()
 
+    def test_access_recency_ignores_wall_clock_jumps(self):
+        """LRU recency should follow monotonic access order even if wall time jumps backward."""
+        wall_now = [1000.0]
+        monotonic_now = [10.0]
+
+        def mock_time():
+            return wall_now[0]
+
+        def mock_monotonic():
+            return monotonic_now[0]
+
+        with patch("cja_auto_sdr.api.cache.time") as mock_time_module:
+            mock_time_module.time = mock_time
+            mock_time_module.monotonic = mock_monotonic
+            mock_time_module.monotonic_ns = lambda: int(monotonic_now[0] * 1e9)
+            cache = SharedValidationCache(max_size=2, ttl_seconds=3600)
+
+            try:
+                df1 = pd.DataFrame({"id": ["a"]})
+                df2 = pd.DataFrame({"id": ["b"]})
+                df3 = pd.DataFrame({"id": ["c"]})
+
+                _, key1 = cache.get(df1, "Metrics", ["id"], ["id"])
+                cache.put(df1, "Metrics", ["id"], ["id"], [{"v": 1}], key1)
+
+                wall_now[0] = 1001.0
+                monotonic_now[0] = 20.0
+                _, key2 = cache.get(df2, "Metrics", ["id"], ["id"])
+                cache.put(df2, "Metrics", ["id"], ["id"], [{"v": 2}], key2)
+
+                # Wall clock jumps backward, but monotonic access ordering keeps advancing.
+                wall_now[0] = 10.0
+                monotonic_now[0] = 30.0
+                cache.get(df1, "Metrics", ["id"], ["id"])
+
+                wall_now[0] = 5.0
+                monotonic_now[0] = 40.0
+                _, key3 = cache.get(df3, "Metrics", ["id"], ["id"])
+                cache.put(df3, "Metrics", ["id"], ["id"], [{"v": 3}], key3)
+
+                result1, _ = cache.get(df1, "Metrics", ["id"], ["id"])
+                result2, _ = cache.get(df2, "Metrics", ["id"], ["id"])
+                result3, _ = cache.get(df3, "Metrics", ["id"], ["id"])
+
+                assert result1 is not None
+                assert result2 is None
+                assert result3 is not None
+            finally:
+                cache.shutdown()
+
     def test_put_defers_full_scans_until_capacity_pressure(self):
         """New keys below capacity should not trigger prune/reconcile full scans."""
         cache = SharedValidationCache(max_size=3, ttl_seconds=3600)
@@ -296,6 +355,7 @@ class TestSharedValidationCacheEviction:
             return fake_now[0]
 
         with patch("cja_auto_sdr.api.cache.time") as mock_time_module:
+            mock_time_module.time = mock_monotonic
             mock_time_module.monotonic = mock_monotonic
             mock_time_module.monotonic_ns = lambda: int(fake_now[0] * 1e9)
             cache = SharedValidationCache(max_size=2, ttl_seconds=1)
@@ -390,25 +450,37 @@ class TestSharedValidationCacheTTL:
     """Test TTL expiration behavior"""
 
     def test_expires_after_ttl(self, sample_metrics_df):
-        """Entries should expire after TTL"""
-        cache = SharedValidationCache(max_size=100, ttl_seconds=0.1)
+        """Entries should expire by monotonic elapsed time even if wall time jumps."""
+        wall_now = [1000.0]
+        monotonic_now = [10.0]
 
-        # Add entry
-        _, key = cache.get(sample_metrics_df, "Metrics", ["id"], ["id"])
-        cache.put(sample_metrics_df, "Metrics", ["id"], ["id"], [{"test": 1}], key)
+        def mock_time():
+            return wall_now[0]
 
-        # Should hit immediately
-        result1, _ = cache.get(sample_metrics_df, "Metrics", ["id"], ["id"])
-        assert result1 is not None
+        def mock_monotonic():
+            return monotonic_now[0]
 
-        # Wait for TTL
-        time.sleep(0.15)
+        with patch("cja_auto_sdr.api.cache.time") as mock_time_module:
+            mock_time_module.time = mock_time
+            mock_time_module.monotonic = mock_monotonic
+            mock_time_module.monotonic_ns = lambda: int(monotonic_now[0] * 1e9)
+            cache = SharedValidationCache(max_size=100, ttl_seconds=1)
 
-        # Should miss after TTL
-        result2, _ = cache.get(sample_metrics_df, "Metrics", ["id"], ["id"])
-        assert result2 is None
+            try:
+                _, key = cache.get(sample_metrics_df, "Metrics", ["id"], ["id"])
+                cache.put(sample_metrics_df, "Metrics", ["id"], ["id"], [{"test": 1}], key)
 
-        cache.shutdown()
+                wall_now[0] = 2000.0
+                monotonic_now[0] = 10.5
+                result1, _ = cache.get(sample_metrics_df, "Metrics", ["id"], ["id"])
+                assert result1 is not None
+
+                wall_now[0] = 1.0
+                monotonic_now[0] = 11.2
+                result2, _ = cache.get(sample_metrics_df, "Metrics", ["id"], ["id"])
+                assert result2 is None
+            finally:
+                cache.shutdown()
 
 
 class TestSharedValidationCacheStatistics:
@@ -527,6 +599,39 @@ class TestSharedValidationCacheSerialization:
             assert parent_stats["size"] == 1
             assert parent_stats["hits"] >= 1
             assert parent_stats["misses"] >= 1
+        finally:
+            cache.shutdown()
+
+    def test_worker_access_refreshes_lru_before_parent_eviction(self):
+        """A worker-process hit should keep that key hot for the parent's next eviction."""
+        cache = SharedValidationCache(max_size=2, ttl_seconds=3600)
+        df1 = pd.DataFrame({"id": ["a"]})
+        df2 = pd.DataFrame({"id": ["b"]})
+        df3 = pd.DataFrame({"id": ["c"]})
+
+        try:
+            _, key1 = cache.get(df1, "Metrics", ["id"], ["id"])
+            cache.put(df1, "Metrics", ["id"], ["id"], [{"v": 1}], key1)
+
+            _, key2 = cache.get(df2, "Metrics", ["id"], ["id"])
+            cache.put(df2, "Metrics", ["id"], ["id"], [{"v": 2}], key2)
+
+            with ProcessPoolExecutor(max_workers=1) as executor:
+                output = executor.submit(_shared_cache_touch_worker, cache, "a").result(timeout=30)
+
+            assert output["status"] == "ok", output.get("error", "worker failed")
+            assert output["hit"] is True
+
+            _, key3 = cache.get(df3, "Metrics", ["id"], ["id"])
+            cache.put(df3, "Metrics", ["id"], ["id"], [{"v": 3}], key3)
+
+            result1, _ = cache.get(df1, "Metrics", ["id"], ["id"])
+            result2, _ = cache.get(df2, "Metrics", ["id"], ["id"])
+            result3, _ = cache.get(df3, "Metrics", ["id"], ["id"])
+
+            assert result1 is not None
+            assert result2 is None
+            assert result3 is not None
         finally:
             cache.shutdown()
 

--- a/tests/test_tuning_edge_cases.py
+++ b/tests/test_tuning_edge_cases.py
@@ -150,7 +150,7 @@ class TestCooldown:
 
         # Simulate cooldown expiry
         with patch("cja_auto_sdr.api.tuning.time") as mock_time:
-            mock_time.time.return_value = tuner._last_adjustment_time + 10  # Well past cooldown
+            mock_time.monotonic.return_value = tuner._last_adjustment_time + 10  # Well past cooldown
             result2 = tuner.record_response_time(100.0)
             assert result2 == 5
 

--- a/tests/test_ux_features.py
+++ b/tests/test_ux_features.py
@@ -344,11 +344,11 @@ class TestCombinedFeatures:
 class TestVersionUpdated:
     """Test that version is correct"""
 
-    def test_version_is_3_5_2(self):
-        """Test that version is 3.5.2"""
+    def test_version_is_3_5_3(self):
+        """Test that version is 3.5.3"""
         from cja_auto_sdr.generator import __version__
 
-        assert __version__ == "3.5.2"
+        assert __version__ == "3.5.3"
 
 
 class TestFormatAutoDetection:

--- a/tests/test_validation_cache.py
+++ b/tests/test_validation_cache.py
@@ -95,11 +95,12 @@ class TestValidationCache:
         """Cache entries should expire after TTL (deterministic, no sleep)"""
         fake_now = [1000000.0]
 
-        def mock_time():
+        def mock_monotonic():
             return fake_now[0]
 
         with patch("cja_auto_sdr.api.cache.time") as mock_time_module:
-            mock_time_module.time = mock_time
+            mock_time_module.monotonic = mock_monotonic
+            mock_time_module.monotonic_ns = lambda: int(fake_now[0] * 1e9)
 
             cache = ValidationCache(max_size=100, ttl_seconds=1)  # 1 second TTL
 
@@ -181,11 +182,12 @@ class TestValidationCache:
         """When full, expired entries should be reclaimed before any live-key eviction."""
         fake_now = [1000000.0]
 
-        def mock_time():
+        def mock_monotonic():
             return fake_now[0]
 
         with patch("cja_auto_sdr.api.cache.time") as mock_time_module:
-            mock_time_module.time = mock_time
+            mock_time_module.monotonic = mock_monotonic
+            mock_time_module.monotonic_ns = lambda: int(fake_now[0] * 1e9)
             cache = ValidationCache(max_size=2, ttl_seconds=1)
             df1 = pd.DataFrame({"id": [1], "name": ["a"], "type": ["x"]})
             df2 = pd.DataFrame({"id": [2], "name": ["b"], "type": ["y"]})


### PR DESCRIPTION
## Summary

- **Clock-source hardening:** Replaced `time.time()` with `time.monotonic()` / `time.perf_counter()` for all in-process elapsed-time, cooldown, and TTL bookkeeping across 7 runtime modules (circuit breaker, API tuner, validation caches, perf tracker, batch processor, CLI execution, org analyzer)
- **Lazy logging cleanup:** Converted 155+ eager f-string logging calls to lazy `%s`-style interpolation across 10 hot-path modules outside `generator.py`
- **Operational hardening:** Extracted shared `_unique_error_key()` helper with nanosecond resolution; added one-shot temp-cleanup guard in `_config_from_env()`
- **Shared cache timing fix:** Switched `SharedValidationCache` and `APIWorkerTuner` to dedicated monotonic clock helpers (`_shared_cache_clock()`, `_local_cache_clock()`); fixed tuner cooldown using `None` sentinel instead of `0.0` to avoid spurious first-call suppression
- **Temp credential cleanup hardening:** `_cleanup_stale_temp_configs()` now returns a next-scan interval, `_config_from_env()` uses a monotonic gate to skip redundant scans, and failed `unlink()` calls trigger an immediate retry on next invocation
- **Release sync:** Version bump 3.5.2 → 3.5.3, changelog, test count update (7,666)

## Test plan

- [x] Full suite green: 7,665 passed, 1 skipped
- [x] Ruff clean across all touched files
- [x] Version sync validated via `check_version_sync.py`
- [x] Test counts synced via `update_test_counts.py --check`
- [x] CI pipeline passes (all 15 checks green)
- [x] Review for patch-scope discipline (no CLI/output contract drift, no generator.py changes)

## Patch-scope discipline review

Verified all 7 criteria:
1. **No CLI/output contract drift** — parser.py, exit_codes.py, agent_output.py, __main__.py untouched
2. **No generator.py changes** — zero diff
3. **Timing changes limited to in-process elapsed logic** — wall-clock preserved for file timestamps, serialized timestamps
4. **Logging preserves rendered messages** — mechanical f-string → %s conversion only
5. **No dependency changes** — pyproject.toml and uv.lock untouched
6. **No import topology changes** — no __init__.py or lazy-forwarding changes
7. **No threshold/heuristic changes** — circuit breaker, retry, tuning thresholds all unchanged