### PR TITLE
v3.5.5 — actionable API error hints across all CLI paths + setup doc improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ All notable changes to the CJA SDR Generator project will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.5] — 2026-04-01
+
+### Added
+- Centralized `api_connection_hint()` in `core/exceptions.py` — maps cryptic API exceptions to plain-English guidance across 12 error paths.
+- `_print_api_hint()` in `generator.py` — consistent stderr hint printer with machine-readable suppression gate.
+- Actionable hints for `--validate-config`, `--profile-test`, `--org-report`, `--batch`, `--diff`, `--stats`, discovery commands, and interactive mode.
+
+### Changed
+- Streamlined QUICKSTART_GUIDE.md prerequisites around uv (auto-manages Python), added pip fallback, elevated AEP API requirement.
+- Added `--validate-config` error patterns section to TROUBLESHOOTING.md.
+
+### Fixed
+- Hardened all hint call sites against unexpected exception shapes (`AttributeError`, missing `.response`).
+- Narrowed 403 hints to avoid false positives on data view lookup failures.
+
 ## [3.5.4] — 2026-04-01
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Package manager: **uv**
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
-- Current version: v3.5.4
+- Current version: v3.5.5
 - Tests: **7,670** across 129 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (7,678+ tests)
+├── tests/                     # Test suite (7,685+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (7,714+ tests)
+├── tests/                     # Test suite (7,719+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (7,696+ tests)
+├── tests/                     # Test suite (7,701+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (7,676+ tests)
+├── tests/                     # Test suite (7,678+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (7,701+ tests)
+├── tests/                     # Test suite (7,714+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (7,685+ tests)
+├── tests/                     # Test suite (7,693+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (7,670+ tests)
+├── tests/                     # Test suite (7,676+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (7,693+ tests)
+├── tests/                     # Test suite (7,696+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -924,7 +924,7 @@ cja_auto_sdr --list-dataviews --log-level DEBUG
 At launch, the tool logs diagnostic lines containing the tool version, Python version, platform, active log level, inferred run mode (batch, single, or discovery), and dependency versions. These appear automatically at `INFO` level and are useful for troubleshooting environment issues in CI/CD logs or support requests:
 
 ```text
-CJA SDR Generator v3.5.4 | Python 3.14.2 | darwin | log_level=INFO | mode=single
+CJA SDR Generator v3.5.5 | Python 3.14.2 | darwin | log_level=INFO | mode=single
 Dependencies: cjapy=0.2.4.post3, pandas=2.3.3, numpy=2.2.1, xlsxwriter=3.2.9, tqdm=4.67.0
 ```
 

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -28,27 +28,11 @@ Before starting, ensure you have:
 
 - [ ] **Adobe CJA Access** - Access to Adobe CJA with at least one Data View configured
 - [ ] **Adobe Developer Console Access** - Permission to create API integrations
-- [ ] **Python 3.14+** - Check with `python3 --version` ([download Python](https://www.python.org/downloads/) if needed)
+- [ ] **uv package manager** (recommended) - Install from [astral.sh/uv](https://docs.astral.sh/uv/) (see [Step 2.1](#21-install-uv-package-manager) below). `uv` automatically manages Python for you — no separate Python install needed.
 - [ ] **Terminal/Command Line** - Basic familiarity with running commands ([terminal basics guide](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Understanding_client-side_tools/Command_line))
 - [ ] **20 minutes** - Most time is spent on Adobe Developer Console setup
 
-### Verify Python Installation
-
-**macOS/Linux:**
-```bash
-$ python3 --version
-Python 3.14.x
-```
-
-**Windows (PowerShell):**
-```powershell
-> python --version
-Python 3.14.x
-```
-
-> **Note:** On macOS and Linux, use `python3` to ensure you're using Python 3. On Windows, the command is typically just `python`. You can also use `py --version` on Windows if the Python Launcher is installed.
-
-If Python isn't installed or is an older version, visit [python.org](https://www.python.org/downloads/) to download the latest version.
+> **Can't install uv?** You can use pip instead — you'll need Python 3.14+ installed manually ([download Python](https://www.python.org/downloads/)). See the [pip-based installation instructions](INSTALLATION.md#option-4-legacy-pip-with-virtual-environment) for the alternative workflow.
 
 ---
 
@@ -195,6 +179,7 @@ Installed 15 packages in 0.8s
 ```
 
 This command:
+- Downloads the required Python version automatically (if not already present)
 - Creates a [virtual environment](https://realpython.com/python-virtual-environments-a-primer/) in `.venv/` (isolates project dependencies)
 - Installs all required packages
 - Installs the `cja_auto_sdr` command
@@ -212,15 +197,14 @@ cja_auto_sdr 3.5.4
 
 ### Running Commands
 
-You have three equivalent options:
+You have two equivalent options:
 
 | Method | Command | Notes |
 |--------|---------|-------|
-| **uv run** | `uv run cja_auto_sdr ...` | Works immediately on macOS/Linux, may have issues on Windows |
+| **uv run** (recommended) | `uv run cja_auto_sdr ...` | No venv activation needed; works immediately on macOS/Linux |
 | **Activated venv** | `cja_auto_sdr ...` | After activating: `source .venv/bin/activate` (Unix) or `.venv\Scripts\activate` (Windows) |
-| **Direct script** | `cja_auto_sdr ...` | Most reliable on Windows |
 
-This guide uses `uv run`. Windows users should substitute with `cja_auto_sdr`. The command examples below omit the prefix for brevity.
+This guide uses `uv run` for all examples. Windows users who encounter issues with `uv run` should activate the venv and use `cja_auto_sdr` directly instead (see [Windows troubleshooting](#windows-uv-run-command-doesnt-work)).
 
 **Alternative: Manual activation**
 
@@ -548,7 +532,7 @@ Generating Excel file...
 ============================================================
 ```
 
-### 5.3 Locate Your Output
+### 5.4 Locate Your Output
 
 The generated file is in the current directory:
 

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -122,7 +122,7 @@ After setup, you'll see your credentials. You need these four values:
 | **Scopes** | OAuth Server-to-Server > Scopes | Pre-filled after both APIs are added |
 
 > **Tip:** Copy your scopes **after** adding both the CJA and AEP APIs. The Developer Console aggregates scopes from all APIs in your project, so copying before both are added may give you an incomplete set.
-
+>
 > **Important:** Keep these credentials secure. Never commit them to version control.
 
 ---

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -190,7 +190,7 @@ This command:
 
 ```bash
 $ uv run cja_auto_sdr -V
-cja_auto_sdr 3.5.4
+cja_auto_sdr 3.5.5
 ```
 
 > **Important:** All commands in this guide assume you're in the `cja_auto_sdr` directory. If you see "command not found", make sure you're in the right directory and have run `uv sync`.

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -86,7 +86,7 @@ Choose **OAuth Server-to-Server** (recommended):
 
 ### 1.5 Add the Adobe Experience Platform (AEP) API
 
-> **Important:** The [Adobe Experience Platform API](https://developer.adobe.com/experience-platform-apis/) must be added to your project. This associates your service account with an Experience Platform product profile, which is required for CJA API authentication.
+> **⚠ Required — do not skip this step.** Your project needs **both** the CJA API (added above) **and** the [Adobe Experience Platform API](https://developer.adobe.com/experience-platform-apis/). The AEP API associates your service account with an Experience Platform product profile, which is required for CJA API authentication. Without it, API calls will fail with a generic error (e.g. `API connection failed: 'content'`).
 
 1. In your project, click **"Add API"** again
 2. Search for **"Experience Platform API"** (under Adobe Experience Platform)
@@ -97,10 +97,10 @@ Choose **OAuth Server-to-Server** (recommended):
 
 1. Select **"OAuth Server-to-Server"** (same as CJA)
 2. Click **"Next"**
-3. Select a product profile (this associates your service account with Experience Platform)
+3. Select a product profile — this grants the **service account** (not your user account) access to Experience Platform
 4. Click **"Save configured API"**
 
-> **Note:** If you don't see any product profiles, contact your Adobe Admin Console administrator to ensure your user has been added to an AEP product profile.
+> **Note:** If you don't see any product profiles, contact your Adobe Admin Console administrator to ensure your organization has AEP product profiles configured. The service account must be explicitly granted access — your own user permissions do not carry over to API calls.
 
 ### 1.7 Verify Both APIs Are Added
 
@@ -119,7 +119,9 @@ After setup, you'll see your credentials. You need these four values:
 | **Organization ID** | Top-right of console, or project overview | `ABC123@AdobeOrg` |
 | **Client ID** | OAuth Server-to-Server > Credentials | `cm12345abcdef...` |
 | **Client Secret** | Click "Retrieve client secret" | `p8e-ABC123...` |
-| **Scopes** | OAuth Server-to-Server > Scopes | Usually pre-filled |
+| **Scopes** | OAuth Server-to-Server > Scopes | Pre-filled after both APIs are added |
+
+> **Tip:** Copy your scopes **after** adding both the CJA and AEP APIs. The Developer Console aggregates scopes from all APIs in your project, so copying before both are added may give you an incomplete set.
 
 > **Important:** Keep these credentials secure. Never commit them to version control.
 
@@ -337,13 +339,13 @@ Before generating reports, verify everything is configured correctly.
 
 ### 4.1 Validate Configuration
 
-First, check that your credentials are valid:
+First, check that your credentials are valid and can reach the API:
 
 ```bash
 uv run cja_auto_sdr --validate-config
 ```
 
-This verifies your configuration without making API calls.
+This runs a 5-step check: environment, dependencies, credentials, API connectivity, and output permissions. If the API connection step fails, see [API Permission Errors](TROUBLESHOOTING.md#api-permission-errors) for common causes.
 
 ### 4.2 Test API Connection
 

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -86,7 +86,7 @@ Choose **OAuth Server-to-Server** (recommended):
 
 ### 1.5 Add the Adobe Experience Platform (AEP) API
 
-> **⚠ Required — do not skip this step.** Your project needs **both** the CJA API (added above) **and** the [Adobe Experience Platform API](https://developer.adobe.com/experience-platform-apis/). The AEP API associates your service account with an Experience Platform product profile, which is required for CJA API authentication. Without it, API calls will fail with a generic error (e.g. `API connection failed: 'content'`).
+> **⚠ Required — do not skip this step.** Your project needs **both** the CJA API (added above) **and** the [Adobe Experience Platform API](https://developer.adobe.com/experience-platform-apis/). The AEP API associates your service account with an Experience Platform product profile, which is required for CJA API authentication. Without it, `--validate-config` will report the failure with guidance on how to fix it.
 
 1. In your project, click **"Add API"** again
 2. Search for **"Experience Platform API"** (under Adobe Experience Platform)

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Quick Reference Card
 
-Single-page command cheat sheet for CJA SDR Generator v3.5.4.
+Single-page command cheat sheet for CJA SDR Generator v3.5.5.
 
 ## Four Main Modes
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -387,12 +387,49 @@ uv pip list | grep cjapy
 
 ---
 
+## `--validate-config` Errors
+
+The `--validate-config` command runs 5 checks. If Step [4/5] (API connection) fails, the error message comes directly from the API response and can be cryptic. Here are the most common ones:
+
+### `API connection failed: 'content'`
+
+**Cause:** The API returned an empty or malformed response. This almost always means the Developer Console project is missing the AEP API, or the service account has not been granted product profile access.
+
+**Solution:**
+
+1. Verify **both** the CJA API and AEP API are added to your project (see [Quickstart Guide — Step 1.5](QUICKSTART_GUIDE.md#15-add-the-adobe-experience-platform-aep-api))
+2. Verify the service account is assigned to the correct product profiles for both APIs
+3. Wait 5-10 minutes after making permission changes, then re-run `--validate-config`
+
+### `API connection failed: HTTP 401` or `HTTP 403`
+
+**Cause:** Authentication or authorization failed — invalid credentials or insufficient permissions.
+
+**Solution:**
+
+1. Re-check your `client_id` and `client_secret` against the Developer Console
+2. Verify your OAuth scopes match the Developer Console exactly (copy scopes **after** adding both APIs)
+3. Ensure the service account has product profile access in [Admin Console](https://adminconsole.adobe.com/)
+
+### `API connection failed (unexpected): ...`
+
+**Cause:** An unexpected error during the API connection test — could be a network issue, proxy misconfiguration, or internal library error.
+
+**Solution:**
+
+1. Check your network connectivity
+2. Re-run with `--log-level DEBUG` to see the full traceback
+3. If the issue persists, try `--config-status` first to validate credentials without an API call
+
+---
+
 ## API Permission Errors
 
 ### Missing AEP API Integration
 
 **Symptoms:**
 ```
+✗ API connection failed: 'content'
 ERROR - Failed to fetch segments: 403 Forbidden
 ERROR - Unable to retrieve calculated metrics
 WARNING - Inventory features may be unavailable

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -401,6 +401,8 @@ The `--validate-config` command runs 5 checks. If Step [4/5] (API connection) fa
 2. Verify the service account is assigned to the correct product profiles for both APIs
 3. Wait 5-10 minutes after making permission changes, then re-run `--validate-config`
 
+For detailed steps, see [Missing AEP API Integration](#missing-aep-api-integration) below.
+
 ### `API connection failed: HTTP 401` or `HTTP 403`
 
 **Cause:** Authentication or authorization failed — invalid credentials or insufficient permissions.

--- a/src/cja_auto_sdr/cli/commands/config.py
+++ b/src/cja_auto_sdr/cli/commands/config.py
@@ -486,7 +486,9 @@ def validate_config_only(
     except generator.RECOVERABLE_CONFIG_API_EXCEPTIONS as e:
         _print_api_connection_failure(generator, e)
         all_passed = False
-    except (AttributeError, RuntimeError) as e:
+    except Exception as e:
+        if isinstance(e, SystemError):
+            raise
         _print_api_connection_failure(generator, e, unexpected=True)
         logging.getLogger(__name__).debug("Unexpected validate-config error", exc_info=True)
         all_passed = False

--- a/src/cja_auto_sdr/cli/commands/config.py
+++ b/src/cja_auto_sdr/cli/commands/config.py
@@ -38,6 +38,22 @@ def _api_connection_hint(exc: Exception) -> str | None:
     return api_connection_hint(exc)
 
 
+def _print_api_connection_failure(
+    generator: Any,
+    exc: Exception,
+    *,
+    unexpected: bool = False,
+) -> None:
+    """Render validate-config API failures with consistent hint handling."""
+    hint = _api_connection_hint(exc)
+    label = "API connection failed (unexpected)" if unexpected and hint is None else "API connection failed"
+    print(generator.ConsoleColors.error(f"  \u2717 {label}: {exc!s}"))
+    if hint:
+        print()
+        for line in hint.splitlines():
+            print(generator.ConsoleColors.warning(f"    {line}"))
+
+
 def generate_sample_config(output_path: str = "config.sample.json") -> bool:
     """Generate a sample configuration file."""
     generator = _generator_module()
@@ -468,15 +484,10 @@ def validate_config_only(
         print(generator.ConsoleColors.warning("Validation cancelled."))
         raise
     except generator.RECOVERABLE_CONFIG_API_EXCEPTIONS as e:
-        print(generator.ConsoleColors.error(f"  \u2717 API connection failed: {e!s}"))
-        hint = _api_connection_hint(e)
-        if hint:
-            print()
-            for line in hint.splitlines():
-                print(generator.ConsoleColors.warning(f"    {line}"))
+        _print_api_connection_failure(generator, e)
         all_passed = False
     except (AttributeError, RuntimeError) as e:
-        print(generator.ConsoleColors.error(f"  \u2717 API connection failed (unexpected): {e!s}"))
+        _print_api_connection_failure(generator, e, unexpected=True)
         logging.getLogger(__name__).debug("Unexpected validate-config error", exc_info=True)
         all_passed = False
 

--- a/src/cja_auto_sdr/cli/commands/config.py
+++ b/src/cja_auto_sdr/cli/commands/config.py
@@ -27,6 +27,35 @@ def _generator_module():
     return _generator
 
 
+def _api_connection_hint(exc: Exception) -> str | None:
+    """Return an actionable hint for common API connection failures.
+
+    Maps opaque exceptions (e.g. ``KeyError('content')``) to plain-English
+    guidance so users don't have to guess what went wrong.
+    """
+    if isinstance(exc, KeyError):
+        key = str(exc).strip("'\"")
+        if key == "content":
+            return (
+                "Hint: This usually means the API returned an empty or malformed response.\n"
+                "      Verify that both the CJA API and AEP API are added to your Adobe\n"
+                "      Developer Console project, and that the service account is granted\n"
+                "      access to the correct product profiles."
+            )
+        return (
+            f"Hint: API response missing expected key '{key}'.\n"
+            "      Check your OAuth credentials and Developer Console project configuration."
+        )
+    status = getattr(exc, "status_code", None)
+    if status in (401, 403):
+        return (
+            f"Hint: Received HTTP {status} — authentication or authorization failed.\n"
+            "      Verify your client_id, client_secret, and OAuth scopes match the\n"
+            "      Developer Console configuration."
+        )
+    return None
+
+
 def generate_sample_config(output_path: str = "config.sample.json") -> bool:
     """Generate a sample configuration file."""
     generator = _generator_module()
@@ -458,6 +487,11 @@ def validate_config_only(
         raise
     except generator.RECOVERABLE_CONFIG_API_EXCEPTIONS as e:
         print(generator.ConsoleColors.error(f"  \u2717 API connection failed: {e!s}"))
+        hint = _api_connection_hint(e)
+        if hint:
+            print()
+            for line in hint.splitlines():
+                print(generator.ConsoleColors.warning(f"    {line}"))
         all_passed = False
     except (AttributeError, RuntimeError) as e:
         print(generator.ConsoleColors.error(f"  \u2717 API connection failed (unexpected): {e!s}"))

--- a/src/cja_auto_sdr/cli/commands/config.py
+++ b/src/cja_auto_sdr/cli/commands/config.py
@@ -30,30 +30,12 @@ def _generator_module():
 def _api_connection_hint(exc: Exception) -> str | None:
     """Return an actionable hint for common API connection failures.
 
-    Maps opaque exceptions (e.g. ``KeyError('content')``) to plain-English
-    guidance so users don't have to guess what went wrong.
+    Thin wrapper around :func:`core.exceptions.api_connection_hint` so that
+    existing tests and call-sites in this module keep working unchanged.
     """
-    if isinstance(exc, KeyError):
-        key = str(exc).strip("'\"")
-        if key == "content":
-            return (
-                "Hint: This usually means the API returned an empty or malformed response.\n"
-                "      Verify that both the CJA API and AEP API are added to your Adobe\n"
-                "      Developer Console project, and that the service account is granted\n"
-                "      access to the correct product profiles."
-            )
-        return (
-            f"Hint: API response missing expected key '{key}'.\n"
-            "      Check your OAuth credentials and Developer Console project configuration."
-        )
-    status = getattr(exc, "status_code", None)
-    if status in (401, 403):
-        return (
-            f"Hint: Received HTTP {status} — authentication or authorization failed.\n"
-            "      Verify your client_id, client_secret, and OAuth scopes match the\n"
-            "      Developer Console configuration."
-        )
-    return None
+    from cja_auto_sdr.core.exceptions import api_connection_hint
+
+    return api_connection_hint(exc)
 
 
 def generate_sample_config(output_path: str = "config.sample.json") -> bool:

--- a/src/cja_auto_sdr/cli/commands/config.py
+++ b/src/cja_auto_sdr/cli/commands/config.py
@@ -27,7 +27,7 @@ def _generator_module():
     return _generator
 
 
-def _api_connection_hint(exc: Exception) -> str | None:
+def _api_connection_hint(exc: Exception, *, context: str | None = None) -> str | None:
     """Return an actionable hint for common API connection failures.
 
     Thin wrapper around :func:`core.exceptions.api_connection_hint` so that
@@ -35,7 +35,7 @@ def _api_connection_hint(exc: Exception) -> str | None:
     """
     from cja_auto_sdr.core.exceptions import api_connection_hint
 
-    return api_connection_hint(exc)
+    return api_connection_hint(exc, context=context)
 
 
 def _print_api_connection_failure(

--- a/src/cja_auto_sdr/cli/commands/list.py
+++ b/src/cja_auto_sdr/cli/commands/list.py
@@ -222,6 +222,7 @@ def _run_list_command(
             error_type="connectivity_error",
             human_to_stderr=False,
         )
+        _generator._print_api_hint(e)
         return False
 
 

--- a/src/cja_auto_sdr/cli/commands/list.py
+++ b/src/cja_auto_sdr/cli/commands/list.py
@@ -222,7 +222,7 @@ def _run_list_command(
             error_type="connectivity_error",
             human_to_stderr=False,
         )
-        _generator._print_api_hint(e)
+        _generator._print_api_hint(e, enabled=not is_machine_readable)
         return False
 
 

--- a/src/cja_auto_sdr/cli/commands/list.py
+++ b/src/cja_auto_sdr/cli/commands/list.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import json
 import logging
 import shutil
+import sys
 import textwrap
 from collections.abc import Callable
 
@@ -222,7 +223,7 @@ def _run_list_command(
             error_type="connectivity_error",
             human_to_stderr=False,
         )
-        _generator._print_api_hint(e, enabled=not is_machine_readable)
+        _generator._print_api_hint(e, enabled=not is_machine_readable, file=sys.stdout)
         return False
 
 

--- a/src/cja_auto_sdr/cli/commands/stats.py
+++ b/src/cja_auto_sdr/cli/commands/stats.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import json
 import logging
+import sys
 from typing import Any
 
 import cjapy
@@ -480,4 +481,5 @@ def show_stats(
             error_type="connectivity_error",
             human_to_stderr=False,
         )
+        generator._print_api_hint(e, enabled=not is_machine_readable, file=sys.stdout)
         return False

--- a/src/cja_auto_sdr/cli/commands/stats.py
+++ b/src/cja_auto_sdr/cli/commands/stats.py
@@ -269,7 +269,9 @@ def resolve_data_view_names(
             resolution_diagnostics,
             include_diagnostics=include_diagnostics,
         )
-    except (AttributeError, RuntimeError) as e:
+    except Exception as e:
+        if isinstance(e, SystemError):
+            raise
         error_message = f"Failed to resolve data view names (unexpected): {e!s}"
         logger.error(error_message)
         generator._print_api_hint(e, enabled=emit_api_hints)

--- a/src/cja_auto_sdr/cli/commands/stats.py
+++ b/src/cja_auto_sdr/cli/commands/stats.py
@@ -256,6 +256,7 @@ def resolve_data_view_names(
     except generator.RECOVERABLE_CONFIG_API_EXCEPTIONS as e:
         error_message = f"Failed to resolve data view names: {e!s}"
         logger.error(error_message)
+        generator._print_api_hint(e)
         resolution_diagnostics = generator.NameResolutionDiagnostics(
             error_type="connectivity_error",
             error_message=error_message,
@@ -269,6 +270,7 @@ def resolve_data_view_names(
     except (AttributeError, RuntimeError) as e:
         error_message = f"Failed to resolve data view names (unexpected): {e!s}"
         logger.error(error_message)
+        generator._print_api_hint(e)
         logger.debug("Unexpected error during name resolution", exc_info=True)
         resolution_diagnostics = generator.NameResolutionDiagnostics(
             error_type="connectivity_error",

--- a/src/cja_auto_sdr/cli/commands/stats.py
+++ b/src/cja_auto_sdr/cli/commands/stats.py
@@ -72,6 +72,7 @@ def resolve_data_view_names(
     profile: str | None = None,
     match_mode: str = "exact",
     include_diagnostics: bool = False,
+    emit_api_hints: bool = True,
 ):
     """Resolve data view names to IDs while preserving legacy return contracts."""
     generator = _generator_module()
@@ -256,7 +257,7 @@ def resolve_data_view_names(
     except generator.RECOVERABLE_CONFIG_API_EXCEPTIONS as e:
         error_message = f"Failed to resolve data view names: {e!s}"
         logger.error(error_message)
-        generator._print_api_hint(e)
+        generator._print_api_hint(e, enabled=emit_api_hints)
         resolution_diagnostics = generator.NameResolutionDiagnostics(
             error_type="connectivity_error",
             error_message=error_message,
@@ -270,7 +271,7 @@ def resolve_data_view_names(
     except (AttributeError, RuntimeError) as e:
         error_message = f"Failed to resolve data view names (unexpected): {e!s}"
         logger.error(error_message)
-        generator._print_api_hint(e)
+        generator._print_api_hint(e, enabled=emit_api_hints)
         logger.debug("Unexpected error during name resolution", exc_info=True)
         resolution_diagnostics = generator.NameResolutionDiagnostics(
             error_type="connectivity_error",

--- a/src/cja_auto_sdr/cli/interactive.py
+++ b/src/cja_auto_sdr/cli/interactive.py
@@ -224,7 +224,7 @@ def interactive_select_dataviews(config_file: str = "config.json", profile: str 
         return []
     except generator.RECOVERABLE_COMMAND_HANDLER_EXCEPTIONS as e:
         print(ConsoleColors.error(f"ERROR: Failed to connect to CJA API: {e!s}"))
-        generator._print_api_hint(e)
+        generator._print_api_hint(e, file=sys.stdout)
         return []
 
 
@@ -390,7 +390,7 @@ def interactive_wizard(config_file: str = "config.json", profile: str | None = N
         return None
     except generator.RECOVERABLE_COMMAND_HANDLER_EXCEPTIONS as e:
         print(ConsoleColors.error(f"ERROR: Failed to connect to CJA API: {e!s}"))
-        generator._print_api_hint(e)
+        generator._print_api_hint(e, file=sys.stdout)
         return None
 
     print()

--- a/src/cja_auto_sdr/cli/interactive.py
+++ b/src/cja_auto_sdr/cli/interactive.py
@@ -224,6 +224,7 @@ def interactive_select_dataviews(config_file: str = "config.json", profile: str 
         return []
     except generator.RECOVERABLE_COMMAND_HANDLER_EXCEPTIONS as e:
         print(ConsoleColors.error(f"ERROR: Failed to connect to CJA API: {e!s}"))
+        generator._print_api_hint(e)
         return []
 
 
@@ -389,6 +390,7 @@ def interactive_wizard(config_file: str = "config.json", profile: str | None = N
         return None
     except generator.RECOVERABLE_COMMAND_HANDLER_EXCEPTIONS as e:
         print(ConsoleColors.error(f"ERROR: Failed to connect to CJA API: {e!s}"))
+        generator._print_api_hint(e)
         return None
 
     print()

--- a/src/cja_auto_sdr/core/exceptions.py
+++ b/src/cja_auto_sdr/core/exceptions.py
@@ -263,6 +263,7 @@ class MemoryLimitExceeded(CJASDRError):
 _API_CONNECTION_HINT_HTTP_STATUSES = frozenset({401, 403})
 _API_CONNECTION_HINT_MESSAGE_MARKERS = ("http", "unauthorized", "forbidden")
 _DATAVIEW_LOOKUP_HINT_CONTEXT = "data_view_lookup"
+_API_CONNECTION_HINT_CONTEXT_ATTR = "_cja_api_hint_context"
 
 
 def _normalize_api_connection_hint_context(context: str | None) -> str | None:
@@ -271,6 +272,19 @@ def _normalize_api_connection_hint_context(context: str | None) -> str | None:
         return None
     normalized = context.casefold().strip().replace("-", "_").replace(" ", "_")
     return normalized or None
+
+
+def attach_api_connection_hint_context(exc: Exception, *, context: str | None) -> Exception:
+    """Attach API-hint context metadata to *exc* and return the same exception."""
+    if context is not None:
+        setattr(exc, _API_CONNECTION_HINT_CONTEXT_ATTR, context)
+    return exc
+
+
+def _exception_api_connection_hint_context(exc: Exception) -> str | None:
+    """Return an API-hint context attached to *exc*, when present."""
+    context = getattr(exc, _API_CONNECTION_HINT_CONTEXT_ATTR, None)
+    return context if isinstance(context, str) else None
 
 
 def _api_connection_hint_status_from_message(message: str) -> int | None:
@@ -325,7 +339,9 @@ def api_connection_hint(exc: Exception, *, context: str | None = None) -> str | 
         )
 
     status = _api_connection_hint_status(exc)
-    normalized_context = _normalize_api_connection_hint_context(context)
+    normalized_context = _normalize_api_connection_hint_context(
+        context if context is not None else _exception_api_connection_hint_context(exc),
+    )
 
     if status == 401:
         return (

--- a/src/cja_auto_sdr/core/exceptions.py
+++ b/src/cja_auto_sdr/core/exceptions.py
@@ -258,3 +258,32 @@ class MemoryLimitExceeded(CJASDRError):
             "or increase --memory-limit."
         )
         super().__init__(message)
+
+
+def api_connection_hint(exc: Exception) -> str | None:
+    """Return an actionable hint for common API connection failures.
+
+    Maps opaque exceptions (e.g. ``KeyError('content')``) to plain-English
+    guidance so users don't have to guess what went wrong.
+    """
+    if isinstance(exc, KeyError):
+        key = str(exc).strip("'\"")
+        if key == "content":
+            return (
+                "Hint: This usually means the API returned an empty or malformed response.\n"
+                "      Verify that both the CJA API and AEP API are added to your Adobe\n"
+                "      Developer Console project, and that the service account is granted\n"
+                "      access to the correct product profiles."
+            )
+        return (
+            f"Hint: API response missing expected key '{key}'.\n"
+            "      Check your OAuth credentials and Developer Console project configuration."
+        )
+    status = getattr(exc, "status_code", None)
+    if status in (401, 403):
+        return (
+            f"Hint: Received HTTP {status} — authentication or authorization failed.\n"
+            "      Verify your client_id, client_secret, and OAuth scopes match the\n"
+            "      Developer Console configuration."
+        )
+    return None

--- a/src/cja_auto_sdr/core/exceptions.py
+++ b/src/cja_auto_sdr/core/exceptions.py
@@ -260,34 +260,58 @@ class MemoryLimitExceeded(CJASDRError):
         super().__init__(message)
 
 
+_AUTH_FAILURE_HTTP_STATUSES = frozenset({401, 403})
+_AUTH_FAILURE_MESSAGE_MARKERS = ("http", "unauthorized", "forbidden")
+
+
+def _api_auth_failure_status_from_message(message: str) -> int | None:
+    """Return 401/403 when *message* clearly looks like an auth failure."""
+    normalized = message.casefold().strip()
+    if not normalized or not any(marker in normalized for marker in _AUTH_FAILURE_MESSAGE_MARKERS):
+        return None
+
+    from cja_auto_sdr.core.discovery_exceptions import coerce_http_status_code
+
+    status = coerce_http_status_code(message)
+    if status in _AUTH_FAILURE_HTTP_STATUSES:
+        return status
+    if "unauthorized" in normalized:
+        return 401
+    if "forbidden" in normalized:
+        return 403
+    return None
+
+
+def _api_auth_failure_status(exc: Exception) -> int | None:
+    """Extract a 401/403 status from structured error metadata or message text."""
+    from cja_auto_sdr.core.discovery_exceptions import extract_http_status_codes
+
+    for status in extract_http_status_codes(exc):
+        if status in _AUTH_FAILURE_HTTP_STATUSES:
+            return status
+    return _api_auth_failure_status_from_message(str(exc))
+
+
 def api_connection_hint(exc: Exception) -> str | None:
     """Return an actionable hint for common API connection failures.
 
-    Maps opaque exceptions (e.g. ``KeyError('content')``) to plain-English
-    guidance so users don't have to guess what went wrong.
+    Keep this intentionally conservative because many CLI command boundaries
+    catch broad runtime exceptions. Only emit hints for well-known API/auth
+    signatures so local parsing bugs do not masquerade as credential problems.
     """
     if isinstance(exc, KeyError):
         key = str(exc).strip("'\"")
-        if key == "content":
-            return (
-                "Hint: This usually means the API returned an empty or malformed response.\n"
-                "      Verify that both the CJA API and AEP API are added to your Adobe\n"
-                "      Developer Console project, and that the service account is granted\n"
-                "      access to the correct product profiles."
-            )
+        if key != "content":
+            return None
         return (
-            f"Hint: API response missing expected key '{key}'.\n"
-            "      Check your OAuth credentials and Developer Console project configuration."
+            "Hint: This usually means the API returned an empty or malformed response.\n"
+            "      Verify that both the CJA API and AEP API are added to your Adobe\n"
+            "      Developer Console project, and that the service account is granted\n"
+            "      access to the correct product profiles."
         )
-    from cja_auto_sdr.core.discovery_exceptions import coerce_http_status_code, extract_http_status_codes
 
-    status = next((code for code in extract_http_status_codes(exc) if code in (401, 403)), None)
-    if status is None:
-        message_status = coerce_http_status_code(str(exc))
-        if message_status in (401, 403):
-            status = message_status
-
-    if status in (401, 403):
+    status = _api_auth_failure_status(exc)
+    if status in _AUTH_FAILURE_HTTP_STATUSES:
         return (
             f"Hint: Received HTTP {status} — authentication or authorization failed.\n"
             "      Verify your client_id, client_secret, and OAuth scopes match the\n"

--- a/src/cja_auto_sdr/core/exceptions.py
+++ b/src/cja_auto_sdr/core/exceptions.py
@@ -260,20 +260,29 @@ class MemoryLimitExceeded(CJASDRError):
         super().__init__(message)
 
 
-_AUTH_FAILURE_HTTP_STATUSES = frozenset({401, 403})
-_AUTH_FAILURE_MESSAGE_MARKERS = ("http", "unauthorized", "forbidden")
+_API_CONNECTION_HINT_HTTP_STATUSES = frozenset({401, 403})
+_API_CONNECTION_HINT_MESSAGE_MARKERS = ("http", "unauthorized", "forbidden")
+_DATAVIEW_LOOKUP_HINT_CONTEXT = "data_view_lookup"
 
 
-def _api_auth_failure_status_from_message(message: str) -> int | None:
+def _normalize_api_connection_hint_context(context: str | None) -> str | None:
+    """Normalize hint context names so callers can use readable variants."""
+    if context is None:
+        return None
+    normalized = context.casefold().strip().replace("-", "_").replace(" ", "_")
+    return normalized or None
+
+
+def _api_connection_hint_status_from_message(message: str) -> int | None:
     """Return 401/403 when *message* clearly looks like an auth failure."""
     normalized = message.casefold().strip()
-    if not normalized or not any(marker in normalized for marker in _AUTH_FAILURE_MESSAGE_MARKERS):
+    if not normalized or not any(marker in normalized for marker in _API_CONNECTION_HINT_MESSAGE_MARKERS):
         return None
 
     from cja_auto_sdr.core.discovery_exceptions import coerce_http_status_code
 
     status = coerce_http_status_code(message)
-    if status in _AUTH_FAILURE_HTTP_STATUSES:
+    if status in _API_CONNECTION_HINT_HTTP_STATUSES:
         return status
     if "unauthorized" in normalized:
         return 401
@@ -282,22 +291,27 @@ def _api_auth_failure_status_from_message(message: str) -> int | None:
     return None
 
 
-def _api_auth_failure_status(exc: Exception) -> int | None:
+def _api_connection_hint_status(exc: Exception) -> int | None:
     """Extract a 401/403 status from structured error metadata or message text."""
     from cja_auto_sdr.core.discovery_exceptions import extract_http_status_codes
 
     for status in extract_http_status_codes(exc):
-        if status in _AUTH_FAILURE_HTTP_STATUSES:
+        if status in _API_CONNECTION_HINT_HTTP_STATUSES:
             return status
-    return _api_auth_failure_status_from_message(str(exc))
+    return _api_connection_hint_status_from_message(str(exc))
 
 
-def api_connection_hint(exc: Exception) -> str | None:
+def api_connection_hint(exc: Exception, *, context: str | None = None) -> str | None:
     """Return an actionable hint for common API connection failures.
 
     Keep this intentionally conservative because many CLI command boundaries
     catch broad runtime exceptions. Only emit hints for well-known API/auth
     signatures so local parsing bugs do not masquerade as credential problems.
+
+    Recognized *context* values:
+      - ``"data_view_lookup"``: tailor HTTP 403 guidance for specific
+        getDataView / single-data-view fetch failures that commonly mean
+        "not found" or "no access" in this codebase.
     """
     if isinstance(exc, KeyError):
         key = str(exc).strip("'\"")
@@ -310,11 +324,31 @@ def api_connection_hint(exc: Exception) -> str | None:
             "      access to the correct product profiles."
         )
 
-    status = _api_auth_failure_status(exc)
-    if status in _AUTH_FAILURE_HTTP_STATUSES:
+    status = _api_connection_hint_status(exc)
+    normalized_context = _normalize_api_connection_hint_context(context)
+
+    if status == 401:
         return (
-            f"Hint: Received HTTP {status} — authentication or authorization failed.\n"
+            "Hint: Received HTTP 401 — authentication failed.\n"
             "      Verify your client_id, client_secret, and OAuth scopes match the\n"
             "      Developer Console configuration."
+        )
+    if status == 403 and normalized_context == _DATAVIEW_LOOKUP_HINT_CONTEXT:
+        return (
+            "Hint: Received HTTP 403 while accessing this data view.\n"
+            "      In CJA this often means the data view does not exist or you do not\n"
+            "      have access to it. Verify the data view ID and confirm this account\n"
+            "      is granted access through the appropriate product profile.\n"
+            "      If other API calls also fail with 403, then re-check your client_id,\n"
+            "      client_secret, and OAuth scopes."
+        )
+    if status == 403:
+        return (
+            "Hint: Received HTTP 403 — authentication or authorization failed, or the\n"
+            "      requested resource is not accessible.\n"
+            "      Verify your client_id, client_secret, and OAuth scopes match the\n"
+            "      Developer Console configuration. For specific data-view lookups,\n"
+            "      also verify that the data view exists and that this account can\n"
+            "      access it."
         )
     return None

--- a/src/cja_auto_sdr/core/exceptions.py
+++ b/src/cja_auto_sdr/core/exceptions.py
@@ -279,7 +279,14 @@ def api_connection_hint(exc: Exception) -> str | None:
             f"Hint: API response missing expected key '{key}'.\n"
             "      Check your OAuth credentials and Developer Console project configuration."
         )
-    status = getattr(exc, "status_code", None)
+    from cja_auto_sdr.core.discovery_exceptions import coerce_http_status_code, extract_http_status_codes
+
+    status = next((code for code in extract_http_status_codes(exc) if code in (401, 403)), None)
+    if status is None:
+        message_status = coerce_http_status_code(str(exc))
+        if message_status in (401, 403):
+            status = message_status
+
     if status in (401, 403):
         return (
             f"Hint: Received HTTP {status} — authentication or authorization failed.\n"

--- a/src/cja_auto_sdr/core/profiles.py
+++ b/src/cja_auto_sdr/core/profiles.py
@@ -688,9 +688,9 @@ def test_profile(profile_name: str) -> bool:
         print()
         print(ConsoleColors.error("Profile test: FAILED"), file=sys.stderr)
         print()
-        from cja_auto_sdr.cli.commands.config import _api_connection_hint
+        from cja_auto_sdr.core.exceptions import api_connection_hint
 
-        hint = _api_connection_hint(e)
+        hint = api_connection_hint(e)
         if hint:
             for line in hint.splitlines():
                 print(ConsoleColors.warning(f"  {line}"))

--- a/src/cja_auto_sdr/core/profiles.py
+++ b/src/cja_auto_sdr/core/profiles.py
@@ -688,9 +688,18 @@ def test_profile(profile_name: str) -> bool:
         print()
         print(ConsoleColors.error("Profile test: FAILED"), file=sys.stderr)
         print()
+        from cja_auto_sdr.cli.commands.config import _api_connection_hint
+
+        hint = _api_connection_hint(e)
+        if hint:
+            for line in hint.splitlines():
+                print(ConsoleColors.warning(f"  {line}"))
+            print()
         print("Common issues:")
         print("  - Invalid client_id or secret")
         print("  - Incorrect OAuth scopes")
         print("  - API project not provisioned for CJA")
+        print("  - Missing AEP API in Developer Console project")
+        print("  - Service account not granted product profile access")
         print()
         return False

--- a/src/cja_auto_sdr/core/profiles.py
+++ b/src/cja_auto_sdr/core/profiles.py
@@ -16,7 +16,7 @@ from cja_auto_sdr.api.quality_policy import _canonical_quality_policy_key
 from cja_auto_sdr.core.colors import ConsoleColors
 from cja_auto_sdr.core.constants import BANNER_WIDTH, CREDENTIAL_FIELDS, ENV_VAR_MAPPING
 from cja_auto_sdr.core.credentials import filter_credentials
-from cja_auto_sdr.core.exceptions import ProfileConfigError, ProfileNotFoundError
+from cja_auto_sdr.core.exceptions import ProfileConfigError, ProfileNotFoundError, api_connection_hint
 from cja_auto_sdr.core.json_io import write_json_atomic
 
 __all__ = [
@@ -663,6 +663,28 @@ def test_profile(profile_name: str) -> bool:
 
     print("3. Testing API connectivity...")
 
+    def _print_profile_test_failure(exc: Exception) -> bool:
+        """Render a controlled profile-test failure with optional remediation hint."""
+        print(ConsoleColors.error("   API connection: FAILED"), file=sys.stderr)
+        print(ConsoleColors.error(f"   Error: {exc}"), file=sys.stderr)
+        print(file=sys.stderr)
+        print(ConsoleColors.error("Profile test: FAILED"), file=sys.stderr)
+        print(file=sys.stderr)
+
+        hint = api_connection_hint(exc)
+        if hint:
+            for line in hint.splitlines():
+                print(ConsoleColors.warning(f"  {line}"))
+            print()
+        print("Common issues:")
+        print("  - Invalid client_id or secret")
+        print("  - Incorrect OAuth scopes")
+        print("  - API project not provisioned for CJA")
+        print("  - Missing AEP API in Developer Console project")
+        print("  - Service account not granted product profile access")
+        print()
+        return False
+
     try:
         generator._config_from_env(credentials, logger)
         cja = generator.cjapy.CJA()
@@ -683,23 +705,9 @@ def test_profile(profile_name: str) -> bool:
         print()
         return True
     except generator.RECOVERABLE_CONFIG_API_EXCEPTIONS as e:
-        print(ConsoleColors.error("   API connection: FAILED"), file=sys.stderr)
-        print(ConsoleColors.error(f"   Error: {e}"), file=sys.stderr)
-        print()
-        print(ConsoleColors.error("Profile test: FAILED"), file=sys.stderr)
-        print()
-        from cja_auto_sdr.core.exceptions import api_connection_hint
-
-        hint = api_connection_hint(e)
-        if hint:
-            for line in hint.splitlines():
-                print(ConsoleColors.warning(f"  {line}"))
-            print()
-        print("Common issues:")
-        print("  - Invalid client_id or secret")
-        print("  - Incorrect OAuth scopes")
-        print("  - API project not provisioned for CJA")
-        print("  - Missing AEP API in Developer Console project")
-        print("  - Service account not granted product profile access")
-        print()
-        return False
+        return _print_profile_test_failure(e)
+    except Exception as e:
+        if isinstance(e, SystemError):
+            raise
+        logger.debug("Unexpected profile-test connectivity error", exc_info=True)
+        return _print_profile_test_failure(e)

--- a/src/cja_auto_sdr/core/version.py
+++ b/src/cja_auto_sdr/core/version.py
@@ -1,3 +1,3 @@
 """Version information for CJA Auto SDR."""
 
-__version__ = "3.5.4"
+__version__ = "3.5.5"

--- a/src/cja_auto_sdr/diff/commands.py
+++ b/src/cja_auto_sdr/diff/commands.py
@@ -50,9 +50,9 @@ def _populate_diff_advisory_rollup(
         logging.getLogger("diff").debug("Advisory rollup computation failed", exc_info=True)
 
 
-def _emit_api_failure_hint(generator: Any, exc: Exception, *, context: str | None = None) -> None:
+def _emit_api_failure_hint(generator: Any, exc: Exception) -> None:
     """Print a diff/snapshot API hint to stderr when one is available."""
-    generator._print_api_hint(exc, file=sys.stderr, context=context)
+    generator._print_api_hint(exc, file=sys.stderr)
 
 
 def handle_snapshot_command(
@@ -104,7 +104,7 @@ def handle_snapshot_command(
             )
         except generator.RECOVERABLE_COMMAND_HANDLER_EXCEPTIONS as e:
             print(generator.ConsoleColors.error(f"ERROR: Failed to create snapshot: {e!s}"), file=sys.stderr)
-            _emit_api_failure_hint(generator, e, context="data_view_lookup")
+            _emit_api_failure_hint(generator, e)
             return False
         saved_path = snapshot_manager.save_snapshot(snapshot, snapshot_file)
 
@@ -273,7 +273,7 @@ def handle_diff_command(
             target_snapshot = snapshot_manager.create_snapshot(cja, target_id, quiet or quiet_diff)
         except generator.RECOVERABLE_COMMAND_HANDLER_EXCEPTIONS as e:
             print(generator.ConsoleColors.error(f"ERROR: Failed to compare data views: {e!s}"), file=sys.stderr)
-            _emit_api_failure_hint(generator, e, context="data_view_lookup")
+            _emit_api_failure_hint(generator, e)
             logger.debug("Diff comparison failed during data view fetch", exc_info=True)
             return False, False, None
 
@@ -572,7 +572,7 @@ def handle_diff_snapshot_command(
             target_snapshot = snapshot_manager.create_snapshot(cja, data_view_id, quiet or quiet_diff)
         except generator.RECOVERABLE_COMMAND_HANDLER_EXCEPTIONS as e:
             print(generator.ConsoleColors.error(f"ERROR: Failed to compare against snapshot: {e!s}"), file=sys.stderr)
-            _emit_api_failure_hint(generator, e, context="data_view_lookup")
+            _emit_api_failure_hint(generator, e)
             logger.debug("Diff-snapshot comparison failed during data view fetch", exc_info=True)
             return False, False, None
 

--- a/src/cja_auto_sdr/diff/commands.py
+++ b/src/cja_auto_sdr/diff/commands.py
@@ -50,6 +50,11 @@ def _populate_diff_advisory_rollup(
         logging.getLogger("diff").debug("Advisory rollup computation failed", exc_info=True)
 
 
+def _emit_api_failure_hint(generator: Any, exc: Exception) -> None:
+    """Print a diff/snapshot API hint to stderr when one is available."""
+    generator._print_api_hint(exc, file=sys.stderr)
+
+
 def handle_snapshot_command(
     data_view_id: str,
     snapshot_file: str,
@@ -119,6 +124,7 @@ def handle_snapshot_command(
         raise
     except generator.RECOVERABLE_COMMAND_HANDLER_EXCEPTIONS as e:
         print(generator.ConsoleColors.error(f"ERROR: Failed to create snapshot: {e!s}"), file=sys.stderr)
+        _emit_api_failure_hint(generator, e)
         return False
 
 
@@ -363,6 +369,7 @@ def handle_diff_command(
         raise
     except generator.RECOVERABLE_COMMAND_HANDLER_EXCEPTIONS as e:
         print(generator.ConsoleColors.error(f"ERROR: Failed to compare data views: {e!s}"), file=sys.stderr)
+        _emit_api_failure_hint(generator, e)
         logger.debug("Diff comparison failed", exc_info=True)
         return False, False, None
 
@@ -686,6 +693,7 @@ def handle_diff_snapshot_command(
         raise
     except generator.RECOVERABLE_COMMAND_HANDLER_EXCEPTIONS as e:
         print(generator.ConsoleColors.error(f"ERROR: Failed to compare against snapshot: {e!s}"), file=sys.stderr)
+        _emit_api_failure_hint(generator, e)
         logger.debug("Diff-snapshot comparison failed", exc_info=True)
         return False, False, None
 

--- a/src/cja_auto_sdr/diff/commands.py
+++ b/src/cja_auto_sdr/diff/commands.py
@@ -50,9 +50,9 @@ def _populate_diff_advisory_rollup(
         logging.getLogger("diff").debug("Advisory rollup computation failed", exc_info=True)
 
 
-def _emit_api_failure_hint(generator: Any, exc: Exception) -> None:
+def _emit_api_failure_hint(generator: Any, exc: Exception, *, context: str | None = None) -> None:
     """Print a diff/snapshot API hint to stderr when one is available."""
-    generator._print_api_hint(exc, file=sys.stderr)
+    generator._print_api_hint(exc, file=sys.stderr, context=context)
 
 
 def handle_snapshot_command(
@@ -94,13 +94,18 @@ def handle_snapshot_command(
         cja = generator.cjapy.CJA()
 
         snapshot_manager = generator.SnapshotManager(logger)
-        snapshot = snapshot_manager.create_snapshot(
-            cja,
-            data_view_id,
-            quiet,
-            include_calculated_metrics=include_calculated_metrics,
-            include_segments=include_segments,
-        )
+        try:
+            snapshot = snapshot_manager.create_snapshot(
+                cja,
+                data_view_id,
+                quiet,
+                include_calculated_metrics=include_calculated_metrics,
+                include_segments=include_segments,
+            )
+        except generator.RECOVERABLE_COMMAND_HANDLER_EXCEPTIONS as e:
+            print(generator.ConsoleColors.error(f"ERROR: Failed to create snapshot: {e!s}"), file=sys.stderr)
+            _emit_api_failure_hint(generator, e, context="data_view_lookup")
+            return False
         saved_path = snapshot_manager.save_snapshot(snapshot, snapshot_file)
 
         if not quiet:
@@ -259,12 +264,18 @@ def handle_diff_command(
         cja = generator.cjapy.CJA()
 
         snapshot_manager = generator.SnapshotManager(logger)
-        if not quiet and not quiet_diff:
-            print("Fetching source data view...")
-        source_snapshot = snapshot_manager.create_snapshot(cja, source_id, quiet or quiet_diff)
-        if not quiet and not quiet_diff:
-            print("Fetching target data view...")
-        target_snapshot = snapshot_manager.create_snapshot(cja, target_id, quiet or quiet_diff)
+        try:
+            if not quiet and not quiet_diff:
+                print("Fetching source data view...")
+            source_snapshot = snapshot_manager.create_snapshot(cja, source_id, quiet or quiet_diff)
+            if not quiet and not quiet_diff:
+                print("Fetching target data view...")
+            target_snapshot = snapshot_manager.create_snapshot(cja, target_id, quiet or quiet_diff)
+        except generator.RECOVERABLE_COMMAND_HANDLER_EXCEPTIONS as e:
+            print(generator.ConsoleColors.error(f"ERROR: Failed to compare data views: {e!s}"), file=sys.stderr)
+            _emit_api_failure_hint(generator, e, context="data_view_lookup")
+            logger.debug("Diff comparison failed during data view fetch", exc_info=True)
+            return False, False, None
 
         if auto_snapshot:
             os.makedirs(snapshot_dir, exist_ok=True)
@@ -555,9 +566,15 @@ def handle_diff_snapshot_command(
             return False, False, None
         cja = generator.cjapy.CJA()
 
-        if not quiet and not quiet_diff:
-            print("Fetching current data view state...")
-        target_snapshot = snapshot_manager.create_snapshot(cja, data_view_id, quiet or quiet_diff)
+        try:
+            if not quiet and not quiet_diff:
+                print("Fetching current data view state...")
+            target_snapshot = snapshot_manager.create_snapshot(cja, data_view_id, quiet or quiet_diff)
+        except generator.RECOVERABLE_COMMAND_HANDLER_EXCEPTIONS as e:
+            print(generator.ConsoleColors.error(f"ERROR: Failed to compare against snapshot: {e!s}"), file=sys.stderr)
+            _emit_api_failure_hint(generator, e, context="data_view_lookup")
+            logger.debug("Diff-snapshot comparison failed during data view fetch", exc_info=True)
+            return False, False, None
 
         if include_calc_metrics or include_segments:
             if not quiet and not quiet_diff:

--- a/src/cja_auto_sdr/diff/snapshot.py
+++ b/src/cja_auto_sdr/diff/snapshot.py
@@ -8,8 +8,17 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from cja_auto_sdr.core.colors import ConsoleColors
 from cja_auto_sdr.core.error_policies import RECOVERABLE_OPTIONAL_ENRICHMENT_EXCEPTIONS
+from cja_auto_sdr.core.exceptions import attach_api_connection_hint_context
 from cja_auto_sdr.core.json_io import write_json_atomic
 from cja_auto_sdr.diff.models import DataViewSnapshot
+
+_SNAPSHOT_FAILURE_STAGE_ATTR = "_cja_snapshot_failure_stage"
+
+
+def _annotate_snapshot_failure(exc: Exception, *, stage: str, api_hint_context: str | None = None) -> Exception:
+    """Attach snapshot-stage metadata to *exc* so callers can emit accurate hints."""
+    setattr(exc, _SNAPSHOT_FAILURE_STAGE_ATTR, stage)
+    return attach_api_connection_hint_context(exc, context=api_hint_context)
 
 
 class SnapshotManager:
@@ -102,9 +111,20 @@ class SnapshotManager:
         """Create a snapshot from a live data view."""
         self.logger.info(f"Creating snapshot for data view: {data_view_id}")
 
-        dv_info = cja.getDataView(data_view_id)
+        try:
+            dv_info = cja.getDataView(data_view_id)
+        except Exception as exc:
+            raise _annotate_snapshot_failure(
+                exc,
+                stage="data_view_lookup",
+                api_hint_context="data_view_lookup",
+            ) from exc
         if not dv_info:
-            raise ValueError(f"Failed to fetch data view info for {data_view_id}")
+            raise _annotate_snapshot_failure(
+                ValueError(f"Failed to fetch data view info for {data_view_id}"),
+                stage="data_view_lookup",
+                api_hint_context="data_view_lookup",
+            )
 
         dv_name = dv_info.get("name", "Unknown")
         dv_owner = dv_info.get("owner", {})
@@ -112,14 +132,20 @@ class SnapshotManager:
         dv_description = dv_info.get("description", "")
 
         self.logger.info("Fetching metrics...")
-        metrics_df = cja.getMetrics(data_view_id, inclType=True, full=True)
+        try:
+            metrics_df = cja.getMetrics(data_view_id, inclType=True, full=True)
+        except Exception as exc:
+            raise _annotate_snapshot_failure(exc, stage="metrics_fetch") from exc
         metrics_list = []
         if metrics_df is not None and not metrics_df.empty:
             metrics_list = metrics_df.to_dict("records")
         self.logger.info(f"  Fetched {len(metrics_list)} metrics")
 
         self.logger.info("Fetching dimensions...")
-        dimensions_df = cja.getDimensions(data_view_id, inclType=True, full=True)
+        try:
+            dimensions_df = cja.getDimensions(data_view_id, inclType=True, full=True)
+        except Exception as exc:
+            raise _annotate_snapshot_failure(exc, stage="dimensions_fetch") from exc
         dimensions_list = []
         if dimensions_df is not None and not dimensions_df.empty:
             dimensions_list = dimensions_df.to_dict("records")

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -171,6 +171,7 @@ from cja_auto_sdr.core.exceptions import (
     ProfileNotFoundError,
     RetryableHTTPError,
     ValidationError,
+    api_connection_hint,
 )
 from cja_auto_sdr.core.locks.manager import normalize_lock_stale_threshold_seconds
 from cja_auto_sdr.core.version import __version__
@@ -736,6 +737,16 @@ RECOVERABLE_VALIDATION_EXCEPTIONS: tuple[type[Exception], ...] = VALIDATION_CATC
 # Per-item stats collection must be fully resilient: one broken DV must never
 # abort the stats command. Intentionally broad.
 RECOVERABLE_STATS_ROW_EXCEPTIONS: tuple[type[Exception], ...] = (Exception,)
+
+
+def _print_api_hint(exc: Exception, *, indent: str = "  ", file=None) -> None:
+    """Print an actionable hint for *exc* if one is available."""
+    hint = api_connection_hint(exc)
+    if hint:
+        _file = file or sys.stderr
+        print(file=_file)
+        for line in hint.splitlines():
+            print(ConsoleColors.warning(f"{indent}{line}"), file=_file)
 
 
 def _log_optional_inventory_failure(
@@ -2657,9 +2668,11 @@ def process_inventory_summary(
         dv_name = lookup_data.get("name", data_view_id) if isinstance(lookup_data, dict) else data_view_id
     except RECOVERABLE_CONFIG_API_EXCEPTIONS as e:
         print(ConsoleColors.error(f"ERROR: Failed to fetch data view: {e}"), file=sys.stderr)
+        _print_api_hint(e)
         return {"error": str(e)}
     except (RuntimeError, AttributeError) as e:  # Residual non-API failures (e.g. cjapy internals)
         print(ConsoleColors.error(f"ERROR: Failed to fetch data view (unexpected): {e}"), file=sys.stderr)
+        _print_api_hint(e)
         logger.debug("Unexpected error fetching data view", exc_info=True)
         return {"error": str(e)}
 
@@ -3987,11 +4000,13 @@ def run_dry_run(data_views: list[str], config_file: str, logger: logging.Logger,
             raise
         except RECOVERABLE_CONFIG_API_EXCEPTIONS as e:
             print(f"  ✗ {dv_id}: Error - {e!s}")
+            _print_api_hint(e, file=sys.stdout)
             invalid_count += 1
             all_passed = False
         except (RuntimeError, AttributeError) as e:  # Residual non-API failures (e.g. cjapy internals)
             logger.debug(f"Unexpected dry-run validation error for {dv_id}: {e!s}", exc_info=True)
             print(f"  ✗ {dv_id}: Error - {_dry_run_error_text(e)}")
+            _print_api_hint(e, file=sys.stdout)
             invalid_count += 1
             all_passed = False
 
@@ -5563,6 +5578,7 @@ def run_org_report(
 
     except RECOVERABLE_COMMAND_HANDLER_EXCEPTIONS as e:
         _status_print(ConsoleColors.error(f"ERROR: Org report failed: {e!s}"))
+        _print_api_hint(e)
         if isinstance(e, RECOVERABLE_ORG_REPORT_EXCEPTIONS):
             logger.exception("Org report error")
         else:

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -2685,6 +2685,13 @@ def process_inventory_summary(
         _print_api_hint(e, context="data_view_lookup")
         logger.debug("Unexpected error fetching data view", exc_info=True)
         return {"error": str(e)}
+    except Exception as e:
+        if isinstance(e, SystemError):
+            raise
+        print(ConsoleColors.error(f"ERROR: Failed to fetch data view (unexpected): {e}"), file=sys.stderr)
+        _print_api_hint(e, context="data_view_lookup")
+        logger.debug("Unexpected error fetching data view", exc_info=True)
+        return {"error": str(e)}
 
     if not quiet:
         print(ConsoleColors.info(f"Fetching inventory data for: {dv_name}"))
@@ -3938,6 +3945,12 @@ def run_dry_run(data_views: list[str], config_file: str, logger: logging.Logger,
         logger.debug("Unexpected dry-run API connection failure", exc_info=True)
         all_passed = False
         return _fail_dry_run_api_connection(e)
+    except Exception as e:
+        if isinstance(e, SystemError):
+            raise
+        logger.debug("Unexpected dry-run API connection failure", exc_info=True)
+        all_passed = False
+        return _fail_dry_run_api_connection(e)
 
     # Step 3: Validate each data view
     print()
@@ -3987,6 +4000,14 @@ def run_dry_run(data_views: list[str], config_file: str, logger: logging.Logger,
             invalid_count += 1
             all_passed = False
             continue
+        except Exception as e:
+            if isinstance(e, SystemError):
+                raise
+            logger.debug(f"Unexpected dry-run validation error for {dv_id}: {e!s}", exc_info=True)
+            _print_dry_run_data_view_error(e, context="data_view_lookup")
+            invalid_count += 1
+            all_passed = False
+            continue
 
         if dv_info is None:
             print(f"  ✗ {dv_id}: Not found or no access")
@@ -4023,6 +4044,14 @@ def run_dry_run(data_views: list[str], config_file: str, logger: logging.Logger,
             all_passed = False
             continue
         except (RuntimeError, AttributeError) as e:  # Residual non-API failures (e.g. cjapy internals)
+            logger.debug(f"Unexpected dry-run component validation error for {dv_id}: {e!s}", exc_info=True)
+            _print_dry_run_data_view_error(e)
+            invalid_count += 1
+            all_passed = False
+            continue
+        except Exception as e:
+            if isinstance(e, SystemError):
+                raise
             logger.debug(f"Unexpected dry-run component validation error for {dv_id}: {e!s}", exc_info=True)
             _print_dry_run_data_view_error(e)
             invalid_count += 1

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -745,11 +745,12 @@ def _print_api_hint(
     indent: str = "  ",
     file=None,
     enabled: bool = True,
+    context: str | None = None,
 ) -> None:
     """Print an actionable hint for *exc* if one is available."""
     if not enabled:
         return
-    hint = api_connection_hint(exc)
+    hint = api_connection_hint(exc, context=context)
     if hint:
         _file = file or sys.stderr
         print(file=_file)
@@ -2676,11 +2677,11 @@ def process_inventory_summary(
         dv_name = lookup_data.get("name", data_view_id) if isinstance(lookup_data, dict) else data_view_id
     except RECOVERABLE_CONFIG_API_EXCEPTIONS as e:
         print(ConsoleColors.error(f"ERROR: Failed to fetch data view: {e}"), file=sys.stderr)
-        _print_api_hint(e)
+        _print_api_hint(e, context="data_view_lookup")
         return {"error": str(e)}
     except (RuntimeError, AttributeError) as e:  # Residual non-API failures (e.g. cjapy internals)
         print(ConsoleColors.error(f"ERROR: Failed to fetch data view (unexpected): {e}"), file=sys.stderr)
-        _print_api_hint(e)
+        _print_api_hint(e, context="data_view_lookup")
         logger.debug("Unexpected error fetching data view", exc_info=True)
         return {"error": str(e)}
 
@@ -4008,13 +4009,13 @@ def run_dry_run(data_views: list[str], config_file: str, logger: logging.Logger,
             raise
         except RECOVERABLE_CONFIG_API_EXCEPTIONS as e:
             print(f"  ✗ {dv_id}: Error - {e!s}")
-            _print_api_hint(e, file=sys.stdout)
+            _print_api_hint(e, file=sys.stdout, context="data_view_lookup")
             invalid_count += 1
             all_passed = False
         except (RuntimeError, AttributeError) as e:  # Residual non-API failures (e.g. cjapy internals)
             logger.debug(f"Unexpected dry-run validation error for {dv_id}: {e!s}", exc_info=True)
             print(f"  ✗ {dv_id}: Error - {_dry_run_error_text(e)}")
-            _print_api_hint(e, file=sys.stdout)
+            _print_api_hint(e, file=sys.stdout, context="data_view_lookup")
             invalid_count += 1
             all_passed = False
 

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -3851,6 +3851,16 @@ def run_dry_run(data_views: list[str], config_file: str, logger: logging.Logger,
         text = str(error).strip()
         return text or error.__class__.__name__
 
+    def _fail_dry_run_api_connection(error: Exception) -> bool:
+        """Print a consistent step-[2/3] API probe failure and stop the dry-run."""
+        print(f"  ✗ API connection failed: {_dry_run_error_text(error)}")
+        _print_api_hint(error, file=sys.stdout)
+        print()
+        print("=" * BANNER_WIDTH)
+        print("DRY-RUN FAILED - Cannot connect to CJA API")
+        print("=" * BANNER_WIDTH)
+        return False
+
     # Step 1: Validate credentials
     print("[1/3] Validating credentials...")
     if profile:
@@ -3915,22 +3925,12 @@ def run_dry_run(data_views: list[str], config_file: str, logger: logging.Logger,
         print(ConsoleColors.warning("Dry-run cancelled."))
         raise
     except RECOVERABLE_CONFIG_API_EXCEPTIONS as e:
-        print(f"  ✗ API connection failed: {_dry_run_error_text(e)}")
         all_passed = False
-        print()
-        print("=" * BANNER_WIDTH)
-        print("DRY-RUN FAILED - Cannot connect to CJA API")
-        print("=" * BANNER_WIDTH)
-        return False
+        return _fail_dry_run_api_connection(e)
     except (RuntimeError, AttributeError) as e:  # Residual non-API failures (e.g. cjapy internals)
         logger.debug("Unexpected dry-run API connection failure", exc_info=True)
-        print(f"  ✗ API connection failed: {_dry_run_error_text(e)}")
         all_passed = False
-        print()
-        print("=" * BANNER_WIDTH)
-        print("DRY-RUN FAILED - Cannot connect to CJA API")
-        print("=" * BANNER_WIDTH)
-        return False
+        return _fail_dry_run_api_connection(e)
 
     # Step 3: Validate each data view
     print()

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -1282,6 +1282,7 @@ def _refetch_git_snapshot_for_commit(
             )
     except RECOVERABLE_GIT_SNAPSHOT_REFETCH_EXCEPTIONS as e:
         print(ConsoleColors.warning(f"  Could not fetch snapshot data: {e}"))
+        _print_api_hint(e, file=sys.stdout)
     return snapshot
 
 
@@ -3862,6 +3863,11 @@ def run_dry_run(data_views: list[str], config_file: str, logger: logging.Logger,
         print("=" * BANNER_WIDTH)
         return False
 
+    def _print_dry_run_data_view_error(error: Exception, *, context: str | None = None) -> None:
+        """Print a consistent per-data-view validation error and optional remediation hint."""
+        print(f"  ✗ {dv_id}: Error - {_dry_run_error_text(error)}")
+        _print_api_hint(error, file=sys.stdout, context=context)
+
     # Step 1: Validate credentials
     print("[1/3] Validating credentials...")
     if profile:
@@ -3966,58 +3972,72 @@ def run_dry_run(data_views: list[str], config_file: str, logger: logging.Logger,
                 raw_dv_info,
                 data_view_id=dv_id,
             )
-            if dv_info is not None:
-                dv_name = dv_info.get("name", "Unknown")
-
-                # Fetch component counts for predictions
-                metrics_count = _count_component_items_for_fetch_spec_with_retry(
-                    cja,
-                    dv_id,
-                    _METRICS_COMPONENT_FETCH_SPEC,
-                    logger=logger,
-                )
-                dimensions_count = _count_component_items_for_fetch_spec_with_retry(
-                    cja,
-                    dv_id,
-                    _DIMENSIONS_COMPONENT_FETCH_SPEC,
-                    logger=logger,
-                )
-
-                total_metrics += metrics_count
-                total_dimensions += dimensions_count
-                dv_details.append(
-                    {"id": dv_id, "name": dv_name, "metrics": metrics_count, "dimensions": dimensions_count},
-                )
-
-                print(f"  ✓ {dv_id}: {dv_name}")
-                print(f"      Components: {metrics_count} metrics, {dimensions_count} dimensions")
-                valid_count += 1
-            else:
-                print(f"  ✗ {dv_id}: Not found or no access")
-                print(f"      Lookup validation failed: {lookup_failure_reason}")
-                logger.debug(
-                    "Dry-run rejected lookup payload for %s: reason=%s raw_type=%s",
-                    dv_id,
-                    lookup_failure_reason,
-                    lookup_raw_type,
-                )
-                invalid_count += 1
-                all_passed = False
         except (KeyboardInterrupt, SystemExit):
             print()
             print(ConsoleColors.warning("Validation cancelled."))
             raise
         except RECOVERABLE_CONFIG_API_EXCEPTIONS as e:
-            print(f"  ✗ {dv_id}: Error - {e!s}")
-            _print_api_hint(e, file=sys.stdout, context="data_view_lookup")
+            _print_dry_run_data_view_error(e, context="data_view_lookup")
             invalid_count += 1
             all_passed = False
+            continue
         except (RuntimeError, AttributeError) as e:  # Residual non-API failures (e.g. cjapy internals)
             logger.debug(f"Unexpected dry-run validation error for {dv_id}: {e!s}", exc_info=True)
-            print(f"  ✗ {dv_id}: Error - {_dry_run_error_text(e)}")
-            _print_api_hint(e, file=sys.stdout, context="data_view_lookup")
+            _print_dry_run_data_view_error(e, context="data_view_lookup")
             invalid_count += 1
             all_passed = False
+            continue
+
+        if dv_info is None:
+            print(f"  ✗ {dv_id}: Not found or no access")
+            print(f"      Lookup validation failed: {lookup_failure_reason}")
+            logger.debug(
+                "Dry-run rejected lookup payload for %s: reason=%s raw_type=%s",
+                dv_id,
+                lookup_failure_reason,
+                lookup_raw_type,
+            )
+            invalid_count += 1
+            all_passed = False
+            continue
+
+        dv_name = dv_info.get("name", "Unknown")
+
+        try:
+            # Fetch component counts for predictions.
+            metrics_count = _count_component_items_for_fetch_spec_with_retry(
+                cja,
+                dv_id,
+                _METRICS_COMPONENT_FETCH_SPEC,
+                logger=logger,
+            )
+            dimensions_count = _count_component_items_for_fetch_spec_with_retry(
+                cja,
+                dv_id,
+                _DIMENSIONS_COMPONENT_FETCH_SPEC,
+                logger=logger,
+            )
+        except RECOVERABLE_CONFIG_API_EXCEPTIONS as e:
+            _print_dry_run_data_view_error(e)
+            invalid_count += 1
+            all_passed = False
+            continue
+        except (RuntimeError, AttributeError) as e:  # Residual non-API failures (e.g. cjapy internals)
+            logger.debug(f"Unexpected dry-run component validation error for {dv_id}: {e!s}", exc_info=True)
+            _print_dry_run_data_view_error(e)
+            invalid_count += 1
+            all_passed = False
+            continue
+
+        total_metrics += metrics_count
+        total_dimensions += dimensions_count
+        dv_details.append(
+            {"id": dv_id, "name": dv_name, "metrics": metrics_count, "dimensions": dimensions_count},
+        )
+
+        print(f"  ✓ {dv_id}: {dv_name}")
+        print(f"      Components: {metrics_count} metrics, {dimensions_count} dimensions")
+        valid_count += 1
 
     # Calculate time estimates
     # Based on benchmarks: ~0.5s per component for validation, ~0.1s without

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -5588,7 +5588,7 @@ def run_org_report(
 
     except RECOVERABLE_COMMAND_HANDLER_EXCEPTIONS as e:
         _status_print(ConsoleColors.error(f"ERROR: Org report failed: {e!s}"))
-        _print_api_hint(e)
+        _print_api_hint(e, file=status_stream)
         if isinstance(e, RECOVERABLE_ORG_REPORT_EXCEPTIONS):
             logger.exception("Org report error")
         else:

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -739,8 +739,16 @@ RECOVERABLE_VALIDATION_EXCEPTIONS: tuple[type[Exception], ...] = VALIDATION_CATC
 RECOVERABLE_STATS_ROW_EXCEPTIONS: tuple[type[Exception], ...] = (Exception,)
 
 
-def _print_api_hint(exc: Exception, *, indent: str = "  ", file=None) -> None:
+def _print_api_hint(
+    exc: Exception,
+    *,
+    indent: str = "  ",
+    file=None,
+    enabled: bool = True,
+) -> None:
     """Print an actionable hint for *exc* if one is available."""
+    if not enabled:
+        return
     hint = api_connection_hint(exc)
     if hint:
         _file = file or sys.stderr
@@ -4348,6 +4356,7 @@ def resolve_data_view_names(
     profile: str | None = None,
     match_mode: str = "exact",
     include_diagnostics: bool = False,
+    emit_api_hints: bool = True,
 ) -> NameResolutionResult | NameResolutionResultWithDiagnostics:
     from cja_auto_sdr.cli.commands.stats import resolve_data_view_names as _impl
 
@@ -4359,6 +4368,7 @@ def resolve_data_view_names(
         profile=profile,
         match_mode=match_mode,
         include_diagnostics=include_diagnostics,
+        emit_api_hints=emit_api_hints,
     )
 
 
@@ -6666,6 +6676,7 @@ def _main_impl(run_state: dict[str, Any] | None = None):
                     profile=getattr(args, "profile", None),
                     match_mode=getattr(args, "name_match", "exact"),
                     include_diagnostics=True,
+                    emit_api_hints=not is_machine_readable_discovery,
                 )
                 resolved_ids, _, resolution_diagnostics = _coerce_name_resolution_result(resolution_result)
                 resolved_name_by_id = resolution_diagnostics.resolved_name_by_id

--- a/tests/README.md
+++ b/tests/README.md
@@ -141,7 +141,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 7,693 comprehensive tests**
+**Total: 7,696 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -150,16 +150,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,587 | 123 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,590 | 123 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 7 | 1 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **7,693** | **129** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **7,696** | **129** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,580 | 122 | `-m "unit and not slow"` |
+| `test-unit` | 7,583 | 122 | `-m "unit and not slow"` |
 | `test-integration` | 103 | 6 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -238,12 +238,12 @@ tests/
 | `test_cli_command_handlers.py` | 152 | CLI dispatch for --stats, --org-report, --list-snapshots, discovery inspection, diff config unpacking |
 | `test_profile_management.py` | 51 | Interactive profile creation, import, test, show |
 | `test_snapshot_commands.py` | 61 | Snapshot creation, comparison, name resolution |
-| `test_config_and_resolution.py` | 110 | Config status, validation, stats, name resolution |
+| `test_config_and_resolution.py` | 111 | Config status, validation, stats, name resolution |
 | `test_derived_fields_edge_cases.py` | 34 | Derived fields edge cases and coverage |
 | `test_diff_command_coverage.py` | 45 | Diff command edge cases and coverage |
 | `test_generator_interactive_and_console.py` | 37 | Generator interactive and console tests |
 | `test_generator_remaining_coverage.py` | 82 | Generator remaining coverage edge cases |
-| `test_interactive_discovery_coverage.py` | 116 | Interactive discovery and helpers coverage |
+| `test_interactive_discovery_coverage.py` | 117 | Interactive discovery and helpers coverage |
 | `test_lock_backends.py` | 46 | Lock backends edge cases and coverage |
 | `test_main_impl_cli_coverage.py` | 90 | _main_impl CLI path coverage |
 | `test_main_impl_coverage.py` | 59 | _main_impl coverage edge cases |
@@ -269,7 +269,7 @@ tests/
 | `test_org_trending_adversarial.py` | 51 | Adversarial and stress tests for trending |
 | `test_cli_diff_contracts.py` | 70 | CLI/diff public API contract tests |
 | `test_list_command_edge_cases.py` | 58 | List command edge cases and coverage |
-| `test_cli_commands_config_coverage.py` | 35 | Config command edge cases and coverage |
+| `test_cli_commands_config_coverage.py` | 36 | Config command edge cases and coverage |
 | `test_cli_execution.py` | 27 | CLI execution edge cases and coverage |
 | `test_diff_git_coverage.py` | 27 | Diff/git subprocess error path coverage |
 | `test_generator_trending_coverage.py` | 19 | Generator trending integration coverage |
@@ -298,7 +298,7 @@ tests/
 | `test_agent_workflows.py` | 69 | Agent workflow shell script validation tests |
 | `test_manifest_agent_contract.py` | 16 | Manifest vs runtime capability drift tests |
 | `test_tool_manifests.py` | 40 | Tool manifest schema and content tests |
-| **Total** | **7,693** | **Collected via pytest --collect-only** |
+| **Total** | **7,696** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -756,7 +756,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (7,693 tests total)
+- [x] Comprehensive test coverage (7,696 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 78 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -141,7 +141,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 7,670 comprehensive tests**
+**Total: 7,676 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -150,16 +150,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,564 | 123 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,570 | 123 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 7 | 1 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **7,670** | **129** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **7,676** | **129** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,557 | 122 | `-m "unit and not slow"` |
+| `test-unit` | 7,563 | 122 | `-m "unit and not slow"` |
 | `test-integration` | 103 | 6 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -269,7 +269,7 @@ tests/
 | `test_org_trending_adversarial.py` | 51 | Adversarial and stress tests for trending |
 | `test_cli_diff_contracts.py` | 70 | CLI/diff public API contract tests |
 | `test_list_command_edge_cases.py` | 58 | List command edge cases and coverage |
-| `test_cli_commands_config_coverage.py` | 25 | Config command edge cases and coverage |
+| `test_cli_commands_config_coverage.py` | 31 | Config command edge cases and coverage |
 | `test_cli_execution.py` | 27 | CLI execution edge cases and coverage |
 | `test_diff_git_coverage.py` | 27 | Diff/git subprocess error path coverage |
 | `test_generator_trending_coverage.py` | 19 | Generator trending integration coverage |
@@ -298,7 +298,7 @@ tests/
 | `test_agent_workflows.py` | 69 | Agent workflow shell script validation tests |
 | `test_manifest_agent_contract.py` | 16 | Manifest vs runtime capability drift tests |
 | `test_tool_manifests.py` | 40 | Tool manifest schema and content tests |
-| **Total** | **7,670** | **Collected via pytest --collect-only** |
+| **Total** | **7,676** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -756,7 +756,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (7,670 tests total)
+- [x] Comprehensive test coverage (7,676 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 78 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -141,7 +141,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 7,678 comprehensive tests**
+**Total: 7,685 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -150,16 +150,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,572 | 123 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,579 | 123 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 7 | 1 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **7,678** | **129** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **7,685** | **129** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,565 | 122 | `-m "unit and not slow"` |
+| `test-unit` | 7,572 | 122 | `-m "unit and not slow"` |
 | `test-integration` | 103 | 6 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -241,9 +241,9 @@ tests/
 | `test_config_and_resolution.py` | 108 | Config status, validation, stats, name resolution |
 | `test_derived_fields_edge_cases.py` | 34 | Derived fields edge cases and coverage |
 | `test_diff_command_coverage.py` | 45 | Diff command edge cases and coverage |
-| `test_generator_interactive_and_console.py` | 36 | Generator interactive and console tests |
+| `test_generator_interactive_and_console.py` | 37 | Generator interactive and console tests |
 | `test_generator_remaining_coverage.py` | 82 | Generator remaining coverage edge cases |
-| `test_interactive_discovery_coverage.py` | 113 | Interactive discovery and helpers coverage |
+| `test_interactive_discovery_coverage.py` | 116 | Interactive discovery and helpers coverage |
 | `test_lock_backends.py` | 46 | Lock backends edge cases and coverage |
 | `test_main_impl_cli_coverage.py` | 90 | _main_impl CLI path coverage |
 | `test_main_impl_coverage.py` | 57 | _main_impl coverage edge cases |
@@ -269,7 +269,7 @@ tests/
 | `test_org_trending_adversarial.py` | 51 | Adversarial and stress tests for trending |
 | `test_cli_diff_contracts.py` | 70 | CLI/diff public API contract tests |
 | `test_list_command_edge_cases.py` | 58 | List command edge cases and coverage |
-| `test_cli_commands_config_coverage.py` | 31 | Config command edge cases and coverage |
+| `test_cli_commands_config_coverage.py` | 34 | Config command edge cases and coverage |
 | `test_cli_execution.py` | 27 | CLI execution edge cases and coverage |
 | `test_diff_git_coverage.py` | 27 | Diff/git subprocess error path coverage |
 | `test_generator_trending_coverage.py` | 19 | Generator trending integration coverage |
@@ -298,7 +298,7 @@ tests/
 | `test_agent_workflows.py` | 69 | Agent workflow shell script validation tests |
 | `test_manifest_agent_contract.py` | 16 | Manifest vs runtime capability drift tests |
 | `test_tool_manifests.py` | 40 | Tool manifest schema and content tests |
-| **Total** | **7,678** | **Collected via pytest --collect-only** |
+| **Total** | **7,685** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -756,7 +756,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (7,678 tests total)
+- [x] Comprehensive test coverage (7,685 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 78 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -141,7 +141,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 7,685 comprehensive tests**
+**Total: 7,693 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -150,16 +150,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,579 | 123 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,587 | 123 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 7 | 1 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **7,685** | **129** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **7,693** | **129** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,572 | 122 | `-m "unit and not slow"` |
+| `test-unit` | 7,580 | 122 | `-m "unit and not slow"` |
 | `test-integration` | 103 | 6 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -235,10 +235,10 @@ tests/
 | `test_generator_discovery_compat_coverage.py` | 42 | Generator discovery helper parity with extracted list-command implementations |
 | `test_segments_coverage.py` | 78 | Segment comparison operators, container types, sequence variants |
 | `test_diff_inventory_output.py` | 96 | Inventory diff output across all formats (console, JSON, HTML, Excel, MD, CSV) |
-| `test_cli_command_handlers.py` | 151 | CLI dispatch for --stats, --org-report, --list-snapshots, discovery inspection, diff config unpacking |
+| `test_cli_command_handlers.py` | 152 | CLI dispatch for --stats, --org-report, --list-snapshots, discovery inspection, diff config unpacking |
 | `test_profile_management.py` | 51 | Interactive profile creation, import, test, show |
-| `test_snapshot_commands.py` | 59 | Snapshot creation, comparison, name resolution |
-| `test_config_and_resolution.py` | 108 | Config status, validation, stats, name resolution |
+| `test_snapshot_commands.py` | 61 | Snapshot creation, comparison, name resolution |
+| `test_config_and_resolution.py` | 110 | Config status, validation, stats, name resolution |
 | `test_derived_fields_edge_cases.py` | 34 | Derived fields edge cases and coverage |
 | `test_diff_command_coverage.py` | 45 | Diff command edge cases and coverage |
 | `test_generator_interactive_and_console.py` | 37 | Generator interactive and console tests |
@@ -246,7 +246,7 @@ tests/
 | `test_interactive_discovery_coverage.py` | 116 | Interactive discovery and helpers coverage |
 | `test_lock_backends.py` | 46 | Lock backends edge cases and coverage |
 | `test_main_impl_cli_coverage.py` | 90 | _main_impl CLI path coverage |
-| `test_main_impl_coverage.py` | 57 | _main_impl coverage edge cases |
+| `test_main_impl_coverage.py` | 59 | _main_impl coverage edge cases |
 | `test_org_cache_branches.py` | 51 | Org cache branch coverage |
 | `test_org_writer_compat_contracts.py` | 107 | Org writer compatibility boundary contract tests |
 | `test_org_writer_coverage.py` | 143 | Org writer edge cases and coverage |
@@ -269,7 +269,7 @@ tests/
 | `test_org_trending_adversarial.py` | 51 | Adversarial and stress tests for trending |
 | `test_cli_diff_contracts.py` | 70 | CLI/diff public API contract tests |
 | `test_list_command_edge_cases.py` | 58 | List command edge cases and coverage |
-| `test_cli_commands_config_coverage.py` | 34 | Config command edge cases and coverage |
+| `test_cli_commands_config_coverage.py` | 35 | Config command edge cases and coverage |
 | `test_cli_execution.py` | 27 | CLI execution edge cases and coverage |
 | `test_diff_git_coverage.py` | 27 | Diff/git subprocess error path coverage |
 | `test_generator_trending_coverage.py` | 19 | Generator trending integration coverage |
@@ -298,7 +298,7 @@ tests/
 | `test_agent_workflows.py` | 69 | Agent workflow shell script validation tests |
 | `test_manifest_agent_contract.py` | 16 | Manifest vs runtime capability drift tests |
 | `test_tool_manifests.py` | 40 | Tool manifest schema and content tests |
-| **Total** | **7,685** | **Collected via pytest --collect-only** |
+| **Total** | **7,693** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -756,7 +756,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (7,685 tests total)
+- [x] Comprehensive test coverage (7,693 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 78 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -141,7 +141,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 7,696 comprehensive tests**
+**Total: 7,701 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -150,16 +150,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,590 | 123 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,595 | 123 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 7 | 1 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **7,696** | **129** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **7,701** | **129** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,583 | 122 | `-m "unit and not slow"` |
+| `test-unit` | 7,588 | 122 | `-m "unit and not slow"` |
 | `test-integration` | 103 | 6 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -235,9 +235,9 @@ tests/
 | `test_generator_discovery_compat_coverage.py` | 42 | Generator discovery helper parity with extracted list-command implementations |
 | `test_segments_coverage.py` | 78 | Segment comparison operators, container types, sequence variants |
 | `test_diff_inventory_output.py` | 96 | Inventory diff output across all formats (console, JSON, HTML, Excel, MD, CSV) |
-| `test_cli_command_handlers.py` | 152 | CLI dispatch for --stats, --org-report, --list-snapshots, discovery inspection, diff config unpacking |
+| `test_cli_command_handlers.py` | 153 | CLI dispatch for --stats, --org-report, --list-snapshots, discovery inspection, diff config unpacking |
 | `test_profile_management.py` | 51 | Interactive profile creation, import, test, show |
-| `test_snapshot_commands.py` | 61 | Snapshot creation, comparison, name resolution |
+| `test_snapshot_commands.py` | 63 | Snapshot creation, comparison, name resolution |
 | `test_config_and_resolution.py` | 111 | Config status, validation, stats, name resolution |
 | `test_derived_fields_edge_cases.py` | 34 | Derived fields edge cases and coverage |
 | `test_diff_command_coverage.py` | 45 | Diff command edge cases and coverage |
@@ -246,7 +246,7 @@ tests/
 | `test_interactive_discovery_coverage.py` | 117 | Interactive discovery and helpers coverage |
 | `test_lock_backends.py` | 46 | Lock backends edge cases and coverage |
 | `test_main_impl_cli_coverage.py` | 90 | _main_impl CLI path coverage |
-| `test_main_impl_coverage.py` | 59 | _main_impl coverage edge cases |
+| `test_main_impl_coverage.py` | 60 | _main_impl coverage edge cases |
 | `test_org_cache_branches.py` | 51 | Org cache branch coverage |
 | `test_org_writer_compat_contracts.py` | 107 | Org writer compatibility boundary contract tests |
 | `test_org_writer_coverage.py` | 143 | Org writer edge cases and coverage |
@@ -269,7 +269,7 @@ tests/
 | `test_org_trending_adversarial.py` | 51 | Adversarial and stress tests for trending |
 | `test_cli_diff_contracts.py` | 70 | CLI/diff public API contract tests |
 | `test_list_command_edge_cases.py` | 58 | List command edge cases and coverage |
-| `test_cli_commands_config_coverage.py` | 36 | Config command edge cases and coverage |
+| `test_cli_commands_config_coverage.py` | 37 | Config command edge cases and coverage |
 | `test_cli_execution.py` | 27 | CLI execution edge cases and coverage |
 | `test_diff_git_coverage.py` | 27 | Diff/git subprocess error path coverage |
 | `test_generator_trending_coverage.py` | 19 | Generator trending integration coverage |
@@ -298,7 +298,7 @@ tests/
 | `test_agent_workflows.py` | 69 | Agent workflow shell script validation tests |
 | `test_manifest_agent_contract.py` | 16 | Manifest vs runtime capability drift tests |
 | `test_tool_manifests.py` | 40 | Tool manifest schema and content tests |
-| **Total** | **7,696** | **Collected via pytest --collect-only** |
+| **Total** | **7,701** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -756,7 +756,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (7,696 tests total)
+- [x] Comprehensive test coverage (7,701 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 78 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -141,7 +141,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 7,701 comprehensive tests**
+**Total: 7,714 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -150,16 +150,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,595 | 123 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,608 | 123 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 7 | 1 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **7,701** | **129** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **7,714** | **129** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,588 | 122 | `-m "unit and not slow"` |
+| `test-unit` | 7,601 | 122 | `-m "unit and not slow"` |
 | `test-integration` | 103 | 6 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -235,18 +235,18 @@ tests/
 | `test_generator_discovery_compat_coverage.py` | 42 | Generator discovery helper parity with extracted list-command implementations |
 | `test_segments_coverage.py` | 78 | Segment comparison operators, container types, sequence variants |
 | `test_diff_inventory_output.py` | 96 | Inventory diff output across all formats (console, JSON, HTML, Excel, MD, CSV) |
-| `test_cli_command_handlers.py` | 153 | CLI dispatch for --stats, --org-report, --list-snapshots, discovery inspection, diff config unpacking |
-| `test_profile_management.py` | 51 | Interactive profile creation, import, test, show |
-| `test_snapshot_commands.py` | 63 | Snapshot creation, comparison, name resolution |
-| `test_config_and_resolution.py` | 111 | Config status, validation, stats, name resolution |
+| `test_cli_command_handlers.py` | 155 | CLI dispatch for --stats, --org-report, --list-snapshots, discovery inspection, diff config unpacking |
+| `test_profile_management.py` | 53 | Interactive profile creation, import, test, show |
+| `test_snapshot_commands.py` | 65 | Snapshot creation, comparison, name resolution |
+| `test_config_and_resolution.py` | 112 | Config status, validation, stats, name resolution |
 | `test_derived_fields_edge_cases.py` | 34 | Derived fields edge cases and coverage |
 | `test_diff_command_coverage.py` | 45 | Diff command edge cases and coverage |
 | `test_generator_interactive_and_console.py` | 37 | Generator interactive and console tests |
 | `test_generator_remaining_coverage.py` | 82 | Generator remaining coverage edge cases |
 | `test_interactive_discovery_coverage.py` | 117 | Interactive discovery and helpers coverage |
 | `test_lock_backends.py` | 46 | Lock backends edge cases and coverage |
-| `test_main_impl_cli_coverage.py` | 90 | _main_impl CLI path coverage |
-| `test_main_impl_coverage.py` | 60 | _main_impl coverage edge cases |
+| `test_main_impl_cli_coverage.py` | 91 | _main_impl CLI path coverage |
+| `test_main_impl_coverage.py` | 61 | _main_impl coverage edge cases |
 | `test_org_cache_branches.py` | 51 | Org cache branch coverage |
 | `test_org_writer_compat_contracts.py` | 107 | Org writer compatibility boundary contract tests |
 | `test_org_writer_coverage.py` | 143 | Org writer edge cases and coverage |
@@ -257,7 +257,7 @@ tests/
 | `test_cli_smoke_modes.py` | 10 | CLI smoke tests for core command modes |
 | `test_generator_mock_contract.py` | 2 | Generator mock symbol contract tests |
 | `test_completion.py` | 56 | Shell completion flag (--completion bash/zsh/fish) |
-| `test_exception_narrowing.py` | 50 | Exception narrowing boundary tests |
+| `test_exception_narrowing.py` | 54 | Exception narrowing boundary tests |
 | `test_coverage_hardening.py` | 100 | Coverage hardening tests |
 | `test_trending_models.py` | 53 | Trending dataclass construction and bridge tests |
 | `test_trending_discovery.py` | 88 | Snapshot cache discovery, deltas, drift scoring |
@@ -298,7 +298,7 @@ tests/
 | `test_agent_workflows.py` | 69 | Agent workflow shell script validation tests |
 | `test_manifest_agent_contract.py` | 16 | Manifest vs runtime capability drift tests |
 | `test_tool_manifests.py` | 40 | Tool manifest schema and content tests |
-| **Total** | **7,701** | **Collected via pytest --collect-only** |
+| **Total** | **7,714** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -756,7 +756,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (7,701 tests total)
+- [x] Comprehensive test coverage (7,714 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 78 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -141,7 +141,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 7,676 comprehensive tests**
+**Total: 7,678 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -150,16 +150,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,570 | 123 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,572 | 123 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 7 | 1 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **7,676** | **129** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **7,678** | **129** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,563 | 122 | `-m "unit and not slow"` |
+| `test-unit` | 7,565 | 122 | `-m "unit and not slow"` |
 | `test-integration` | 103 | 6 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -235,7 +235,7 @@ tests/
 | `test_generator_discovery_compat_coverage.py` | 42 | Generator discovery helper parity with extracted list-command implementations |
 | `test_segments_coverage.py` | 78 | Segment comparison operators, container types, sequence variants |
 | `test_diff_inventory_output.py` | 96 | Inventory diff output across all formats (console, JSON, HTML, Excel, MD, CSV) |
-| `test_cli_command_handlers.py` | 150 | CLI dispatch for --stats, --org-report, --list-snapshots, discovery inspection, diff config unpacking |
+| `test_cli_command_handlers.py` | 151 | CLI dispatch for --stats, --org-report, --list-snapshots, discovery inspection, diff config unpacking |
 | `test_profile_management.py` | 51 | Interactive profile creation, import, test, show |
 | `test_snapshot_commands.py` | 59 | Snapshot creation, comparison, name resolution |
 | `test_config_and_resolution.py` | 108 | Config status, validation, stats, name resolution |
@@ -243,7 +243,7 @@ tests/
 | `test_diff_command_coverage.py` | 45 | Diff command edge cases and coverage |
 | `test_generator_interactive_and_console.py` | 36 | Generator interactive and console tests |
 | `test_generator_remaining_coverage.py` | 82 | Generator remaining coverage edge cases |
-| `test_interactive_discovery_coverage.py` | 112 | Interactive discovery and helpers coverage |
+| `test_interactive_discovery_coverage.py` | 113 | Interactive discovery and helpers coverage |
 | `test_lock_backends.py` | 46 | Lock backends edge cases and coverage |
 | `test_main_impl_cli_coverage.py` | 90 | _main_impl CLI path coverage |
 | `test_main_impl_coverage.py` | 57 | _main_impl coverage edge cases |
@@ -298,7 +298,7 @@ tests/
 | `test_agent_workflows.py` | 69 | Agent workflow shell script validation tests |
 | `test_manifest_agent_contract.py` | 16 | Manifest vs runtime capability drift tests |
 | `test_tool_manifests.py` | 40 | Tool manifest schema and content tests |
-| **Total** | **7,676** | **Collected via pytest --collect-only** |
+| **Total** | **7,678** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -756,7 +756,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (7,676 tests total)
+- [x] Comprehensive test coverage (7,678 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 78 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -141,7 +141,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 7,714 comprehensive tests**
+**Total: 7,719 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -150,16 +150,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,608 | 123 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,613 | 123 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 7 | 1 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **7,714** | **129** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **7,719** | **129** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,601 | 122 | `-m "unit and not slow"` |
+| `test-unit` | 7,606 | 122 | `-m "unit and not slow"` |
 | `test-integration` | 103 | 6 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -235,7 +235,7 @@ tests/
 | `test_generator_discovery_compat_coverage.py` | 42 | Generator discovery helper parity with extracted list-command implementations |
 | `test_segments_coverage.py` | 78 | Segment comparison operators, container types, sequence variants |
 | `test_diff_inventory_output.py` | 96 | Inventory diff output across all formats (console, JSON, HTML, Excel, MD, CSV) |
-| `test_cli_command_handlers.py` | 155 | CLI dispatch for --stats, --org-report, --list-snapshots, discovery inspection, diff config unpacking |
+| `test_cli_command_handlers.py` | 156 | CLI dispatch for --stats, --org-report, --list-snapshots, discovery inspection, diff config unpacking |
 | `test_profile_management.py` | 53 | Interactive profile creation, import, test, show |
 | `test_snapshot_commands.py` | 65 | Snapshot creation, comparison, name resolution |
 | `test_config_and_resolution.py` | 112 | Config status, validation, stats, name resolution |
@@ -246,7 +246,7 @@ tests/
 | `test_interactive_discovery_coverage.py` | 117 | Interactive discovery and helpers coverage |
 | `test_lock_backends.py` | 46 | Lock backends edge cases and coverage |
 | `test_main_impl_cli_coverage.py` | 91 | _main_impl CLI path coverage |
-| `test_main_impl_coverage.py` | 61 | _main_impl coverage edge cases |
+| `test_main_impl_coverage.py` | 64 | _main_impl coverage edge cases |
 | `test_org_cache_branches.py` | 51 | Org cache branch coverage |
 | `test_org_writer_compat_contracts.py` | 107 | Org writer compatibility boundary contract tests |
 | `test_org_writer_coverage.py` | 143 | Org writer edge cases and coverage |
@@ -257,7 +257,7 @@ tests/
 | `test_cli_smoke_modes.py` | 10 | CLI smoke tests for core command modes |
 | `test_generator_mock_contract.py` | 2 | Generator mock symbol contract tests |
 | `test_completion.py` | 56 | Shell completion flag (--completion bash/zsh/fish) |
-| `test_exception_narrowing.py` | 54 | Exception narrowing boundary tests |
+| `test_exception_narrowing.py` | 55 | Exception narrowing boundary tests |
 | `test_coverage_hardening.py` | 100 | Coverage hardening tests |
 | `test_trending_models.py` | 53 | Trending dataclass construction and bridge tests |
 | `test_trending_discovery.py` | 88 | Snapshot cache discovery, deltas, drift scoring |
@@ -298,7 +298,7 @@ tests/
 | `test_agent_workflows.py` | 69 | Agent workflow shell script validation tests |
 | `test_manifest_agent_contract.py` | 16 | Manifest vs runtime capability drift tests |
 | `test_tool_manifests.py` | 40 | Tool manifest schema and content tests |
-| **Total** | **7,714** | **Collected via pytest --collect-only** |
+| **Total** | **7,719** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -756,7 +756,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (7,714 tests total)
+- [x] Comprehensive test coverage (7,719 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 78 tests

--- a/tests/test_cli_command_handlers.py
+++ b/tests/test_cli_command_handlers.py
@@ -801,6 +801,52 @@ class TestHandleDiffCommand:
         assert "AEP API" in captured.err
         assert captured.out == ""
 
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_diff_lookup_403_shows_data_view_access_hint(self, mock_conf, mock_cjapy, capsys):
+        """Lookup 403s during diff should keep the narrower data-view guidance."""
+        mock_conf.return_value = (True, "config_path", {})
+        mock_cja = MagicMock()
+        mock_cjapy.CJA.return_value = mock_cja
+        mock_cja.getDataView.side_effect = RuntimeError("HTTP 403 Forbidden")
+
+        success, has_changes, exit_override = handle_diff_command(
+            source_id="dv_a",
+            target_id="dv_b",
+            quiet=True,
+        )
+
+        assert success is False
+        assert has_changes is False
+        assert exit_override is None
+        captured = capsys.readouterr()
+        assert "Failed to compare data views: HTTP 403 Forbidden" in captured.err
+        assert "accessing this data view" in captured.err
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_diff_component_403_shows_generic_auth_hint(self, mock_conf, mock_cjapy, capsys):
+        """Component-fetch 403s during diff should avoid lookup-specific remediation."""
+        mock_conf.return_value = (True, "config_path", {})
+        mock_cja = MagicMock()
+        mock_cjapy.CJA.return_value = mock_cja
+        mock_cja.getDataView.return_value = {"name": "DV", "owner": "o", "description": ""}
+        mock_cja.getMetrics.side_effect = RuntimeError("HTTP 403 Forbidden")
+
+        success, has_changes, exit_override = handle_diff_command(
+            source_id="dv_a",
+            target_id="dv_b",
+            quiet=True,
+        )
+
+        assert success is False
+        assert has_changes is False
+        assert exit_override is None
+        captured = capsys.readouterr()
+        assert "Failed to compare data views: HTTP 403 Forbidden" in captured.err
+        assert "authentication or authorization failed" in captured.err
+        assert "accessing this data view" not in captured.err
+
     @patch("cja_auto_sdr.generator.SnapshotManager")
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")

--- a/tests/test_cli_command_handlers.py
+++ b/tests/test_cli_command_handlers.py
@@ -191,6 +191,34 @@ class TestProcessInventorySummary:
     @patch("cja_auto_sdr.generator.initialize_cja")
     @patch("cja_auto_sdr.generator.with_log_context")
     @patch("cja_auto_sdr.generator.setup_logging")
+    def test_data_view_fetch_plain_exception_http_403_shows_lookup_access_hint(
+        self,
+        mock_setup,
+        mock_ctx,
+        mock_init,
+        mock_display,
+        capsys,
+    ):
+        """Plain Exception 403 lookup failures should stay controlled and hinted."""
+        mock_setup.return_value = logging.getLogger("test")
+        mock_ctx.return_value = logging.getLogger("test")
+
+        mock_cja = MagicMock()
+        mock_cja.dataviews.get_single.side_effect = Exception("HTTP 403 Forbidden")
+        mock_init.return_value = mock_cja
+
+        result = process_inventory_summary("dv_bad_id", config_file="config.json")
+
+        assert "error" in result
+        captured = capsys.readouterr()
+        assert "Failed to fetch data view (unexpected): HTTP 403 Forbidden" in captured.err
+        assert "accessing this data view" in captured.err
+        assert "have access to it" in captured.err
+
+    @patch("cja_auto_sdr.generator.display_inventory_summary")
+    @patch("cja_auto_sdr.generator.initialize_cja")
+    @patch("cja_auto_sdr.generator.with_log_context")
+    @patch("cja_auto_sdr.generator.setup_logging")
     def test_successful_fetch_no_inventory(self, mock_setup, mock_ctx, mock_init, mock_display):
         """Successful fetch with no inventory flags returns display_inventory_summary result."""
         mock_setup.return_value = logging.getLogger("test")

--- a/tests/test_cli_command_handlers.py
+++ b/tests/test_cli_command_handlers.py
@@ -752,6 +752,27 @@ class TestHandleDiffCommand:
         assert has_changes is False
         assert exit_override is None
 
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_diff_plain_hint_stays_on_stderr(self, mock_conf, mock_cjapy, capsys):
+        """Hint-bearing diff failures should keep the error and remediation text on stderr."""
+        mock_conf.return_value = (True, "config_path", {})
+        mock_cjapy.CJA.side_effect = KeyError("content")
+
+        success, has_changes, exit_override = handle_diff_command(
+            source_id="dv_a",
+            target_id="dv_b",
+            quiet=True,
+        )
+
+        assert success is False
+        assert has_changes is False
+        assert exit_override is None
+        captured = capsys.readouterr()
+        assert "Failed to compare data views: 'content'" in captured.err
+        assert "AEP API" in captured.err
+        assert captured.out == ""
+
     @patch("cja_auto_sdr.generator.SnapshotManager")
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")

--- a/tests/test_cli_command_handlers.py
+++ b/tests/test_cli_command_handlers.py
@@ -2591,6 +2591,27 @@ class TestDiscoveryInspectionNameResolution:
         assert "resolver plain log line" not in stderr_output
 
     @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.configure_cjapy", side_effect=KeyError("content"))
+    @patch("cja_auto_sdr.generator.describe_dataview")
+    def test_machine_readable_resolution_hinted_failure_keeps_stderr_json_only(
+        self,
+        mock_fn,
+        _mock_configure,
+        capsys,
+    ):
+        """Hint-bearing resolution failures must not append plain-text guidance to stderr JSON."""
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("cja_auto_sdr.generator.parse_arguments") as mock_pa:
+                mock_pa.return_value = parse_arguments(["--describe-dataview", "Broken View", "--output", "-"])
+                _main_impl(run_state={})
+
+        assert exc_info.value.code == 1
+        mock_fn.assert_not_called()
+        payload = json.loads(capsys.readouterr().err)
+        assert payload["error_type"] == "connectivity_error"
+        assert payload["error"] == "Failed to resolve data view names: 'content'"
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
     @patch("cja_auto_sdr.generator.prompt_for_selection")
     @patch("cja_auto_sdr.generator.resolve_data_view_names")
     @patch("cja_auto_sdr.generator.describe_dataview")

--- a/tests/test_cli_command_handlers.py
+++ b/tests/test_cli_command_handlers.py
@@ -163,6 +163,34 @@ class TestProcessInventorySummary:
     @patch("cja_auto_sdr.generator.initialize_cja")
     @patch("cja_auto_sdr.generator.with_log_context")
     @patch("cja_auto_sdr.generator.setup_logging")
+    def test_data_view_fetch_http_403_shows_lookup_access_hint(
+        self,
+        mock_setup,
+        mock_ctx,
+        mock_init,
+        mock_display,
+        capsys,
+    ):
+        """Inventory summary 403 lookup failures should mention no-access guidance."""
+        mock_setup.return_value = logging.getLogger("test")
+        mock_ctx.return_value = logging.getLogger("test")
+
+        mock_cja = MagicMock()
+        mock_cja.dataviews.get_single.side_effect = RuntimeError("HTTP 403 Forbidden")
+        mock_init.return_value = mock_cja
+
+        result = process_inventory_summary("dv_bad_id", config_file="config.json")
+
+        assert "error" in result
+        captured = capsys.readouterr()
+        assert "Failed to fetch data view (unexpected): HTTP 403 Forbidden" in captured.err
+        assert "accessing this data view" in captured.err
+        assert "have access to it" in captured.err
+
+    @patch("cja_auto_sdr.generator.display_inventory_summary")
+    @patch("cja_auto_sdr.generator.initialize_cja")
+    @patch("cja_auto_sdr.generator.with_log_context")
+    @patch("cja_auto_sdr.generator.setup_logging")
     def test_successful_fetch_no_inventory(self, mock_setup, mock_ctx, mock_init, mock_display):
         """Successful fetch with no inventory flags returns display_inventory_summary result."""
         mock_setup.return_value = logging.getLogger("test")

--- a/tests/test_cli_commands_config_coverage.py
+++ b/tests/test_cli_commands_config_coverage.py
@@ -655,6 +655,18 @@ class TestApiConnectionHint:
         hint = _api_connection_hint(exc)
         assert hint is not None
         assert "HTTP 403" in hint
+        assert "resource is not accessible" in hint
+
+    def test_http_403_data_view_lookup_context_mentions_no_access(self):
+        from cja_auto_sdr.cli.commands.config import _api_connection_hint
+
+        exc = Exception("Forbidden")
+        exc.status_code = 403
+        hint = _api_connection_hint(exc, context="data_view_lookup")
+        assert hint is not None
+        assert "accessing this data view" in hint
+        assert "have access to it" in hint
+        assert "client_id" in hint
 
     def test_wrapped_response_status_code_returns_auth_hint(self):
         from cja_auto_sdr.cli.commands.config import _api_connection_hint

--- a/tests/test_cli_commands_config_coverage.py
+++ b/tests/test_cli_commands_config_coverage.py
@@ -631,13 +631,11 @@ class TestApiConnectionHint:
         assert "AEP API" in hint
         assert "product profiles" in hint
 
-    def test_key_error_other_key_returns_generic_hint(self):
+    def test_key_error_other_key_returns_none(self):
         from cja_auto_sdr.cli.commands.config import _api_connection_hint
 
         hint = _api_connection_hint(KeyError("globalCompanyId"))
-        assert hint is not None
-        assert "globalCompanyId" in hint
-        assert "OAuth credentials" in hint
+        assert hint is None
 
     def test_http_401_returns_auth_hint(self):
         from cja_auto_sdr.cli.commands.config import _api_connection_hint
@@ -682,6 +680,12 @@ class TestApiConnectionHint:
         hint = _api_connection_hint(RuntimeError("Request failed with HTTP 401 Unauthorized"))
         assert hint is not None
         assert "HTTP 401" in hint
+
+    def test_unrelated_numeric_runtime_text_returns_none(self):
+        from cja_auto_sdr.cli.commands.config import _api_connection_hint
+
+        hint = _api_connection_hint(RuntimeError("expected 403 columns in export"))
+        assert hint is None
 
     def test_generic_exception_returns_none(self):
         from cja_auto_sdr.cli.commands.config import _api_connection_hint

--- a/tests/test_cli_commands_config_coverage.py
+++ b/tests/test_cli_commands_config_coverage.py
@@ -722,3 +722,29 @@ class TestValidateConfigHintOutput:
         captured = capsys.readouterr()
         assert "API connection failed" in captured.out
         assert "AEP API" in captured.out
+
+    def test_runtime_http_403_shows_hint_in_fallback_output(self, capsys):
+        from cja_auto_sdr.cli.commands.config import validate_config_only
+
+        gen = _make_generator_mock(
+            python_version_info=(3, 14, 0),
+            recoverable_exceptions=(KeyError,),
+        )
+        gen.load_credentials_from_env.return_value = {
+            "org_id": "org@AdobeOrg",
+            "client_id": "cid12345678",
+            "secret": "sec12345678",
+            "scopes": "openid",
+        }
+        gen.validate_env_credentials.return_value = True
+        gen.cjapy.CJA.return_value.getDataViews.side_effect = RuntimeError("HTTP 403 Forbidden")
+
+        with patch("cja_auto_sdr.cli.commands.config._generator_module", return_value=gen):
+            with patch("cja_auto_sdr.cli.commands.config._check_output_dir_access"):
+                result = validate_config_only()
+
+        assert result is False
+        captured = capsys.readouterr()
+        assert "API connection failed: HTTP 403 Forbidden" in captured.out
+        assert "authentication or authorization failed" in captured.out
+        assert "unexpected" not in captured.out

--- a/tests/test_cli_commands_config_coverage.py
+++ b/tests/test_cli_commands_config_coverage.py
@@ -658,6 +658,31 @@ class TestApiConnectionHint:
         assert hint is not None
         assert "HTTP 403" in hint
 
+    def test_wrapped_response_status_code_returns_auth_hint(self):
+        from cja_auto_sdr.cli.commands.config import _api_connection_hint
+
+        exc = Exception("Unauthorized wrapper")
+        exc.response = {"error": {"statusCode": "401"}}  # type: ignore[attr-defined]
+        hint = _api_connection_hint(exc)
+        assert hint is not None
+        assert "HTTP 401" in hint
+
+    def test_status_attribute_string_returns_auth_hint(self):
+        from cja_auto_sdr.cli.commands.config import _api_connection_hint
+
+        exc = Exception("wrapped auth failure")
+        exc.status = "HTTP 403 Forbidden"  # type: ignore[attr-defined]
+        hint = _api_connection_hint(exc)
+        assert hint is not None
+        assert "HTTP 403" in hint
+
+    def test_exception_text_http_status_returns_auth_hint(self):
+        from cja_auto_sdr.cli.commands.config import _api_connection_hint
+
+        hint = _api_connection_hint(RuntimeError("Request failed with HTTP 401 Unauthorized"))
+        assert hint is not None
+        assert "HTTP 401" in hint
+
     def test_generic_exception_returns_none(self):
         from cja_auto_sdr.cli.commands.config import _api_connection_hint
 

--- a/tests/test_cli_commands_config_coverage.py
+++ b/tests/test_cli_commands_config_coverage.py
@@ -613,3 +613,87 @@ class TestValidateConfigOutputDirErrorMessages:
 
         assert result is False
         assert "Cannot determine writable parent" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# _api_connection_hint — diagnostic hint generation
+# ---------------------------------------------------------------------------
+
+
+class TestApiConnectionHint:
+    """Tests for _api_connection_hint helper."""
+
+    def test_key_error_content_returns_aep_hint(self):
+        from cja_auto_sdr.cli.commands.config import _api_connection_hint
+
+        hint = _api_connection_hint(KeyError("content"))
+        assert hint is not None
+        assert "AEP API" in hint
+        assert "product profiles" in hint
+
+    def test_key_error_other_key_returns_generic_hint(self):
+        from cja_auto_sdr.cli.commands.config import _api_connection_hint
+
+        hint = _api_connection_hint(KeyError("globalCompanyId"))
+        assert hint is not None
+        assert "globalCompanyId" in hint
+        assert "OAuth credentials" in hint
+
+    def test_http_401_returns_auth_hint(self):
+        from cja_auto_sdr.cli.commands.config import _api_connection_hint
+
+        exc = Exception("Unauthorized")
+        exc.status_code = 401
+        hint = _api_connection_hint(exc)
+        assert hint is not None
+        assert "HTTP 401" in hint
+        assert "client_id" in hint
+
+    def test_http_403_returns_auth_hint(self):
+        from cja_auto_sdr.cli.commands.config import _api_connection_hint
+
+        exc = Exception("Forbidden")
+        exc.status_code = 403
+        hint = _api_connection_hint(exc)
+        assert hint is not None
+        assert "HTTP 403" in hint
+
+    def test_generic_exception_returns_none(self):
+        from cja_auto_sdr.cli.commands.config import _api_connection_hint
+
+        hint = _api_connection_hint(ValueError("something else"))
+        assert hint is None
+
+
+# ---------------------------------------------------------------------------
+# validate_config_only — hint output in step [4/5]
+# ---------------------------------------------------------------------------
+
+
+class TestValidateConfigHintOutput:
+    """Verify that API connection failure in validate_config_only prints hints."""
+
+    def test_key_error_content_shows_hint_in_output(self, capsys):
+        from cja_auto_sdr.cli.commands.config import validate_config_only
+
+        gen = _make_generator_mock(
+            python_version_info=(3, 14, 0),
+            recoverable_exceptions=(KeyError,),
+        )
+        gen.load_credentials_from_env.return_value = {
+            "org_id": "org@AdobeOrg",
+            "client_id": "cid12345678",
+            "secret": "sec12345678",
+            "scopes": "openid",
+        }
+        gen.validate_env_credentials.return_value = True
+        gen.cjapy.CJA.return_value.getDataViews.side_effect = KeyError("content")
+
+        with patch("cja_auto_sdr.cli.commands.config._generator_module", return_value=gen):
+            with patch("cja_auto_sdr.cli.commands.config._check_output_dir_access"):
+                result = validate_config_only()
+
+        assert result is False
+        captured = capsys.readouterr()
+        assert "API connection failed" in captured.out
+        assert "AEP API" in captured.out

--- a/tests/test_config_and_resolution.py
+++ b/tests/test_config_and_resolution.py
@@ -1137,6 +1137,47 @@ class TestShowStats:
 
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_cja_constructor_hint_shows_on_human_stdout(
+        self,
+        mock_config,
+        mock_cjapy,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """Hint-bearing exact-ID stats failures should keep the error and hint on stdout."""
+        from cja_auto_sdr.generator import show_stats
+
+        mock_config.return_value = (True, "file", None)
+        mock_cjapy.CJA.side_effect = KeyError("content")
+
+        assert show_stats(["dv_test"]) is False
+        captured = capsys.readouterr()
+        assert "Failed to get stats: 'content'" in captured.out
+        assert "AEP API" in captured.out
+        assert captured.err == ""
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_cja_constructor_hint_suppressed_for_machine_readable(
+        self,
+        mock_config,
+        mock_cjapy,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """Machine-readable stats failures must keep stderr as JSON only."""
+        from cja_auto_sdr.generator import show_stats
+
+        mock_config.return_value = (True, "file", None)
+        mock_cjapy.CJA.side_effect = KeyError("content")
+
+        assert show_stats(["dv_test"], output_format="json") is False
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        payload = json.loads(captured.err)
+        assert payload["error"] == "Failed to get stats: 'content'"
+        assert payload["error_type"] == "connectivity_error"
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
     def test_cja_constructor_exception_returns_controlled_failure(
         self,
         mock_config,

--- a/tests/test_config_and_resolution.py
+++ b/tests/test_config_and_resolution.py
@@ -379,6 +379,21 @@ class TestValidateConfigOnly:
             result = validate_config_only(config_file=str(config))
         assert result is False
 
+    @patch("cja_auto_sdr.generator.cjapy")
+    def test_api_cja_init_plain_exception(self, mock_cjapy, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        """Bare constructor Exception from CJA() should return False, not traceback."""
+        from cja_auto_sdr.generator import validate_config_only
+
+        config = tmp_path / "config.json"
+        config.write_text(
+            json.dumps({"org_id": "org@Adobe", "client_id": "abcd1234efgh", "secret": "secret12345678"}),
+        )
+        mock_cjapy.CJA.side_effect = Exception("auth bootstrap failed")
+        with patch("cja_auto_sdr.generator.load_credentials_from_env", return_value=None):
+            result = validate_config_only(config_file=str(config))
+        assert result is False
+        assert "API connection failed (unexpected)" in capsys.readouterr().out
+
     @patch("cja_auto_sdr.generator._config_from_env")
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.load_credentials_from_env")

--- a/tests/test_config_and_resolution.py
+++ b/tests/test_config_and_resolution.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pandas as pd
 import pytest
@@ -1175,6 +1175,28 @@ class TestShowStats:
         payload = json.loads(captured.err)
         assert payload["error"] == "Failed to get stats: 'content'"
         assert payload["error_type"] == "connectivity_error"
+
+    @patch("cja_auto_sdr.cli.commands.stats._collect_stats_row_with_fallback", side_effect=KeyError("name"))
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_local_stats_key_error_does_not_emit_api_hint(
+        self,
+        mock_config,
+        mock_cjapy,
+        _mock_collect,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """Local stats-processing KeyErrors should not claim an auth/config issue."""
+        from cja_auto_sdr.generator import show_stats
+
+        mock_config.return_value = (True, "file", None)
+        mock_cjapy.CJA.return_value = Mock()
+
+        assert show_stats(["dv_test"]) is False
+        captured = capsys.readouterr()
+        assert "Failed to get stats: 'name'" in captured.out
+        assert "AEP API" not in captured.out
+        assert "OAuth credentials" not in captured.out
 
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")

--- a/tests/test_exception_narrowing.py
+++ b/tests/test_exception_narrowing.py
@@ -190,12 +190,12 @@ class TestRequireAccessibleDataviewExceptionNarrowing:
 
 
 # ===========================================================================
-# Group A: process_inventory_summary  (fallback -> (RuntimeError, AttributeError))
+# Group A: process_inventory_summary  (fallback -> plain Exception, except SystemError)
 # ===========================================================================
 
 
 class TestProcessInventorySummaryExceptionNarrowing:
-    """Verify process_inventory_summary fallback catches (RuntimeError, AttributeError)."""
+    """Verify process_inventory_summary fallback catches third-party Exception failures."""
 
     def _run_with_side_effect(self, exc):
         """Mock CJA init + dataviews.get_single raising *exc*."""
@@ -228,6 +228,12 @@ class TestProcessInventorySummaryExceptionNarrowing:
         result = self._run_with_side_effect(ConfigurationError("invalid auth bootstrap"))
         assert "error" in result
         assert "invalid auth bootstrap" in result["error"]
+
+    def test_plain_exception_caught(self):
+        """Bare Exception from cjapy bootstrap should return a controlled error payload."""
+        result = self._run_with_side_effect(Exception("auth bootstrap failed"))
+        assert "error" in result
+        assert "auth bootstrap failed" in result["error"]
 
     def test_system_error_propagates(self):
         """SystemError is NOT in either handler -> propagates."""

--- a/tests/test_exception_narrowing.py
+++ b/tests/test_exception_narrowing.py
@@ -34,12 +34,12 @@ def _make_logger() -> logging.Logger:
 
 
 # ===========================================================================
-# Group B: test_profile  (catches RECOVERABLE_CONFIG_API_EXCEPTIONS)
+# Group B: test_profile  (catches RECOVERABLE_CONFIG_API_EXCEPTIONS + plain Exception fallback)
 # ===========================================================================
 
 
 class TestTestProfileExceptionNarrowing:
-    """Verify test_profile catches recoverable API/bootstrap failures and propagates others."""
+    """Verify test_profile catches recoverable/bootstrap failures and propagates others."""
 
     def _run_with_side_effect(self, exc, tmp_path, capsys):
         """Helper: invoke test_profile with in-memory cjapy configuration raising *exc*."""
@@ -73,10 +73,22 @@ class TestTestProfileExceptionNarrowing:
         assert result is False
         assert "FAILED" in capsys.readouterr().err
 
-    def test_runtime_error_propagates(self, tmp_path, capsys):
-        """RuntimeError is NOT in RECOVERABLE_API_EXCEPTIONS -> propagates."""
-        with pytest.raises(RuntimeError, match="should escape"):
-            self._run_with_side_effect(RuntimeError("should escape"), tmp_path, capsys)
+    def test_runtime_error_caught(self, tmp_path, capsys):
+        """RuntimeError in the fallback tuple should return a controlled failure."""
+        result = self._run_with_side_effect(RuntimeError("should not escape"), tmp_path, capsys)
+        assert result is False
+        assert "FAILED" in capsys.readouterr().err
+
+    def test_attribute_error_caught(self, tmp_path, capsys):
+        """AttributeError in the fallback tuple should return a controlled failure."""
+        result = self._run_with_side_effect(AttributeError("missing bootstrap field"), tmp_path, capsys)
+        assert result is False
+
+    def test_plain_exception_caught(self, tmp_path, capsys):
+        """Bare Exception from bootstrap should return a controlled failure."""
+        result = self._run_with_side_effect(Exception("auth bootstrap failed"), tmp_path, capsys)
+        assert result is False
+        assert "FAILED" in capsys.readouterr().err
 
     def test_system_error_propagates(self, tmp_path, capsys):
         """SystemError is NOT in RECOVERABLE_API_EXCEPTIONS -> propagates."""
@@ -224,12 +236,12 @@ class TestProcessInventorySummaryExceptionNarrowing:
 
 
 # ===========================================================================
-# Group A: validate_config_only  (fallback -> (RuntimeError, AttributeError))
+# Group A: validate_config_only  (fallback -> plain Exception, except SystemError)
 # ===========================================================================
 
 
 class TestValidateConfigOnlyExceptionNarrowing:
-    """Verify validate_config_only fallback catches (RuntimeError, AttributeError)."""
+    """Verify validate_config_only fallback catches third-party Exception failures."""
 
     def _run_with_cja_side_effect(self, exc):
         """Mock credential resolution + cjapy.CJA() raising *exc*."""
@@ -260,6 +272,11 @@ class TestValidateConfigOnlyExceptionNarrowing:
         result = self._run_with_cja_side_effect(ConfigurationError("invalid oauth configuration"))
         assert result is False
 
+    def test_plain_exception_caught(self):
+        """Bare Exception from CJA bootstrap should return False."""
+        result = self._run_with_cja_side_effect(Exception("auth bootstrap failed"))
+        assert result is False
+
     def test_system_error_propagates(self):
         """SystemError is NOT in either handler -> propagates."""
         with pytest.raises(SystemError, match="should escape"):
@@ -281,6 +298,21 @@ class TestResolveDataViewNamesExceptionBoundary:
         assert name_map == {}
         assert diagnostics.error_type == "connectivity_error"
         assert "bad org credentials" in diagnostics.error_message
+
+    def test_plain_exception_returns_connectivity_diagnostics(self):
+        """Bare Exception from cjapy bootstrap should produce controlled diagnostics."""
+        with patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "env", {})):
+            with patch("cja_auto_sdr.generator.cjapy") as mock_cjapy:
+                mock_cjapy.CJA.side_effect = Exception("auth bootstrap failed")
+                ids, name_map, diagnostics = generator.resolve_data_view_names(
+                    ["My DV"],
+                    include_diagnostics=True,
+                )
+
+        assert ids == []
+        assert name_map == {}
+        assert diagnostics.error_type == "connectivity_error"
+        assert "auth bootstrap failed" in diagnostics.error_message
 
 
 # ===========================================================================

--- a/tests/test_generator_interactive_and_console.py
+++ b/tests/test_generator_interactive_and_console.py
@@ -1119,6 +1119,33 @@ def test_run_org_report_unexpected_cja_runtime_error_returns_controlled_failure(
     assert "ERROR: Org report failed: bootstrap exploded" in capsys.readouterr().out
 
 
+def test_run_org_report_hint_stays_on_stdout_for_console_errors(tmp_path: Path, capsys):
+    mock_logger = Mock()
+
+    with (
+        patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "mock", {"org_id": "test_org@AdobeOrg"})),
+        patch("cja_auto_sdr.generator.cjapy") as mock_cjapy,
+        patch("cja_auto_sdr.generator.logging.getLogger", return_value=mock_logger),
+    ):
+        mock_cjapy.CJA.side_effect = KeyError("content")
+
+        ok, exceeded = generator.run_org_report(
+            config_file="config.json",
+            output_format="console",
+            output_path=None,
+            output_dir=str(tmp_path),
+            org_config=OrgReportConfig(),
+            quiet=True,
+        )
+
+    assert ok is False
+    assert exceeded is False
+    captured = capsys.readouterr()
+    assert "ERROR: Org report failed: 'content'" in captured.out
+    assert "AEP API" in captured.out
+    assert captured.err == ""
+
+
 def test_run_org_report_org_stats_json_stdout_branch(tmp_path: Path, capsys, rich_org_report_result):
     result = rich_org_report_result
     config = OrgReportConfig(org_stats_only=True)

--- a/tests/test_interactive_discovery_coverage.py
+++ b/tests/test_interactive_discovery_coverage.py
@@ -546,6 +546,22 @@ class TestRunListCommand:
         assert payload["error_type"] == "connectivity_error"
 
     @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy", side_effect=KeyError("content"))
+    def test_human_readable_hinted_failure_writes_hint_to_stdout(self, _mock_config, _mock_cjapy, capsys):
+        """Human-readable discovery errors should keep the hint on stdout with the banner."""
+        result = _run_list_command(
+            banner_text="TEST",
+            command_name="test",
+            fetch_and_format=lambda cja, mr: "data",
+            config_file="config.json",
+        )
+        assert result is False
+        captured = capsys.readouterr()
+        assert "Failed to connect to CJA API: 'content'" in captured.out
+        assert "AEP API" in captured.out
+        assert captured.err == ""
+
+    @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "mock", None))
     def test_attribute_error_from_fetch_is_recoverable(self, _mock_config, mock_cjapy, capsys):
         """AttributeError in fetch callback should return False with a user-facing API error."""
@@ -684,6 +700,21 @@ class TestInteractiveSelectDataviews:
         assert result == []
         out = capsys.readouterr().out
         assert "Failed to connect to CJA API: network error" in out
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "mock", None))
+    def test_hint_stays_on_stdout_for_interactive_select(self, _cfg, mock_cjapy, capsys):
+        """Hint-bearing interactive selection failures should not split streams."""
+        mock_cja = Mock()
+        mock_cja.getDataViews.side_effect = KeyError("content")
+        mock_cjapy.CJA.return_value = mock_cja
+
+        result = interactive_select_dataviews("config.json")
+        assert result == []
+        captured = capsys.readouterr()
+        assert "Failed to connect to CJA API: 'content'" in captured.out
+        assert "AEP API" in captured.out
+        assert captured.err == ""
 
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "mock", None))
@@ -1086,6 +1117,21 @@ class TestInteractiveWizard:
         assert result is None
         out = capsys.readouterr().out
         assert "Failed to connect to CJA API: API down" in out
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "mock", None))
+    def test_hint_stays_on_stdout_for_interactive_wizard(self, _cfg, mock_cjapy, capsys):
+        """Hint-bearing wizard startup failures should keep the error and hint together."""
+        mock_cja = Mock()
+        mock_cja.getDataViews.side_effect = KeyError("content")
+        mock_cjapy.CJA.return_value = mock_cja
+
+        result = interactive_wizard("config.json")
+        assert result is None
+        captured = capsys.readouterr()
+        assert "Failed to connect to CJA API: 'content'" in captured.out
+        assert "AEP API" in captured.out
+        assert captured.err == ""
 
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "mock", None))

--- a/tests/test_interactive_discovery_coverage.py
+++ b/tests/test_interactive_discovery_coverage.py
@@ -528,6 +528,24 @@ class TestRunListCommand:
         assert "API timeout" in parsed["error"]
 
     @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy", side_effect=KeyError("content"))
+    def test_machine_readable_hinted_failure_keeps_stderr_json_only(self, _mock_config, _mock_cjapy, capsys):
+        """Hint-bearing discovery failures must not append plain text to stderr JSON."""
+        result = _run_list_command(
+            banner_text="TEST",
+            command_name="test",
+            fetch_and_format=lambda cja, mr: "data",
+            config_file="config.json",
+            output_format="json",
+        )
+        assert result is False
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        payload = json.loads(captured.err)
+        assert payload["error"] == "Failed to connect to CJA API: 'content'"
+        assert payload["error_type"] == "connectivity_error"
+
+    @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "mock", None))
     def test_attribute_error_from_fetch_is_recoverable(self, _mock_config, mock_cjapy, capsys):
         """AttributeError in fetch callback should return False with a user-facing API error."""

--- a/tests/test_interactive_discovery_coverage.py
+++ b/tests/test_interactive_discovery_coverage.py
@@ -582,6 +582,27 @@ class TestRunListCommand:
 
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "mock", None))
+    def test_key_error_from_fetch_does_not_emit_api_hint(self, _mock_config, mock_cjapy, capsys):
+        """Non-API KeyErrors should not print Adobe credential remediation text."""
+        mock_cjapy.CJA.return_value = Mock()
+
+        def _raise_key_error(_cja, _machine_readable):
+            raise KeyError("name")
+
+        result = _run_list_command(
+            banner_text="TEST",
+            command_name="test",
+            fetch_and_format=_raise_key_error,
+            config_file="config.json",
+        )
+        assert result is False
+        out = capsys.readouterr().out
+        assert "Failed to connect to CJA API: 'name'" in out
+        assert "AEP API" not in out
+        assert "OAuth credentials" not in out
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "mock", None))
     def test_cja_constructor_exception_is_recoverable(self, _mock_config, mock_cjapy, capsys):
         """Bare constructor failures from cjapy should return a controlled command error."""
         mock_cjapy.CJA.side_effect = Exception("auth bootstrap failed")

--- a/tests/test_main_impl_cli_coverage.py
+++ b/tests/test_main_impl_cli_coverage.py
@@ -1540,6 +1540,43 @@ class TestGitCommitIntegration:
     @patch("cja_auto_sdr.generator.SnapshotManager")
     @patch("cja_auto_sdr.generator.save_git_friendly_snapshot")
     @patch("cja_auto_sdr.generator.git_commit_snapshot", return_value=(True, "abc123"))
+    def test_git_commit_refetch_hint_bearing_failure_prints_hint(
+        self, mock_commit, mock_save, mock_sm_cls, _init_cja, _is_git, _bqs, _aghs, _aqi, mock_proc, _resolve, capsys
+    ):
+        """Hint-bearing re-fetch failures should still surface remediation before falling back."""
+        mock_proc.return_value = self._make_success_result()
+        mock_sm = MagicMock()
+        mock_sm.create_snapshot.side_effect = RuntimeError("HTTP 403 Forbidden")
+        mock_sm_cls.return_value = mock_sm
+
+        args = _make_args(
+            data_views=["dv_123"],
+            git_commit=True,
+            include_segments_inventory=True,
+        )
+        with patch("cja_auto_sdr.generator.parse_arguments", return_value=args):
+            try:
+                _main_impl()
+            except SystemExit:
+                pass
+
+        out = capsys.readouterr().out
+        assert "Could not fetch snapshot data" in out
+        assert "authentication or authorization failed" in out
+        mock_save.assert_called_once()
+        mock_commit.assert_called_once()
+
+    @patch("cja_auto_sdr.generator._cli_option_specified", _mock_cli_option_specified)
+    @patch("cja_auto_sdr.generator.resolve_data_view_names", return_value=(["dv_123"], {}))
+    @patch("cja_auto_sdr.generator.process_single_dataview")
+    @patch("cja_auto_sdr.generator.aggregate_quality_issues", return_value=[])
+    @patch("cja_auto_sdr.generator.append_github_step_summary")
+    @patch("cja_auto_sdr.generator.build_quality_step_summary", return_value="")
+    @patch("cja_auto_sdr.generator.is_git_repository", return_value=True)
+    @patch("cja_auto_sdr.generator.initialize_cja", return_value=MagicMock())
+    @patch("cja_auto_sdr.generator.SnapshotManager")
+    @patch("cja_auto_sdr.generator.save_git_friendly_snapshot")
+    @patch("cja_auto_sdr.generator.git_commit_snapshot", return_value=(True, "abc123"))
     def test_git_commit_refetch_api_error_continues(
         self, mock_commit, mock_save, mock_sm_cls, _init_cja, _is_git, _bqs, _aghs, _aqi, mock_proc, _resolve, capsys
     ):

--- a/tests/test_main_impl_coverage.py
+++ b/tests/test_main_impl_coverage.py
@@ -1985,6 +1985,30 @@ class TestRunDryRunAPIValidation:
         captured = capsys.readouterr()
         assert "dv_err: Error - per-view runtime failure" in captured.out
 
+    def test_dv_validation_http_403_uses_data_view_access_hint(self, capsys):
+        """Per-data-view 403 failures should mention no-access/not-found guidance."""
+        logger = logging.getLogger("test_dry_run_dv_403_hint")
+        with (
+            patch("cja_auto_sdr.generator.validate_config_file", return_value=True),
+            patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "config", {})),
+            patch("cja_auto_sdr.generator.cjapy") as mock_cjapy,
+            patch("cja_auto_sdr.generator.make_api_call_with_retry") as mock_retry,
+        ):
+            mock_cja = MagicMock()
+            mock_cjapy.CJA.return_value = mock_cja
+
+            mock_retry.side_effect = [
+                [],  # getDataViews
+                RuntimeError("HTTP 403 Forbidden"),
+            ]
+
+            result = run_dry_run(["dv_forbidden"], "config.json", logger)
+        assert result is False
+        captured = capsys.readouterr()
+        assert "dv_forbidden: Error - HTTP 403 Forbidden" in captured.out
+        assert "accessing this data view" in captured.out
+        assert "have access to it" in captured.out
+
     def test_dv_validation_retryable_error_continues_to_next_view(self, capsys):
         """Retryable transport failure for one data view should not abort the full loop."""
         logger = logging.getLogger("test_dry_run_retryable_continue")

--- a/tests/test_main_impl_coverage.py
+++ b/tests/test_main_impl_coverage.py
@@ -1816,6 +1816,38 @@ class TestRunDryRunAPIValidation:
         captured = capsys.readouterr()
         assert "API connection failed" in captured.out
 
+    def test_api_connection_key_error_shows_hint(self, capsys):
+        """KeyError('content') during the step-[2/3] probe should include the remediation hint."""
+        logger = logging.getLogger("test_dry_run_api_keyerror_hint")
+        with (
+            patch("cja_auto_sdr.generator.validate_config_file", return_value=True),
+            patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "config", {})),
+            patch("cja_auto_sdr.generator.cjapy") as mock_cjapy,
+            patch("cja_auto_sdr.generator.make_api_call_with_retry", side_effect=KeyError("content")),
+        ):
+            mock_cjapy.CJA.return_value = MagicMock()
+            result = run_dry_run(["dv_test"], "config.json", logger)
+        assert result is False
+        captured = capsys.readouterr()
+        assert "API connection failed: 'content'" in captured.out
+        assert "AEP API" in captured.out
+
+    def test_api_connection_runtime_auth_error_shows_hint(self, capsys):
+        """HTTP 401/403 text in the fallback branch should still surface the API hint."""
+        logger = logging.getLogger("test_dry_run_api_runtime_hint")
+        with (
+            patch("cja_auto_sdr.generator.validate_config_file", return_value=True),
+            patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "config", {})),
+            patch("cja_auto_sdr.generator.cjapy") as mock_cjapy,
+            patch("cja_auto_sdr.generator.make_api_call_with_retry", side_effect=RuntimeError("HTTP 403 Forbidden")),
+        ):
+            mock_cjapy.CJA.return_value = MagicMock()
+            result = run_dry_run(["dv_test"], "config.json", logger)
+        assert result is False
+        captured = capsys.readouterr()
+        assert "API connection failed: HTTP 403 Forbidden" in captured.out
+        assert "authentication or authorization failed" in captured.out
+
     def test_api_connection_unexpected_runtime_exception(self, capsys):
         """Unexpected runtime exceptions during API probe should still fail gracefully."""
         logger = logging.getLogger("test_dry_run_api_runtime")

--- a/tests/test_main_impl_coverage.py
+++ b/tests/test_main_impl_coverage.py
@@ -2009,6 +2009,34 @@ class TestRunDryRunAPIValidation:
         assert "accessing this data view" in captured.out
         assert "have access to it" in captured.out
 
+    def test_dv_component_validation_http_403_uses_generic_auth_hint(self, capsys):
+        """Later component-count 403s should not be mislabeled as lookup failures."""
+        logger = logging.getLogger("test_dry_run_dv_component_403_hint")
+        with (
+            patch("cja_auto_sdr.generator.validate_config_file", return_value=True),
+            patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "config", {})),
+            patch("cja_auto_sdr.generator.cjapy") as mock_cjapy,
+            patch("cja_auto_sdr.generator.make_api_call_with_retry") as mock_retry,
+            patch(
+                "cja_auto_sdr.generator._count_component_items_for_fetch_spec_with_retry",
+                side_effect=RuntimeError("HTTP 403 Forbidden"),
+            ),
+        ):
+            mock_cja = MagicMock()
+            mock_cjapy.CJA.return_value = mock_cja
+
+            mock_retry.side_effect = [
+                [],  # getDataViews
+                {"id": "dv_components", "name": "Component DV"},
+            ]
+
+            result = run_dry_run(["dv_components"], "config.json", logger)
+        assert result is False
+        captured = capsys.readouterr()
+        assert "dv_components: Error - HTTP 403 Forbidden" in captured.out
+        assert "authentication or authorization failed" in captured.out
+        assert "accessing this data view" not in captured.out
+
     def test_dv_validation_retryable_error_continues_to_next_view(self, capsys):
         """Retryable transport failure for one data view should not abort the full loop."""
         logger = logging.getLogger("test_dry_run_retryable_continue")

--- a/tests/test_main_impl_coverage.py
+++ b/tests/test_main_impl_coverage.py
@@ -1848,6 +1848,22 @@ class TestRunDryRunAPIValidation:
         assert "API connection failed: HTTP 403 Forbidden" in captured.out
         assert "authentication or authorization failed" in captured.out
 
+    def test_api_connection_plain_exception_auth_error_shows_hint(self, capsys):
+        """Bare Exception auth failures during API probe should still fail gracefully with a hint."""
+        logger = logging.getLogger("test_dry_run_api_plain_exception_hint")
+        with (
+            patch("cja_auto_sdr.generator.validate_config_file", return_value=True),
+            patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "config", {})),
+            patch("cja_auto_sdr.generator.cjapy") as mock_cjapy,
+            patch("cja_auto_sdr.generator.make_api_call_with_retry", side_effect=Exception("HTTP 403 Forbidden")),
+        ):
+            mock_cjapy.CJA.return_value = MagicMock()
+            result = run_dry_run(["dv_test"], "config.json", logger)
+        assert result is False
+        captured = capsys.readouterr()
+        assert "API connection failed: HTTP 403 Forbidden" in captured.out
+        assert "authentication or authorization failed" in captured.out
+
     def test_api_connection_unexpected_runtime_exception(self, capsys):
         """Unexpected runtime exceptions during API probe should still fail gracefully."""
         logger = logging.getLogger("test_dry_run_api_runtime")
@@ -2009,6 +2025,30 @@ class TestRunDryRunAPIValidation:
         assert "accessing this data view" in captured.out
         assert "have access to it" in captured.out
 
+    def test_dv_validation_plain_exception_http_403_uses_data_view_access_hint(self, capsys):
+        """Plain Exception 403s during per-view lookup should stay controlled and lookup-scoped."""
+        logger = logging.getLogger("test_dry_run_dv_plain_403_hint")
+        with (
+            patch("cja_auto_sdr.generator.validate_config_file", return_value=True),
+            patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "config", {})),
+            patch("cja_auto_sdr.generator.cjapy") as mock_cjapy,
+            patch("cja_auto_sdr.generator.make_api_call_with_retry") as mock_retry,
+        ):
+            mock_cja = MagicMock()
+            mock_cjapy.CJA.return_value = mock_cja
+
+            mock_retry.side_effect = [
+                [],  # getDataViews
+                Exception("HTTP 403 Forbidden"),
+            ]
+
+            result = run_dry_run(["dv_forbidden"], "config.json", logger)
+        assert result is False
+        captured = capsys.readouterr()
+        assert "dv_forbidden: Error - HTTP 403 Forbidden" in captured.out
+        assert "accessing this data view" in captured.out
+        assert "have access to it" in captured.out
+
     def test_dv_component_validation_http_403_uses_generic_auth_hint(self, capsys):
         """Later component-count 403s should not be mislabeled as lookup failures."""
         logger = logging.getLogger("test_dry_run_dv_component_403_hint")
@@ -2020,6 +2060,34 @@ class TestRunDryRunAPIValidation:
             patch(
                 "cja_auto_sdr.generator._count_component_items_for_fetch_spec_with_retry",
                 side_effect=RuntimeError("HTTP 403 Forbidden"),
+            ),
+        ):
+            mock_cja = MagicMock()
+            mock_cjapy.CJA.return_value = mock_cja
+
+            mock_retry.side_effect = [
+                [],  # getDataViews
+                {"id": "dv_components", "name": "Component DV"},
+            ]
+
+            result = run_dry_run(["dv_components"], "config.json", logger)
+        assert result is False
+        captured = capsys.readouterr()
+        assert "dv_components: Error - HTTP 403 Forbidden" in captured.out
+        assert "authentication or authorization failed" in captured.out
+        assert "accessing this data view" not in captured.out
+
+    def test_dv_component_validation_plain_exception_uses_generic_auth_hint(self, capsys):
+        """Plain Exception 403s during component counts should use the generic auth hint."""
+        logger = logging.getLogger("test_dry_run_dv_component_plain_403_hint")
+        with (
+            patch("cja_auto_sdr.generator.validate_config_file", return_value=True),
+            patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "config", {})),
+            patch("cja_auto_sdr.generator.cjapy") as mock_cjapy,
+            patch("cja_auto_sdr.generator.make_api_call_with_retry") as mock_retry,
+            patch(
+                "cja_auto_sdr.generator._count_component_items_for_fetch_spec_with_retry",
+                side_effect=Exception("HTTP 403 Forbidden"),
             ),
         ):
             mock_cja = MagicMock()

--- a/tests/test_output_content_validation.py
+++ b/tests/test_output_content_validation.py
@@ -38,7 +38,7 @@ def rich_data_dict():
         "Metadata": pd.DataFrame(
             {
                 "Property": ["Generated At", "Data View ID", "Tool Version", "Total Metrics"],
-                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.5.4", 3],
+                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.5.5", 3],
             },
         ),
         "Data Quality": pd.DataFrame(
@@ -104,7 +104,7 @@ def rich_metadata_dict():
         "Generated At": "2025-01-15 10:30:00 PST",
         "Data View ID": "dv_content_test",
         "Data View Name": "Test DataView",
-        "Tool Version": "3.5.4",
+        "Tool Version": "3.5.5",
         "Metrics Count": "3",
         "Dimensions Count": "4",
     }
@@ -224,7 +224,7 @@ class TestJSONContentValidation:
             data = json.load(f)
 
         assert data["metadata"]["Data View ID"] == "dv_content_test"
-        assert data["metadata"]["Tool Version"] == "3.5.4"
+        assert data["metadata"]["Tool Version"] == "3.5.5"
 
     def test_json_metadata_preserves_partial_markers(self, tmp_path, rich_data_dict, rich_metadata_dict):
         logger = logging.getLogger("json_test")

--- a/tests/test_profile_management.py
+++ b/tests/test_profile_management.py
@@ -634,6 +634,47 @@ class TestTestProfile:
         assert "Profile test: FAILED" in captured.err
         assert "Common issues:" in captured.out
 
+    def test_runtime_auth_failure_shows_hint(self, tmp_path, capsys):
+        """Bare runtime auth failures should return a controlled hinted failure."""
+        profile_dir = tmp_path / "orgs" / "runtime-auth-fail"
+        _write_config_json(profile_dir)
+
+        with (
+            patch("cja_auto_sdr.generator.get_profile_path", return_value=profile_dir),
+            patch("cja_auto_sdr.generator.cjapy"),
+            patch("cja_auto_sdr.generator.ConfigValidator") as mock_validator,
+            patch("cja_auto_sdr.generator._config_from_env", side_effect=RuntimeError("HTTP 403 Forbidden")),
+        ):
+            mock_validator.validate_all.return_value = []
+            result = run_test_profile("runtime-auth-fail")
+
+        assert result is False
+        captured = capsys.readouterr()
+        assert "Profile test: FAILED" in captured.err
+        assert "HTTP 403 Forbidden" in captured.err
+        assert "authentication or authorization failed" in captured.out
+
+    def test_plain_constructor_failure_returns_controlled_failure(self, tmp_path, capsys):
+        """Bare constructor failures should still return a controlled profile-test error."""
+        profile_dir = tmp_path / "orgs" / "plain-cja-fail"
+        _write_config_json(profile_dir)
+
+        with (
+            patch("cja_auto_sdr.generator.get_profile_path", return_value=profile_dir),
+            patch("cja_auto_sdr.generator.cjapy") as mock_cjapy,
+            patch("cja_auto_sdr.generator.ConfigValidator") as mock_validator,
+            patch("cja_auto_sdr.generator._config_from_env") as mock_config_from_env,
+        ):
+            mock_cjapy.CJA.side_effect = Exception("auth bootstrap failed")
+            mock_validator.validate_all.return_value = []
+            result = run_test_profile("plain-cja-fail")
+
+        assert result is False
+        mock_config_from_env.assert_called_once()
+        captured = capsys.readouterr()
+        assert "Profile test: FAILED" in captured.err
+        assert "auth bootstrap failed" in captured.err
+
     def test_validation_warnings_displayed(self, tmp_path, capsys):
         """Validation warnings should be displayed but not block the test."""
         profile_dir = tmp_path / "orgs" / "warnings"

--- a/tests/test_snapshot_commands.py
+++ b/tests/test_snapshot_commands.py
@@ -165,6 +165,7 @@ class TestHandleSnapshotCommand:
         result = handle_snapshot_command(
             data_view_id="dv_123",
             snapshot_file=out_file,
+            quiet=True,
         )
 
         assert result is False
@@ -210,6 +211,7 @@ class TestHandleSnapshotCommand:
         result = handle_snapshot_command(
             data_view_id="dv_123",
             snapshot_file=out_file,
+            quiet=True,
         )
 
         assert result is False
@@ -232,6 +234,26 @@ class TestHandleSnapshotCommand:
         assert result is False
         captured = capsys.readouterr()
         assert "Failed to create snapshot: auth bootstrap failed" in captured.err
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_snapshot_constructor_hint_stays_on_stderr(self, mock_configure, mock_cjapy, tmp_path, capsys):
+        """Hint-bearing snapshot failures should keep the error and hint together on stderr."""
+        mock_configure.return_value = (True, "config", None)
+        mock_cjapy.CJA.side_effect = KeyError("content")
+
+        out_file = str(tmp_path / "snap.json")
+        result = handle_snapshot_command(
+            data_view_id="dv_123",
+            snapshot_file=out_file,
+            quiet=True,
+        )
+
+        assert result is False
+        captured = capsys.readouterr()
+        assert "Failed to create snapshot: 'content'" in captured.err
+        assert "AEP API" in captured.err
+        assert captured.out == ""
 
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")
@@ -1074,6 +1096,27 @@ class TestHandleDiffSnapshotCommand:
         assert success is False
         captured = capsys.readouterr()
         assert "Failed to compare against snapshot" in captured.err
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_diff_snapshot_constructor_hint_stays_on_stderr(self, mock_configure, mock_cjapy, tmp_path, capsys):
+        """Hint-bearing diff-snapshot failures should keep stderr together."""
+        mock_configure.return_value = (True, "config", None)
+        mock_cjapy.CJA.side_effect = RuntimeError("HTTP 403 Forbidden")
+
+        snap_file = str(tmp_path / "baseline.json")
+        _write_snapshot_file(snap_file)
+
+        success, _has_changes, _exit_code = handle_diff_snapshot_command(
+            data_view_id="dv_test",
+            snapshot_file=snap_file,
+            quiet=True,
+        )
+
+        assert success is False
+        captured = capsys.readouterr()
+        assert "Failed to compare against snapshot: HTTP 403 Forbidden" in captured.err
+        assert "authentication or authorization failed" in captured.err
 
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")

--- a/tests/test_snapshot_commands.py
+++ b/tests/test_snapshot_commands.py
@@ -279,6 +279,29 @@ class TestHandleSnapshotCommand:
 
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_snapshot_component_403_shows_generic_auth_hint(self, mock_configure, mock_cjapy, tmp_path, capsys):
+        """Component-fetch 403s during snapshot build should not imply lookup failure."""
+        mock_configure.return_value = (True, "config", None)
+        mock_cja = MagicMock()
+        mock_cjapy.CJA.return_value = mock_cja
+        mock_cja.getDataView.return_value = {"name": "DV", "owner": "o", "description": ""}
+        mock_cja.getMetrics.side_effect = RuntimeError("HTTP 403 Forbidden")
+
+        out_file = str(tmp_path / "snap.json")
+        result = handle_snapshot_command(
+            data_view_id="dv_123",
+            snapshot_file=out_file,
+            quiet=True,
+        )
+
+        assert result is False
+        captured = capsys.readouterr()
+        assert "Failed to create snapshot: HTTP 403 Forbidden" in captured.err
+        assert "authentication or authorization failed" in captured.err
+        assert "accessing this data view" not in captured.err
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
     def test_snapshot_with_profile(self, mock_configure, mock_cjapy, tmp_path):
         """Profile parameter is passed to configure_cjapy."""
         mock_configure.return_value = (True, "config", None)
@@ -1163,6 +1186,32 @@ class TestHandleDiffSnapshotCommand:
         assert "Failed to compare against snapshot: HTTP 403 Forbidden" in captured.err
         assert "accessing this data view" in captured.err
         assert "have access to it" in captured.err
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_diff_snapshot_component_403_shows_generic_auth_hint(self, mock_configure, mock_cjapy, tmp_path, capsys):
+        """Component-fetch 403s during diff-snapshot should use the generic auth hint."""
+        mock_configure.return_value = (True, "config", None)
+        mock_cja = MagicMock()
+        mock_cjapy.CJA.return_value = mock_cja
+        mock_cja.getDataView.return_value = {"name": "Test DV", "owner": "o", "description": ""}
+        mock_cja.getMetrics.return_value = MagicMock(empty=False, to_dict=MagicMock(return_value=[]))
+        mock_cja.getDimensions.side_effect = RuntimeError("HTTP 403 Forbidden")
+
+        snap_file = str(tmp_path / "baseline.json")
+        _write_snapshot_file(snap_file)
+
+        success, _has_changes, _exit_code = handle_diff_snapshot_command(
+            data_view_id="dv_test",
+            snapshot_file=snap_file,
+            quiet=True,
+        )
+
+        assert success is False
+        captured = capsys.readouterr()
+        assert "Failed to compare against snapshot: HTTP 403 Forbidden" in captured.err
+        assert "authentication or authorization failed" in captured.err
+        assert "accessing this data view" not in captured.err
 
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")

--- a/tests/test_snapshot_commands.py
+++ b/tests/test_snapshot_commands.py
@@ -257,6 +257,28 @@ class TestHandleSnapshotCommand:
 
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_snapshot_lookup_403_shows_data_view_access_hint(self, mock_configure, mock_cjapy, tmp_path, capsys):
+        """Specific data-view lookup 403s should mention no-access guidance."""
+        mock_configure.return_value = (True, "config", None)
+        mock_cja = MagicMock()
+        mock_cjapy.CJA.return_value = mock_cja
+        mock_cja.getDataView.side_effect = RuntimeError("HTTP 403 Forbidden")
+
+        out_file = str(tmp_path / "snap.json")
+        result = handle_snapshot_command(
+            data_view_id="dv_123",
+            snapshot_file=out_file,
+            quiet=True,
+        )
+
+        assert result is False
+        captured = capsys.readouterr()
+        assert "Failed to create snapshot: HTTP 403 Forbidden" in captured.err
+        assert "accessing this data view" in captured.err
+        assert "have access to it" in captured.err
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
     def test_snapshot_with_profile(self, mock_configure, mock_cjapy, tmp_path):
         """Profile parameter is passed to configure_cjapy."""
         mock_configure.return_value = (True, "config", None)
@@ -1117,6 +1139,30 @@ class TestHandleDiffSnapshotCommand:
         captured = capsys.readouterr()
         assert "Failed to compare against snapshot: HTTP 403 Forbidden" in captured.err
         assert "authentication or authorization failed" in captured.err
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_diff_snapshot_lookup_403_shows_data_view_access_hint(self, mock_configure, mock_cjapy, tmp_path, capsys):
+        """Live data-view lookup 403s should mention no-access/not-found guidance."""
+        mock_configure.return_value = (True, "config", None)
+        mock_cja = MagicMock()
+        mock_cjapy.CJA.return_value = mock_cja
+        mock_cja.getDataView.side_effect = RuntimeError("HTTP 403 Forbidden")
+
+        snap_file = str(tmp_path / "baseline.json")
+        _write_snapshot_file(snap_file)
+
+        success, _has_changes, _exit_code = handle_diff_snapshot_command(
+            data_view_id="dv_test",
+            snapshot_file=snap_file,
+            quiet=True,
+        )
+
+        assert success is False
+        captured = capsys.readouterr()
+        assert "Failed to compare against snapshot: HTTP 403 Forbidden" in captured.err
+        assert "accessing this data view" in captured.err
+        assert "have access to it" in captured.err
 
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")

--- a/tests/test_ux_features.py
+++ b/tests/test_ux_features.py
@@ -344,11 +344,11 @@ class TestCombinedFeatures:
 class TestVersionUpdated:
     """Test that version is correct"""
 
-    def test_version_is_3_5_4(self):
-        """Test that version is 3.5.4"""
+    def test_version_is_3_5_5(self):
+        """Test that version is 3.5.5"""
         from cja_auto_sdr.generator import __version__
 
-        assert __version__ == "3.5.4"
+        assert __version__ == "3.5.5"
 
 
 class TestFormatAutoDetection:

--- a/tests/test_validation_cache.py
+++ b/tests/test_validation_cache.py
@@ -388,44 +388,57 @@ class TestValidationCache:
         assert stats["size"] == 1
 
     @pytest.mark.slow
-    def test_performance_improvement(self, sample_metrics_df):
-        """Cache should provide significant performance improvement"""
-        logger = logging.getLogger("test")
-        cache = ValidationCache(max_size=100, ttl_seconds=3600, logger=logger)
+    def test_performance_improvement(self, large_sample_dataframe):
+        """Cache should provide measurable benefit on a realistic dataset."""
+        logger = logging.getLogger("test.validation_cache.performance")
+        logger.setLevel(logging.WARNING)
+        logger.propagate = False
+        if not logger.handlers:
+            logger.addHandler(logging.NullHandler())
 
-        # Time without cache
-        checker_no_cache = DataQualityChecker(logger, validation_cache=None)
-        start = time.time()
-        for _ in range(10):
-            checker_no_cache.issues = []  # Reset
-            checker_no_cache.check_all_quality_issues_optimized(
-                sample_metrics_df,
-                "Metrics",
-                ["id", "name", "type"],
-                ["id", "name", "description"],
-            )
-        time_no_cache = time.time() - start
+        required_fields = ["id", "name", "type"]
+        critical_fields = ["id", "name", "description"]
+        repetitions = 10
+        samples = 5
 
-        # Time with cache
-        checker_with_cache = DataQualityChecker(logger, validation_cache=cache)
-        start = time.time()
-        for _ in range(10):
-            checker_with_cache.issues = []  # Reset
-            checker_with_cache.check_all_quality_issues_optimized(
-                sample_metrics_df,
-                "Metrics",
-                ["id", "name", "type"],
-                ["id", "name", "description"],
-            )
-        time_with_cache = time.time() - start
+        def _run_iterations(checker: DataQualityChecker) -> None:
+            for _ in range(repetitions):
+                checker.issues = []  # Reset
+                checker.check_all_quality_issues_optimized(
+                    large_sample_dataframe,
+                    "Metrics",
+                    required_fields,
+                    critical_fields,
+                )
 
-        # Cache should be faster (at least 5% improvement)
+        no_cache_runs = []
+        with_cache_runs = []
+
+        for _ in range(samples):
+            checker_no_cache = DataQualityChecker(logger, validation_cache=None)
+            start = time.perf_counter()
+            _run_iterations(checker_no_cache)
+            no_cache_runs.append(time.perf_counter() - start)
+
+            cache = ValidationCache(max_size=100, ttl_seconds=3600, logger=logger)
+            checker_with_cache = DataQualityChecker(logger, validation_cache=cache)
+            start = time.perf_counter()
+            _run_iterations(checker_with_cache)
+            with_cache_runs.append(time.perf_counter() - start)
+
+            stats = cache.get_statistics()
+            assert stats["hits"] == repetitions - 1
+            assert stats["misses"] == 1
+
+        time_no_cache = sorted(no_cache_runs)[len(no_cache_runs) // 2]
+        time_with_cache = sorted(with_cache_runs)[len(with_cache_runs) // 2]
+
         improvement = (time_no_cache - time_with_cache) / time_no_cache * 100
         print(
-            f"\nPerformance: no_cache={time_no_cache:.3f}s, with_cache={time_with_cache:.3f}s, improvement={improvement:.1f}%",
+            f"\nPerformance (median of {samples} runs, dataset size={len(large_sample_dataframe)}): "
+            f"no_cache={time_no_cache:.3f}s, with_cache={time_with_cache:.3f}s, improvement={improvement:.1f}%",
         )
 
-        # Should be at least 5% faster (conservative for small datasets on slow CI runners)
         assert improvement >= 5, f"Cache only improved performance by {improvement:.1f}% (expected >= 5%)"
 
     def test_cache_clear(self, sample_metrics_df):


### PR DESCRIPTION
## Summary

Addresses user feedback about opaque API error messages and confusing setup documentation. Surfaces actionable hints when API connections fail, across all major CLI paths.

### Code changes

- **`api_connection_hint()`** in `core/exceptions.py` — centralized hint function mapping cryptic exceptions to plain-English guidance:
  - `KeyError('content')` → verify both CJA + AEP APIs added, service account has product profile access
  - `KeyError(other)` → credential/config check guidance
  - HTTP 401/403 → auth/scope verification guidance (narrowed to avoid false positives on data view lookups)
- **`_print_api_hint()`** in `generator.py` — consistent stderr hint printer with `enabled` gate for machine-readable suppression
- **12 error paths** now print hints on API failure:
  - `--validate-config` step [4/5] (config.py)
  - `--profile-test` (profiles.py)
  - Single data view fetch (generator.py)
  - `--dry-run --validate` per-DV errors (generator.py)
  - `--org-report` (generator.py)
  - `--batch` status stream (generator.py)
  - Batch dry-run validate — both per-DV sites (generator.py)
  - Discovery commands — `--list-dataviews`, `--list-connections`, etc. (list.py)
  - Interactive mode — both data view selection and wizard API init (interactive.py)
  - `--stats` name resolution — all three call sites (stats.py)
  - `--diff` commands (diff/commands.py)
- Machine-readable stderr JSON preserved — hints suppressed when `--output-format json` active
- Hardened all hint call sites against unexpected exception shapes (`AttributeError`, missing `.response`, etc.)

### Documentation improvements

- **QUICKSTART_GUIDE.md** — streamlined prerequisites around uv (auto-manages Python), added pip fallback, elevated AEP API requirement to explicit warning, fixed duplicate section numbering
- **TROUBLESHOOTING.md** — added `--validate-config` error patterns section with cross-references

## Test plan

- [x] 49 new tests across 11 test files for `api_connection_hint`, hint output, exception narrowing, and command boundary coverage
- [x] Full suite passes (7,719 collected)
- [x] Ruff lint + format clean
- [x] Test counts up to date