### PR TITLE
v3.5.12 — Inventory defensive guard coverage hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fallback branch
 - Total tests: 7,783 (was 7,765)
 
+### Documentation
+
+- Refreshed CLAUDE.md package layout tree — added 4 missing source files
+  (`api/validation.py`, `core/advisories.py`, `core/advisory_builders.py`,
+  `output/excel.py`)
+
 ## [3.5.11] — 2026-04-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ All notable changes to the CJA SDR Generator project will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.12] — 2026-04-04
+
+### Changed
+
+- Removed 5 `pragma: no cover` annotations from inventory subsystem by adding
+  edge-case tests that exercise defensive guard code paths directly
+- Confirmed `derived_fields.py:982` pragma is correct (genuinely unreachable) —
+  retained as-is
+
+### Tests
+
+- Added 18 tests covering: calculated_metrics `traverse()` non-dict guard,
+  segments `traverse()` non-dict guard, derived_fields `pd.isna` exception
+  fallback, `_coerce_int_index` overflow guard, and classify `lookup_references`
+  fallback branch
+- Total tests: 7,783 (was 7,765)
+
 ## [3.5.11] — 2026-04-03
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,8 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Package manager: **uv**
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
-- Current version: v3.5.11
-- Tests: **7,764** across 129 files at **95% coverage gate**
+- Current version: v3.5.12
+- Tests: **7,783** across 130 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 ```
 src/cja_auto_sdr/
 ├── __init__.py              # Lazy forwarding (__version__, main → generator)
-├── __main__.py              # Fast-path entry point (~550 lines)
+├── __main__.py              # Fast-path entry point (~553 lines)
 ├── generator.py             # Main orchestrator (~7K lines, monolithic workhorse)
 │
 ├── api/                     # API client, resilience & caching
@@ -41,7 +41,8 @@ src/cja_auto_sdr/
 │   ├── fetch.py             # Parallel fetching with worker optimization
 │   ├── quality.py           # Core data quality validation engine
 │   ├── quality_policy.py    # Quality policy metadata
-│   └── tuning.py            # API worker auto-tuning
+│   ├── tuning.py            # API worker auto-tuning
+│   └── validation.py        # API response validation helpers
 │
 ├── cli/                     # Argument parsing & command dispatch
 │   ├── agent_output.py      # Centralized agent-mode output contract resolver
@@ -67,6 +68,8 @@ src/cja_auto_sdr/
 │   ├── credentials.py       # API credential resolution
 │   ├── exit_codes.py        # Exit code definitions + explainer
 │   ├── exceptions.py        # Custom exception hierarchy
+│   ├── advisories.py        # Advisory system for actionable warnings
+│   ├── advisory_builders.py # Advisory builder helpers
 │   ├── discovery_exceptions.py  # Discovery-specific exceptions
 │   ├── discovery_payloads.py    # Discovery payload classification
 │   ├── discovery_normalization.py # Normalization helpers
@@ -119,6 +122,7 @@ src/cja_auto_sdr/
 │   ├── protocols.py         # Writer protocol definitions
 │   ├── registry.py          # Format registry
 │   ├── run_summary.py       # Run summary output helpers
+│   ├── excel.py             # Shared Excel formatting utilities
 │   ├── writers/             # Format writers (csv, excel, json, html, markdown)
 │   ├── sdr/                 # SDR document generators
 │   ├── diff/                # Diff renderers (console, grouped, csv, json, html, excel, markdown, pr_comment)

--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (7,765+ tests)
+├── tests/                     # Test suite (7,783+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -924,7 +924,7 @@ cja_auto_sdr --list-dataviews --log-level DEBUG
 At launch, the tool logs diagnostic lines containing the tool version, Python version, platform, active log level, inferred run mode (batch, single, or discovery), and dependency versions. These appear automatically at `INFO` level and are useful for troubleshooting environment issues in CI/CD logs or support requests:
 
 ```text
-CJA SDR Generator v3.5.11 | Python 3.14.2 | darwin | log_level=INFO | mode=single
+CJA SDR Generator v3.5.12 | Python 3.14.2 | darwin | log_level=INFO | mode=single
 Dependencies: cjapy=0.2.4.post3, pandas=2.3.3, numpy=2.2.1, xlsxwriter=3.2.9, tqdm=4.67.0
 ```
 

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -190,7 +190,7 @@ This command:
 
 ```bash
 $ uv run cja_auto_sdr -V
-cja_auto_sdr 3.5.11
+cja_auto_sdr 3.5.12
 ```
 
 > **Important:** All commands in this guide assume you're in the `cja_auto_sdr` directory. If you see "command not found", make sure you're in the right directory and have run `uv sync`.

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Quick Reference Card
 
-Single-page command cheat sheet for CJA SDR Generator v3.5.11.
+Single-page command cheat sheet for CJA SDR Generator v3.5.12.
 
 ## Four Main Modes
 

--- a/src/cja_auto_sdr/core/version.py
+++ b/src/cja_auto_sdr/core/version.py
@@ -1,3 +1,3 @@
 """Version information for CJA Auto SDR."""
 
-__version__ = "3.5.11"
+__version__ = "3.5.12"

--- a/src/cja_auto_sdr/inventory/calculated_metrics.py
+++ b/src/cja_auto_sdr/inventory/calculated_metrics.py
@@ -627,7 +627,7 @@ class CalculatedMetricsInventoryBuilder:
         def traverse(node: Any, current_depth: int) -> None:
             nonlocal total_operators, max_nesting, total_conditionals
 
-            if not isinstance(node, dict):  # pragma: no cover — all callers guard with isinstance
+            if not isinstance(node, dict):
                 return
 
             max_nesting = max(max_nesting, current_depth)

--- a/src/cja_auto_sdr/inventory/derived_fields.py
+++ b/src/cja_auto_sdr/inventory/derived_fields.py
@@ -785,7 +785,7 @@ class DerivedFieldInventoryBuilder:
                 else:
                     rules_str = ", ".join(rule_names[:3]) + f", +{len(rule_names) - 3} more"
                 parts.append(f"Lookup classification: {rules_str}")
-            elif parsed["lookup_references"]:  # pragma: no cover — _describe_lookup_logic covers this
+            elif parsed["lookup_references"]:
                 parts.append(f"Lookup from {parsed['lookup_references'][0]}")
             else:
                 parts.append("Lookup/classify operation")

--- a/src/cja_auto_sdr/inventory/derived_fields.py
+++ b/src/cja_auto_sdr/inventory/derived_fields.py
@@ -614,7 +614,7 @@ class DerivedFieldInventoryBuilder:
                 return default
             try:
                 return int(value)
-            except TypeError, ValueError, OverflowError:  # pragma: no cover — finite floats always convert
+            except TypeError, ValueError, OverflowError:
                 return default
 
         if isinstance(value, str):

--- a/src/cja_auto_sdr/inventory/derived_fields.py
+++ b/src/cja_auto_sdr/inventory/derived_fields.py
@@ -373,7 +373,7 @@ class DerivedFieldInventoryBuilder:
                 is_na = bool(is_na.all()) if len(is_na) > 0 else True
             else:
                 is_na = bool(is_na)
-        except TypeError, ValueError:  # pragma: no cover — pd.isna rarely raises
+        except TypeError, ValueError:
             is_na = field_def_str is None
 
         if is_na or field_def_str in ("NaN", "", "null", None):

--- a/src/cja_auto_sdr/inventory/segments.py
+++ b/src/cja_auto_sdr/inventory/segments.py
@@ -591,7 +591,7 @@ class SegmentsInventoryBuilder:
         def traverse(node: Any, current_depth: int) -> None:
             nonlocal total_predicates, total_logic_operators, max_nesting, total_containers, regex_count, container_type
 
-            if not isinstance(node, dict):  # pragma: no cover — all callers guard with isinstance
+            if not isinstance(node, dict):
                 return
 
             max_nesting = max(max_nesting, current_depth)

--- a/tests/README.md
+++ b/tests/README.md
@@ -35,6 +35,7 @@ tests/
 ├── test_fetch_edge_cases.py         # Fetch edge-case tests
 ├── test_explain_exit_code.py        # Exit-code explainer, fast-path dispatch, and run-summary tests
 ├── test_git_integration.py          # Git integration and snapshot tests
+├── test_inventory_pragma_coverage.py # Inventory pragma coverage hardening tests
 ├── test_inventory_utils.py          # Inventory utilities tests
 ├── test_logging_optimization.py     # Logging optimization tests
 ├── test_name_resolution.py          # Data view name resolution tests
@@ -141,7 +142,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 7,765 comprehensive tests**
+**Total: 7,783 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -150,16 +151,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,659 | 123 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,677 | 124 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 7 | 1 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **7,765** | **129** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **7,783** | **130** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,652 | 122 | `-m "unit and not slow"` |
+| `test-unit` | 7,670 | 123 | `-m "unit and not slow"` |
 | `test-integration` | 103 | 6 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -176,6 +177,7 @@ tests/
 | `test_cli.py` | 412 | Command-line interface and argument parsing |
 | `test_profiles.py` | 78 | Multi-organization profile support |
 | `test_derived_inventory.py` | 62 | Derived fields inventory feature |
+| `test_inventory_pragma_coverage.py` | 18 | Inventory pragma coverage hardening |
 | `test_inventory_utils.py` | 56 | Inventory utilities and helpers |
 | `test_segments_inventory.py` | 48 | Segments inventory feature |
 | `test_edge_cases.py` | 39 | Edge cases, configuration dataclasses, custom exceptions |
@@ -298,7 +300,7 @@ tests/
 | `test_agent_workflows.py` | 69 | Agent workflow shell script validation tests |
 | `test_manifest_agent_contract.py` | 16 | Manifest vs runtime capability drift tests |
 | `test_tool_manifests.py` | 40 | Tool manifest schema and content tests |
-| **Total** | **7,765** | **Collected via pytest --collect-only** |
+| **Total** | **7,783** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -756,7 +758,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (7,765 tests total)
+- [x] Comprehensive test coverage (7,783 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 78 tests

--- a/tests/test_inventory_pragma_coverage.py
+++ b/tests/test_inventory_pragma_coverage.py
@@ -4,6 +4,9 @@ Tests that exercise pragma-guarded defensive code paths in inventory modules.
 v3.5.12: Coverage hardening — removes pragma: no cover from 5 lines across
 calculated_metrics.py, segments.py, and derived_fields.py by crafting payloads
 that bypass upstream isinstance filters.
+
+Note: ``except TypeError, ValueError:`` in the source uses PEP 758 bare-comma
+syntax (Python 3.14+), not the legacy Python 2 form — no parentheses required.
 """
 
 from __future__ import annotations
@@ -287,7 +290,7 @@ class TestClassifyLookupReferencesFallback:
         assert summary.total_derived_fields == 1
         field = summary.fields[0]
         # Line 789 produces: "Lookup from {parsed['lookup_references'][0]}"
-        assert "lookup" in field.logic_summary.lower() or "0" in field.logic_summary
+        assert "Lookup from" in field.logic_summary
 
     def test_classify_with_false_key_field_hits_fallback(self):
         """classify with key-field=False: same divergence pattern."""
@@ -302,4 +305,4 @@ class TestClassifyLookupReferencesFallback:
         assert summary.total_derived_fields == 1
         field = summary.fields[0]
         # "False" is truthy as a string, so lookup_references gets ["False"]
-        assert "lookup" in field.logic_summary.lower() or "false" in field.logic_summary.lower()
+        assert "Lookup from" in field.logic_summary

--- a/tests/test_inventory_pragma_coverage.py
+++ b/tests/test_inventory_pragma_coverage.py
@@ -65,3 +65,48 @@ class TestCalcMetricsTraverseNonDict:
         result = builder._parse_formula([{"func": "add"}])
         assert result["functions_internal"] == []
         assert result["operator_count"] == 0
+
+
+from cja_auto_sdr.inventory.segments import SegmentsInventoryBuilder
+
+
+def _seg_builder():
+    return SegmentsInventoryBuilder()
+
+
+# ==================== Task 2: segments traverse() non-dict guard ====================
+
+
+class TestSegmentsTraverseNonDict:
+    """Exercise line 594: `if not isinstance(node, dict)` inside traverse().
+
+    _parse_definition() calls traverse(definition, depth) at line 701 without
+    a guard. Passing a non-dict as definition hits line 594 directly.
+    """
+
+    def test_string_definition_returns_zero_counts(self):
+        """String definition hits the guard; all counters stay at zero."""
+        builder = _seg_builder()
+        result = builder._parse_definition("not_a_dict")
+        assert result["predicate_count"] == 0
+        assert result["nesting_depth"] == 0
+        assert result["logic_operator_count"] == 0
+        assert result["container_count"] == 0
+
+    def test_none_definition_returns_zero_counts(self):
+        """None definition hits the guard."""
+        builder = _seg_builder()
+        result = builder._parse_definition(None)
+        assert result["predicate_count"] == 0
+
+    def test_int_definition_returns_zero_counts(self):
+        """Integer definition hits the guard."""
+        builder = _seg_builder()
+        result = builder._parse_definition(42)
+        assert result["predicate_count"] == 0
+
+    def test_list_definition_returns_zero_counts(self):
+        """List definition hits the guard (list is not a dict)."""
+        builder = _seg_builder()
+        result = builder._parse_definition([{"func": "eq"}])
+        assert result["predicate_count"] == 0

--- a/tests/test_inventory_pragma_coverage.py
+++ b/tests/test_inventory_pragma_coverage.py
@@ -16,7 +16,8 @@ import pandas as pd
 from cja_auto_sdr.inventory.calculated_metrics import (
     CalculatedMetricsInventoryBuilder,
 )
-
+from cja_auto_sdr.inventory.derived_fields import DerivedFieldInventoryBuilder
+from cja_auto_sdr.inventory.segments import SegmentsInventoryBuilder
 
 # ==================== HELPERS ====================
 
@@ -67,9 +68,6 @@ class TestCalcMetricsTraverseNonDict:
         assert result["operator_count"] == 0
 
 
-from cja_auto_sdr.inventory.segments import SegmentsInventoryBuilder
-
-
 def _seg_builder():
     return SegmentsInventoryBuilder()
 
@@ -112,9 +110,6 @@ class TestSegmentsTraverseNonDict:
         assert result["predicate_count"] == 0
 
 
-from cja_auto_sdr.inventory.derived_fields import DerivedFieldInventoryBuilder
-
-
 def _df_builder():
     return DerivedFieldInventoryBuilder()
 
@@ -134,8 +129,7 @@ def _build_one_df(definition):
             }
         ]
     )
-    inventory = builder.build(pd.DataFrame(), df, "dv_test", "Test")
-    return inventory
+    return builder.build(pd.DataFrame(), df, "dv_test", "Test")
 
 
 # ==================== Task 3: pd.isna TypeError/ValueError guard ====================
@@ -262,3 +256,50 @@ class TestCoerceIntIndexOverflowGuard:
         val = BadFloat(1.0)
         result = builder._coerce_int_index(val, default=42)
         assert result == 42
+
+
+# ==================== Task 5: classify lookup_references fallback ====================
+
+
+class TestClassifyLookupReferencesFallback:
+    """Exercise line 788: `elif parsed['lookup_references']` branch.
+
+    This branch fires when:
+    1. functions_internal contains 'classify'
+    2. _describe_lookup_logic() returns '' (no truthy key-field)
+    3. parsed['rule_names'] is empty
+    4. parsed['lookup_references'] is non-empty
+
+    The edge case: key-field=0 passes str() normalization in _parse_definition
+    but fails the truthiness check in _describe_lookup_logic.
+    """
+
+    def test_classify_with_falsy_key_field_hits_lookup_refs_fallback(self):
+        """classify with key-field=0 populates lookup_references but not lookup details."""
+        definition = [
+            {"func": "raw-field", "id": "test.field", "label": "base"},
+            {
+                "func": "classify",
+                "mapping": {"key-field": 0, "value-field": "result", "dataset": "lookup/my_dataset"},
+            },
+        ]
+        summary = _build_one_df(definition)
+        assert summary.total_derived_fields == 1
+        field = summary.fields[0]
+        # Line 789 produces: "Lookup from {parsed['lookup_references'][0]}"
+        assert "lookup" in field.logic_summary.lower() or "0" in field.logic_summary
+
+    def test_classify_with_false_key_field_hits_fallback(self):
+        """classify with key-field=False: same divergence pattern."""
+        definition = [
+            {"func": "raw-field", "id": "test.field", "label": "base"},
+            {
+                "func": "classify",
+                "mapping": {"key-field": False, "value-field": "result"},
+            },
+        ]
+        summary = _build_one_df(definition)
+        assert summary.total_derived_fields == 1
+        field = summary.fields[0]
+        # "False" is truthy as a string, so lookup_references gets ["False"]
+        assert "lookup" in field.logic_summary.lower() or "false" in field.logic_summary.lower()

--- a/tests/test_inventory_pragma_coverage.py
+++ b/tests/test_inventory_pragma_coverage.py
@@ -110,3 +110,103 @@ class TestSegmentsTraverseNonDict:
         builder = _seg_builder()
         result = builder._parse_definition([{"func": "eq"}])
         assert result["predicate_count"] == 0
+
+
+from cja_auto_sdr.inventory.derived_fields import DerivedFieldInventoryBuilder
+
+
+def _df_builder():
+    return DerivedFieldInventoryBuilder()
+
+
+def _build_one_df(definition):
+    """Build a single derived field from a definition and return the inventory."""
+    builder = _df_builder()
+    field_def = json.dumps(definition) if isinstance(definition, list) else definition
+    df = pd.DataFrame(
+        [
+            {
+                "id": "dimensions/test_field",
+                "name": "Test Field",
+                "sourceFieldType": "derived",
+                "fieldDefinition": field_def,
+                "dataSetType": "event",
+            }
+        ]
+    )
+    inventory = builder.build(pd.DataFrame(), df, "dv_test", "Test")
+    return inventory
+
+
+# ==================== Task 3: pd.isna TypeError/ValueError guard ====================
+
+
+class TestParseDefinitionIsnaGuard:
+    """Exercise line 376: except TypeError, ValueError around pd.isna().
+
+    pd.isna() can raise TypeError on objects that define __len__ in ways
+    that conflict with pandas internals. We mock pd.isna to force the
+    exception and verify the fallback path treats the value as non-null.
+    """
+
+    def test_isna_typeerror_falls_back_to_none_check(self):
+        """When pd.isna raises TypeError, field_def is treated as non-null."""
+        definition = [{"func": "raw-field", "id": "test.field", "label": "f"}]
+        field_def_str = json.dumps(definition)
+
+        builder = _df_builder()
+        row = pd.Series(
+            {
+                "id": "dimensions/test",
+                "name": "Test",
+                "sourceFieldType": "derived",
+                "fieldDefinition": field_def_str,
+                "dataSetType": "event",
+            }
+        )
+
+        with patch("cja_auto_sdr.inventory.derived_fields.pd.isna", side_effect=TypeError("mock")):
+            result = builder._process_row(row, "event", stats=None)
+
+        assert result is not None
+        assert result.component_name == "Test"
+
+    def test_isna_valueerror_falls_back_to_none_check(self):
+        """When pd.isna raises ValueError, field_def is treated as non-null."""
+        definition = [{"func": "raw-field", "id": "test.field", "label": "f"}]
+        field_def_str = json.dumps(definition)
+
+        builder = _df_builder()
+        row = pd.Series(
+            {
+                "id": "dimensions/test",
+                "name": "Test",
+                "sourceFieldType": "derived",
+                "fieldDefinition": field_def_str,
+                "dataSetType": "event",
+            }
+        )
+
+        with patch("cja_auto_sdr.inventory.derived_fields.pd.isna", side_effect=ValueError("mock")):
+            result = builder._process_row(row, "event", stats=None)
+
+        assert result is not None
+
+    def test_isna_exception_with_none_field_def_returns_none(self):
+        """When pd.isna raises and field_def IS None, fallback detects it."""
+        builder = _df_builder()
+        row = pd.Series(
+            {
+                "id": "dimensions/test",
+                "name": "Test",
+                "sourceFieldType": "derived",
+                "fieldDefinition": None,
+                "dataSetType": "event",
+            }
+        )
+
+        with patch("cja_auto_sdr.inventory.derived_fields.pd.isna", side_effect=TypeError("mock")):
+            result = builder._process_row(row, "event", stats=None)
+
+        # field_def is None → is_na fallback sets True → returns None
+        assert result is None

--- a/tests/test_inventory_pragma_coverage.py
+++ b/tests/test_inventory_pragma_coverage.py
@@ -1,0 +1,67 @@
+"""
+Tests that exercise pragma-guarded defensive code paths in inventory modules.
+
+v3.5.12: Coverage hardening — removes pragma: no cover from 5 lines across
+calculated_metrics.py, segments.py, and derived_fields.py by crafting payloads
+that bypass upstream isinstance filters.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pandas as pd
+
+from cja_auto_sdr.inventory.calculated_metrics import (
+    CalculatedMetricsInventoryBuilder,
+)
+
+
+# ==================== HELPERS ====================
+
+
+def _cm_builder():
+    return CalculatedMetricsInventoryBuilder()
+
+
+# ==================== Task 1: calculated_metrics traverse() non-dict guard ====================
+
+
+class TestCalcMetricsTraverseNonDict:
+    """Exercise line 630: `if not isinstance(node, dict)` inside traverse().
+
+    _parse_formula() calls traverse(formula, depth) at line 702 without any
+    isinstance guard. Passing a non-dict as the formula argument hits line 630
+    directly, causing an early return with zero-valued defaults.
+    """
+
+    def test_string_formula_returns_empty_result(self):
+        """String formula hits the guard; returns dict with empty/zero fields."""
+        builder = _cm_builder()
+        result = builder._parse_formula("not_a_dict")
+        assert result["functions_internal"] == []
+        assert result["metric_references"] == []
+        assert result["operator_count"] == 0
+        assert result["nesting_depth"] == 0
+
+    def test_int_formula_returns_empty_result(self):
+        """Integer formula hits the guard."""
+        builder = _cm_builder()
+        result = builder._parse_formula(42)
+        assert result["functions_internal"] == []
+        assert result["operator_count"] == 0
+
+    def test_none_formula_returns_empty_result(self):
+        """None formula hits the guard."""
+        builder = _cm_builder()
+        result = builder._parse_formula(None)
+        assert result["functions_internal"] == []
+        assert result["operator_count"] == 0
+
+    def test_list_formula_returns_empty_result(self):
+        """List formula hits the guard (list is not a dict)."""
+        builder = _cm_builder()
+        result = builder._parse_formula([{"func": "add"}])
+        assert result["functions_internal"] == []
+        assert result["operator_count"] == 0

--- a/tests/test_inventory_pragma_coverage.py
+++ b/tests/test_inventory_pragma_coverage.py
@@ -210,3 +210,55 @@ class TestParseDefinitionIsnaGuard:
 
         # field_def is None → is_na fallback sets True → returns None
         assert result is None
+
+
+# ==================== Task 4: _coerce_int_index overflow guard ====================
+
+
+class TestCoerceIntIndexOverflowGuard:
+    """Exercise line 617: except TypeError, ValueError, OverflowError on int().
+
+    The isfinite() check at line 613 catches inf/nan, but a float subclass
+    that passes isfinite yet fails int() exercises the guard directly.
+    """
+
+    def test_normal_float_converts(self):
+        """Baseline: normal float converts correctly."""
+        builder = _df_builder()
+        assert builder._coerce_int_index(3.0) == 3
+
+    def test_inf_returns_default(self):
+        """math.inf caught by isfinite check, returns default."""
+        import math
+
+        builder = _df_builder()
+        assert builder._coerce_int_index(math.inf) == 0
+        assert builder._coerce_int_index(math.inf, default=99) == 99
+
+    def test_nan_returns_default(self):
+        """NaN caught by isfinite check, returns default."""
+        import math
+
+        builder = _df_builder()
+        assert builder._coerce_int_index(math.nan) == 0
+
+    def test_neg_inf_returns_default(self):
+        """Negative infinity returns default."""
+        import math
+
+        builder = _df_builder()
+        assert builder._coerce_int_index(-math.inf, default=-1) == -1
+
+    def test_int_conversion_exception_returns_default(self):
+        """Force the guard path via a float subclass that fails int()."""
+        builder = _df_builder()
+
+        class BadFloat(float):
+            """A float subclass that passes isfinite but fails int()."""
+
+            def __int__(self):
+                raise OverflowError("cannot convert")
+
+        val = BadFloat(1.0)
+        result = builder._coerce_int_index(val, default=42)
+        assert result == 42

--- a/tests/test_output_content_validation.py
+++ b/tests/test_output_content_validation.py
@@ -38,7 +38,7 @@ def rich_data_dict():
         "Metadata": pd.DataFrame(
             {
                 "Property": ["Generated At", "Data View ID", "Tool Version", "Total Metrics"],
-                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.5.11", 3],
+                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.5.12", 3],
             },
         ),
         "Data Quality": pd.DataFrame(
@@ -104,7 +104,7 @@ def rich_metadata_dict():
         "Generated At": "2025-01-15 10:30:00 PST",
         "Data View ID": "dv_content_test",
         "Data View Name": "Test DataView",
-        "Tool Version": "3.5.11",
+        "Tool Version": "3.5.12",
         "Metrics Count": "3",
         "Dimensions Count": "4",
     }
@@ -224,7 +224,7 @@ class TestJSONContentValidation:
             data = json.load(f)
 
         assert data["metadata"]["Data View ID"] == "dv_content_test"
-        assert data["metadata"]["Tool Version"] == "3.5.11"
+        assert data["metadata"]["Tool Version"] == "3.5.12"
 
     def test_json_metadata_preserves_partial_markers(self, tmp_path, rich_data_dict, rich_metadata_dict):
         logger = logging.getLogger("json_test")

--- a/tests/test_ux_features.py
+++ b/tests/test_ux_features.py
@@ -345,10 +345,10 @@ class TestVersionUpdated:
     """Test that version is correct"""
 
     def test_version_is_3_5_11(self):
-        """Test that version is 3.5.11"""
+        """Test that version is 3.5.12"""
         from cja_auto_sdr.generator import __version__
 
-        assert __version__ == "3.5.11"
+        assert __version__ == "3.5.12"
 
 
 class TestFormatAutoDetection:

--- a/tests/test_ux_features.py
+++ b/tests/test_ux_features.py
@@ -344,7 +344,7 @@ class TestCombinedFeatures:
 class TestVersionUpdated:
     """Test that version is correct"""
 
-    def test_version_is_3_5_11(self):
+    def test_version_is_3_5_12(self):
         """Test that version is 3.5.12"""
         from cja_auto_sdr.generator import __version__
 


### PR DESCRIPTION
## Summary

- Remove 5 `pragma: no cover` annotations from inventory subsystem by adding edge-case tests that exercise defensive guard code paths directly
- Confirmed `derived_fields.py:982` pragma is correct (genuinely unreachable) — retained as-is
- Zero behavioral changes to production code — only pragma comment removal + new tests
- Version bumped to v3.5.12 across all 8 tracked files
- CLAUDE.md package layout tree refreshed (4 missing source files added)

## Pragmas Removed

| File | Line | Guard |
|------|------|-------|
| `inventory/calculated_metrics.py` | 630 | `traverse()` non-dict isinstance guard |
| `inventory/segments.py` | 594 | `traverse()` non-dict isinstance guard |
| `inventory/derived_fields.py` | 376 | `pd.isna()` TypeError/ValueError catch |
| `inventory/derived_fields.py` | 617 | `_coerce_int_index` OverflowError catch |
| `inventory/derived_fields.py` | 788 | classify `lookup_references` fallback |

## Tests Added

18 new tests in `tests/test_inventory_pragma_coverage.py` across 5 test classes:
- `TestCalcMetricsTraverseNonDict` (4 tests)
- `TestSegmentsTraverseNonDict` (4 tests)
- `TestParseDefinitionIsnaGuard` (3 tests)
- `TestCoerceIntIndexOverflowGuard` (5 tests)
- `TestClassifyLookupReferencesFallback` (2 tests)

## Changes

- 9 commits, 14 files changed (+357/−26)
- 3 production files modified (pragma removal only, no logic changes)
- 1 new test file (308 lines)
- 8 version-bump files updated
- 2 doc/README files updated (test counts, tree listing)

## Test Plan

- [x] All 18 new tests pass
- [x] Full suite passes (7,783 collected, 7,780 passed, 3 skipped)
- [x] Ruff lint + format clean
- [x] Version bump to v3.5.12 (all 8 files)
- [x] Version sync check passes (`check_version_sync.py`)
- [x] Test counts updated (README.md, tests/README.md, CLAUDE.md)
- [x] Changelog updated
- [x] Contract tests pass (mock contract, backwards compat, lazy forwarding)
- [x] Only `derived_fields.py:982` pragma remains in inventory (verified)
- [x] Production smoke test passes (133/133 across 10 phases)