### PR TITLE
v3.5.8 fix --inventory-summary broken cjapy API calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to the CJA SDR Generator project will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.8] — 2026-04-03
+
+### Fixed
+- Fixed `--inventory-summary` failing with `AttributeError: 'CJA' object has no attribute 'dataviews'` — replaced 3 non-existent namespace-style cjapy calls (`cja.dataviews.get_single`, `cja.dataviews.get_metrics`, `cja.dataviews.get_dimensions`) with the correct flat methods (`cja.getDataView`, `cja.getMetrics`, `cja.getDimensions`) in `process_inventory_summary()`.
+
 ## [3.5.7] — 2026-04-03
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Package manager: **uv**
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
-- Current version: v3.5.7
+- Current version: v3.5.8
 - Tests: **7,754** across 129 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -924,7 +924,7 @@ cja_auto_sdr --list-dataviews --log-level DEBUG
 At launch, the tool logs diagnostic lines containing the tool version, Python version, platform, active log level, inferred run mode (batch, single, or discovery), and dependency versions. These appear automatically at `INFO` level and are useful for troubleshooting environment issues in CI/CD logs or support requests:
 
 ```text
-CJA SDR Generator v3.5.7 | Python 3.14.2 | darwin | log_level=INFO | mode=single
+CJA SDR Generator v3.5.8 | Python 3.14.2 | darwin | log_level=INFO | mode=single
 Dependencies: cjapy=0.2.4.post3, pandas=2.3.3, numpy=2.2.1, xlsxwriter=3.2.9, tqdm=4.67.0
 ```
 

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -190,7 +190,7 @@ This command:
 
 ```bash
 $ uv run cja_auto_sdr -V
-cja_auto_sdr 3.5.7
+cja_auto_sdr 3.5.8
 ```
 
 > **Important:** All commands in this guide assume you're in the `cja_auto_sdr` directory. If you see "command not found", make sure you're in the right directory and have run `uv sync`.

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Quick Reference Card
 
-Single-page command cheat sheet for CJA SDR Generator v3.5.7.
+Single-page command cheat sheet for CJA SDR Generator v3.5.8.
 
 ## Four Main Modes
 

--- a/src/cja_auto_sdr/core/version.py
+++ b/src/cja_auto_sdr/core/version.py
@@ -1,3 +1,3 @@
 """Version information for CJA Auto SDR."""
 
-__version__ = "3.5.7"
+__version__ = "3.5.8"

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -2674,7 +2674,7 @@ def process_inventory_summary(
 
     # Get data view info
     try:
-        lookup_data = cja.dataviews.get_single(data_view_id)
+        lookup_data = cja.getDataView(data_view_id)
         dv_name = lookup_data.get("name", data_view_id) if isinstance(lookup_data, dict) else data_view_id
     except RECOVERABLE_CONFIG_API_EXCEPTIONS as e:
         print(ConsoleColors.error(f"ERROR: Failed to fetch data view: {e}"), file=sys.stderr)
@@ -2707,8 +2707,8 @@ def process_inventory_summary(
             from cja_auto_sdr.inventory.derived_fields import DerivedFieldInventoryBuilder
 
             # Need metrics and dimensions for derived fields
-            metrics_data = cja.dataviews.get_metrics(data_view_id)
-            dimensions_data = cja.dataviews.get_dimensions(data_view_id)
+            metrics_data = cja.getMetrics(data_view_id)
+            dimensions_data = cja.getDimensions(data_view_id)
 
             metrics_df = pd.DataFrame(metrics_data) if metrics_data else pd.DataFrame()
             dimensions_df = pd.DataFrame(dimensions_data) if dimensions_data else pd.DataFrame()

--- a/tests/test_cli_command_handlers.py
+++ b/tests/test_cli_command_handlers.py
@@ -110,12 +110,12 @@ class TestProcessInventorySummary:
     @patch("cja_auto_sdr.generator.with_log_context")
     @patch("cja_auto_sdr.generator.setup_logging")
     def test_data_view_fetch_failure_returns_error(self, mock_setup, mock_ctx, mock_init, mock_display):
-        """When cja.dataviews.get_single raises, function should return error dict."""
+        """When cja.getDataView raises, function should return error dict."""
         mock_setup.return_value = logging.getLogger("test")
         mock_ctx.return_value = logging.getLogger("test")
 
         mock_cja = MagicMock()
-        mock_cja.dataviews.get_single.side_effect = APIError("API Error 404")
+        mock_cja.getDataView.side_effect = APIError("API Error 404")
         mock_init.return_value = mock_cja
 
         result = process_inventory_summary("dv_bad_id", config_file="config.json")
@@ -133,7 +133,7 @@ class TestProcessInventorySummary:
         mock_ctx.return_value = logging.getLogger("test")
 
         mock_cja = MagicMock()
-        mock_cja.dataviews.get_single.side_effect = ConnectionError("network timeout")
+        mock_cja.getDataView.side_effect = ConnectionError("network timeout")
         mock_init.return_value = mock_cja
 
         result = process_inventory_summary("dv_bad_id", config_file="config.json")
@@ -151,7 +151,7 @@ class TestProcessInventorySummary:
         mock_ctx.return_value = logging.getLogger("test")
 
         mock_cja = MagicMock()
-        mock_cja.dataviews.get_single.side_effect = RuntimeError("unexpected client crash")
+        mock_cja.getDataView.side_effect = RuntimeError("unexpected client crash")
         mock_init.return_value = mock_cja
 
         result = process_inventory_summary("dv_bad_id", config_file="config.json")
@@ -176,7 +176,7 @@ class TestProcessInventorySummary:
         mock_ctx.return_value = logging.getLogger("test")
 
         mock_cja = MagicMock()
-        mock_cja.dataviews.get_single.side_effect = RuntimeError("HTTP 403 Forbidden")
+        mock_cja.getDataView.side_effect = RuntimeError("HTTP 403 Forbidden")
         mock_init.return_value = mock_cja
 
         result = process_inventory_summary("dv_bad_id", config_file="config.json")
@@ -204,7 +204,7 @@ class TestProcessInventorySummary:
         mock_ctx.return_value = logging.getLogger("test")
 
         mock_cja = MagicMock()
-        mock_cja.dataviews.get_single.side_effect = Exception("HTTP 403 Forbidden")
+        mock_cja.getDataView.side_effect = Exception("HTTP 403 Forbidden")
         mock_init.return_value = mock_cja
 
         result = process_inventory_summary("dv_bad_id", config_file="config.json")
@@ -225,7 +225,7 @@ class TestProcessInventorySummary:
         mock_ctx.return_value = logging.getLogger("test")
 
         mock_cja = MagicMock()
-        mock_cja.dataviews.get_single.return_value = {"name": "My DV"}
+        mock_cja.getDataView.return_value = {"name": "My DV"}
         mock_init.return_value = mock_cja
         mock_display.return_value = {"total": 0}
 
@@ -244,7 +244,7 @@ class TestProcessInventorySummary:
         mock_ctx.return_value = logging.getLogger("test")
 
         mock_cja = MagicMock()
-        mock_cja.dataviews.get_single.return_value = {"name": "Quiet DV"}
+        mock_cja.getDataView.return_value = {"name": "Quiet DV"}
         mock_init.return_value = mock_cja
         mock_display.return_value = {"status": "ok"}
 
@@ -262,9 +262,9 @@ class TestProcessInventorySummary:
         mock_ctx.return_value = logging.getLogger("test")
 
         mock_cja = MagicMock()
-        mock_cja.dataviews.get_single.return_value = {"name": "DV1"}
-        mock_cja.dataviews.get_metrics.return_value = [{"id": "m1"}]
-        mock_cja.dataviews.get_dimensions.return_value = [{"id": "d1"}]
+        mock_cja.getDataView.return_value = {"name": "DV1"}
+        mock_cja.getMetrics.return_value = [{"id": "m1"}]
+        mock_cja.getDimensions.return_value = [{"id": "d1"}]
         mock_init.return_value = mock_cja
         mock_display.return_value = {"derived": 5}
 
@@ -292,8 +292,8 @@ class TestProcessInventorySummary:
         mock_ctx.return_value = logger
 
         mock_cja = MagicMock()
-        mock_cja.dataviews.get_single.return_value = {"name": "DV1"}
-        mock_cja.dataviews.get_metrics.side_effect = APIError("metrics API error")
+        mock_cja.getDataView.return_value = {"name": "DV1"}
+        mock_cja.getMetrics.side_effect = APIError("metrics API error")
         mock_init.return_value = mock_cja
         mock_display.return_value = {"ok": True}
 
@@ -312,7 +312,7 @@ class TestProcessInventorySummary:
         mock_ctx.return_value = logging.getLogger("test")
 
         mock_cja = MagicMock()
-        mock_cja.dataviews.get_single.return_value = {"name": "DV1"}
+        mock_cja.getDataView.return_value = {"name": "DV1"}
         mock_init.return_value = mock_cja
         mock_display.return_value = {"ok": True}
 
@@ -335,7 +335,7 @@ class TestProcessInventorySummary:
         mock_ctx.return_value = logging.getLogger("test")
 
         mock_cja = MagicMock()
-        mock_cja.dataviews.get_single.return_value = {"name": "DV1"}
+        mock_cja.getDataView.return_value = {"name": "DV1"}
         mock_init.return_value = mock_cja
         mock_display.return_value = {"ok": True}
 
@@ -365,7 +365,7 @@ class TestProcessInventorySummary:
         mock_ctx.return_value = logging.getLogger("test")
 
         mock_cja = MagicMock()
-        mock_cja.dataviews.get_single.return_value = {"name": "DV1"}
+        mock_cja.getDataView.return_value = {"name": "DV1"}
         mock_init.return_value = mock_cja
         mock_display.return_value = {"ok": True}
 
@@ -388,7 +388,7 @@ class TestProcessInventorySummary:
         mock_ctx.return_value = logging.getLogger("test")
 
         mock_cja = MagicMock()
-        mock_cja.dataviews.get_single.return_value = {"name": "DV1"}
+        mock_cja.getDataView.return_value = {"name": "DV1"}
         mock_init.return_value = mock_cja
         mock_display.return_value = {"ok": True}
 
@@ -447,9 +447,9 @@ class TestProcessInventorySummary:
         mock_ctx.return_value = logging.getLogger("test")
 
         mock_cja = MagicMock()
-        mock_cja.dataviews.get_single.return_value = {"name": "DV1"}
-        mock_cja.dataviews.get_metrics.return_value = [{"id": "m1"}]
-        mock_cja.dataviews.get_dimensions.return_value = [{"id": "d1"}]
+        mock_cja.getDataView.return_value = {"name": "DV1"}
+        mock_cja.getMetrics.return_value = [{"id": "m1"}]
+        mock_cja.getDimensions.return_value = [{"id": "d1"}]
         mock_init.return_value = mock_cja
         mock_display.return_value = {"ok": True}
 
@@ -476,7 +476,7 @@ class TestProcessInventorySummary:
         mock_ctx.return_value = logging.getLogger("test")
 
         mock_cja = MagicMock()
-        mock_cja.dataviews.get_single.return_value = "not_a_dict"
+        mock_cja.getDataView.return_value = "not_a_dict"
         mock_init.return_value = mock_cja
         mock_display.return_value = {}
 

--- a/tests/test_exception_narrowing.py
+++ b/tests/test_exception_narrowing.py
@@ -198,9 +198,9 @@ class TestProcessInventorySummaryExceptionNarrowing:
     """Verify process_inventory_summary fallback catches third-party Exception failures."""
 
     def _run_with_side_effect(self, exc):
-        """Mock CJA init + dataviews.get_single raising *exc*."""
+        """Mock CJA init + getDataView raising *exc*."""
         mock_cja = MagicMock()
-        mock_cja.dataviews.get_single.side_effect = exc
+        mock_cja.getDataView.side_effect = exc
 
         with (
             patch("cja_auto_sdr.generator.initialize_cja", return_value=mock_cja),

--- a/tests/test_generator_remaining_coverage.py
+++ b/tests/test_generator_remaining_coverage.py
@@ -514,7 +514,7 @@ class TestProcessInventorySummaryImportErrors:
         mock_setup_log.return_value = mock_logger
         mock_log_ctx.return_value = mock_logger
         mock_cja = MagicMock()
-        mock_cja.dataviews.get_single.return_value = {"name": "Test DV"}
+        mock_cja.getDataView.return_value = {"name": "Test DV"}
         mock_init_cja.return_value = mock_cja
         mock_display.return_value = {"data_view_id": "dv_test"}
 
@@ -543,7 +543,7 @@ class TestProcessInventorySummaryImportErrors:
         mock_setup_log.return_value = mock_logger
         mock_log_ctx.return_value = mock_logger
         mock_cja = MagicMock()
-        mock_cja.dataviews.get_single.return_value = {"name": "Test DV"}
+        mock_cja.getDataView.return_value = {"name": "Test DV"}
         mock_init_cja.return_value = mock_cja
         mock_display.return_value = {"data_view_id": "dv_test"}
 

--- a/tests/test_main_impl_coverage.py
+++ b/tests/test_main_impl_coverage.py
@@ -2216,7 +2216,7 @@ class TestProcessInventorySummaryExceptionHandlers:
 
         mock_cja = MagicMock()
         mock_init_cja.return_value = mock_cja
-        mock_cja.dataviews.get_single.return_value = {"name": "Test DV"}
+        mock_cja.getDataView.return_value = {"name": "Test DV"}
 
         mock_display.return_value = {"status": "ok"}
 
@@ -2265,7 +2265,7 @@ class TestProcessInventorySummaryExceptionHandlers:
 
         mock_cja = MagicMock()
         mock_init_cja.return_value = mock_cja
-        mock_cja.dataviews.get_single.return_value = {"name": "Test DV"}
+        mock_cja.getDataView.return_value = {"name": "Test DV"}
 
         mock_display.return_value = {"status": "ok"}
 

--- a/tests/test_output_content_validation.py
+++ b/tests/test_output_content_validation.py
@@ -38,7 +38,7 @@ def rich_data_dict():
         "Metadata": pd.DataFrame(
             {
                 "Property": ["Generated At", "Data View ID", "Tool Version", "Total Metrics"],
-                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.5.7", 3],
+                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.5.8", 3],
             },
         ),
         "Data Quality": pd.DataFrame(
@@ -104,7 +104,7 @@ def rich_metadata_dict():
         "Generated At": "2025-01-15 10:30:00 PST",
         "Data View ID": "dv_content_test",
         "Data View Name": "Test DataView",
-        "Tool Version": "3.5.7",
+        "Tool Version": "3.5.8",
         "Metrics Count": "3",
         "Dimensions Count": "4",
     }
@@ -224,7 +224,7 @@ class TestJSONContentValidation:
             data = json.load(f)
 
         assert data["metadata"]["Data View ID"] == "dv_content_test"
-        assert data["metadata"]["Tool Version"] == "3.5.7"
+        assert data["metadata"]["Tool Version"] == "3.5.8"
 
     def test_json_metadata_preserves_partial_markers(self, tmp_path, rich_data_dict, rich_metadata_dict):
         logger = logging.getLogger("json_test")

--- a/tests/test_ux_features.py
+++ b/tests/test_ux_features.py
@@ -344,11 +344,11 @@ class TestCombinedFeatures:
 class TestVersionUpdated:
     """Test that version is correct"""
 
-    def test_version_is_3_5_7(self):
-        """Test that version is 3.5.7"""
+    def test_version_is_3_5_8(self):
+        """Test that version is 3.5.8"""
         from cja_auto_sdr.generator import __version__
 
-        assert __version__ == "3.5.7"
+        assert __version__ == "3.5.8"
 
 
 class TestFormatAutoDetection:


### PR DESCRIPTION
## Summary

- Fix `--inventory-summary` failing with `AttributeError: 'CJA' object has no attribute 'dataviews'` for all data views
- Replace 3 non-existent namespace-style cjapy calls with correct flat methods in `process_inventory_summary()`
- Update 25 test mock references across 4 test files to match
- Bump version to 3.5.8

| Broken Call | Fixed To |
|---|---|
| `cja.dataviews.get_single(dv_id)` | `cja.getDataView(dv_id)` |
| `cja.dataviews.get_metrics(dv_id)` | `cja.getMetrics(dv_id)` |
| `cja.dataviews.get_dimensions(dv_id)` | `cja.getDimensions(dv_id)` |

## Test plan
- [x] 357 targeted tests pass (test_cli_command_handlers, test_generator_remaining_coverage, test_main_impl_coverage, test_exception_narrowing)
- [x] Full suite green: 7,754 collected, 7,751 passed, 3 skipped
- [x] Version sync passes (all 8 files reference 3.5.8)
- [x] Ruff lint clean
- [x] Live smoke tested all 4 previously-broken commands against real API:
  - `--inventory-summary --include-all-inventory` 
  - `--inventory-summary --include-derived`
  - `--inventory-summary --include-calculated`
  - `--inventory-summary --include-segments`