### PR TITLE
v3.5.6 — Generator timing completion & cache TTL hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to the CJA SDR Generator project will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.6] — 2026-04-01
+
+### Changed
+- Completed generator elapsed-duration timing hardening: moved all remaining `process_single_dataview()` and `main()` duration-only paths from `time.time()` to `time.perf_counter()`.
+- Hardened `DataViewCache` in-process TTL bookkeeping from `time.time()` to `time.monotonic()`, making cache expiry immune to wall-clock jumps.
+- Converted touched generator duration-banner and exception-handler log lines from eager f-string interpolation to lazy `%s`-style logger interpolation.
+
 ## [3.5.5] — 2026-04-01
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,8 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Package manager: **uv**
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
-- Current version: v3.5.5
-- Tests: **7,670** across 129 files at **95% coverage gate**
+- Current version: v3.5.6
+- Tests: **7,725** across 129 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)
 

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (7,719+ tests)
+├── tests/                     # Test suite (7,725+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -924,7 +924,7 @@ cja_auto_sdr --list-dataviews --log-level DEBUG
 At launch, the tool logs diagnostic lines containing the tool version, Python version, platform, active log level, inferred run mode (batch, single, or discovery), and dependency versions. These appear automatically at `INFO` level and are useful for troubleshooting environment issues in CI/CD logs or support requests:
 
 ```text
-CJA SDR Generator v3.5.5 | Python 3.14.2 | darwin | log_level=INFO | mode=single
+CJA SDR Generator v3.5.6 | Python 3.14.2 | darwin | log_level=INFO | mode=single
 Dependencies: cjapy=0.2.4.post3, pandas=2.3.3, numpy=2.2.1, xlsxwriter=3.2.9, tqdm=4.67.0
 ```
 

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -190,7 +190,7 @@ This command:
 
 ```bash
 $ uv run cja_auto_sdr -V
-cja_auto_sdr 3.5.5
+cja_auto_sdr 3.5.6
 ```
 
 > **Important:** All commands in this guide assume you're in the `cja_auto_sdr` directory. If you see "command not found", make sure you're in the right directory and have run `uv sync`.

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Quick Reference Card
 
-Single-page command cheat sheet for CJA SDR Generator v3.5.5.
+Single-page command cheat sheet for CJA SDR Generator v3.5.6.
 
 ## Four Main Modes
 

--- a/src/cja_auto_sdr/core/version.py
+++ b/src/cja_auto_sdr/core/version.py
@@ -1,3 +1,3 @@
 """Version information for CJA Auto SDR."""
 
-__version__ = "3.5.5"
+__version__ = "3.5.6"

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -2181,7 +2181,7 @@ def _build_run_summary_payload(
         "environment": _collect_environment_info(),
         "started_at": summary_start,
         "ended_at": datetime.now(UTC).isoformat(),
-        "duration_seconds": round(time.time() - summary_start_perf, 3),
+        "duration_seconds": round(time.perf_counter() - summary_start_perf, 3),
         "exit_code": exit_code,
         "status": _infer_run_status(exit_code, run_state),
         "mode": run_state.get("mode", "unknown"),
@@ -2909,7 +2909,7 @@ def process_single_dataview(
     production_mode = processing_config.production_mode
     batch_id = processing_config.batch_id
 
-    start_time = time.time()
+    start_time = time.perf_counter()
 
     # Setup logging for this data view
     base_logger = setup_logging(data_view_id, batch_mode=False, log_level=log_level, log_format=log_format)
@@ -2941,7 +2941,7 @@ def process_single_dataview(
             data_view_id=data_view_id,
             data_view_name=data_view_name,
             success=success,
-            duration=time.time() - start_time if duration is None else duration,
+            duration=time.perf_counter() - start_time if duration is None else duration,
             partial_reasons=partial_reasons if partial_reasons_override is None else partial_reasons_override,
             **kwargs,
         )
@@ -3077,9 +3077,9 @@ def process_single_dataview(
                 logger.info("=" * BANNER_WIDTH)
                 logger.info("EXECUTION FAILED")
                 logger.info("=" * BANNER_WIDTH)
-                logger.info(f"Data View: {dv_name} ({data_view_id})")
+                logger.info("Data View: %s (%s)", dv_name, data_view_id)
                 logger.info("Error: Component fetch failed")
-                logger.info(f"Duration: {time.time() - start_time:.2f}s")
+                logger.info("Duration: %.2fs", time.perf_counter() - start_time)
                 logger.info("=" * BANNER_WIDTH)
                 flush_logging_handlers(logger)
                 failed_endpoints = sorted({part.split(":", 1)[0].strip() for part in component_failures if part})
@@ -3150,12 +3150,12 @@ def process_single_dataview(
                 logger.info("=" * BANNER_WIDTH)
                 logger.info("EXECUTION FAILED")
                 logger.info("=" * BANNER_WIDTH)
-                logger.info(f"Data View: {dv_name} ({data_view_id})")
+                logger.info("Data View: %s (%s)", dv_name, data_view_id)
                 if missing_all_standard_components:
                     logger.info("Error: No metrics or dimensions found")
                 else:
-                    logger.info(f"Error: Required component payloads were empty: {empty_required_components}")
-                logger.info(f"Duration: {time.time() - start_time:.2f}s")
+                    logger.info("Error: Required component payloads were empty: %s", empty_required_components)
+                logger.info("Duration: %.2fs", time.perf_counter() - start_time)
                 logger.info("=" * BANNER_WIDTH)
                 # Flush handlers to ensure log is written
                 flush_logging_handlers(logger)
@@ -3214,9 +3214,9 @@ def process_single_dataview(
                 logger.info("=" * BANNER_WIDTH)
                 logger.info("EXECUTION FAILED")
                 logger.info("=" * BANNER_WIDTH)
-                logger.info(f"Data View: {dv_name} ({data_view_id})")
+                logger.info("Data View: %s (%s)", dv_name, data_view_id)
                 logger.info("Error: Data quality validation failed")
-                logger.info(f"Duration: {time.time() - start_time:.2f}s")
+                logger.info("Duration: %.2fs", time.perf_counter() - start_time)
                 logger.info("=" * BANNER_WIDTH)
                 flush_logging_handlers(logger)
                 return _finalize_result(
@@ -3694,7 +3694,7 @@ def process_single_dataview(
             if show_timings:
                 print(perf_tracker.get_summary())
 
-            duration = time.time() - start_time
+            duration = time.perf_counter() - start_time
 
             # Calculate total file size
             total_size = 0
@@ -3754,14 +3754,14 @@ def process_single_dataview(
             )
 
         except PermissionError as e:
-            logger.critical(f"Permission denied writing to {output_path}. File may be open in another program.")
+            logger.critical("Permission denied writing to %s. File may be open in another program.", output_path)
             logger.critical("Please close the file and try again.")
             logger.info("=" * BANNER_WIDTH)
             logger.info("EXECUTION FAILED")
             logger.info("=" * BANNER_WIDTH)
-            logger.info(f"Data View: {dv_name} ({data_view_id})")
+            logger.info("Data View: %s (%s)", dv_name, data_view_id)
             logger.info("Error: Permission denied")
-            logger.info(f"Duration: {time.time() - start_time:.2f}s")
+            logger.info("Duration: %.2fs", time.perf_counter() - start_time)
             logger.info("=" * BANNER_WIDTH)
             flush_logging_handlers(logger)
             return _finalize_result(
@@ -3772,14 +3772,14 @@ def process_single_dataview(
                 failure_reason="output_permission_denied",
             )
         except (OSError, KeyError, TypeError, ValueError) as e:
-            logger.critical(f"Failed to generate output file: {e!s}")
+            logger.critical("Failed to generate output file: %s", e)
             logger.exception("Full exception details:")
             logger.info("=" * BANNER_WIDTH)
             logger.info("EXECUTION FAILED")
             logger.info("=" * BANNER_WIDTH)
-            logger.info(f"Data View: {dv_name} ({data_view_id})")
-            logger.info(f"Error: {e!s}")
-            logger.info(f"Duration: {time.time() - start_time:.2f}s")
+            logger.info("Data View: %s (%s)", dv_name, data_view_id)
+            logger.info("Error: %s", e)
+            logger.info("Duration: %.2fs", time.perf_counter() - start_time)
             logger.info("=" * BANNER_WIDTH)
             flush_logging_handlers(logger)
             return _finalize_result(
@@ -3791,14 +3791,14 @@ def process_single_dataview(
             )
 
     except Exception as e:  # Intentional: top-level processing boundary for API + runtime errors
-        logger.critical(f"Unexpected error processing data view {data_view_id}: {e!s}")
+        logger.critical("Unexpected error processing data view %s: %s", data_view_id, e)
         logger.exception("Full exception details:")
         logger.info("=" * BANNER_WIDTH)
         logger.info("EXECUTION FAILED")
         logger.info("=" * BANNER_WIDTH)
-        logger.info(f"Data View ID: {data_view_id}")
-        logger.info(f"Error: {e!s}")
-        logger.info(f"Duration: {time.time() - start_time:.2f}s")
+        logger.info("Data View ID: %s", data_view_id)
+        logger.info("Error: %s", e)
+        logger.info("Duration: %.2fs", time.perf_counter() - start_time)
         logger.info("=" * BANNER_WIDTH)
         flush_logging_handlers(logger)
         return _finalize_result(
@@ -4247,7 +4247,7 @@ class DataViewCache:
         with self._lock:
             if cache_key in self._cache:
                 data, timestamp = self._cache[cache_key]
-                if time.time() - timestamp < self._ttl_seconds:
+                if time.monotonic() - timestamp < self._ttl_seconds:
                     return data
                 # Expired - remove from cache
                 del self._cache[cache_key]
@@ -4262,7 +4262,7 @@ class DataViewCache:
             data: List of data view dicts to cache
         """
         with self._lock:
-            self._cache[cache_key] = (data, time.time())
+            self._cache[cache_key] = (data, time.monotonic())
 
     def clear(self) -> None:
         """Clear all cached data."""
@@ -7089,7 +7089,7 @@ def main():
     """Main entry point with optional run summary emission."""
 
     summary_start = datetime.now(UTC).isoformat()
-    summary_start_perf = time.time()
+    summary_start_perf = time.perf_counter()
     run_state: dict[str, Any] = {
         "mode": "unknown",
         "data_view_inputs": [],

--- a/tests/README.md
+++ b/tests/README.md
@@ -141,7 +141,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 7,719 comprehensive tests**
+**Total: 7,725 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -150,16 +150,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,613 | 123 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,619 | 123 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 7 | 1 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **7,719** | **129** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **7,725** | **129** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,606 | 122 | `-m "unit and not slow"` |
+| `test-unit` | 7,612 | 122 | `-m "unit and not slow"` |
 | `test-integration` | 103 | 6 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -193,7 +193,7 @@ tests/
 | `test_retry.py` | 25 | Retry with exponential backoff |
 | `test_batch_processor.py` | 26 | Batch processing of multiple data views |
 | `test_validation_cache.py` | 25 | Validation result caching |
-| `test_process_single_dataview.py` | 44 | End-to-end single data view processing |
+| `test_process_single_dataview.py` | 46 | End-to-end single data view processing |
 | `test_optimized_validation.py` | 16 | Optimized data quality validation |
 | `test_name_resolution.py` | 24 | Data view name to ID resolution |
 | `test_shared_cache.py` | 28 | Shared validation cache |
@@ -213,7 +213,7 @@ tests/
 | `test_output_extraction_contracts.py` | 345 | Extraction contracts for output.diff and output.inventory |
 | `test_malformed_api_responses.py` | 20 | Negative tests for malformed/unexpected API responses |
 | `test_main_entry_points.py` | 43 | main() and _main_impl() entry points, dispatch, run_state, run summary |
-| `test_quality_policy_and_run_summary.py` | 169 | Quality policy functions and run summary/status inference |
+| `test_quality_policy_and_run_summary.py` | 171 | Quality policy functions and run summary/status inference |
 | `test_e2e_integration.py` | 16 | End-to-end integration tests with real pipeline, mocked API boundary |
 | `test_api_client.py` | 31 | API client exception paths and error handling |
 | `test_config_validation.py` | 55 | Configuration validation logic |
@@ -238,7 +238,7 @@ tests/
 | `test_cli_command_handlers.py` | 156 | CLI dispatch for --stats, --org-report, --list-snapshots, discovery inspection, diff config unpacking |
 | `test_profile_management.py` | 53 | Interactive profile creation, import, test, show |
 | `test_snapshot_commands.py` | 65 | Snapshot creation, comparison, name resolution |
-| `test_config_and_resolution.py` | 112 | Config status, validation, stats, name resolution |
+| `test_config_and_resolution.py` | 114 | Config status, validation, stats, name resolution |
 | `test_derived_fields_edge_cases.py` | 34 | Derived fields edge cases and coverage |
 | `test_diff_command_coverage.py` | 45 | Diff command edge cases and coverage |
 | `test_generator_interactive_and_console.py` | 37 | Generator interactive and console tests |
@@ -298,7 +298,7 @@ tests/
 | `test_agent_workflows.py` | 69 | Agent workflow shell script validation tests |
 | `test_manifest_agent_contract.py` | 16 | Manifest vs runtime capability drift tests |
 | `test_tool_manifests.py` | 40 | Tool manifest schema and content tests |
-| **Total** | **7,719** | **Collected via pytest --collect-only** |
+| **Total** | **7,725** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -756,7 +756,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (7,719 tests total)
+- [x] Comprehensive test coverage (7,725 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 78 tests

--- a/tests/test_config_and_resolution.py
+++ b/tests/test_config_and_resolution.py
@@ -1510,9 +1510,51 @@ class TestDataViewCache:
         cache.__init__()
         cache.set_ttl(1)
         cache.set("key1", [{"id": "dv1"}])
-        # Manually set timestamp to past to simulate expiry
-        cache._cache["key1"] = (cache._cache["key1"][0], time.time() - 2)
+        # Manually set timestamp to past to simulate expiry (monotonic clock)
+        cache._cache["key1"] = (cache._cache["key1"][0], time.monotonic() - 2)
         assert cache.get("key1") is None
+
+    def test_cache_ttl_hit_before_expiry(self) -> None:
+        """Cache returns data when TTL has not expired."""
+        from cja_auto_sdr.generator import DataViewCache
+
+        cache = DataViewCache.__new__(DataViewCache)
+        cache._initialized = False
+        cache.__init__()
+        cache.set_ttl(300)
+        cache.set("key1", [{"id": "dv1"}])
+        assert cache.get("key1") == [{"id": "dv1"}]
+
+    def test_cache_ttl_uses_monotonic_clock(self) -> None:
+        """Cache expiry is immune to wall-clock rollback."""
+        import time
+        from unittest.mock import patch
+
+        from cja_auto_sdr.generator import DataViewCache
+
+        cache = DataViewCache.__new__(DataViewCache)
+        cache._initialized = False
+        cache.__init__()
+        cache.set_ttl(10)
+
+        # Store with a known monotonic baseline
+        mono_base = 1000.0
+        with patch("cja_auto_sdr.generator.time") as mock_time:
+            mock_time.monotonic.return_value = mono_base
+            mock_time.perf_counter = time.perf_counter
+            cache.set("key1", [{"id": "dv1"}])
+
+        # 5 seconds later (within TTL) — should hit
+        with patch("cja_auto_sdr.generator.time") as mock_time:
+            mock_time.monotonic.return_value = mono_base + 5
+            mock_time.perf_counter = time.perf_counter
+            assert cache.get("key1") == [{"id": "dv1"}]
+
+        # 11 seconds later (past TTL) — should miss
+        with patch("cja_auto_sdr.generator.time") as mock_time:
+            mock_time.monotonic.return_value = mono_base + 11
+            mock_time.perf_counter = time.perf_counter
+            assert cache.get("key1") is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_output_content_validation.py
+++ b/tests/test_output_content_validation.py
@@ -38,7 +38,7 @@ def rich_data_dict():
         "Metadata": pd.DataFrame(
             {
                 "Property": ["Generated At", "Data View ID", "Tool Version", "Total Metrics"],
-                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.5.5", 3],
+                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.5.6", 3],
             },
         ),
         "Data Quality": pd.DataFrame(
@@ -104,7 +104,7 @@ def rich_metadata_dict():
         "Generated At": "2025-01-15 10:30:00 PST",
         "Data View ID": "dv_content_test",
         "Data View Name": "Test DataView",
-        "Tool Version": "3.5.5",
+        "Tool Version": "3.5.6",
         "Metrics Count": "3",
         "Dimensions Count": "4",
     }
@@ -224,7 +224,7 @@ class TestJSONContentValidation:
             data = json.load(f)
 
         assert data["metadata"]["Data View ID"] == "dv_content_test"
-        assert data["metadata"]["Tool Version"] == "3.5.5"
+        assert data["metadata"]["Tool Version"] == "3.5.6"
 
     def test_json_metadata_preserves_partial_markers(self, tmp_path, rich_data_dict, rich_metadata_dict):
         logger = logging.getLogger("json_test")

--- a/tests/test_process_single_dataview.py
+++ b/tests/test_process_single_dataview.py
@@ -2207,3 +2207,79 @@ class TestProcessingResultDataclass:
 
         formatted = result.file_size_formatted
         assert "KB" in formatted or "B" in formatted
+
+
+# ---------------------------------------------------------------------------
+# Elapsed-duration timing hardening (v3.5.6)
+# ---------------------------------------------------------------------------
+
+
+class TestElapsedDurationTimingHardening:
+    """Verify process_single_dataview uses perf_counter for duration, not wall-clock."""
+
+    def test_duration_uses_perf_counter(self) -> None:
+        """Duration is derived from perf_counter, not time.time."""
+        import time
+        from unittest.mock import MagicMock, patch
+
+        from cja_auto_sdr.generator import process_single_dataview
+
+        perf_start = 100.0
+        perf_end = 102.5
+
+        mock_time = MagicMock(wraps=time)
+        mock_time.perf_counter = MagicMock(side_effect=[perf_start, perf_end, perf_end])
+        mock_time.monotonic = time.monotonic
+
+        with (
+            patch("cja_auto_sdr.generator.time", mock_time),
+            patch("cja_auto_sdr.generator.initialize_cja", side_effect=RuntimeError("test")),
+            patch("cja_auto_sdr.generator.setup_logging", return_value=MagicMock()),
+            patch("cja_auto_sdr.generator.with_log_context", return_value=MagicMock()),
+            patch("cja_auto_sdr.generator.flush_logging_handlers"),
+            patch("cja_auto_sdr.generator.PerformanceTracker"),
+        ):
+            result = process_single_dataview(data_view_id="dv_test")
+
+        assert result.success is False
+        assert result.duration >= 0
+        assert abs(result.duration - 2.5) < 0.01
+
+    def test_failure_banner_duration_text_shape(self) -> None:
+        """Failure banners emit 'Duration: X.XXs' format using perf_counter."""
+        import time
+        from unittest.mock import MagicMock, patch
+
+        from cja_auto_sdr.generator import process_single_dataview
+
+        counter = iter([500.0, 503.75, 503.75, 503.75, 503.75])
+
+        mock_time = MagicMock(wraps=time)
+        mock_time.perf_counter = MagicMock(side_effect=counter)
+        mock_time.monotonic = time.monotonic
+
+        captured_messages: list[str] = []
+
+        def capture_info(msg, *args):
+            captured_messages.append(msg % args if args else msg)
+
+        mock_logger = MagicMock()
+        mock_logger.info = MagicMock(side_effect=capture_info)
+        mock_logger.debug = MagicMock()
+        mock_logger.critical = MagicMock()
+        mock_logger.exception = MagicMock()
+
+        with (
+            patch("cja_auto_sdr.generator.time", mock_time),
+            patch("cja_auto_sdr.generator.initialize_cja", side_effect=RuntimeError("boom")),
+            patch("cja_auto_sdr.generator.setup_logging", return_value=mock_logger),
+            patch("cja_auto_sdr.generator.with_log_context", return_value=mock_logger),
+            patch("cja_auto_sdr.generator.flush_logging_handlers"),
+            patch("cja_auto_sdr.generator.PerformanceTracker"),
+        ):
+            result = process_single_dataview(data_view_id="dv_test")
+
+        assert result.success is False
+        duration_lines = [m for m in captured_messages if "Duration:" in m]
+        assert len(duration_lines) >= 1
+        assert duration_lines[0] == "Duration: 3.75s"

--- a/tests/test_quality_policy_and_run_summary.py
+++ b/tests/test_quality_policy_and_run_summary.py
@@ -2293,3 +2293,78 @@ class TestDiffAdvisoryRollupRunSummaryContract:
         rollup = runtime_details["advisory_rollup"]
         assert rollup["severity"] == "critical"
         assert "breaking_changes" in rollup["types"]
+
+
+# ---------------------------------------------------------------------------
+# Run-summary elapsed-duration timing hardening (v3.5.6)
+# ---------------------------------------------------------------------------
+
+
+class TestRunSummaryTimingHardening:
+    """Verify run-summary uses perf_counter for duration while keeping wall-clock timestamps."""
+
+    def test_duration_seconds_uses_perf_counter(self) -> None:
+        """_build_run_summary_payload derives duration_seconds from perf_counter, not wall-clock."""
+        from cja_auto_sdr.generator import _build_run_summary_payload
+
+        run_state: dict = {
+            "mode": "single",
+            "processed_results": [],
+            "data_view_inputs": [],
+            "resolved_data_views": [],
+        }
+        # Simulate perf_counter start at 1000.0; current perf_counter returns 1005.25
+        import time
+        from unittest.mock import MagicMock, patch
+
+        mock_time = MagicMock(wraps=time)
+        mock_time.perf_counter.return_value = 1005.25
+
+        with patch("cja_auto_sdr.generator.time", mock_time):
+            payload = _build_run_summary_payload(
+                run_state=run_state,
+                exit_code=0,
+                summary_start="2026-04-01T12:00:00+00:00",
+                summary_start_perf=1000.0,
+            )
+
+        assert payload["duration_seconds"] == 5.25
+        assert payload["started_at"] == "2026-04-01T12:00:00+00:00"
+        assert isinstance(payload["ended_at"], str)
+        assert "T" in payload["ended_at"]  # ISO 8601
+
+    def test_started_at_ended_at_are_wall_clock(self) -> None:
+        """started_at and ended_at remain wall-clock UTC timestamps, not elapsed clocks."""
+        import time as real_time
+        from datetime import UTC, datetime
+        from unittest.mock import MagicMock, patch
+
+        from cja_auto_sdr.generator import _build_run_summary_payload
+
+        run_state: dict = {
+            "mode": "single",
+            "processed_results": [],
+            "data_view_inputs": [],
+            "resolved_data_views": [],
+        }
+
+        fixed_now = datetime(2026, 4, 1, 15, 30, 0, tzinfo=UTC)
+        mock_time = MagicMock(wraps=real_time)
+        mock_time.perf_counter.return_value = 2000.0
+
+        with (
+            patch("cja_auto_sdr.generator.time", mock_time),
+            patch("cja_auto_sdr.generator.datetime") as mock_dt,
+        ):
+            mock_dt.now.return_value = fixed_now
+            mock_dt.side_effect = datetime
+            payload = _build_run_summary_payload(
+                run_state=run_state,
+                exit_code=0,
+                summary_start="2026-04-01T15:29:55+00:00",
+                summary_start_perf=1995.0,
+            )
+
+        assert payload["started_at"] == "2026-04-01T15:29:55+00:00"
+        assert payload["ended_at"] == fixed_now.isoformat()
+        assert payload["duration_seconds"] == 5.0

--- a/tests/test_ux_features.py
+++ b/tests/test_ux_features.py
@@ -344,11 +344,11 @@ class TestCombinedFeatures:
 class TestVersionUpdated:
     """Test that version is correct"""
 
-    def test_version_is_3_5_5(self):
-        """Test that version is 3.5.5"""
+    def test_version_is_3_5_6(self):
+        """Test that version is 3.5.6"""
         from cja_auto_sdr.generator import __version__
 
-        assert __version__ == "3.5.5"
+        assert __version__ == "3.5.6"
 
 
 class TestFormatAutoDetection:


### PR DESCRIPTION
## Summary

- Complete generator elapsed-duration timing hardening: move all remaining `process_single_dataview()` and `main()` duration-only paths from `time.time()` to `time.perf_counter()`
- Harden `DataViewCache` in-process TTL bookkeeping from `time.time()` to `time.monotonic()`, making cache expiry immune to wall-clock jumps
- Convert touched duration-banner and exception-handler log lines to lazy `%s`-style interpolation (9 sites)
- Add 6 regression tests backstopping deterministic timing, failure-banner text shape, run-summary wall-clock/elapsed separation, and cache TTL with patched monotonic clocks
- Bump version to 3.5.6 and sync all release artifacts (7,725 tests, 129 files)

## Non-goals

- No CLI, output-contract, or dependency changes
- No broad generator refactor or repo-wide logging rewrite
- No continuation of v3.5.5 API-hint work

## Test plan

- [x] Ruff lint clean on all touched files
- [x] Version sync passes (`scripts/check_version_sync.py`)
- [x] Focused suites green (607 passed)
- [x] Full suite green (7,724 passed, 1 skipped in 86s)
- [ ] CI green on push
- [ ] Confirm no public contract drift in review