### PR TITLE
fix: complete inventory-summary derived fields fix (v3.5.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to the CJA SDR Generator project will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.9] — 2026-04-03
+
+### Fixed
+- Fixed `--inventory-summary --include-derived` silently failing with `ValueError: The truth value of a DataFrame is ambiguous` — replaced bare truthiness checks (`if derived_inventory:`) with explicit identity checks (`if derived_inventory is not None:`) in `display_inventory_summary()` for all three inventory types (derived, calculated, segments).
+
 ## [3.5.8] — 2026-04-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.5.9] — 2026-04-03
 
 ### Fixed
-- Fixed `--inventory-summary --include-derived` silently failing with `ValueError: The truth value of a DataFrame is ambiguous` — replaced bare truthiness checks (`if derived_inventory:`) with explicit identity checks (`if derived_inventory is not None:`) in `display_inventory_summary()` for all three inventory types (derived, calculated, segments).
+- Fixed `--inventory-summary --include-derived` silently failing with `ValueError: The truth value of a DataFrame is ambiguous` — two root causes:
+  1. `_build_derived_inventory_summary()` called `cja.getMetrics()`/`cja.getDimensions()` without `inclType=True, full=True`, returning lightweight DataFrames missing `sourceFieldType="derived"` and `fieldDefinition` columns needed for derived field detection. Added the missing API flags to match the SDR pipeline's fetch path.
+  2. Same function used bare truthiness checks (`if metrics_data:`) on the returned DataFrames, which raises `ValueError` in pandas. Replaced with `isinstance()` guards.
+  3. `display_inventory_summary()` used bare truthiness checks (`if derived_inventory:`) on inventory objects. Replaced with explicit `is not None` identity checks for all three inventory types.
 
 ## [3.5.8] — 2026-04-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.5.9] — 2026-04-03
 
 ### Fixed
-- Fixed `--inventory-summary --include-derived` silently failing with `ValueError: The truth value of a DataFrame is ambiguous` — two root causes:
+- Fixed `--inventory-summary --include-derived` silently failing with `ValueError: The truth value of a DataFrame is ambiguous` — three root causes:
   1. `_build_derived_inventory_summary()` called `cja.getMetrics()`/`cja.getDimensions()` without `inclType=True, full=True`, returning lightweight DataFrames missing `sourceFieldType="derived"` and `fieldDefinition` columns needed for derived field detection. Added the missing API flags to match the SDR pipeline's fetch path.
   2. Same function used bare truthiness checks (`if metrics_data:`) on the returned DataFrames, which raises `ValueError` in pandas. Replaced with `isinstance()` guards.
   3. `display_inventory_summary()` used bare truthiness checks (`if derived_inventory:`) on inventory objects. Replaced with explicit `is not None` identity checks for all three inventory types.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Package manager: **uv**
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
-- Current version: v3.5.8
+- Current version: v3.5.9
 - Tests: **7,754** across 129 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -924,7 +924,7 @@ cja_auto_sdr --list-dataviews --log-level DEBUG
 At launch, the tool logs diagnostic lines containing the tool version, Python version, platform, active log level, inferred run mode (batch, single, or discovery), and dependency versions. These appear automatically at `INFO` level and are useful for troubleshooting environment issues in CI/CD logs or support requests:
 
 ```text
-CJA SDR Generator v3.5.8 | Python 3.14.2 | darwin | log_level=INFO | mode=single
+CJA SDR Generator v3.5.9 | Python 3.14.2 | darwin | log_level=INFO | mode=single
 Dependencies: cjapy=0.2.4.post3, pandas=2.3.3, numpy=2.2.1, xlsxwriter=3.2.9, tqdm=4.67.0
 ```
 

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -190,7 +190,7 @@ This command:
 
 ```bash
 $ uv run cja_auto_sdr -V
-cja_auto_sdr 3.5.8
+cja_auto_sdr 3.5.9
 ```
 
 > **Important:** All commands in this guide assume you're in the `cja_auto_sdr` directory. If you see "command not found", make sure you're in the right directory and have run `uv sync`.

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Quick Reference Card
 
-Single-page command cheat sheet for CJA SDR Generator v3.5.8.
+Single-page command cheat sheet for CJA SDR Generator v3.5.9.
 
 ## Four Main Modes
 

--- a/src/cja_auto_sdr/core/version.py
+++ b/src/cja_auto_sdr/core/version.py
@@ -1,3 +1,3 @@
 """Version information for CJA Auto SDR."""
 
-__version__ = "3.5.8"
+__version__ = "3.5.9"

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -2706,12 +2706,12 @@ def process_inventory_summary(
         def _build_derived_inventory_summary() -> Any:
             from cja_auto_sdr.inventory.derived_fields import DerivedFieldInventoryBuilder
 
-            # Need metrics and dimensions for derived fields
-            metrics_data = cja.getMetrics(data_view_id)
-            dimensions_data = cja.getDimensions(data_view_id)
+            # Need full metrics/dimensions (inclType + full) for derived field detection
+            metrics_data = cja.getMetrics(data_view_id, inclType=True, full=True)
+            dimensions_data = cja.getDimensions(data_view_id, inclType=True, full=True)
 
-            metrics_df = pd.DataFrame(metrics_data) if metrics_data else pd.DataFrame()
-            dimensions_df = pd.DataFrame(dimensions_data) if dimensions_data else pd.DataFrame()
+            metrics_df = metrics_data if isinstance(metrics_data, pd.DataFrame) else pd.DataFrame(metrics_data or [])
+            dimensions_df = dimensions_data if isinstance(dimensions_data, pd.DataFrame) else pd.DataFrame(dimensions_data or [])
 
             builder = DerivedFieldInventoryBuilder(logger=logger)
             derived = builder.build(metrics_df, dimensions_df, data_view_id, dv_name)

--- a/src/cja_auto_sdr/output/inventory/summary.py
+++ b/src/cja_auto_sdr/output/inventory/summary.py
@@ -54,7 +54,7 @@ def display_inventory_summary(
     high_complexity_items: list[dict[str, Any]] = []
 
     # Process derived fields inventory
-    if derived_inventory:
+    if derived_inventory is not None:
         derived_summary = derived_inventory.get_summary()
         summary["inventories"]["derived_fields"] = derived_summary
 
@@ -71,7 +71,7 @@ def display_inventory_summary(
         )
 
     # Process calculated metrics inventory
-    if calculated_inventory:
+    if calculated_inventory is not None:
         calc_summary = calculated_inventory.get_summary()
         summary["inventories"]["calculated_metrics"] = calc_summary
 
@@ -90,7 +90,7 @@ def display_inventory_summary(
         )
 
     # Process segments inventory
-    if segments_inventory:
+    if segments_inventory is not None:
         seg_summary = segments_inventory.get_summary()
         summary["inventories"]["segments"] = seg_summary
 

--- a/tests/test_output_content_validation.py
+++ b/tests/test_output_content_validation.py
@@ -38,7 +38,7 @@ def rich_data_dict():
         "Metadata": pd.DataFrame(
             {
                 "Property": ["Generated At", "Data View ID", "Tool Version", "Total Metrics"],
-                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.5.8", 3],
+                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.5.9", 3],
             },
         ),
         "Data Quality": pd.DataFrame(
@@ -104,7 +104,7 @@ def rich_metadata_dict():
         "Generated At": "2025-01-15 10:30:00 PST",
         "Data View ID": "dv_content_test",
         "Data View Name": "Test DataView",
-        "Tool Version": "3.5.8",
+        "Tool Version": "3.5.9",
         "Metrics Count": "3",
         "Dimensions Count": "4",
     }
@@ -224,7 +224,7 @@ class TestJSONContentValidation:
             data = json.load(f)
 
         assert data["metadata"]["Data View ID"] == "dv_content_test"
-        assert data["metadata"]["Tool Version"] == "3.5.8"
+        assert data["metadata"]["Tool Version"] == "3.5.9"
 
     def test_json_metadata_preserves_partial_markers(self, tmp_path, rich_data_dict, rich_metadata_dict):
         logger = logging.getLogger("json_test")

--- a/tests/test_ux_features.py
+++ b/tests/test_ux_features.py
@@ -344,11 +344,11 @@ class TestCombinedFeatures:
 class TestVersionUpdated:
     """Test that version is correct"""
 
-    def test_version_is_3_5_8(self):
-        """Test that version is 3.5.8"""
+    def test_version_is_3_5_9(self):
+        """Test that version is 3.5.9"""
         from cja_auto_sdr.generator import __version__
 
-        assert __version__ == "3.5.8"
+        assert __version__ == "3.5.9"
 
 
 class TestFormatAutoDetection:


### PR DESCRIPTION
## Summary
Fixed `--inventory-summary --include-derived` silently failing — three root causes identified and fixed via production smoke testing:

1. **Missing API flags** — `_build_derived_inventory_summary()` called `cja.getMetrics()`/`cja.getDimensions()` without `inclType=True, full=True`, returning lightweight DataFrames missing `sourceFieldType="derived"` and `fieldDefinition` columns needed for derived field detection (0 fields found instead of 15)
2. **DataFrame truthiness in builder** — same function used `if metrics_data:` on DataFrames returned by the API, raising `ValueError` because pandas disallows ambiguous boolean coercion. Replaced with `isinstance()` guards.
3. **DataFrame truthiness in display** — `display_inventory_summary()` used `if derived_inventory:` on inventory objects. Replaced with explicit `is not None` identity checks for all three inventory types.

## Root Cause
The v3.5.8 fix corrected broken `cjapy` namespace calls in `process_inventory_summary()`, but the inventory-summary code path had three additional issues: wrong API call parameters (no `full=True`), and two instances of bare truthiness checks on pandas DataFrames.

## Files Changed
- `src/cja_auto_sdr/generator.py` — added `inclType=True, full=True` to API calls + `isinstance()` DataFrame guards
- `src/cja_auto_sdr/output/inventory/summary.py` — 3 truthiness checks → `is not None`
- Version bump: `core/version.py`, `CLAUDE.md`, `CHANGELOG.md`, `tests/test_ux_features.py`, `tests/test_output_content_validation.py`, `docs/QUICK_REFERENCE.md`, `docs/QUICKSTART_GUIDE.md`, `docs/CONFIGURATION.md`

## Test Plan
- [x] Full test suite: 7,751 passed, 3 skipped
- [x] Ruff lint: clean
- [x] Version sync: all 8 files match v3.5.9
- [x] Contract tests: 109 passed
- [x] Production smoke test: 45+ CLI command variations verified against live API
- [x] `--inventory-summary --include-derived`: 15 derived fields detected (was 0 / erroring on v3.5.8)
- [x] `--inventory-summary --include-all-inventory`: all 3 sections render correctly
- [x] `--inventory-summary --format json`: JSON output verified with correct counts