### PR TITLE
v3.5.4: Complete monotonic timing hardening and lazy logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,22 @@ All notable changes to the CJA SDR Generator project will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.4] — 2026-04-01
+
+### Changed
+- Completed monotonic timing hardening: moved the remaining non-`generator.py` wall-clock duration path in `ParallelAPIFetcher._timed_api_call()` to `time.perf_counter()`.
+- Converted remaining eager f-string logging to lazy `%s`-style interpolation in startup/config/report-cache modules (`config_validation.py`, `credentials.py`, `profiles.py`, `stats.py`, `org/cache.py`).
+
+### Fixed
+- Corrected `v3.5.3` changelog entry: temp-file cleanup in `_config_from_env()` uses throttled monotonic rechecks, not a permanent one-shot guard.
+
 ## [3.5.3] — 2026-04-01
 
 ### Changed
 - Replaced wall-clock `time.time()` with `time.monotonic()` / `time.perf_counter()` for all in-process elapsed-time, cooldown, and TTL bookkeeping in circuit breaker, API tuner, validation caches, performance tracker, batch processor, CLI execution, and org analyzer.
 - Converted eager f-string logging to lazy `%s`-style interpolation across hot-path runtime modules outside `generator.py` (`api/`, `core/`, `pipeline/`, `org/`).
 - Extracted shared `_unique_error_key()` helper for cache fallback key generation using monotonic nanosecond resolution.
-- Added one-shot guard for legacy temp-file cleanup in `_config_from_env()` to avoid repeated `/tmp` scans.
+- Added throttled monotonic rechecks for legacy temp-file cleanup in `_config_from_env()` to avoid repeated `/tmp` scans while still periodically cleaning up stale temp configs.
 
 ## [3.5.2] — 2026-03-31
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,8 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Package manager: **uv**
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
-- Current version: v3.5.3
-- Tests: **7,662** across 129 files at **95% coverage gate**
+- Current version: v3.5.4
+- Tests: **7,670** across 129 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)
 

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (7,666+ tests)
+├── tests/                     # Test suite (7,670+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -924,7 +924,7 @@ cja_auto_sdr --list-dataviews --log-level DEBUG
 At launch, the tool logs diagnostic lines containing the tool version, Python version, platform, active log level, inferred run mode (batch, single, or discovery), and dependency versions. These appear automatically at `INFO` level and are useful for troubleshooting environment issues in CI/CD logs or support requests:
 
 ```text
-CJA SDR Generator v3.5.3 | Python 3.14.2 | darwin | log_level=INFO | mode=single
+CJA SDR Generator v3.5.4 | Python 3.14.2 | darwin | log_level=INFO | mode=single
 Dependencies: cjapy=0.2.4.post3, pandas=2.3.3, numpy=2.2.1, xlsxwriter=3.2.9, tqdm=4.67.0
 ```
 

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -203,7 +203,7 @@ This command:
 
 ```bash
 $ uv run cja_auto_sdr -V
-cja_auto_sdr 3.5.3
+cja_auto_sdr 3.5.4
 ```
 
 > **Important:** All commands in this guide assume you're in the `cja_auto_sdr` directory. If you see "command not found", make sure you're in the right directory and have run `uv sync`.

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Quick Reference Card
 
-Single-page command cheat sheet for CJA SDR Generator v3.5.3.
+Single-page command cheat sheet for CJA SDR Generator v3.5.4.
 
 ## Four Main Modes
 

--- a/src/cja_auto_sdr/api/fetch.py
+++ b/src/cja_auto_sdr/api/fetch.py
@@ -215,7 +215,7 @@ class ParallelAPIFetcher:
         Wraps make_api_call_with_retry with timing measurement and tuner feedback.
         Only records timing on successful calls so retries don't inflate metrics.
         """
-        start_time = time.time()
+        start_time = time.perf_counter()
         result = make_api_call_with_retry(
             api_func,
             *args,
@@ -226,7 +226,7 @@ class ParallelAPIFetcher:
         )
         # Record response time only on success to avoid retry delays inflating metrics
         if self.tuner is not None:
-            duration_ms = (time.time() - start_time) * 1000
+            duration_ms = (time.perf_counter() - start_time) * 1000
             new_workers = self.tuner.record_response_time(duration_ms)
             if new_workers is not None:
                 self.max_workers = new_workers

--- a/src/cja_auto_sdr/cli/commands/stats.py
+++ b/src/cja_auto_sdr/cli/commands/stats.py
@@ -89,7 +89,7 @@ def resolve_data_view_names(
     unresolved_names: list[str] = []
 
     try:
-        logger.info(f"Resolving data view identifiers: {identifiers}")
+        logger.info("Resolving data view identifiers: %s", identifiers)
         success, source, credentials = generator.configure_cjapy(profile, config_file, logger)
         if not success:
             error_message = f"Failed to configure credentials: {source}"

--- a/src/cja_auto_sdr/core/config_validation.py
+++ b/src/cja_auto_sdr/core/config_validation.py
@@ -133,27 +133,27 @@ class ConfigValidator:
             valid, error = cls.validate_org_id(credentials["org_id"])
             if not valid:
                 issues.append(error)
-                logger.warning(f"Configuration issue: {error}")
+                logger.warning("Configuration issue: %s", error)
 
         # Validate CLIENT_ID
         if "client_id" in credentials:
             valid, error = cls.validate_client_id(credentials["client_id"])
             if not valid:
                 issues.append(error)
-                logger.warning(f"Configuration issue: {error}")
+                logger.warning("Configuration issue: %s", error)
 
         # Validate SECRET
         if "secret" in credentials:
             valid, error = cls.validate_secret(credentials["secret"])
             if not valid:
                 issues.append(error)
-                logger.warning(f"Configuration issue: {error}")
+                logger.warning("Configuration issue: %s", error)
 
         # Validate SCOPES (warning only - not strictly required)
         if "scopes" in credentials:
             valid, error, _missing = cls.validate_scopes(credentials["scopes"])
             if not valid:
-                logger.warning(f"Configuration warning: {error}")
+                logger.warning("Configuration warning: %s", error)
                 # Don't add to issues - scopes are a warning, not an error
 
         return issues
@@ -195,14 +195,15 @@ def validate_credentials(
     # Check for scopes (warning, not error)
     if "scopes" not in credentials or not credentials.get("scopes", "").strip():
         logger.warning(
-            f"Credentials from {source} missing OAuth scopes - "
+            "Credentials from %s missing OAuth scopes - "
             "recommend setting scopes (copy from Adobe Developer Console)",
+            source,
         )
 
     # Filter credentials to known fields only
     unknown_fields = set(credentials.keys()) - CREDENTIAL_FIELDS["all"]
     if unknown_fields:
-        logger.debug(f"Ignoring unknown fields from {source}: {', '.join(unknown_fields)}")
+        logger.debug("Ignoring unknown fields from %s: %s", source, ", ".join(unknown_fields))
 
     is_valid = (
         len(issues) == 0
@@ -212,7 +213,7 @@ def validate_credentials(
 
     if issues:
         for issue in issues:
-            logger.warning(f"Credential validation ({source}): {issue}")
+            logger.warning("Credential validation (%s): %s", source, issue)
 
     return is_valid, issues
 
@@ -243,7 +244,7 @@ def validate_config_file(config_file: str | Path, logger: logging.Logger) -> boo
     validation_warnings = []
 
     try:
-        logger.info(f"Validating configuration file: {config_file}")
+        logger.info("Validating configuration file: %s", config_file)
 
         config_path = Path(config_file)
 
@@ -258,7 +259,7 @@ def validate_config_file(config_file: str | Path, logger: logging.Logger) -> boo
 
         # Check if file is readable
         if not config_path.is_file():
-            logger.error(f"'{config_file}' is not a valid file")
+            logger.error("'%s' is not a valid file", config_file)
             return False
 
         # Validate JSON structure
@@ -333,7 +334,7 @@ def validate_config_file(config_file: str | Path, logger: logging.Logger) -> boo
         if validation_errors:
             logger.error("Configuration validation FAILED:")
             for error in validation_errors:
-                logger.error(f"  - {error}")
+                logger.error("  - %s", error)
             logger.error("")
 
             # Provide enhanced error message if missing credentials
@@ -354,15 +355,15 @@ def validate_config_file(config_file: str | Path, logger: logging.Logger) -> boo
         if validation_warnings:
             logger.warning("Configuration validation warnings:")
             for warning in validation_warnings:
-                logger.warning(f"  - {warning}")
+                logger.warning("  - %s", warning)
 
         logger.info("Configuration file validated successfully")
         return True
 
     except PermissionError as e:
-        logger.error(f"Permission denied reading config file: {e}")
+        logger.error("Permission denied reading config file: %s", e)
         logger.error("Check file permissions for the configuration file")
         return False
     except (OSError, AttributeError, TypeError, ValueError) as e:
-        logger.error(f"Unexpected error validating config file ({type(e).__name__}): {e!s}")
+        logger.error("Unexpected error validating config file (%s): %s", type(e).__name__, e)
         return False

--- a/src/cja_auto_sdr/core/config_validation.py
+++ b/src/cja_auto_sdr/core/config_validation.py
@@ -195,8 +195,7 @@ def validate_credentials(
     # Check for scopes (warning, not error)
     if "scopes" not in credentials or not credentials.get("scopes", "").strip():
         logger.warning(
-            "Credentials from %s missing OAuth scopes - "
-            "recommend setting scopes (copy from Adobe Developer Console)",
+            "Credentials from %s missing OAuth scopes - recommend setting scopes (copy from Adobe Developer Console)",
             source,
         )
 

--- a/src/cja_auto_sdr/core/credentials.py
+++ b/src/cja_auto_sdr/core/credentials.py
@@ -127,7 +127,7 @@ class CredentialLoader(ABC):
                 return filter_credentials(creds)
             return None
         except (OSError, json.JSONDecodeError) as e:
-            logger.debug(f"Failed to load credentials from {self.source_name}: {e}")
+            logger.debug("Failed to load credentials from %s: %s", self.source_name, e)
             return None
 
     @abstractmethod
@@ -300,7 +300,7 @@ class CredentialResolver:
         # Import here to avoid circular dependency — profile functions are still in generator.py
         from cja_auto_sdr.generator import load_profile_credentials
 
-        self.logger.info(f"Loading credentials from profile '{profile_name}'...")
+        self.logger.info("Loading credentials from profile '%s'...", profile_name)
         try:
             creds = load_profile_credentials(profile_name, self.logger)
             if creds:
@@ -311,9 +311,9 @@ class CredentialResolver:
                     source=f"profile:{profile_name}",
                 )
                 if is_valid:
-                    self.logger.info(f"Using credentials from profile '{profile_name}'")
+                    self.logger.info("Using credentials from profile '%s'", profile_name)
                     return creds, f"profile:{profile_name}"
-                self.logger.warning(f"Profile '{profile_name}' credentials have issues: {issues}")
+                self.logger.warning("Profile '%s' credentials have issues: %s", profile_name, issues)
         except ProfileNotFoundError as e:
             raise CredentialSourceError(
                 str(e),
@@ -364,7 +364,7 @@ class CredentialResolver:
         config_path = Path(config_file)
 
         if not config_path.exists():
-            self.logger.debug(f"Config file not found: {config_path}")
+            self.logger.debug("Config file not found: %s", config_path)
             return None, ""
 
         loader = JsonFileCredentialLoader(config_path)
@@ -378,7 +378,7 @@ class CredentialResolver:
                 source=f"config:{config_path.name}",
             )
             if is_valid:
-                self.logger.info(f"Using credentials from {config_file}")
+                self.logger.info("Using credentials from %s", config_file)
                 return creds, f"config:{config_path.name}"
             # Config file exists but has issues
             raise CredentialSourceError(
@@ -395,7 +395,7 @@ class CredentialResolver:
         self.logger.warning("=" * BANNER_WIDTH)
         self.logger.warning("NOTICE: Both environment variables AND config file detected")
         self.logger.warning("  Environment variables: ORG_ID, CLIENT_ID, SECRET, etc.")
-        self.logger.warning(f"  Config file: {config_path}")
+        self.logger.warning("  Config file: %s", config_path)
         self.logger.warning("  Using: ENVIRONMENT VARIABLES (takes precedence)")
         self.logger.warning("")
         self.logger.warning("To avoid confusion:")
@@ -448,7 +448,7 @@ def validate_env_credentials(credentials: dict[str, str], logger: logging.Logger
     # Use CREDENTIAL_FIELDS for required fields (single source of truth)
     for field in CREDENTIAL_FIELDS["required"]:
         if field not in credentials or not credentials[field].strip():
-            logger.debug(f"Missing required environment variable: {ENV_VAR_MAPPING.get(field, field)}")
+            logger.debug("Missing required environment variable: %s", ENV_VAR_MAPPING.get(field, field))
             return False
 
     # Use unified validation function

--- a/src/cja_auto_sdr/core/profiles.py
+++ b/src/cja_auto_sdr/core/profiles.py
@@ -169,11 +169,11 @@ def load_profile_credentials(profile_name: str, logger: logging.Logger) -> dict[
         )
 
     if json_source and env_credentials:
-        logger.debug(f"Profile '{profile_name}': merged config.json with .env overrides")
+        logger.debug("Profile '%s': merged config.json with .env overrides", profile_name)
     elif json_source:
-        logger.debug(f"Profile '{profile_name}': loaded from config.json")
+        logger.debug("Profile '%s': loaded from config.json", profile_name)
     else:
-        logger.debug(f"Profile '{profile_name}': loaded from .env")
+        logger.debug("Profile '%s': loaded from .env", profile_name)
 
     return credentials
 

--- a/src/cja_auto_sdr/core/version.py
+++ b/src/cja_auto_sdr/core/version.py
@@ -1,3 +1,3 @@
 """Version information for CJA Auto SDR."""
 
-__version__ = "3.5.3"
+__version__ = "3.5.4"

--- a/src/cja_auto_sdr/org/cache.py
+++ b/src/cja_auto_sdr/org/cache.py
@@ -175,7 +175,7 @@ class OrgReportCache:
                 with open(self.cache_file, encoding="utf-8") as f:
                     self._cache = json.load(f)
             except (OSError, json.JSONDecodeError) as e:
-                self.logger.warning(f"Failed to load org report cache from {self.cache_file}: {e}")
+                self.logger.warning("Failed to load org report cache from %s: %s", self.cache_file, e)
                 self._cache = {}
 
     def _save_cache(self) -> None:
@@ -184,7 +184,7 @@ class OrgReportCache:
         try:
             write_json_atomic(self.cache_file, self._cache, indent=2, default=str)
         except OSError as e:
-            self.logger.warning(f"Failed to save org report cache to {self.cache_file}: {e}")
+            self.logger.warning("Failed to save org report cache to %s: %s", self.cache_file, e)
 
     @staticmethod
     def _sanitize_org_id(org_id: str | None) -> str:

--- a/tests/README.md
+++ b/tests/README.md
@@ -141,7 +141,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 7,666 comprehensive tests**
+**Total: 7,670 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -150,16 +150,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,560 | 123 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,564 | 123 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 7 | 1 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **7,666** | **129** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **7,670** | **129** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,553 | 122 | `-m "unit and not slow"` |
+| `test-unit` | 7,557 | 122 | `-m "unit and not slow"` |
 | `test-integration` | 103 | 6 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -229,7 +229,7 @@ tests/
 | `test_lock_backend_edge_cases.py` | 165 | Lock backend metadata I/O, stale detection, legacy parsing |
 | `test_derived_fields_coverage.py` | 161 | Derived field complexity scoring, logic summary, predicates |
 | `test_org_analyzer_coverage.py` | 160 | Org analyzer governance, naming audit, sampling, memory, drift, clustering |
-| `test_api_coverage.py` | 94 | API cache, quality, fetch, resilience exception paths |
+| `test_api_coverage.py` | 98 | API cache, quality, fetch, resilience exception paths |
 | `test_diff_coverage.py` | 61 | Diff comparator, models, git integration edge cases |
 | `test_generator_coverage.py` | 143 | Generator utility functions — coercion, normalization, diff formatting |
 | `test_generator_discovery_compat_coverage.py` | 42 | Generator discovery helper parity with extracted list-command implementations |
@@ -298,7 +298,7 @@ tests/
 | `test_agent_workflows.py` | 69 | Agent workflow shell script validation tests |
 | `test_manifest_agent_contract.py` | 16 | Manifest vs runtime capability drift tests |
 | `test_tool_manifests.py` | 40 | Tool manifest schema and content tests |
-| **Total** | **7,666** | **Collected via pytest --collect-only** |
+| **Total** | **7,670** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -756,7 +756,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (7,666 tests total)
+- [x] Comprehensive test coverage (7,670 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 78 tests

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -593,9 +593,7 @@ class TestParallelAPIFetcherErrors:
         logger = _make_logger()
         perf = PerformanceTracker(logger=logger)
         cja = MagicMock()
-        fetcher = ParallelAPIFetcher(
-            cja=cja, logger=logger, perf_tracker=perf, max_workers=3, quiet=True
-        )
+        fetcher = ParallelAPIFetcher(cja=cja, logger=logger, perf_tracker=perf, max_workers=3, quiet=True)
         assert fetcher.tuner is None
         with patch("cja_auto_sdr.api.fetch.make_api_call_with_retry", return_value="data"):
             result = fetcher._timed_api_call(lambda: None, operation_name="test")

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -537,6 +537,97 @@ class TestParallelAPIFetcherErrors:
             result = fetcher._timed_api_call(lambda: None, operation_name="test")
         assert result == "ok"
 
+    def test_timed_api_call_uses_monotonic_clock(self):
+        """_timed_api_call measures duration with perf_counter, not wall clock."""
+        from cja_auto_sdr.api.fetch import ParallelAPIFetcher
+        from cja_auto_sdr.core.config import APITuningConfig
+        from cja_auto_sdr.core.perf import PerformanceTracker
+
+        logger = _make_logger()
+        perf = PerformanceTracker(logger=logger)
+        cja = MagicMock()
+        config = APITuningConfig(min_workers=1, max_workers=5, sample_window=1, cooldown_seconds=0)
+        fetcher = ParallelAPIFetcher(
+            cja=cja, logger=logger, perf_tracker=perf, max_workers=3, quiet=True, tuning_config=config
+        )
+        # Simulate a deterministic 0.05s elapsed via patched perf_counter
+        clock = iter([100.0, 100.05])
+        with (
+            patch("cja_auto_sdr.api.fetch.time.perf_counter", side_effect=clock),
+            patch("cja_auto_sdr.api.fetch.make_api_call_with_retry", return_value="ok"),
+        ):
+            result = fetcher._timed_api_call(lambda: None, operation_name="test")
+        assert result == "ok"
+        # Tuner should have received ~50ms
+        stats = fetcher.get_tuner_statistics()
+        assert stats is not None
+        assert stats["total_requests"] >= 1
+
+    def test_timed_api_call_nonnegative_even_if_clock_wraps(self):
+        """Duration stays non-negative even with unusual perf_counter values."""
+        from cja_auto_sdr.api.fetch import ParallelAPIFetcher
+        from cja_auto_sdr.core.config import APITuningConfig
+        from cja_auto_sdr.core.perf import PerformanceTracker
+
+        logger = _make_logger()
+        perf = PerformanceTracker(logger=logger)
+        cja = MagicMock()
+        config = APITuningConfig(min_workers=1, max_workers=5, sample_window=1, cooldown_seconds=0)
+        fetcher = ParallelAPIFetcher(
+            cja=cja, logger=logger, perf_tracker=perf, max_workers=3, quiet=True, tuning_config=config
+        )
+        # perf_counter returns identical values → 0ms duration (non-negative)
+        clock = iter([42.0, 42.0])
+        with (
+            patch("cja_auto_sdr.api.fetch.time.perf_counter", side_effect=clock),
+            patch("cja_auto_sdr.api.fetch.make_api_call_with_retry", return_value="ok"),
+        ):
+            result = fetcher._timed_api_call(lambda: None, operation_name="test")
+        assert result == "ok"
+
+    def test_timed_api_call_no_tuner(self):
+        """_timed_api_call works without a tuner (no timing recorded)."""
+        from cja_auto_sdr.api.fetch import ParallelAPIFetcher
+        from cja_auto_sdr.core.perf import PerformanceTracker
+
+        logger = _make_logger()
+        perf = PerformanceTracker(logger=logger)
+        cja = MagicMock()
+        fetcher = ParallelAPIFetcher(
+            cja=cja, logger=logger, perf_tracker=perf, max_workers=3, quiet=True
+        )
+        assert fetcher.tuner is None
+        with patch("cja_auto_sdr.api.fetch.make_api_call_with_retry", return_value="data"):
+            result = fetcher._timed_api_call(lambda: None, operation_name="test")
+        assert result == "data"
+
+    def test_timed_api_call_max_workers_update(self):
+        """_timed_api_call updates max_workers only when tuner returns a new value."""
+        from cja_auto_sdr.api.fetch import ParallelAPIFetcher
+        from cja_auto_sdr.core.config import APITuningConfig
+        from cja_auto_sdr.core.perf import PerformanceTracker
+
+        logger = _make_logger()
+        perf = PerformanceTracker(logger=logger)
+        cja = MagicMock()
+        config = APITuningConfig(min_workers=1, max_workers=5, sample_window=1, cooldown_seconds=0)
+        fetcher = ParallelAPIFetcher(
+            cja=cja, logger=logger, perf_tracker=perf, max_workers=3, quiet=True, tuning_config=config
+        )
+        # Force the tuner to return a new worker count
+        fetcher.tuner.record_response_time = MagicMock(return_value=4)
+        clock = iter([0.0, 0.1])
+        with (
+            patch("cja_auto_sdr.api.fetch.time.perf_counter", side_effect=clock),
+            patch("cja_auto_sdr.api.fetch.make_api_call_with_retry", return_value="ok"),
+        ):
+            fetcher._timed_api_call(lambda: None, operation_name="test")
+        assert fetcher.max_workers == 4
+        fetcher.tuner.record_response_time.assert_called_once()
+        # Duration should be ~100ms
+        actual_ms = fetcher.tuner.record_response_time.call_args[0][0]
+        assert 99.0 <= actual_ms <= 101.0
+
 
 # ===================================================================
 # resilience.py — _parse_env_numeric and _effective_retry_config

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -276,7 +276,8 @@ class TestValidateCredentials:
         }
         _is_valid, _issues = validate_credentials(credentials, logger, strict=False, source="test")
         logger.debug.assert_called()
-        debug_msg = logger.debug.call_args[0][0]
+        debug_call_args = logger.debug.call_args[0]
+        debug_msg = debug_call_args[0] % debug_call_args[1:]
         assert "unknown_field" in debug_msg or "another_unknown" in debug_msg
 
     def test_strict_mode_fails_on_validation_issues(self):

--- a/tests/test_output_content_validation.py
+++ b/tests/test_output_content_validation.py
@@ -38,7 +38,7 @@ def rich_data_dict():
         "Metadata": pd.DataFrame(
             {
                 "Property": ["Generated At", "Data View ID", "Tool Version", "Total Metrics"],
-                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.5.3", 3],
+                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.5.4", 3],
             },
         ),
         "Data Quality": pd.DataFrame(
@@ -104,7 +104,7 @@ def rich_metadata_dict():
         "Generated At": "2025-01-15 10:30:00 PST",
         "Data View ID": "dv_content_test",
         "Data View Name": "Test DataView",
-        "Tool Version": "3.5.3",
+        "Tool Version": "3.5.4",
         "Metrics Count": "3",
         "Dimensions Count": "4",
     }
@@ -224,7 +224,7 @@ class TestJSONContentValidation:
             data = json.load(f)
 
         assert data["metadata"]["Data View ID"] == "dv_content_test"
-        assert data["metadata"]["Tool Version"] == "3.5.3"
+        assert data["metadata"]["Tool Version"] == "3.5.4"
 
     def test_json_metadata_preserves_partial_markers(self, tmp_path, rich_data_dict, rich_metadata_dict):
         logger = logging.getLogger("json_test")

--- a/tests/test_ux_features.py
+++ b/tests/test_ux_features.py
@@ -344,11 +344,11 @@ class TestCombinedFeatures:
 class TestVersionUpdated:
     """Test that version is correct"""
 
-    def test_version_is_3_5_3(self):
-        """Test that version is 3.5.3"""
+    def test_version_is_3_5_4(self):
+        """Test that version is 3.5.4"""
         from cja_auto_sdr.generator import __version__
 
-        assert __version__ == "3.5.3"
+        assert __version__ == "3.5.4"
 
 
 class TestFormatAutoDetection:


### PR DESCRIPTION
## Summary
- Moved the last wall-clock `time.time()` path in `ParallelAPIFetcher._timed_api_call()` to `time.perf_counter()`, completing monotonic timing hardening across all non-`generator.py` modules.
- Converted remaining eager f-string logging to lazy `%s`-style interpolation in startup/config/report-cache modules (`config_validation.py`, `credentials.py`, `profiles.py`, `stats.py`, `org/cache.py`).
- Corrected `v3.5.3` changelog entry: temp-file cleanup uses throttled monotonic rechecks, not a one-shot guard.
- Added 4 new tests for `perf_counter` timing in `fetch.py` (7,670 total).

## Test plan
- [x] Full test suite passes (`uv run pytest tests/ -x -q`)
- [x] Live smoke test against real CJA API (discovery, single SDR, batch, config validation, describe)
- [x] DEBUG-level logging verified clean (no format string errors)
- [x] CI green on push