### PR TITLE
release: v3.5.14 — cjapy 0.3.1 response-normalization fix & retry-layer audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ All notable changes to the CJA SDR Generator project will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.14] — 2026-04-23
+
+### Fixed
+
+- **cjapy 0.3.1 response-shape blind spot at the retry boundary.** The project
+  retry wrapper `make_api_call_with_retry()` previously recognized retryable
+  statuses only via snake_case `status_code`, but cjapy 0.3.1 returns parsed
+  JSON payloads exposing camelCase `statusCode` (sometimes nested under `error`
+  or `response`). Adapter-exhausted cjapy responses therefore bypassed the
+  retry wrapper and circuit breaker. A new `_extract_http_status_code_from_result()`
+  helper normalizes all supported shapes (top-level and nested,
+  camelCase/snake_case, mappings and response-like attributes).
+- **`ParallelAPIFetcher` misclassifying component error payloads as success.**
+  `_fetch_metrics()` and `_fetch_dimensions()` now normalize payloads through
+  `assess_component_payload()` before recording a fetch status. An error-shaped
+  dict like `{"statusCode": 500, "message": "backend timeout"}` is now recorded
+  as `failed` with a useful error message instead of being returned as
+  "metrics" with `item_count=2`.
+- **`initialize_cja()` reporting connection success on error-shaped
+  `getDataViews()` payloads.** The connection probe now only logs success for
+  list/tuple/DataFrame payloads; error-shaped dicts warn with the parsed
+  `statusCode`/`message`. The dry-run `getDataViews()` path got the same
+  tightening.
+
+### Changed
+
+- **Narrowed `RETRYABLE_STATUS_CODES` to `{408}`.** cjapy 0.3.1 already handles
+  429/500/502/503/504 via its urllib3.Retry adapter (`status_forcelist`,
+  `backoff_factor=1`, `raise_on_status=False`). Keeping those statuses in the
+  project set stacked retries on top of the upstream adapter, multiplying wait
+  time and consuming CircuitBreaker budget faster than intended. 408 is not in
+  cjapy's `status_forcelist`, so it remains project-owned.
+
+### Documentation
+
+- Added `docs/RESILIENCE_LAYERING.md` documenting the upstream cjapy retry
+  adapter, the project retry/circuit-breaker layer, and the non-overlap
+  contract between them.
+
 ## [3.5.13] — 2026-04-23
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `UPSTREAM_ADAPTER_STATUS_CODES` set (mirroring cjapy's `status_forcelist`)
   now routes those returns to `record_failure()` and suppresses the
   success-after-retry log. Non-upstream-failure 4xx (401/403/404/400/422) stay
-  breaker-neutral (record success, as before).
+  breaker-positive (records success, as before).
+- **`retry_with_backoff` decorator emitting success log on error-shaped returns.**
+  The sibling decorator (publicly re-exported from `cja_auto_sdr.api`) had the
+  same shape of telemetry bug: any non-exception return logged
+  `✓ … succeeded on attempt …`, even when the return carried an adapter-exhausted
+  5xx/429 status. Extracted the shared `_is_upstream_failure_payload()` predicate
+  and applied it to both `make_api_call_with_retry` and `retry_with_backoff`.
+  The decorator has no circuit-breaker plumbing, so only the log-suppression
+  half of the rule applies there.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `docs/RESILIENCE_LAYERING.md` documenting the upstream cjapy retry
   adapter, the project retry/circuit-breaker layer, and the non-overlap
   contract between them.
+- Extended the "Before v3.5.14" section in `docs/RESILIENCE_LAYERING.md` to
+  cover all six behaviors the release fixes (previously the preamble promised
+  "fixes all six points" but the before-list enumerated only four), so the
+  rationale for the breaker-success regression and the decorator
+  log-suppression bug is self-contained in the doc. (Post-review polish.)
+- Synced `CLAUDE.md` test-count badge to match the collected count.
+  (Post-review polish.)
+
+### Tests
+
+- Added `TestResolveDataViewNames::test_error_shaped_getdataviews_payload_returns_connectivity_error`
+  locking in the `cli/commands/stats.py` name-resolution path when
+  `get_cached_data_views()` raises `APIError` on an adapter-exhausted
+  `getDataViews()` payload: the handler surfaces a `connectivity_error`
+  diagnostic with the parsed upstream `statusCode` rather than the misleading
+  "no data views found" configuration error the pre-v3.5.14 lenient path
+  would have produced. (Post-review polish.)
 
 ## [3.5.13] — 2026-04-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   list/tuple/DataFrame payloads; error-shaped dicts warn with the parsed
   `statusCode`/`message`. The dry-run `getDataViews()` path got the same
   tightening.
+- **Circuit breaker treating adapter-exhausted upstream failures as successes.**
+  After `RETRYABLE_STATUS_CODES` was narrowed to `{408}`, payloads carrying
+  429/500/502/503/504 pass through the retry wrapper unchanged — but the
+  wrapper was recording `circuit_breaker.record_success()` and emitting
+  `✓ … succeeded on attempt …` on those returns, so repeated upstream distress
+  never tripped the breaker and telemetry contradicted the caller-side failure
+  classification in `ParallelAPIFetcher` and the `initialize_cja()` probe. A new
+  `UPSTREAM_ADAPTER_STATUS_CODES` set (mirroring cjapy's `status_forcelist`)
+  now routes those returns to `record_failure()` and suppresses the
+  success-after-retry log. Non-upstream-failure 4xx (401/403/404/400/422) stay
+  breaker-neutral (record success, as before).
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
 - Current version: v3.5.14
-- Tests: **7,822** across 131 files at **95% coverage gate**
+- Tests: **7,861** across 131 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
 - Current version: v3.5.14
-- Tests: **7,783** across 130 files at **95% coverage gate**
+- Tests: **7,822** across 131 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Package manager: **uv**
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
-- Current version: v3.5.13
+- Current version: v3.5.14
 - Tests: **7,783** across 130 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)

--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (7,783+ tests)
+├── tests/                     # Test suite (7,822+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (7,827+ tests)
+├── tests/                     # Test suite (7,847+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (7,860+ tests)
+├── tests/                     # Test suite (7,861+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (7,847+ tests)
+├── tests/                     # Test suite (7,860+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (7,822+ tests)
+├── tests/                     # Test suite (7,827+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -924,7 +924,7 @@ cja_auto_sdr --list-dataviews --log-level DEBUG
 At launch, the tool logs diagnostic lines containing the tool version, Python version, platform, active log level, inferred run mode (batch, single, or discovery), and dependency versions. These appear automatically at `INFO` level and are useful for troubleshooting environment issues in CI/CD logs or support requests:
 
 ```text
-CJA SDR Generator v3.5.13 | Python 3.14.2 | darwin | log_level=INFO | mode=single
+CJA SDR Generator v3.5.14 | Python 3.14.2 | darwin | log_level=INFO | mode=single
 Dependencies: cjapy=0.3.0, pandas=2.3.3, numpy=2.2.1, xlsxwriter=3.2.9, tqdm=4.67.0
 ```
 

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -190,7 +190,7 @@ This command:
 
 ```bash
 $ uv run cja_auto_sdr -V
-cja_auto_sdr 3.5.13
+cja_auto_sdr 3.5.14
 ```
 
 > **Important:** All commands in this guide assume you're in the `cja_auto_sdr` directory. If you see "command not found", make sure you're in the right directory and have run `uv sync`.

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Quick Reference Card
 
-Single-page command cheat sheet for CJA SDR Generator v3.5.13.
+Single-page command cheat sheet for CJA SDR Generator v3.5.14.
 
 ## Four Main Modes
 

--- a/docs/RESILIENCE_LAYERING.md
+++ b/docs/RESILIENCE_LAYERING.md
@@ -1,0 +1,123 @@
+# Resilience Layering: cjapy Adapter vs. Project Retry Layer
+
+This doc describes how retry handling is split between the upstream `cjapy`
+library and the project's retry/circuit-breaker layer. It is the source of
+truth for what statuses each layer owns and why.
+
+## Upstream: `cjapy.connector.AdobeRequest`
+
+`cjapy>=0.3.1` installs a session-level `urllib3.Retry` adapter inside
+`AdobeRequest._build_session`:
+
+| Setting                        | Value                              |
+| ------------------------------ | ---------------------------------- |
+| `total`                        | `max(max_retries, 3)`              |
+| `status_forcelist`             | `[429, 500, 502, 503, 504]`        |
+| `backoff_factor`               | `1`                                |
+| `respect_retry_after_header`   | `True`                             |
+| `raise_on_status`              | `False`                            |
+
+Key consequences:
+
+- For statuses in `status_forcelist`, the adapter retries internally with
+  exponential backoff before returning a response. `Retry-After` headers are
+  honored on 429.
+- Because `raise_on_status=False`, when the adapter's budget is exhausted it
+  returns the final error response rather than raising. `cjapy` request methods
+  then call `res.json()` and **return the parsed JSON payload** — they do not
+  return `requests.Response` objects, and they do not inject a snake_case
+  `status_code` field into the returned dict.
+- The payloads that reach the project layer therefore typically look like:
+
+  ```json
+  {"statusCode": 503, "message": "backend timeout"}
+  ```
+
+  with the status carried in camelCase `statusCode` (sometimes nested under
+  `error` or `response`).
+
+## Project layer: `cja_auto_sdr.api.resilience`
+
+### Response-shape normalization
+
+`make_api_call_with_retry()` uses `_extract_http_status_code_from_result()` to
+recognize:
+
+- attributes `status_code` and `statusCode` on response-like objects
+- top-level mapping keys: `status_code`, `statusCode`, `status`, `http_status`,
+  `httpStatus`, `code`
+- the same keys nested under `error` or `response`
+
+The helper reuses `coerce_http_status_code()` from
+`cja_auto_sdr.core.discovery_exceptions`, so it rejects out-of-range or
+non-numeric values.
+
+### Retry-status set (v3.5.14+)
+
+```python
+RETRYABLE_STATUS_CODES: set[int] = {408}
+```
+
+Only 408 (Request Timeout) triggers a project-layer retry. This is the only
+retryable status that is **not** in `cjapy`'s `status_forcelist`, so project
+retries on 408 do not stack with upstream adapter retries.
+
+For 429/500/502/503/504, `cjapy` has already retried before the response
+reaches the project layer. Retrying again would:
+
+- multiply total wait time (project backoff × upstream backoff already applied)
+- exhaust CircuitBreaker budget faster than intended
+- confuse debugging: a single logical failure shows up as many retries across
+  two layers
+
+These statuses therefore pass through the retry wrapper as ordinary return
+values. Callers are expected to detect error-shaped payloads and handle them
+appropriately — e.g. `ParallelAPIFetcher` now classifies them via
+`assess_component_payload()` before recording a fetch as successful, and
+`initialize_cja()` only reports connection success when `getDataViews()`
+returns a list/tuple/DataFrame.
+
+### Circuit breaker contract
+
+`CircuitBreaker.record_failure()` is called **once per exhausted operation**,
+not once per retry attempt. After `make_api_call_with_retry()` has used its
+full budget and is about to raise, it records one breaker failure and raises.
+Non-retryable exceptions also record one breaker failure and raise immediately.
+
+### Non-overlap contract summary
+
+| Status | Owner           | Behavior                                      |
+| ------ | --------------- | --------------------------------------------- |
+| 408    | project layer   | `make_api_call_with_retry` retries with jitter |
+| 429    | cjapy adapter   | upstream retries; project passes through      |
+| 500    | cjapy adapter   | upstream retries; project passes through      |
+| 502    | cjapy adapter   | upstream retries; project passes through      |
+| 503    | cjapy adapter   | upstream retries; project passes through      |
+| 504    | cjapy adapter   | upstream retries; project passes through      |
+| 4xx (other) | caller       | returned as-is; classified by caller          |
+
+## Why this split exists
+
+Before v3.5.14:
+
+- The project retry wrapper detected statuses only via the snake_case
+  `status_code` key, so actual `cjapy` payloads (`statusCode`) bypassed it.
+- `RETRYABLE_STATUS_CODES` overlapped with `cjapy`'s `status_forcelist`,
+  meaning the retry intent was duplicated on the few shapes that *did* go
+  through the wrapper.
+- `ParallelAPIFetcher._fetch_metrics()` and `_fetch_dimensions()` treated any
+  non-empty dict payload as a successful fetch, so an error dict like
+  `{"statusCode": 500, ...}` was logged as "success" with `item_count = 2`.
+- `initialize_cja()` treated any non-`None` `getDataViews()` payload as a
+  successful connection test.
+
+v3.5.14 fixes all four points:
+
+1. Retry-wrapper status extraction recognizes `statusCode`, nested
+   `error.statusCode`, and `response.statusCode`.
+2. `RETRYABLE_STATUS_CODES` is narrowed to `{408}` so project retries are
+   disjoint from cjapy adapter retries.
+3. `ParallelAPIFetcher` classifies component payloads via
+   `assess_component_payload()` before success accounting.
+4. `initialize_cja()` and the dry-run `getDataViews()` probe only log
+   success for list/tuple/DataFrame payloads; error-shaped dicts warn.

--- a/docs/RESILIENCE_LAYERING.md
+++ b/docs/RESILIENCE_LAYERING.md
@@ -117,15 +117,15 @@ set).
 
 ### Non-overlap contract summary
 
-| Status | Owner           | Behavior                                                                  |
-| ------ | --------------- | ------------------------------------------------------------------------- |
-| 408    | project layer   | `make_api_call_with_retry` retries with jitter; exhaustion → breaker failure |
-| 429    | cjapy adapter   | upstream retries; project passes through; breaker records failure         |
-| 500    | cjapy adapter   | upstream retries; project passes through; breaker records failure         |
-| 502    | cjapy adapter   | upstream retries; project passes through; breaker records failure         |
-| 503    | cjapy adapter   | upstream retries; project passes through; breaker records failure         |
-| 504    | cjapy adapter   | upstream retries; project passes through; breaker records failure         |
-| 4xx (other) | caller       | returned as-is; classified by caller; breaker records success (no failure)|
+| Status      | Owner         | Behavior                                                                     |
+| ----------- | ------------- | ---------------------------------------------------------------------------- |
+| 408         | project layer | `make_api_call_with_retry` retries with jitter; exhaustion → breaker failure |
+| 429         | cjapy adapter | upstream retries; project passes through; breaker records failure            |
+| 500         | cjapy adapter | upstream retries; project passes through; breaker records failure            |
+| 502         | cjapy adapter | upstream retries; project passes through; breaker records failure            |
+| 503         | cjapy adapter | upstream retries; project passes through; breaker records failure            |
+| 504         | cjapy adapter | upstream retries; project passes through; breaker records failure            |
+| 4xx (other) | caller        | returned as-is; classified by caller; breaker records success (no failure)   |
 
 ## Why this split exists
 

--- a/docs/RESILIENCE_LAYERING.md
+++ b/docs/RESILIENCE_LAYERING.md
@@ -94,8 +94,10 @@ already retried and gave up. The retry wrapper handles it as follows:
   429 trips the breaker and blocks further traffic until recovery
 
 Non-upstream-failure HTTP error codes (e.g. 401/403/404/400/422) are caller
-errors, not infrastructure distress; they do not consume breaker failure
-budget.
+errors, not infrastructure distress; the breaker records them as successes
+(the endpoint answered, so infrastructure is healthy) and the caller-side
+classifier in `ParallelAPIFetcher._normalize_component_payload()` renders
+the payload-level failure detail.
 
 ### Circuit breaker contract
 
@@ -120,7 +122,7 @@ set).
 | 502    | cjapy adapter   | upstream retries; project passes through; breaker records failure         |
 | 503    | cjapy adapter   | upstream retries; project passes through; breaker records failure         |
 | 504    | cjapy adapter   | upstream retries; project passes through; breaker records failure         |
-| 4xx (other) | caller       | returned as-is; classified by caller; breaker neutral (records success)   |
+| 4xx (other) | caller       | returned as-is; classified by caller; breaker records success (no failure)|
 
 ## Why this split exists
 

--- a/docs/RESILIENCE_LAYERING.md
+++ b/docs/RESILIENCE_LAYERING.md
@@ -141,6 +141,14 @@ Before v3.5.14:
   `{"statusCode": 500, ...}` was logged as "success" with `item_count = 2`.
 - `initialize_cja()` treated any non-`None` `getDataViews()` payload as a
   successful connection test.
+- Adapter-exhausted pass-through payloads (`{"statusCode": 503, ...}` etc.)
+  were silently recorded as circuit-breaker **successes**, so repeated
+  upstream 5xx/429 never tripped the breaker even though caller-side
+  classifiers already treated the payloads as failures.
+- The `retry_with_backoff` decorator had no upstream-failure awareness, so
+  external callers of the decorator inherited the same telemetry bug: the
+  `✓ … succeeded on attempt …` log fired even when the final return was an
+  adapter-exhausted error payload.
 
 v3.5.14 fixes all six points:
 

--- a/docs/RESILIENCE_LAYERING.md
+++ b/docs/RESILIENCE_LAYERING.md
@@ -85,13 +85,16 @@ UPSTREAM_ADAPTER_STATUS_CODES: frozenset[int] = frozenset({429, 500, 502, 503, 5
 
 This mirrors cjapy's `status_forcelist`. A payload that reaches the project
 layer carrying one of these codes is an *adapter-exhausted* failure: cjapy
-already retried and gave up. The retry wrapper handles it as follows:
+already retried and gave up. Both retry forms in this module
+(`make_api_call_with_retry` and the `retry_with_backoff` decorator) consult
+`_is_upstream_failure_payload(result)` on every non-exception return and:
 
-- does **not** retry again (that would stack on top of the adapter)
-- does **not** emit the `✓ … succeeded on attempt …` log even if prior attempts
+- do **not** retry again (that would stack on top of the adapter)
+- do **not** emit the `✓ … succeeded on attempt …` log even if prior attempts
   raised — the final return is not a success
-- **does** call `circuit_breaker.record_failure(...)` so repeated upstream 5xx/
-  429 trips the breaker and blocks further traffic until recovery
+- (wrapper only — the decorator has no breaker parameter) call
+  `circuit_breaker.record_failure(...)` so repeated upstream 5xx/429 trips the
+  breaker and blocks further traffic until recovery
 
 Non-upstream-failure HTTP error codes (e.g. 401/403/404/400/422) are caller
 errors, not infrastructure distress; the breaker records them as successes
@@ -139,7 +142,7 @@ Before v3.5.14:
 - `initialize_cja()` treated any non-`None` `getDataViews()` payload as a
   successful connection test.
 
-v3.5.14 fixes all five points:
+v3.5.14 fixes all six points:
 
 1. Retry-wrapper status extraction recognizes `statusCode`, nested
    `error.statusCode`, and `response.statusCode`.
@@ -155,3 +158,9 @@ v3.5.14 fixes all five points:
    recorded as breaker successes, so repeated upstream 5xx/429 never tripped
    the circuit even though caller-side classifiers already treated the
    payloads as failures.
+6. The `retry_with_backoff` decorator (publicly re-exported from
+   `cja_auto_sdr.api`) shares the same log-suppression rule via
+   `_is_upstream_failure_payload()`, so future external callers of the
+   decorator don't inherit the telemetry bug. The decorator has no
+   circuit-breaker parameter, so only the log-suppression half of the rule
+   applies there.

--- a/docs/RESILIENCE_LAYERING.md
+++ b/docs/RESILIENCE_LAYERING.md
@@ -77,24 +77,50 @@ appropriately — e.g. `ParallelAPIFetcher` now classifies them via
 `initialize_cja()` only reports connection success when `getDataViews()`
 returns a list/tuple/DataFrame.
 
+### Upstream-failure signaling set (v3.5.14+)
+
+```python
+UPSTREAM_ADAPTER_STATUS_CODES: frozenset[int] = frozenset({429, 500, 502, 503, 504})
+```
+
+This mirrors cjapy's `status_forcelist`. A payload that reaches the project
+layer carrying one of these codes is an *adapter-exhausted* failure: cjapy
+already retried and gave up. The retry wrapper handles it as follows:
+
+- does **not** retry again (that would stack on top of the adapter)
+- does **not** emit the `✓ … succeeded on attempt …` log even if prior attempts
+  raised — the final return is not a success
+- **does** call `circuit_breaker.record_failure(...)` so repeated upstream 5xx/
+  429 trips the breaker and blocks further traffic until recovery
+
+Non-upstream-failure HTTP error codes (e.g. 401/403/404/400/422) are caller
+errors, not infrastructure distress; they do not consume breaker failure
+budget.
+
 ### Circuit breaker contract
 
-`CircuitBreaker.record_failure()` is called **once per exhausted operation**,
-not once per retry attempt. After `make_api_call_with_retry()` has used its
-full budget and is about to raise, it records one breaker failure and raises.
-Non-retryable exceptions also record one breaker failure and raise immediately.
+`CircuitBreaker.record_failure()` is called **once per logical failure**:
+
+- once per retry loop that exhausts its budget and raises (408 loop, network
+  error loop, non-retryable exception)
+- once per adapter-exhausted pass-through whose status is in
+  `UPSTREAM_ADAPTER_STATUS_CODES`
+
+It is **not** called once per retry attempt, and it is **not** called for
+non-upstream-failure returns (2xx/3xx, or 4xx outside the upstream-failure
+set).
 
 ### Non-overlap contract summary
 
-| Status | Owner           | Behavior                                      |
-| ------ | --------------- | --------------------------------------------- |
-| 408    | project layer   | `make_api_call_with_retry` retries with jitter |
-| 429    | cjapy adapter   | upstream retries; project passes through      |
-| 500    | cjapy adapter   | upstream retries; project passes through      |
-| 502    | cjapy adapter   | upstream retries; project passes through      |
-| 503    | cjapy adapter   | upstream retries; project passes through      |
-| 504    | cjapy adapter   | upstream retries; project passes through      |
-| 4xx (other) | caller       | returned as-is; classified by caller          |
+| Status | Owner           | Behavior                                                                  |
+| ------ | --------------- | ------------------------------------------------------------------------- |
+| 408    | project layer   | `make_api_call_with_retry` retries with jitter; exhaustion → breaker failure |
+| 429    | cjapy adapter   | upstream retries; project passes through; breaker records failure         |
+| 500    | cjapy adapter   | upstream retries; project passes through; breaker records failure         |
+| 502    | cjapy adapter   | upstream retries; project passes through; breaker records failure         |
+| 503    | cjapy adapter   | upstream retries; project passes through; breaker records failure         |
+| 504    | cjapy adapter   | upstream retries; project passes through; breaker records failure         |
+| 4xx (other) | caller       | returned as-is; classified by caller; breaker neutral (records success)   |
 
 ## Why this split exists
 
@@ -111,7 +137,7 @@ Before v3.5.14:
 - `initialize_cja()` treated any non-`None` `getDataViews()` payload as a
   successful connection test.
 
-v3.5.14 fixes all four points:
+v3.5.14 fixes all five points:
 
 1. Retry-wrapper status extraction recognizes `statusCode`, nested
    `error.statusCode`, and `response.statusCode`.
@@ -121,3 +147,9 @@ v3.5.14 fixes all four points:
    `assess_component_payload()` before success accounting.
 4. `initialize_cja()` and the dry-run `getDataViews()` probe only log
    success for list/tuple/DataFrame payloads; error-shaped dicts warn.
+5. Adapter-exhausted pass-through payloads (status in
+   `UPSTREAM_ADAPTER_STATUS_CODES`) record a circuit-breaker failure and
+   suppress the success-after-retry log. Before v3.5.14 they were silently
+   recorded as breaker successes, so repeated upstream 5xx/429 never tripped
+   the circuit even though caller-side classifiers already treated the
+   payloads as failures.

--- a/src/cja_auto_sdr/api/client.py
+++ b/src/cja_auto_sdr/api/client.py
@@ -6,10 +6,11 @@ import tempfile
 import time
 from collections.abc import Mapping, Sequence
 from pathlib import Path
+from typing import Any
 
 import cjapy
 
-from cja_auto_sdr.api.resilience import make_api_call_with_retry
+from cja_auto_sdr.api.resilience import _extract_http_status_code_from_result, make_api_call_with_retry
 from cja_auto_sdr.core.constants import BANNER_WIDTH
 from cja_auto_sdr.core.credentials import (
     CredentialResolver,
@@ -222,9 +223,11 @@ def _looks_like_dataview_listing(payload: object) -> bool:
 
 def _describe_unexpected_probe_payload(payload: object) -> str:
     """Summarize an error-shaped probe payload for logging."""
+    status = _extract_http_status_code_from_result(payload)
     if isinstance(payload, dict):
-        status = payload.get("statusCode") or payload.get("status_code")
         message = payload.get("message") or payload.get("error")
+        if isinstance(message, dict):
+            message = message.get("message") or message.get("description") or message.get("error")
         parts: list[str] = []
         if status is not None:
             parts.append(f"statusCode={status}")
@@ -233,6 +236,23 @@ def _describe_unexpected_probe_payload(payload: object) -> str:
         if parts:
             return ", ".join(parts)
     return f"type={type(payload).__name__}"
+
+
+def _normalize_dataview_listing_payload(payload: object) -> list[Any] | None:
+    """Normalize a getDataViews() payload into rows, or return None when invalid."""
+    if payload is None:
+        return []
+
+    if type(payload).__name__ == "DataFrame" and hasattr(payload, "to_dict"):
+        return payload.to_dict("records")
+
+    if isinstance(payload, list):
+        return payload
+
+    if isinstance(payload, tuple):
+        return list(payload)
+
+    return None
 
 
 def initialize_cja(

--- a/src/cja_auto_sdr/api/client.py
+++ b/src/cja_auto_sdr/api/client.py
@@ -6,7 +6,7 @@ import tempfile
 import time
 from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import Any
+from typing import Any, NoReturn
 
 import cjapy
 
@@ -22,6 +22,7 @@ from cja_auto_sdr.core.error_policies import (
     RECOVERABLE_DOTENV_BOOTSTRAP_EXCEPTIONS,
 )
 from cja_auto_sdr.core.exceptions import (
+    APIError,
     CredentialSourceError,
     ProfileConfigError,
     ProfileNotFoundError,
@@ -253,6 +254,33 @@ def _normalize_dataview_listing_payload(payload: object) -> list[Any] | None:
         return list(payload)
 
     return None
+
+
+def _raise_unexpected_dataview_listing_payload(
+    payload: object,
+    *,
+    operation: str = "getDataViews",
+) -> NoReturn:
+    """Raise a structured APIError for an invalid getDataViews() payload."""
+    detail = _describe_unexpected_probe_payload(payload)
+    raise APIError(
+        "Unexpected getDataViews() payload",
+        status_code=_extract_http_status_code_from_result(payload),
+        operation=operation,
+        details=detail,
+    )
+
+
+def _normalize_dataview_listing_payload_or_raise(
+    payload: object,
+    *,
+    operation: str = "getDataViews",
+) -> list[Any]:
+    """Normalize a getDataViews() payload or raise when the shape is invalid."""
+    normalized = _normalize_dataview_listing_payload(payload)
+    if normalized is None:
+        _raise_unexpected_dataview_listing_payload(payload, operation=operation)
+    return normalized
 
 
 def initialize_cja(

--- a/src/cja_auto_sdr/api/client.py
+++ b/src/cja_auto_sdr/api/client.py
@@ -203,6 +203,38 @@ def configure_cjapy(
         return False, f"Profile error: {e}", None
 
 
+def _looks_like_dataview_listing(payload: object) -> bool:
+    """Return True when a getDataViews() payload is plausibly a data-view list.
+
+    cjapy 0.3.1 returns parsed JSON, so a dict like ``{"statusCode": 500, ...}``
+    would previously be treated as a successful connection. A real listing is
+    either a list/tuple of rows or a pandas DataFrame.
+    """
+    if payload is None:
+        return False
+
+    # Avoid importing pandas eagerly; check by duck-typing instead.
+    if type(payload).__name__ == "DataFrame":
+        return True
+
+    return isinstance(payload, (list, tuple))
+
+
+def _describe_unexpected_probe_payload(payload: object) -> str:
+    """Summarize an error-shaped probe payload for logging."""
+    if isinstance(payload, dict):
+        status = payload.get("statusCode") or payload.get("status_code")
+        message = payload.get("message") or payload.get("error")
+        parts: list[str] = []
+        if status is not None:
+            parts.append(f"statusCode={status}")
+        if message is not None:
+            parts.append(f"message={message!r}")
+        if parts:
+            return ", ".join(parts)
+    return f"type={type(payload).__name__}"
+
+
 def initialize_cja(
     config_file: str | Path = "config.json",
     logger: logging.Logger | None = None,
@@ -289,13 +321,17 @@ def initialize_cja(
                 logger=logger,
                 operation_name="getDataViews (connection test)",
             )
-            if test_call is not None:
-                logger.info(
-                    "\u2713 API connection successful! Found %s data view(s)",
-                    len(test_call) if hasattr(test_call, "__len__") else "multiple",
-                )
-            else:
+            if _looks_like_dataview_listing(test_call):
+                count = len(test_call) if hasattr(test_call, "__len__") else "multiple"
+                logger.info("\u2713 API connection successful! Found %s data view(s)", count)
+            elif test_call is None:
                 logger.warning("API connection test returned None - connection may be unstable")
+            else:
+                # Error-shaped payload (e.g. {"statusCode": 500, "message": ...}) reached
+                # the probe because the status was non-retryable or retries were exhausted.
+                detail = _describe_unexpected_probe_payload(test_call)
+                logger.warning("API connection test returned unexpected payload: %s", detail)
+                logger.warning("Proceeding anyway - errors may occur during data fetching")
         except RECOVERABLE_CONNECTION_TEST_EXCEPTIONS as test_error:
             logger.warning("Could not verify connection with test call: %s", test_error)
             logger.warning("Proceeding anyway - errors may occur during data fetching")

--- a/src/cja_auto_sdr/api/fetch.py
+++ b/src/cja_auto_sdr/api/fetch.py
@@ -12,7 +12,7 @@ import cjapy
 import pandas as pd
 from tqdm import tqdm
 
-from cja_auto_sdr.api.resilience import CircuitBreaker, make_api_call_with_retry
+from cja_auto_sdr.api.resilience import CircuitBreaker, _is_upstream_failure_payload, make_api_call_with_retry
 from cja_auto_sdr.api.tuning import APIWorkerTuner
 from cja_auto_sdr.core.config import APITuningConfig
 from cja_auto_sdr.core.constants import TQDM_BAR_FORMAT
@@ -228,8 +228,8 @@ class ParallelAPIFetcher:
             circuit_breaker=self.circuit_breaker,
             **kwargs,
         )
-        # Record response time only on success to avoid retry delays inflating metrics
-        if self.tuner is not None:
+        # Record response time only on success to avoid retry delays/error payloads inflating metrics.
+        if self.tuner is not None and not _is_upstream_failure_payload(result):
             duration_ms = (time.perf_counter() - start_time) * 1000
             new_workers = self.tuner.record_response_time(duration_ms)
             if new_workers is not None:

--- a/src/cja_auto_sdr/api/fetch.py
+++ b/src/cja_auto_sdr/api/fetch.py
@@ -16,7 +16,11 @@ from cja_auto_sdr.api.resilience import CircuitBreaker, make_api_call_with_retry
 from cja_auto_sdr.api.tuning import APIWorkerTuner
 from cja_auto_sdr.core.config import APITuningConfig
 from cja_auto_sdr.core.constants import TQDM_BAR_FORMAT
-from cja_auto_sdr.core.discovery_payloads import assess_dataview_lookup_payload
+from cja_auto_sdr.core.discovery_payloads import (
+    PayloadKind,
+    assess_component_payload,
+    assess_dataview_lookup_payload,
+)
 from cja_auto_sdr.core.exceptions import CircuitBreakerOpen
 from cja_auto_sdr.core.perf import PerformanceTracker
 
@@ -232,6 +236,58 @@ class ParallelAPIFetcher:
                 self.max_workers = new_workers
         return result
 
+    def _normalize_component_payload(
+        self,
+        payload: Any,
+        *,
+        endpoint: str,
+        label: str,
+    ) -> pd.DataFrame:
+        """Classify a component payload and record the correct fetch status.
+
+        cjapy 0.3.1 can return parsed JSON error dicts (e.g. ``{"statusCode": 500, ...}``)
+        for component endpoints. Treating these as successful fetches is wrong because
+        downstream SDR rendering then consumes an error shape as "data". This helper
+        delegates classification to ``assess_component_payload`` and converts the result
+        into a DataFrame + fetch-status update.
+        """
+        # Preserve the existing DataFrame fast path: non-empty DataFrames are successes.
+        if isinstance(payload, pd.DataFrame):
+            if payload.empty:
+                self.logger.warning("No %s returned from API", label)
+                self._record_fetch_status(endpoint, "empty", reason="empty_response", item_count=0)
+                return pd.DataFrame()
+            self.logger.info("Successfully fetched %s %s", len(payload), label)
+            self._record_fetch_status(endpoint, "success", item_count=len(payload))
+            return payload
+
+        assessment = assess_component_payload(payload)
+        if assessment.kind is PayloadKind.DATA:
+            frame = pd.DataFrame(assessment.rows)
+            self.logger.info("Successfully fetched %s %s", len(frame), label)
+            self._record_fetch_status(endpoint, "success", item_count=len(frame))
+            return frame
+
+        if assessment.kind is PayloadKind.EMPTY:
+            self.logger.warning("No %s returned from API", label)
+            self._record_fetch_status(endpoint, "empty", reason=assessment.reason or "empty_response", item_count=0)
+            return pd.DataFrame()
+
+        # ERROR or INVALID — record failure with a useful detail and return empty.
+        error_detail = ""
+        if isinstance(payload, dict):
+            error_detail = str(payload.get("message") or payload.get("error") or "")
+        self.logger.error(
+            "%s fetch returned %s payload (%s)", label.capitalize(), assessment.kind.value, assessment.reason
+        )
+        self._record_fetch_status(
+            endpoint,
+            "failed",
+            reason=assessment.reason or f"{assessment.kind.value}_payload",
+            error_message=error_detail or f"{assessment.kind.value} payload shape",
+        )
+        return pd.DataFrame()
+
     def _fetch_metrics(self, data_view_id: str) -> pd.DataFrame:
         """Fetch metrics with error handling and retry"""
         try:
@@ -246,14 +302,11 @@ class ParallelAPIFetcher:
                 operation_name="getMetrics",
             )
 
-            if metrics is None or (isinstance(metrics, pd.DataFrame) and metrics.empty):
-                self.logger.warning("No metrics returned from API")
-                self._record_fetch_status("metrics", "empty", reason="empty_response", item_count=0)
-                return pd.DataFrame()
-
-            self.logger.info("Successfully fetched %s metrics", len(metrics))
-            self._record_fetch_status("metrics", "success", item_count=len(metrics))
-            return metrics
+            return self._normalize_component_payload(
+                metrics,
+                endpoint="metrics",
+                label="metrics",
+            )
 
         except CircuitBreakerOpen as e:
             self.logger.warning("Circuit breaker open for metrics fetch: %s", e.message)
@@ -292,14 +345,11 @@ class ParallelAPIFetcher:
                 operation_name="getDimensions",
             )
 
-            if dimensions is None or (isinstance(dimensions, pd.DataFrame) and dimensions.empty):
-                self.logger.warning("No dimensions returned from API")
-                self._record_fetch_status("dimensions", "empty", reason="empty_response", item_count=0)
-                return pd.DataFrame()
-
-            self.logger.info("Successfully fetched %s dimensions", len(dimensions))
-            self._record_fetch_status("dimensions", "success", item_count=len(dimensions))
-            return dimensions
+            return self._normalize_component_payload(
+                dimensions,
+                endpoint="dimensions",
+                label="dimensions",
+            )
 
         except CircuitBreakerOpen as e:
             self.logger.warning("Circuit breaker open for dimensions fetch: %s", e.message)

--- a/src/cja_auto_sdr/api/resilience.py
+++ b/src/cja_auto_sdr/api/resilience.py
@@ -16,8 +16,60 @@ from typing import Any, TypeVar
 
 from cja_auto_sdr.core.config import CircuitBreakerConfig, CircuitState
 from cja_auto_sdr.core.constants import DEFAULT_RETRY_CONFIG, RETRY_JITTER_RANGE, RETRYABLE_STATUS_CODES
+from cja_auto_sdr.core.discovery_exceptions import coerce_http_status_code
 from cja_auto_sdr.core.exceptions import CircuitBreakerOpen, RetryableHTTPError
 from cja_auto_sdr.core.logging import emit_diagnostic
+
+# Keys examined on dict-shaped cjapy payloads when recovering the HTTP status code.
+# cjapy 0.3.1 returns parsed JSON and does not inject a snake_case status_code; the
+# real payloads expose statusCode (camelCase), optionally nested under error/response.
+_STATUS_KEY_CANDIDATES: tuple[str, ...] = (
+    "status_code",
+    "statusCode",
+    "status",
+    "http_status",
+    "httpStatus",
+    "code",
+)
+_NESTED_STATUS_KEYS: tuple[str, ...] = ("error", "response")
+
+
+def _extract_http_status_code_from_result(result: Any) -> int | None:
+    """Best-effort extraction of an HTTP status code from an API result.
+
+    Supports:
+    - Response-like objects exposing ``status_code`` or ``statusCode`` attributes
+    - Mappings with top-level status keys
+    - Mappings with status keys nested under ``error`` or ``response``
+
+    Returns None when no plausible HTTP status code is present.
+    """
+    if result is None:
+        return None
+
+    for attr in ("status_code", "statusCode"):
+        if hasattr(result, attr):
+            code = coerce_http_status_code(getattr(result, attr, None))
+            if code is not None:
+                return code
+
+    if isinstance(result, dict):
+        for key in _STATUS_KEY_CANDIDATES:
+            if key in result:
+                code = coerce_http_status_code(result.get(key))
+                if code is not None:
+                    return code
+
+        for nested_key in _NESTED_STATUS_KEYS:
+            nested = result.get(nested_key)
+            if isinstance(nested, dict):
+                for key in _STATUS_KEY_CANDIDATES:
+                    if key in nested:
+                        code = coerce_http_status_code(nested.get(key))
+                        if code is not None:
+                            return code
+
+    return None
 
 
 def _parse_env_numeric(value: str | None, cast: Callable[[str], Any]) -> Any | None:
@@ -886,14 +938,10 @@ def make_api_call_with_retry[T](
         try:
             result = api_func(*args, **kwargs)
 
-            # Check for HTTP status code in response (if exposed by the library)
-            status_code = None
-            if hasattr(result, "status_code"):
-                status_code = result.status_code
-            elif isinstance(result, dict) and "status_code" in result:
-                status_code = result["status_code"]
-            elif isinstance(result, dict) and "error" in result and isinstance(result["error"], dict):
-                status_code = result["error"].get("status_code")
+            # Check for HTTP status code in response. cjapy 0.3.1 returns parsed
+            # JSON dicts exposing camelCase statusCode (optionally nested under
+            # error/response), so we normalize across all supported shapes.
+            status_code = _extract_http_status_code_from_result(result)
 
             if status_code is not None and status_code in RETRYABLE_STATUS_CODES:
                 raise RetryableHTTPError(status_code, f"Retryable status from {operation_name}")

--- a/src/cja_auto_sdr/api/resilience.py
+++ b/src/cja_auto_sdr/api/resilience.py
@@ -15,7 +15,12 @@ from collections.abc import Callable
 from typing import Any, TypeVar
 
 from cja_auto_sdr.core.config import CircuitBreakerConfig, CircuitState
-from cja_auto_sdr.core.constants import DEFAULT_RETRY_CONFIG, RETRY_JITTER_RANGE, RETRYABLE_STATUS_CODES
+from cja_auto_sdr.core.constants import (
+    DEFAULT_RETRY_CONFIG,
+    RETRY_JITTER_RANGE,
+    RETRYABLE_STATUS_CODES,
+    UPSTREAM_ADAPTER_STATUS_CODES,
+)
 from cja_auto_sdr.core.discovery_exceptions import coerce_http_status_code
 from cja_auto_sdr.core.exceptions import CircuitBreakerOpen, RetryableHTTPError
 from cja_auto_sdr.core.logging import emit_diagnostic
@@ -946,13 +951,25 @@ def make_api_call_with_retry[T](
             if status_code is not None and status_code in RETRYABLE_STATUS_CODES:
                 raise RetryableHTTPError(status_code, f"Retryable status from {operation_name}")
 
-            # Log success after retry
-            if attempt > 0:
+            # Adapter-exhausted upstream failure: cjapy's urllib3.Retry adapter
+            # already retried 429/500/502/503/504 before this payload reached us.
+            # We don't retry again (that stacks), but we must signal the failure
+            # so repeated 5xx/429 trips the breaker and telemetry stays coherent.
+            is_upstream_failure = status_code is not None and status_code in UPSTREAM_ADAPTER_STATUS_CODES
+
+            if attempt > 0 and not is_upstream_failure:
                 _logger.info("✓ %s succeeded on attempt %s/%s", operation_name, attempt + 1, max_retries + 1)
 
-            # Record success to circuit breaker
             if circuit_breaker is not None:
-                circuit_breaker.record_success()
+                if is_upstream_failure:
+                    circuit_breaker.record_failure(
+                        RetryableHTTPError(
+                            status_code,
+                            f"Adapter-exhausted upstream status {status_code} from {operation_name}",
+                        ),
+                    )
+                else:
+                    circuit_breaker.record_success()
 
             return result
         except RETRYABLE_EXCEPTIONS as e:

--- a/src/cja_auto_sdr/api/resilience.py
+++ b/src/cja_auto_sdr/api/resilience.py
@@ -77,6 +77,18 @@ def _extract_http_status_code_from_result(result: Any) -> int | None:
     return None
 
 
+def _is_upstream_failure_payload(result: Any) -> bool:
+    """True when a returned payload carries a status in ``UPSTREAM_ADAPTER_STATUS_CODES``.
+
+    Used by both ``make_api_call_with_retry`` and ``retry_with_backoff`` to
+    suppress the ``✓ … succeeded on attempt …`` log (and, where a circuit
+    breaker is available, route the breaker signal) on adapter-exhausted
+    5xx/429 returns — the payloads cjapy already retried and gave up on.
+    """
+    status_code = _extract_http_status_code_from_result(result)
+    return status_code is not None and status_code in UPSTREAM_ADAPTER_STATUS_CODES
+
+
 def _parse_env_numeric(value: str | None, cast: Callable[[str], Any]) -> Any | None:
     """Parse an environment value, returning None when invalid."""
     if value is None:
@@ -824,8 +836,12 @@ def retry_with_backoff(
             for attempt in range(_max_retries + 1):  # +1 for initial attempt
                 try:
                     result = func(*args, **kwargs)
-                    # Log success after retry
-                    if attempt > 0:
+                    # Log success after retry, unless the return carries an
+                    # adapter-exhausted upstream-failure status (5xx/429) — in
+                    # that case the "return" is actually an upstream failure
+                    # payload and the caller will classify it; logging success
+                    # would contradict that classification.
+                    if attempt > 0 and not _is_upstream_failure_payload(result):
                         _logger.info("✓ %s succeeded on attempt %s/%s", func.__name__, attempt + 1, _max_retries + 1)
                     return result
                 except _retryable_exceptions as e:

--- a/src/cja_auto_sdr/cli/commands/config.py
+++ b/src/cja_auto_sdr/cli/commands/config.py
@@ -474,7 +474,11 @@ def validate_config_only(
 
         available_dvs = cja.getDataViews()
         if available_dvs is not None:
-            dv_count = len(available_dvs) if hasattr(available_dvs, "__len__") else 0
+            normalized_dvs = generator._normalize_dataview_listing_payload_or_raise(
+                available_dvs,
+                operation="getDataViews (validate-config)",
+            )
+            dv_count = len(normalized_dvs)
             print(generator.ConsoleColors.success("  \u2713 API connection successful"))
             print(generator.ConsoleColors.success(f"  \u2713 Found {dv_count} accessible data view(s)"))
         else:

--- a/src/cja_auto_sdr/cli/commands/discovery.py
+++ b/src/cja_auto_sdr/cli/commands/discovery.py
@@ -20,7 +20,7 @@ from typing import Any
 
 import pandas as pd
 
-from cja_auto_sdr.api.client import _describe_unexpected_probe_payload, _normalize_dataview_listing_payload
+from cja_auto_sdr.api.client import _normalize_dataview_listing_payload_or_raise
 from cja_auto_sdr.api.resilience import make_api_call_with_retry
 from cja_auto_sdr.core.colors import ConsoleColors
 from cja_auto_sdr.core.discovery_exceptions import (
@@ -917,14 +917,14 @@ def _fetch_dataviews(
         from cja_auto_sdr.generator import _format_as_csv, _format_as_table
 
         available_dvs = cja.getDataViews()
-        normalized_dvs = _normalize_dataview_listing_payload(available_dvs)
-
-        if normalized_dvs is None:
-            logging.getLogger(__name__).warning(
-                "Ignoring unexpected getDataViews() payload in list_dataviews: %s",
-                _describe_unexpected_probe_payload(available_dvs),
+        normalized_dvs = (
+            []
+            if available_dvs is None
+            else _normalize_dataview_listing_payload_or_raise(
+                available_dvs,
+                operation="getDataViews (list_dataviews)",
             )
-            normalized_dvs = []
+        )
 
         if len(normalized_dvs) == 0:
             if is_machine_readable:
@@ -1278,8 +1278,14 @@ def _fetch_connections(
             # Check whether data views reference connections we can't see
             # (the GET /connections API requires product-admin privileges).
             available_dvs = cja.getDataViews()
-            if isinstance(available_dvs, pd.DataFrame):
-                available_dvs = available_dvs.to_dict("records")
+            available_dvs = (
+                []
+                if available_dvs is None
+                else _normalize_dataview_listing_payload_or_raise(
+                    available_dvs,
+                    operation="getDataViews (list_connections fallback)",
+                )
+            )
 
             conn_ids_from_dvs: dict[str, int] = {}  # conn_id -> count of data views
             for dv in available_dvs or []:
@@ -1465,8 +1471,14 @@ def _fetch_datasets(
 
         # Step 2: Fetch all data views
         available_dvs = cja.getDataViews()
-        if isinstance(available_dvs, pd.DataFrame):
-            available_dvs = available_dvs.to_dict("records")
+        available_dvs = (
+            []
+            if available_dvs is None
+            else _normalize_dataview_listing_payload_or_raise(
+                available_dvs,
+                operation="getDataViews (list_datasets)",
+            )
+        )
 
         if not available_dvs:
             if is_machine_readable:

--- a/src/cja_auto_sdr/cli/commands/discovery.py
+++ b/src/cja_auto_sdr/cli/commands/discovery.py
@@ -20,6 +20,7 @@ from typing import Any
 
 import pandas as pd
 
+from cja_auto_sdr.api.client import _describe_unexpected_probe_payload, _normalize_dataview_listing_payload
 from cja_auto_sdr.api.resilience import make_api_call_with_retry
 from cja_auto_sdr.core.colors import ConsoleColors
 from cja_auto_sdr.core.discovery_exceptions import (
@@ -916,19 +917,24 @@ def _fetch_dataviews(
         from cja_auto_sdr.generator import _format_as_csv, _format_as_table
 
         available_dvs = cja.getDataViews()
+        normalized_dvs = _normalize_dataview_listing_payload(available_dvs)
 
-        if available_dvs is None or (hasattr(available_dvs, "__len__") and len(available_dvs) == 0):
+        if normalized_dvs is None:
+            logging.getLogger(__name__).warning(
+                "Ignoring unexpected getDataViews() payload in list_dataviews: %s",
+                _describe_unexpected_probe_payload(available_dvs),
+            )
+            normalized_dvs = []
+
+        if len(normalized_dvs) == 0:
             if is_machine_readable:
                 if output_format == "json":
                     return json.dumps({"dataViews": [], "count": 0}, indent=2)
                 return "id,name,owner\n"
             return "\nNo data views found or no access to any data views.\n"
 
-        if isinstance(available_dvs, pd.DataFrame):
-            available_dvs = available_dvs.to_dict("records")
-
         display_data = []
-        for dv in available_dvs:
+        for dv in normalized_dvs:
             if isinstance(dv, dict):
                 dv_id = _normalize_optional_text(dv.get("id"), default="N/A")
                 dv_name = _normalize_optional_text(dv.get("name"), default="N/A")

--- a/src/cja_auto_sdr/cli/interactive.py
+++ b/src/cja_auto_sdr/cli/interactive.py
@@ -6,8 +6,6 @@ from __future__ import annotations
 
 import sys
 
-import pandas as pd
-
 from cja_auto_sdr.core.colors import ConsoleColors
 from cja_auto_sdr.core.constants import BANNER_WIDTH
 
@@ -124,17 +122,22 @@ def interactive_select_dataviews(config_file: str = "config.json", profile: str 
 
         print("Fetching available data views...")
         available_dvs = cja.getDataViews()
+        normalized_dvs = (
+            []
+            if available_dvs is None
+            else generator._normalize_dataview_listing_payload_or_raise(
+                available_dvs,
+                operation="getDataViews (interactive selection)",
+            )
+        )
 
-        if available_dvs is None or (hasattr(available_dvs, "__len__") and len(available_dvs) == 0):
+        if len(normalized_dvs) == 0:
             print()
             print(ConsoleColors.warning("No data views found or no access to any data views."))
             return []
 
-        if isinstance(available_dvs, pd.DataFrame):
-            available_dvs = available_dvs.to_dict("records")
-
         display_data = []
-        for dv in available_dvs:
+        for dv in normalized_dvs:
             if isinstance(dv, dict):
                 dv_id = generator._normalize_optional_text(dv.get("id"), default="N/A")
                 dv_name = generator._normalize_optional_text(dv.get("name"), default="N/A")
@@ -323,17 +326,22 @@ def interactive_wizard(config_file: str = "config.json", profile: str | None = N
 
         print("Fetching available data views...")
         available_dvs = cja.getDataViews()
+        normalized_dvs = (
+            []
+            if available_dvs is None
+            else generator._normalize_dataview_listing_payload_or_raise(
+                available_dvs,
+                operation="getDataViews (interactive prompt)",
+            )
+        )
 
-        if available_dvs is None or (hasattr(available_dvs, "__len__") and len(available_dvs) == 0):
+        if len(normalized_dvs) == 0:
             print()
             print(ConsoleColors.warning("No data views found or no access to any data views."))
             return None
 
-        if isinstance(available_dvs, pd.DataFrame):
-            available_dvs = available_dvs.to_dict("records")
-
         display_data = []
-        for dv in available_dvs:
+        for dv in normalized_dvs:
             if isinstance(dv, dict):
                 dv_id = generator._normalize_optional_text(dv.get("id"), default="N/A")
                 dv_name = generator._normalize_optional_text(dv.get("name"), default="N/A")

--- a/src/cja_auto_sdr/core/constants.py
+++ b/src/cja_auto_sdr/core/constants.py
@@ -107,6 +107,17 @@ RETRY_JITTER_RANGE: tuple[float, float] = (0.5, 1.5)
 # responsibility.
 RETRYABLE_STATUS_CODES: set[int] = {408}
 
+# Statuses handled by cjapy 0.3.1's urllib3.Retry adapter `status_forcelist`.
+# When a payload carrying one of these codes reaches the project layer, the
+# adapter has already exhausted its own retries — the payload is a genuine
+# upstream failure signal. The project retry wrapper does NOT retry these
+# (that would stack on top of the adapter), but it must still record a
+# circuit-breaker failure and suppress the success-after-retry log so repeated
+# upstream distress trips the breaker and telemetry stays coherent. Callers
+# still receive the raw payload so payload-specific error detail (message,
+# nested error) can be rendered downstream.
+UPSTREAM_ADAPTER_STATUS_CODES: frozenset[int] = frozenset({429, 500, 502, 503, 504})
+
 # ==================== QUALITY / SEVERITY ====================
 
 # Canonical severity ordering — used by CLI, validation, and quality-gate logic

--- a/src/cja_auto_sdr/core/constants.py
+++ b/src/cja_auto_sdr/core/constants.py
@@ -95,8 +95,17 @@ DEFAULT_RETRY_CONFIG: dict[str, Any] = DEFAULT_RETRY.to_dict()
 # Final delay = base_delay * uniform(*RETRY_JITTER_RANGE)
 RETRY_JITTER_RANGE: tuple[float, float] = (0.5, 1.5)
 
-# HTTP status codes that should trigger a retry
-RETRYABLE_STATUS_CODES: set[int] = {408, 429, 500, 502, 503, 504}
+# HTTP status codes that should trigger a retry at the project layer.
+#
+# cjapy 0.3.1's AdobeRequest._build_session installs a urllib3.Retry adapter that
+# handles 429/500/502/503/504 with exponential backoff (status_forcelist). By the
+# time responses for those statuses reach us, cjapy has already retried. Keeping
+# them in this set would stack project retries on top of the adapter's retries
+# and confuse both budgets and debugging. See docs/RESILIENCE_LAYERING.md.
+#
+# 408 is NOT in cjapy's status_forcelist, so it remains the project layer's
+# responsibility.
+RETRYABLE_STATUS_CODES: set[int] = {408}
 
 # ==================== QUALITY / SEVERITY ====================
 

--- a/src/cja_auto_sdr/core/profiles.py
+++ b/src/cja_auto_sdr/core/profiles.py
@@ -12,6 +12,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from cja_auto_sdr.api.client import _describe_unexpected_probe_payload, _normalize_dataview_listing_payload
 from cja_auto_sdr.api.quality_policy import _canonical_quality_policy_key
 from cja_auto_sdr.core.colors import ConsoleColors
 from cja_auto_sdr.core.constants import BANNER_WIDTH, CREDENTIAL_FIELDS, ENV_VAR_MAPPING
@@ -689,9 +690,14 @@ def test_profile(profile_name: str) -> bool:
         generator._config_from_env(credentials, logger)
         cja = generator.cjapy.CJA()
         dataviews = cja.getDataViews()
+        normalized_dataviews = _normalize_dataview_listing_payload(dataviews)
+
+        if normalized_dataviews is None:
+            detail = _describe_unexpected_probe_payload(dataviews)
+            return _print_profile_test_failure(RuntimeError(f"Unexpected getDataViews() payload: {detail}"))
 
         if dataviews is not None:
-            count = len(dataviews) if hasattr(dataviews, "__len__") else 0
+            count = len(normalized_dataviews)
             print("   API connection: SUCCESS")
             print(f"   Data views accessible: {count}")
             print()

--- a/src/cja_auto_sdr/core/profiles.py
+++ b/src/cja_auto_sdr/core/profiles.py
@@ -12,7 +12,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from cja_auto_sdr.api.client import _describe_unexpected_probe_payload, _normalize_dataview_listing_payload
+from cja_auto_sdr.api.client import _normalize_dataview_listing_payload_or_raise
 from cja_auto_sdr.api.quality_policy import _canonical_quality_policy_key
 from cja_auto_sdr.core.colors import ConsoleColors
 from cja_auto_sdr.core.constants import BANNER_WIDTH, CREDENTIAL_FIELDS, ENV_VAR_MAPPING
@@ -690,11 +690,14 @@ def test_profile(profile_name: str) -> bool:
         generator._config_from_env(credentials, logger)
         cja = generator.cjapy.CJA()
         dataviews = cja.getDataViews()
-        normalized_dataviews = _normalize_dataview_listing_payload(dataviews)
-
-        if normalized_dataviews is None:
-            detail = _describe_unexpected_probe_payload(dataviews)
-            return _print_profile_test_failure(RuntimeError(f"Unexpected getDataViews() payload: {detail}"))
+        normalized_dataviews = (
+            []
+            if dataviews is None
+            else _normalize_dataview_listing_payload_or_raise(
+                dataviews,
+                operation="getDataViews (profile test)",
+            )
+        )
 
         if dataviews is not None:
             count = len(normalized_dataviews)

--- a/src/cja_auto_sdr/core/version.py
+++ b/src/cja_auto_sdr/core/version.py
@@ -1,3 +1,3 @@
 """Version information for CJA Auto SDR."""
 
-__version__ = "3.5.13"
+__version__ = "3.5.14"

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -2388,7 +2388,7 @@ from cja_auto_sdr.api.client import (
     _bootstrap_dotenv,
     _config_from_env,
     _describe_unexpected_probe_payload,
-    _normalize_dataview_listing_payload,
+    _normalize_dataview_listing_payload_or_raise,
     configure_cjapy,
     initialize_cja,
 )
@@ -2482,11 +2482,19 @@ def validate_data_view(cja: cjapy.CJA, data_view_id: str, logger: logging.Logger
             available_count = None
             try:
                 available_dvs = cja.getDataViews()
-                available_count = len(available_dvs) if available_dvs else 0
+                normalized_dvs = (
+                    []
+                    if available_dvs is None
+                    else _normalize_dataview_listing_payload_or_raise(
+                        available_dvs,
+                        operation="getDataViews (lookup context)",
+                    )
+                )
+                available_count = len(normalized_dvs)
 
                 if available_count > 0:
                     logger.info(f"You have access to {available_count} data view(s):")
-                    for i, dv in enumerate(available_dvs[:10]):  # Show first 10
+                    for i, dv in enumerate(normalized_dvs[:10]):  # Show first 10
                         dv_id = dv.get("id", "unknown")
                         dv_name = dv.get("name", "unknown")
                         logger.info(f"  {i + 1}. {dv_name} (ID: {dv_id})")
@@ -4346,16 +4354,13 @@ def get_cached_data_views(cja, cache_key: str, logger: logging.Logger) -> list[d
     # Fetch from API
     logger.debug("Fetching data views from API (cache miss)")
     available_dvs = cja.getDataViews()
-    normalized_dvs = _normalize_dataview_listing_payload(available_dvs)
 
-    if normalized_dvs == []:
+    if available_dvs is None:
         return []
-    if normalized_dvs is None:
-        logger.warning(
-            "Ignoring unexpected getDataViews() payload while populating cache: %s",
-            _describe_unexpected_probe_payload(available_dvs),
-        )
-        return []
+    normalized_dvs = _normalize_dataview_listing_payload_or_raise(
+        available_dvs,
+        operation="getDataViews (cache fill)",
+    )
 
     # Cache the result
     _data_view_cache.set(cache_key, normalized_dvs)

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -2384,7 +2384,14 @@ def test_profile(profile_name: str) -> bool:
 
 # ==================== CONFIG VALIDATION (moved to core/config_validation.py) ====================
 # ==================== CJA CLIENT (moved to api/client.py) ====================
-from cja_auto_sdr.api.client import _bootstrap_dotenv, _config_from_env, configure_cjapy, initialize_cja
+from cja_auto_sdr.api.client import (
+    _bootstrap_dotenv,
+    _config_from_env,
+    _describe_unexpected_probe_payload,
+    _normalize_dataview_listing_payload,
+    configure_cjapy,
+    initialize_cja,
+)
 from cja_auto_sdr.core.config_validation import (
     ConfigValidator,
     validate_config_file,
@@ -3937,19 +3944,7 @@ def run_dry_run(data_views: list[str], config_file: str, logger: logging.Logger,
             print("  ⚠ API connection returned None - may be unstable")
             available_dvs = []
         else:
-            # cjapy 0.3.1 returns parsed JSON; an error-shaped dict reached us
-            # because the status was non-retryable or retries were exhausted.
-            status = None
-            message = None
-            if isinstance(available_dvs, dict):
-                status = available_dvs.get("statusCode") or available_dvs.get("status_code")
-                message = available_dvs.get("message") or available_dvs.get("error")
-            detail_parts = []
-            if status is not None:
-                detail_parts.append(f"statusCode={status}")
-            if message is not None:
-                detail_parts.append(f"message={message!r}")
-            detail = ", ".join(detail_parts) or f"type={type(available_dvs).__name__}"
+            detail = _describe_unexpected_probe_payload(available_dvs)
             print(f"  ⚠ API connection returned unexpected payload ({detail})")
             available_dvs = []
     except KeyboardInterrupt, SystemExit:
@@ -4351,19 +4346,22 @@ def get_cached_data_views(cja, cache_key: str, logger: logging.Logger) -> list[d
     # Fetch from API
     logger.debug("Fetching data views from API (cache miss)")
     available_dvs = cja.getDataViews()
+    normalized_dvs = _normalize_dataview_listing_payload(available_dvs)
 
-    if available_dvs is None:
+    if normalized_dvs == []:
+        return []
+    if normalized_dvs is None:
+        logger.warning(
+            "Ignoring unexpected getDataViews() payload while populating cache: %s",
+            _describe_unexpected_probe_payload(available_dvs),
+        )
         return []
 
-    # Convert to list if DataFrame
-    if isinstance(available_dvs, pd.DataFrame):
-        available_dvs = available_dvs.to_dict("records")
-
     # Cache the result
-    _data_view_cache.set(cache_key, available_dvs)
-    logger.debug(f"Cached {len(available_dvs)} data views")
+    _data_view_cache.set(cache_key, normalized_dvs)
+    logger.debug(f"Cached {len(normalized_dvs)} data views")
 
-    return available_dvs
+    return normalized_dvs
 
 
 def prompt_for_selection(options: list[tuple[str, str]], prompt_text: str) -> str | None:

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -3929,12 +3929,28 @@ def run_dry_run(data_views: list[str], config_file: str, logger: logging.Logger,
             logger=logger,
             operation_name="getDataViews (dry-run)",
         )
-        if available_dvs is not None:
+        if isinstance(available_dvs, (list, tuple, pd.DataFrame)):
             dv_count = len(available_dvs) if hasattr(available_dvs, "__len__") else 0
             print("  ✓ API connection successful")
             print(f"  ✓ Found {dv_count} accessible data view(s)")
-        else:
+        elif available_dvs is None:
             print("  ⚠ API connection returned None - may be unstable")
+            available_dvs = []
+        else:
+            # cjapy 0.3.1 returns parsed JSON; an error-shaped dict reached us
+            # because the status was non-retryable or retries were exhausted.
+            status = None
+            message = None
+            if isinstance(available_dvs, dict):
+                status = available_dvs.get("statusCode") or available_dvs.get("status_code")
+                message = available_dvs.get("message") or available_dvs.get("error")
+            detail_parts = []
+            if status is not None:
+                detail_parts.append(f"statusCode={status}")
+            if message is not None:
+                detail_parts.append(f"message={message!r}")
+            detail = ", ".join(detail_parts) or f"type={type(available_dvs).__name__}"
+            print(f"  ⚠ API connection returned unexpected payload ({detail})")
             available_dvs = []
     except KeyboardInterrupt, SystemExit:
         print()

--- a/src/cja_auto_sdr/org/analyzer.py
+++ b/src/cja_auto_sdr/org/analyzer.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Any
 import pandas as pd
 from tqdm import tqdm
 
+from cja_auto_sdr.api.client import _describe_unexpected_probe_payload, _normalize_dataview_listing_payload
 from cja_auto_sdr.core.constants import (
     DEFAULT_ORG_REPORT_WORKERS,
     GOVERNANCE_MAX_OVERLAP_THRESHOLD,
@@ -348,7 +349,14 @@ class OrgComponentAnalyzer:
         # This provides better UX - users learn about empty results before long work begins
         try:
             quick_check = self.cja.getDataViews()
-            if quick_check is None or (hasattr(quick_check, "__len__") and len(quick_check) == 0):
+            normalized_quick_check = _normalize_dataview_listing_payload(quick_check)
+            if normalized_quick_check is None:
+                self.logger.warning(
+                    "Ignoring unexpected getDataViews() payload during org-report quick check: %s",
+                    _describe_unexpected_probe_payload(quick_check),
+                )
+                return None
+            if len(normalized_quick_check) == 0:
                 self.logger.warning("No data views found in organization; returning empty org report")
                 return OrgReportResult(
                     timestamp=datetime.now(UTC).isoformat(),

--- a/src/cja_auto_sdr/org/analyzer.py
+++ b/src/cja_auto_sdr/org/analyzer.py
@@ -22,7 +22,11 @@ from typing import TYPE_CHECKING, Any
 import pandas as pd
 from tqdm import tqdm
 
-from cja_auto_sdr.api.client import _describe_unexpected_probe_payload, _normalize_dataview_listing_payload
+from cja_auto_sdr.api.client import (
+    _describe_unexpected_probe_payload,
+    _normalize_dataview_listing_payload,
+    _normalize_dataview_listing_payload_or_raise,
+)
 from cja_auto_sdr.core.constants import (
     DEFAULT_ORG_REPORT_WORKERS,
     GOVERNANCE_MAX_OVERLAP_THRESHOLD,
@@ -582,12 +586,15 @@ class OrgComponentAnalyzer:
             self.logger.error("Failed to list data views: %s", e)
             return [], False, 0
 
-        if all_data_views is None or len(all_data_views) == 0:
+        if all_data_views is None:
             return [], False, 0
 
-        # Convert to list of dicts if needed
-        if isinstance(all_data_views, pd.DataFrame):
-            all_data_views = all_data_views.to_dict("records")
+        all_data_views = _normalize_dataview_listing_payload_or_raise(
+            all_data_views,
+            operation="getDataViews (org-report)",
+        )
+        if len(all_data_views) == 0:
+            return [], False, 0
 
         filtered = all_data_views
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -143,7 +143,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 7,827 comprehensive tests**
+**Total: 7,847 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -152,16 +152,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,721 | 125 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,741 | 125 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 7 | 1 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **7,827** | **131** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **7,847** | **131** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,714 | 124 | `-m "unit and not slow"` |
+| `test-unit` | 7,734 | 124 | `-m "unit and not slow"` |
 | `test-integration` | 103 | 6 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -186,7 +186,7 @@ tests/
 | `test_git_integration.py` | 41 | Git integration, snapshot management, inventory snapshots |
 | `test_output_formats.py` | 37 | CSV, JSON, HTML, Markdown output generation |
 | `test_cja_initialization.py` | 50 | CJA connection and configuration validation |
-| `test_cjapy_retry_interaction.py` | 38 | cjapy retry/status-payload normalization contract |
+| `test_cjapy_retry_interaction.py` | 58 | cjapy retry/status-payload normalization contract |
 | `test_utils.py` | 50 | Utility functions and helpers |
 | `test_excel_formatting.py` | 28 | Excel sheet formatting and styling |
 | `test_parallel_api_fetcher.py` | 39 | Parallel API data fetching |
@@ -302,7 +302,7 @@ tests/
 | `test_agent_workflows.py` | 69 | Agent workflow shell script validation tests |
 | `test_manifest_agent_contract.py` | 16 | Manifest vs runtime capability drift tests |
 | `test_tool_manifests.py` | 40 | Tool manifest schema and content tests |
-| **Total** | **7,827** | **Collected via pytest --collect-only** |
+| **Total** | **7,847** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -760,7 +760,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (7,827 tests total)
+- [x] Comprehensive test coverage (7,847 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 78 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -143,7 +143,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 7,847 comprehensive tests**
+**Total: 7,860 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -152,16 +152,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,741 | 125 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,754 | 125 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 7 | 1 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **7,847** | **131** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **7,860** | **131** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,734 | 124 | `-m "unit and not slow"` |
+| `test-unit` | 7,747 | 124 | `-m "unit and not slow"` |
 | `test-integration` | 103 | 6 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -185,11 +185,11 @@ tests/
 | `test_calculated_metrics_inventory.py` | 366 | Calculated metrics inventory feature |
 | `test_git_integration.py` | 41 | Git integration, snapshot management, inventory snapshots |
 | `test_output_formats.py` | 37 | CSV, JSON, HTML, Markdown output generation |
-| `test_cja_initialization.py` | 50 | CJA connection and configuration validation |
+| `test_cja_initialization.py` | 51 | CJA connection and configuration validation |
 | `test_cjapy_retry_interaction.py` | 58 | cjapy retry/status-payload normalization contract |
 | `test_utils.py` | 50 | Utility functions and helpers |
 | `test_excel_formatting.py` | 28 | Excel sheet formatting and styling |
-| `test_parallel_api_fetcher.py` | 39 | Parallel API data fetching |
+| `test_parallel_api_fetcher.py` | 40 | Parallel API data fetching |
 | `test_api_tuning.py` | 25 | API worker auto-tuning |
 | `test_error_messages.py` | 23 | Enhanced error messages and guidance |
 | `test_explain_exit_code.py` | 44 | --explain-exit-code shared explainer, parser, fast-path, and run-summary behavior |
@@ -219,7 +219,7 @@ tests/
 | `test_main_entry_points.py` | 43 | main() and _main_impl() entry points, dispatch, run_state, run summary |
 | `test_quality_policy_and_run_summary.py` | 171 | Quality policy functions and run summary/status inference |
 | `test_e2e_integration.py` | 16 | End-to-end integration tests with real pipeline, mocked API boundary |
-| `test_api_client.py` | 31 | API client exception paths and error handling |
+| `test_api_client.py` | 35 | API client exception paths and error handling |
 | `test_config_validation.py` | 55 | Configuration validation logic |
 | `test_credentials.py` | 73 | Credential resolution and source selection |
 | `test_perf.py` | 7 | Performance utilities (cache eviction, statistics) |
@@ -232,7 +232,7 @@ tests/
 | `test_lazy_forwarding.py` | 73 | Lazy-forwarding infrastructure and make_getattr() |
 | `test_lock_backend_edge_cases.py` | 165 | Lock backend metadata I/O, stale detection, legacy parsing |
 | `test_derived_fields_coverage.py` | 161 | Derived field complexity scoring, logic summary, predicates |
-| `test_org_analyzer_coverage.py` | 160 | Org analyzer governance, naming audit, sampling, memory, drift, clustering |
+| `test_org_analyzer_coverage.py` | 162 | Org analyzer governance, naming audit, sampling, memory, drift, clustering |
 | `test_api_coverage.py` | 98 | API cache, quality, fetch, resilience exception paths |
 | `test_diff_coverage.py` | 72 | Diff comparator, models, git integration edge cases |
 | `test_generator_coverage.py` | 143 | Generator utility functions — coercion, normalization, diff formatting |
@@ -240,14 +240,14 @@ tests/
 | `test_segments_coverage.py` | 78 | Segment comparison operators, container types, sequence variants |
 | `test_diff_inventory_output.py` | 96 | Inventory diff output across all formats (console, JSON, HTML, Excel, MD, CSV) |
 | `test_cli_command_handlers.py` | 156 | CLI dispatch for --stats, --org-report, --list-snapshots, discovery inspection, diff config unpacking |
-| `test_profile_management.py` | 53 | Interactive profile creation, import, test, show |
+| `test_profile_management.py` | 54 | Interactive profile creation, import, test, show |
 | `test_snapshot_commands.py` | 65 | Snapshot creation, comparison, name resolution |
 | `test_config_and_resolution.py` | 114 | Config status, validation, stats, name resolution |
 | `test_derived_fields_edge_cases.py` | 34 | Derived fields edge cases and coverage |
 | `test_diff_command_coverage.py` | 45 | Diff command edge cases and coverage |
 | `test_generator_interactive_and_console.py` | 37 | Generator interactive and console tests |
 | `test_generator_remaining_coverage.py` | 82 | Generator remaining coverage edge cases |
-| `test_interactive_discovery_coverage.py` | 117 | Interactive discovery and helpers coverage |
+| `test_interactive_discovery_coverage.py` | 118 | Interactive discovery and helpers coverage |
 | `test_lock_backends.py` | 46 | Lock backends edge cases and coverage |
 | `test_main_impl_cli_coverage.py` | 91 | _main_impl CLI path coverage |
 | `test_main_impl_coverage.py` | 64 | _main_impl coverage edge cases |
@@ -272,7 +272,7 @@ tests/
 | `test_org_trending_contracts.py` | 108 | Org/trending public API contract tests |
 | `test_org_trending_adversarial.py` | 51 | Adversarial and stress tests for trending |
 | `test_cli_diff_contracts.py` | 70 | CLI/diff public API contract tests |
-| `test_list_command_edge_cases.py` | 58 | List command edge cases and coverage |
+| `test_list_command_edge_cases.py` | 61 | List command edge cases and coverage |
 | `test_cli_commands_config_coverage.py` | 37 | Config command edge cases and coverage |
 | `test_cli_execution.py` | 27 | CLI execution edge cases and coverage |
 | `test_diff_git_coverage.py` | 27 | Diff/git subprocess error path coverage |
@@ -302,7 +302,7 @@ tests/
 | `test_agent_workflows.py` | 69 | Agent workflow shell script validation tests |
 | `test_manifest_agent_contract.py` | 16 | Manifest vs runtime capability drift tests |
 | `test_tool_manifests.py` | 40 | Tool manifest schema and content tests |
-| **Total** | **7,847** | **Collected via pytest --collect-only** |
+| **Total** | **7,860** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -760,7 +760,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (7,847 tests total)
+- [x] Comprehensive test coverage (7,860 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 78 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -16,6 +16,7 @@ tests/
 ├── test_calculated_metrics_inventory.py  # Calculated metrics inventory tests
 ├── test_circuit_breaker.py          # Circuit breaker pattern tests
 ├── test_cja_initialization.py       # CJA initialization and validation tests
+├── test_cjapy_retry_interaction.py  # cjapy retry/status-payload normalization contract tests
 ├── test_cli.py                      # Command-line interface tests
 ├── test_data_quality.py             # Data quality validation tests
 ├── test_derived_inventory.py        # Derived fields inventory tests
@@ -142,7 +143,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 7,783 comprehensive tests**
+**Total: 7,822 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -151,16 +152,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,677 | 124 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,716 | 125 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 7 | 1 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **7,783** | **130** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **7,822** | **131** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,670 | 123 | `-m "unit and not slow"` |
+| `test-unit` | 7,709 | 124 | `-m "unit and not slow"` |
 | `test-integration` | 103 | 6 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -184,10 +185,11 @@ tests/
 | `test_calculated_metrics_inventory.py` | 366 | Calculated metrics inventory feature |
 | `test_git_integration.py` | 41 | Git integration, snapshot management, inventory snapshots |
 | `test_output_formats.py` | 37 | CSV, JSON, HTML, Markdown output generation |
-| `test_cja_initialization.py` | 48 | CJA connection and configuration validation |
+| `test_cja_initialization.py` | 50 | CJA connection and configuration validation |
+| `test_cjapy_retry_interaction.py` | 33 | cjapy retry/status-payload normalization contract |
 | `test_utils.py` | 50 | Utility functions and helpers |
 | `test_excel_formatting.py` | 28 | Excel sheet formatting and styling |
-| `test_parallel_api_fetcher.py` | 35 | Parallel API data fetching |
+| `test_parallel_api_fetcher.py` | 39 | Parallel API data fetching |
 | `test_api_tuning.py` | 25 | API worker auto-tuning |
 | `test_error_messages.py` | 23 | Enhanced error messages and guidance |
 | `test_explain_exit_code.py` | 44 | --explain-exit-code shared explainer, parser, fast-path, and run-summary behavior |
@@ -300,7 +302,7 @@ tests/
 | `test_agent_workflows.py` | 69 | Agent workflow shell script validation tests |
 | `test_manifest_agent_contract.py` | 16 | Manifest vs runtime capability drift tests |
 | `test_tool_manifests.py` | 40 | Tool manifest schema and content tests |
-| **Total** | **7,783** | **Collected via pytest --collect-only** |
+| **Total** | **7,822** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -758,7 +760,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (7,783 tests total)
+- [x] Comprehensive test coverage (7,822 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 78 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -143,7 +143,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 7,860 comprehensive tests**
+**Total: 7,861 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -152,16 +152,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,754 | 125 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,755 | 125 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 7 | 1 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **7,860** | **131** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **7,861** | **131** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,747 | 124 | `-m "unit and not slow"` |
+| `test-unit` | 7,748 | 124 | `-m "unit and not slow"` |
 | `test-integration` | 103 | 6 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -242,7 +242,7 @@ tests/
 | `test_cli_command_handlers.py` | 156 | CLI dispatch for --stats, --org-report, --list-snapshots, discovery inspection, diff config unpacking |
 | `test_profile_management.py` | 54 | Interactive profile creation, import, test, show |
 | `test_snapshot_commands.py` | 65 | Snapshot creation, comparison, name resolution |
-| `test_config_and_resolution.py` | 114 | Config status, validation, stats, name resolution |
+| `test_config_and_resolution.py` | 115 | Config status, validation, stats, name resolution |
 | `test_derived_fields_edge_cases.py` | 34 | Derived fields edge cases and coverage |
 | `test_diff_command_coverage.py` | 45 | Diff command edge cases and coverage |
 | `test_generator_interactive_and_console.py` | 37 | Generator interactive and console tests |
@@ -302,7 +302,7 @@ tests/
 | `test_agent_workflows.py` | 69 | Agent workflow shell script validation tests |
 | `test_manifest_agent_contract.py` | 16 | Manifest vs runtime capability drift tests |
 | `test_tool_manifests.py` | 40 | Tool manifest schema and content tests |
-| **Total** | **7,860** | **Collected via pytest --collect-only** |
+| **Total** | **7,861** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -760,7 +760,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (7,860 tests total)
+- [x] Comprehensive test coverage (7,861 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 78 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -143,7 +143,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 7,822 comprehensive tests**
+**Total: 7,827 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -152,16 +152,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,716 | 125 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,721 | 125 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 7 | 1 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **7,822** | **131** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **7,827** | **131** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,709 | 124 | `-m "unit and not slow"` |
+| `test-unit` | 7,714 | 124 | `-m "unit and not slow"` |
 | `test-integration` | 103 | 6 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -186,7 +186,7 @@ tests/
 | `test_git_integration.py` | 41 | Git integration, snapshot management, inventory snapshots |
 | `test_output_formats.py` | 37 | CSV, JSON, HTML, Markdown output generation |
 | `test_cja_initialization.py` | 50 | CJA connection and configuration validation |
-| `test_cjapy_retry_interaction.py` | 33 | cjapy retry/status-payload normalization contract |
+| `test_cjapy_retry_interaction.py` | 38 | cjapy retry/status-payload normalization contract |
 | `test_utils.py` | 50 | Utility functions and helpers |
 | `test_excel_formatting.py` | 28 | Excel sheet formatting and styling |
 | `test_parallel_api_fetcher.py` | 39 | Parallel API data fetching |
@@ -302,7 +302,7 @@ tests/
 | `test_agent_workflows.py` | 69 | Agent workflow shell script validation tests |
 | `test_manifest_agent_contract.py` | 16 | Manifest vs runtime capability drift tests |
 | `test_tool_manifests.py` | 40 | Tool manifest schema and content tests |
-| **Total** | **7,822** | **Collected via pytest --collect-only** |
+| **Total** | **7,827** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -760,7 +760,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (7,822 tests total)
+- [x] Comprehensive test coverage (7,827 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 78 tests

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -29,10 +29,12 @@ from cja_auto_sdr.api.client import (
     _config_from_env,
     _describe_unexpected_probe_payload,
     _normalize_dataview_listing_payload,
+    _normalize_dataview_listing_payload_or_raise,
     configure_cjapy,
     initialize_cja,
 )
 from cja_auto_sdr.core.exceptions import (
+    APIError,
     CredentialSourceError,
     ProfileConfigError,
     ProfileNotFoundError,
@@ -136,6 +138,13 @@ class TestDataviewListingPayloadHelpers:
 
     def test_normalize_dataview_listing_payload_rejects_error_dict(self):
         assert _normalize_dataview_listing_payload({"statusCode": 500, "message": "backend timeout"}) is None
+
+    def test_normalize_dataview_listing_payload_or_raise_surfaces_api_error(self):
+        with pytest.raises(APIError, match="Unexpected getDataViews\\(\\) payload"):
+            _normalize_dataview_listing_payload_or_raise(
+                {"statusCode": 503, "message": "backend timeout"},
+                operation="getDataViews (test)",
+            )
 
     def test_describe_unexpected_probe_payload_reads_nested_error_status(self):
         detail = _describe_unexpected_probe_payload({"error": {"statusCode": 500, "message": "backend timeout"}})

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -27,6 +27,8 @@ import cja_auto_sdr.api.client as _client_module
 from cja_auto_sdr.api.client import (
     _bootstrap_dotenv,
     _config_from_env,
+    _describe_unexpected_probe_payload,
+    _normalize_dataview_listing_payload,
     configure_cjapy,
     initialize_cja,
 )
@@ -121,6 +123,24 @@ class TestBootstrapDotenv:
 
         calls = [str(c) for c in mock_logger.debug.call_args_list]
         assert any("python-dotenv not installed" in c for c in calls)
+
+
+class TestDataviewListingPayloadHelpers:
+    """Helpers should normalize real listings and describe error dicts coherently."""
+
+    def test_normalize_dataview_listing_payload_converts_tuple(self):
+        assert _normalize_dataview_listing_payload(({"id": "dv_1"}, {"id": "dv_2"})) == [
+            {"id": "dv_1"},
+            {"id": "dv_2"},
+        ]
+
+    def test_normalize_dataview_listing_payload_rejects_error_dict(self):
+        assert _normalize_dataview_listing_payload({"statusCode": 500, "message": "backend timeout"}) is None
+
+    def test_describe_unexpected_probe_payload_reads_nested_error_status(self):
+        detail = _describe_unexpected_probe_payload({"error": {"statusCode": 500, "message": "backend timeout"}})
+        assert "statusCode=500" in detail
+        assert "backend timeout" in detail
 
     def test_dotenv_import_runtime_error_is_non_fatal(self, mock_logger):
         """Unexpected dotenv import errors should remain best-effort."""

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -897,21 +897,22 @@ class TestMakeApiCallWithRetry:
             make_api_call_with_retry(lambda: None, logger=_make_logger(), circuit_breaker=cb)
 
     def test_retryable_status_in_response_dict(self, monkeypatch):
-        """Cover dict response with status_code field."""
+        """Cover dict response with status_code field for a project-retryable status."""
         monkeypatch.setenv("MAX_RETRIES", "0")
+        # 408 is project-retryable (not in cjapy adapter status_forcelist).
         with pytest.raises(RetryableHTTPError):
             make_api_call_with_retry(
-                lambda: {"status_code": 503},
+                lambda: {"status_code": 408},
                 logger=_make_logger(),
                 operation_name="test_op",
             )
 
     def test_retryable_status_in_error_dict(self, monkeypatch):
-        """Cover dict response with nested error.status_code."""
+        """Cover dict response with nested error.status_code for a project-retryable status."""
         monkeypatch.setenv("MAX_RETRIES", "0")
         with pytest.raises(RetryableHTTPError):
             make_api_call_with_retry(
-                lambda: {"error": {"status_code": 429}},
+                lambda: {"error": {"status_code": 408}},
                 logger=_make_logger(),
                 operation_name="test_op",
             )
@@ -981,11 +982,12 @@ class TestMakeApiCallWithRetry:
             make_api_call_with_retry(always_os_err, logger=_make_logger(), operation_name="os_op")
 
     def test_status_code_on_result_object(self, monkeypatch):
-        """Cover the hasattr(result, 'status_code') branch."""
+        """Cover the hasattr(result, 'status_code') branch on a project-retryable status."""
         monkeypatch.setenv("MAX_RETRIES", "0")
 
         class FakeResponse:
-            status_code = 503
+            # 408 is project-retryable (not in cjapy adapter status_forcelist).
+            status_code = 408
 
         with pytest.raises(RetryableHTTPError):
             make_api_call_with_retry(

--- a/tests/test_cja_initialization.py
+++ b/tests/test_cja_initialization.py
@@ -870,3 +870,72 @@ class TestInitializeCjaEnvFallback:
 
         assert result is None
         mock_logger.critical.assert_called()
+
+
+class TestInitializeCjaConnectionProbeContract:
+    """CONTRACT (v3.5.14): getDataViews() error-shaped dict must not be reported as success.
+
+    cjapy 0.3.1 returns parsed JSON (not Response objects). An error-shaped payload
+    like ``{"statusCode": 500, ...}`` must warn, not log connection success. A real
+    listing is a list/tuple of rows or a pandas DataFrame.
+    """
+
+    @patch("cja_auto_sdr.api.client.CredentialResolver")
+    @patch("cja_auto_sdr.api.client.cjapy")
+    @patch("cja_auto_sdr.api.client.make_api_call_with_retry")
+    def test_error_shaped_getDataViews_payload_does_not_log_connection_success(
+        self,
+        mock_api_call,
+        mock_cjapy,
+        mock_resolver_class,
+        mock_logger,
+        mock_config_file,
+    ):
+        mock_resolver = Mock()
+        mock_resolver.resolve.return_value = (
+            {"org_id": "test@AdobeOrg", "client_id": "x", "secret": "y", "scopes": "openid"},
+            f"config:{Path(mock_config_file).name}",
+        )
+        mock_resolver_class.return_value = mock_resolver
+        mock_cjapy.CJA.return_value = Mock()
+        mock_api_call.return_value = {"statusCode": 500, "message": "backend timeout"}
+
+        result = initialize_cja(mock_config_file, mock_logger)
+
+        # The function still returns a CJA instance (the probe is non-fatal)
+        assert result is not None
+
+        info_calls = [str(call) for call in mock_logger.info.call_args_list]
+        warning_calls = [str(call) for call in mock_logger.warning.call_args_list]
+
+        # Must not claim connection success
+        assert not any("API connection successful" in c for c in info_calls)
+        # Must surface the error-shaped payload as a warning with the statusCode/message
+        assert any("unexpected payload" in c for c in warning_calls)
+        assert any("statusCode=500" in c for c in warning_calls)
+
+    @patch("cja_auto_sdr.api.client.CredentialResolver")
+    @patch("cja_auto_sdr.api.client.cjapy")
+    @patch("cja_auto_sdr.api.client.make_api_call_with_retry")
+    def test_list_payload_still_logs_connection_success(
+        self,
+        mock_api_call,
+        mock_cjapy,
+        mock_resolver_class,
+        mock_logger,
+        mock_config_file,
+    ):
+        mock_resolver = Mock()
+        mock_resolver.resolve.return_value = (
+            {"org_id": "test@AdobeOrg", "client_id": "x", "secret": "y", "scopes": "openid"},
+            f"config:{Path(mock_config_file).name}",
+        )
+        mock_resolver_class.return_value = mock_resolver
+        mock_cjapy.CJA.return_value = Mock()
+        mock_api_call.return_value = [{"id": "dv_1"}, {"id": "dv_2"}]
+
+        result = initialize_cja(mock_config_file, mock_logger)
+
+        assert result is not None
+        info_calls = [str(call) for call in mock_logger.info.call_args_list]
+        assert any("API connection successful" in c for c in info_calls)

--- a/tests/test_cja_initialization.py
+++ b/tests/test_cja_initialization.py
@@ -794,6 +794,26 @@ class TestValidateConfigOnly:
     @patch("cja_auto_sdr.generator.load_credentials_from_env")
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("builtins.print")
+    def test_fails_on_error_shaped_dataview_listing_payload(
+        self,
+        mock_print,
+        mock_cjapy,
+        mock_load_env,
+        mock_config_file,
+    ):
+        """validate-config must not report success for a dict-shaped API error payload."""
+        mock_load_env.return_value = None
+        mock_cja = Mock()
+        mock_cjapy.CJA.return_value = mock_cja
+        mock_cja.getDataViews.return_value = {"statusCode": 500, "message": "backend timeout"}
+
+        result = validate_config_only(mock_config_file)
+
+        assert result is False
+
+    @patch("cja_auto_sdr.generator.load_credentials_from_env")
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("builtins.print")
     def test_shows_credential_status(self, mock_print, mock_cjapy, mock_load_env, mock_config_file):
         """Test that credential status is shown"""
         mock_load_env.return_value = None

--- a/tests/test_cjapy_retry_interaction.py
+++ b/tests/test_cjapy_retry_interaction.py
@@ -1,0 +1,223 @@
+"""Contract tests for real cjapy-style status payload normalization.
+
+cjapy 0.3.1 returns parsed JSON dicts (not Response objects) and does not
+inject a snake_case ``status_code`` field. The upstream ``AdobeRequest._build_session``
+installs a urllib3.Retry adapter that covers 429/500/502/503/504 with exponential
+backoff.
+
+Post-v3.5.14 contract:
+
+- the retry wrapper normalizes camelCase ``statusCode``, nested ``error.statusCode``,
+  and ``response.statusCode`` the same way it normalized legacy ``status_code``
+- ``RETRYABLE_STATUS_CODES`` is narrowed to ``{408}`` so we don't stack retries on
+  top of cjapy's adapter; 429/500/502/503/504 pass through to the caller
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from cja_auto_sdr.api.resilience import (
+    CircuitBreaker,
+    _extract_http_status_code_from_result,
+    make_api_call_with_retry,
+)
+from cja_auto_sdr.core.config import CircuitBreakerConfig
+from cja_auto_sdr.core.exceptions import RetryableHTTPError
+
+
+@pytest.fixture
+def recorded_sleeps(monkeypatch):
+    """Capture retry sleeps without actually blocking the test."""
+    sleeps: list[float] = []
+
+    def _fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    monkeypatch.setattr("cja_auto_sdr.api.resilience.time.sleep", _fake_sleep)
+    return sleeps
+
+
+class TestUpstreamAdapterNonOverlapContract:
+    """Project retries are disjoint from cjapy adapter statuses.
+
+    ``cjapy.connector.AdobeRequest._build_session`` installs a urllib3.Retry adapter
+    that handles 429/500/502/503/504 with exponential backoff. When a response
+    reaches the project layer, the adapter has already retried. Project-layer retries
+    on the same statuses would stack, so ``RETRYABLE_STATUS_CODES`` must exclude them.
+
+    408 is NOT in cjapy's status_forcelist, so it remains the project layer's responsibility.
+    """
+
+    @pytest.mark.parametrize("status", [429, 500, 502, 503, 504])
+    def test_upstream_adapter_statuses_do_not_trigger_project_retry(self, recorded_sleeps, status):
+        """Adapter-visible statuses reach us only after cjapy already retried — we must pass them through."""
+        payload = {"statusCode": status, "message": "upstream exhausted"}
+        api_func = MagicMock(return_value=payload)
+
+        result = make_api_call_with_retry(api_func, operation_name="probe")
+
+        assert result == payload
+        assert api_func.call_count == 1, "project layer must not retry adapter-visible statuses"
+        assert recorded_sleeps == []
+
+    @pytest.mark.parametrize("status", [429, 500, 502, 503, 504])
+    def test_legacy_status_code_key_also_passes_through_for_adapter_statuses(self, recorded_sleeps, status):
+        """Snake_case status_code must behave the same as camelCase for adapter-visible statuses."""
+        payload = {"status_code": status, "message": "upstream exhausted"}
+        api_func = MagicMock(return_value=payload)
+
+        result = make_api_call_with_retry(api_func, operation_name="probe")
+
+        assert result == payload
+        assert api_func.call_count == 1
+        assert recorded_sleeps == []
+
+
+class TestProjectOwnedRetryableStatuses:
+    """408 remains project-retryable (not in cjapy's status_forcelist)."""
+
+    def test_408_retries_on_camelCase_statusCode(self, recorded_sleeps):
+        api_func = MagicMock(
+            side_effect=[
+                {"statusCode": 408, "message": "request timeout"},
+                {"statusCode": 200, "data": "ok"},
+            ],
+        )
+
+        result = make_api_call_with_retry(api_func, operation_name="probe")
+
+        assert result == {"statusCode": 200, "data": "ok"}
+        assert api_func.call_count == 2
+        assert len(recorded_sleeps) == 1
+
+    def test_408_retries_on_legacy_status_code_key(self, recorded_sleeps):
+        api_func = MagicMock(
+            side_effect=[
+                {"status_code": 408, "message": "request timeout"},
+                {"status_code": 200, "data": "ok"},
+            ],
+        )
+
+        result = make_api_call_with_retry(api_func, operation_name="probe")
+
+        assert result == {"status_code": 200, "data": "ok"}
+        assert api_func.call_count == 2
+        assert len(recorded_sleeps) == 1
+
+    def test_408_raises_retryable_http_error_after_exhaustion(self, monkeypatch):
+        monkeypatch.setenv("MAX_RETRIES", "0")
+
+        with pytest.raises(RetryableHTTPError) as exc_info:
+            make_api_call_with_retry(
+                lambda: {"statusCode": 408, "message": "request timeout"},
+                operation_name="probe",
+            )
+
+        assert exc_info.value.status_code == 408
+
+    def test_408_raises_on_nested_error_statusCode(self, monkeypatch):
+        monkeypatch.setenv("MAX_RETRIES", "0")
+
+        with pytest.raises(RetryableHTTPError):
+            make_api_call_with_retry(
+                lambda: {"error": {"statusCode": 408, "message": "request timeout"}},
+                operation_name="probe",
+            )
+
+    def test_408_raises_on_response_nested_statusCode(self, monkeypatch):
+        monkeypatch.setenv("MAX_RETRIES", "0")
+
+        with pytest.raises(RetryableHTTPError):
+            make_api_call_with_retry(
+                lambda: {"response": {"statusCode": 408, "message": "request timeout"}},
+                operation_name="probe",
+            )
+
+
+class TestCircuitBreakerFailureAccounting:
+    """CircuitBreaker records one failure per exhausted op, not per retry attempt."""
+
+    def test_circuit_breaker_records_one_failure_after_retry_exhaustion(self, recorded_sleeps):
+        breaker = CircuitBreaker(config=CircuitBreakerConfig(failure_threshold=2))
+        # 408 is project-retryable, so this will exhaust all retries.
+        api_func = MagicMock(return_value={"statusCode": 408, "message": "request timeout"})
+
+        with pytest.raises(RetryableHTTPError):
+            make_api_call_with_retry(api_func, operation_name="probe", circuit_breaker=breaker)
+
+        stats = breaker.get_statistics()
+        assert api_func.call_count == 4  # initial + 3 default retries
+        assert stats["total_failures"] == 1
+
+    def test_circuit_breaker_records_no_failure_when_status_passes_through(self, recorded_sleeps):
+        """503 is no longer project-retryable, so the breaker doesn't see a failure."""
+        breaker = CircuitBreaker(config=CircuitBreakerConfig(failure_threshold=2))
+        api_func = MagicMock(return_value={"statusCode": 503, "message": "backend timeout"})
+
+        result = make_api_call_with_retry(api_func, operation_name="probe", circuit_breaker=breaker)
+
+        assert result == {"statusCode": 503, "message": "backend timeout"}
+        stats = breaker.get_statistics()
+        # A returned (non-raising) payload is recorded as success for the circuit breaker.
+        assert stats["total_failures"] == 0
+
+
+class TestNonRetryableStatusesPassThrough:
+    """Payloads carrying non-retryable statuses are returned as-is with no retry."""
+
+    @pytest.mark.parametrize("status", [400, 401, 403, 404, 422])
+    def test_client_error_passes_through(self, recorded_sleeps, status):
+        payload = {"statusCode": status, "message": "client error"}
+        api_func = MagicMock(return_value=payload)
+
+        result = make_api_call_with_retry(api_func, operation_name="probe")
+
+        assert result == payload
+        assert api_func.call_count == 1
+        assert recorded_sleeps == []
+
+
+class TestExtractHttpStatusCode:
+    """Direct tests for the status-extraction helper."""
+
+    def test_extracts_top_level_statusCode(self):
+        assert _extract_http_status_code_from_result({"statusCode": 503}) == 503
+
+    def test_extracts_top_level_status_code(self):
+        assert _extract_http_status_code_from_result({"status_code": 503}) == 503
+
+    def test_extracts_nested_error_statusCode(self):
+        assert _extract_http_status_code_from_result({"error": {"statusCode": 500}}) == 500
+
+    def test_extracts_nested_response_statusCode(self):
+        assert _extract_http_status_code_from_result({"response": {"statusCode": 429}}) == 429
+
+    def test_extracts_status_attribute(self):
+        class _Resp:
+            status_code = 502
+
+        assert _extract_http_status_code_from_result(_Resp()) == 502
+
+    def test_extracts_statusCode_attribute(self):
+        class _Resp:
+            statusCode = 504
+
+        assert _extract_http_status_code_from_result(_Resp()) == 504
+
+    def test_returns_none_for_no_status(self):
+        assert _extract_http_status_code_from_result({"data": "ok"}) is None
+
+    def test_returns_none_for_none(self):
+        assert _extract_http_status_code_from_result(None) is None
+
+    def test_returns_none_for_out_of_range_status(self):
+        assert _extract_http_status_code_from_result({"statusCode": 9999}) is None
+
+    def test_returns_none_for_bool_status(self):
+        assert _extract_http_status_code_from_result({"statusCode": True}) is None
+
+    def test_extracts_http_status_key(self):
+        assert _extract_http_status_code_from_result({"http_status": 503}) == 503

--- a/tests/test_cjapy_retry_interaction.py
+++ b/tests/test_cjapy_retry_interaction.py
@@ -11,10 +11,15 @@ Post-v3.5.14 contract:
   and ``response.statusCode`` the same way it normalized legacy ``status_code``
 - ``RETRYABLE_STATUS_CODES`` is narrowed to ``{408}`` so we don't stack retries on
   top of cjapy's adapter; 429/500/502/503/504 pass through to the caller
+- when an adapter-exhausted payload carries a status in
+  ``UPSTREAM_ADAPTER_STATUS_CODES`` (429/500/502/503/504), the wrapper records a
+  circuit-breaker failure and suppresses the success-after-retry log so
+  repeated upstream distress trips the breaker and telemetry is coherent
 """
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import MagicMock
 
 import pytest
@@ -152,8 +157,13 @@ class TestCircuitBreakerFailureAccounting:
         assert api_func.call_count == 4  # initial + 3 default retries
         assert stats["total_failures"] == 1
 
-    def test_circuit_breaker_records_no_failure_when_status_passes_through(self, recorded_sleeps):
-        """503 is no longer project-retryable, so the breaker doesn't see a failure."""
+    def test_circuit_breaker_records_failure_when_adapter_exhausted_status_passes_through(self, recorded_sleeps):
+        """Adapter-exhausted 5xx/429 pass-throughs must count as breaker failures.
+
+        cjapy already retried these upstream. The payload reaching us is a real
+        upstream failure signal, so the breaker must see it even though we don't
+        retry again at the project layer.
+        """
         breaker = CircuitBreaker(config=CircuitBreakerConfig(failure_threshold=2))
         api_func = MagicMock(return_value={"statusCode": 503, "message": "backend timeout"})
 
@@ -161,8 +171,93 @@ class TestCircuitBreakerFailureAccounting:
 
         assert result == {"statusCode": 503, "message": "backend timeout"}
         stats = breaker.get_statistics()
-        # A returned (non-raising) payload is recorded as success for the circuit breaker.
+        assert stats["total_failures"] == 1
+        assert api_func.call_count == 1
+
+    def test_back_to_back_adapter_exhausted_503_trips_circuit_breaker(self, recorded_sleeps):
+        """Two consecutive 503 pass-throughs open a threshold-2 breaker."""
+        breaker = CircuitBreaker(config=CircuitBreakerConfig(failure_threshold=2))
+        api_func = MagicMock(return_value={"statusCode": 503, "message": "backend timeout"})
+
+        make_api_call_with_retry(api_func, operation_name="probe", circuit_breaker=breaker)
+        make_api_call_with_retry(api_func, operation_name="probe", circuit_breaker=breaker)
+
+        stats = breaker.get_statistics()
+        assert stats["total_failures"] == 2
+        assert stats["state"] == "open"
+        assert stats["trips"] == 1
+
+    def test_nested_error_statusCode_503_records_breaker_failure(self, recorded_sleeps):
+        """Nested upstream-failure status carries through the same contract."""
+        breaker = CircuitBreaker(config=CircuitBreakerConfig(failure_threshold=5))
+        api_func = MagicMock(return_value={"error": {"statusCode": 500, "message": "upstream"}})
+
+        make_api_call_with_retry(api_func, operation_name="probe", circuit_breaker=breaker)
+
+        assert breaker.get_statistics()["total_failures"] == 1
+
+    def test_non_upstream_4xx_payload_still_records_breaker_success(self, recorded_sleeps):
+        """401/403/404 are caller-side errors, not infrastructure distress.
+
+        They are not in UPSTREAM_ADAPTER_STATUS_CODES and must not consume
+        breaker failure budget; the endpoint answered, the breaker is healthy.
+        """
+        breaker = CircuitBreaker(config=CircuitBreakerConfig(failure_threshold=2))
+        api_func = MagicMock(return_value={"statusCode": 401, "message": "unauthorized"})
+
+        make_api_call_with_retry(api_func, operation_name="probe", circuit_breaker=breaker)
+
+        stats = breaker.get_statistics()
         assert stats["total_failures"] == 0
+        assert stats["state"] == "closed"
+
+    def test_success_after_retry_log_suppressed_on_adapter_exhausted_pass_through(
+        self,
+        recorded_sleeps,
+        monkeypatch,
+        caplog,
+    ):
+        """ConnectionError -> 503 pass-through must NOT log '✓ succeeded on attempt'.
+
+        Previously the retry wrapper logged success for any non-exception return,
+        even when the return was an error-shaped payload — contradictory telemetry
+        next to caller-side failure handling.
+        """
+        monkeypatch.setenv("MAX_RETRIES", "2")
+        api_func = MagicMock(
+            side_effect=[
+                ConnectionError("transient"),
+                {"statusCode": 503, "message": "backend timeout"},
+            ],
+        )
+
+        with caplog.at_level(logging.INFO, logger="cja_auto_sdr.api.resilience"):
+            result = make_api_call_with_retry(api_func, operation_name="probe")
+
+        assert result == {"statusCode": 503, "message": "backend timeout"}
+        assert api_func.call_count == 2
+        assert not any("succeeded on attempt" in record.getMessage() for record in caplog.records)
+
+    def test_success_after_retry_log_emitted_on_genuine_recovery(
+        self,
+        recorded_sleeps,
+        monkeypatch,
+        caplog,
+    ):
+        """ConnectionError -> 200 still logs the success-after-retry line."""
+        monkeypatch.setenv("MAX_RETRIES", "2")
+        api_func = MagicMock(
+            side_effect=[
+                ConnectionError("transient"),
+                {"statusCode": 200, "data": "ok"},
+            ],
+        )
+
+        with caplog.at_level(logging.INFO, logger="cja_auto_sdr.api.resilience"):
+            result = make_api_call_with_retry(api_func, operation_name="probe")
+
+        assert result == {"statusCode": 200, "data": "ok"}
+        assert any("succeeded on attempt" in record.getMessage() for record in caplog.records)
 
 
 class TestNonRetryableStatusesPassThrough:

--- a/tests/test_cjapy_retry_interaction.py
+++ b/tests/test_cjapy_retry_interaction.py
@@ -27,7 +27,9 @@ import pytest
 from cja_auto_sdr.api.resilience import (
     CircuitBreaker,
     _extract_http_status_code_from_result,
+    _is_upstream_failure_payload,
     make_api_call_with_retry,
+    retry_with_backoff,
 )
 from cja_auto_sdr.core.config import CircuitBreakerConfig
 from cja_auto_sdr.core.exceptions import RetryableHTTPError
@@ -316,3 +318,78 @@ class TestExtractHttpStatusCode:
 
     def test_extracts_http_status_key(self):
         assert _extract_http_status_code_from_result({"http_status": 503}) == 503
+
+
+class TestIsUpstreamFailurePayload:
+    """The shared predicate used by both make_api_call_with_retry and retry_with_backoff."""
+
+    @pytest.mark.parametrize("status", [429, 500, 502, 503, 504])
+    def test_true_for_adapter_statuses(self, status):
+        assert _is_upstream_failure_payload({"statusCode": status}) is True
+
+    def test_true_for_nested_error_statusCode(self):
+        assert _is_upstream_failure_payload({"error": {"statusCode": 500}}) is True
+
+    @pytest.mark.parametrize("status", [200, 204, 301, 400, 401, 403, 404, 408, 422])
+    def test_false_for_non_upstream_statuses(self, status):
+        assert _is_upstream_failure_payload({"statusCode": status}) is False
+
+    def test_false_for_no_status_payload(self):
+        assert _is_upstream_failure_payload({"data": "ok"}) is False
+
+    def test_false_for_none(self):
+        assert _is_upstream_failure_payload(None) is False
+
+
+class TestRetryWithBackoffDecorator:
+    """The decorator shares the log-suppression rule with make_api_call_with_retry.
+
+    It has no circuit-breaker plumbing, so the only signal to fix is the
+    ``✓ … succeeded on attempt …`` log — which must not fire when the final
+    return is an adapter-exhausted 5xx/429 payload (cjapy already retried).
+    """
+
+    def test_success_log_suppressed_on_adapter_exhausted_pass_through(self, recorded_sleeps, caplog):
+        calls = {"n": 0}
+
+        @retry_with_backoff(max_retries=2, base_delay=0.001, max_delay=0.01)
+        def flaky():
+            calls["n"] += 1
+            if calls["n"] < 2:
+                raise ConnectionError("transient")
+            return {"statusCode": 503, "message": "backend timeout"}
+
+        with caplog.at_level(logging.INFO, logger="cja_auto_sdr.api.resilience"):
+            result = flaky()
+
+        assert result == {"statusCode": 503, "message": "backend timeout"}
+        assert calls["n"] == 2
+        assert not any("succeeded on attempt" in record.getMessage() for record in caplog.records)
+
+    def test_success_log_emitted_on_genuine_recovery(self, recorded_sleeps, caplog):
+        calls = {"n": 0}
+
+        @retry_with_backoff(max_retries=2, base_delay=0.001, max_delay=0.01)
+        def flaky():
+            calls["n"] += 1
+            if calls["n"] < 2:
+                raise ConnectionError("transient")
+            return {"statusCode": 200, "data": "ok"}
+
+        with caplog.at_level(logging.INFO, logger="cja_auto_sdr.api.resilience"):
+            result = flaky()
+
+        assert result == {"statusCode": 200, "data": "ok"}
+        assert any("succeeded on attempt" in record.getMessage() for record in caplog.records)
+
+    def test_no_log_on_first_attempt_success_even_with_upstream_status(self, recorded_sleeps, caplog):
+        """attempt == 0 never emits the success-after-retry log regardless of payload."""
+
+        @retry_with_backoff(max_retries=2, base_delay=0.001, max_delay=0.01)
+        def immediate():
+            return {"statusCode": 503, "message": "backend timeout"}
+
+        with caplog.at_level(logging.INFO, logger="cja_auto_sdr.api.resilience"):
+            immediate()
+
+        assert not any("succeeded on attempt" in record.getMessage() for record in caplog.records)

--- a/tests/test_config_and_resolution.py
+++ b/tests/test_config_and_resolution.py
@@ -1346,6 +1346,33 @@ class TestResolveDataViewNames:
         assert ids == []
         assert name_map == {}
 
+    @patch("cja_auto_sdr.generator.get_cached_data_views")
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_error_shaped_getdataviews_payload_returns_connectivity_error(
+        self, mock_config, mock_cjapy, mock_cache
+    ) -> None:
+        """Error-shaped getDataViews payloads (cjapy 0.3.1 adapter-exhausted)
+        now raise APIError from get_cached_data_views via
+        _normalize_dataview_listing_payload_or_raise; the stats name-resolution
+        handler must surface that as a connectivity_error diagnostic rather
+        than a misleading "no data views found" configuration_error."""
+        from cja_auto_sdr.generator import resolve_data_view_names
+
+        mock_config.return_value = (True, "file", None)
+        mock_cjapy.CJA.return_value = MagicMock()
+        mock_cache.side_effect = APIError(
+            "getDataViews (cache fill) returned error payload: {'statusCode': 503, 'message': 'backend timeout'}"
+        )
+
+        ids, name_map, diagnostics = resolve_data_view_names(["My DV"], include_diagnostics=True)
+
+        assert ids == []
+        assert name_map == {}
+        assert diagnostics.error_type == "connectivity_error"
+        assert "Failed to resolve data view names" in (diagnostics.error_message or "")
+        assert "503" in (diagnostics.error_message or "")
+
     def test_invalid_match_mode(self) -> None:
         from cja_auto_sdr.generator import resolve_data_view_names
 

--- a/tests/test_config_dataclasses.py
+++ b/tests/test_config_dataclasses.py
@@ -470,7 +470,10 @@ class TestConstantValues:
         assert LOG_FILE_BACKUP_COUNT == 5
 
     def test_retryable_status_codes(self):
-        assert RETRYABLE_STATUS_CODES == {408, 429, 500, 502, 503, 504}
+        # v3.5.14: narrowed to {408}. cjapy's urllib3.Retry adapter already handles
+        # 429/500/502/503/504 upstream; project retries on those would stack.
+        # See docs/RESILIENCE_LAYERING.md.
+        assert RETRYABLE_STATUS_CODES == {408}
 
     def test_default_retry_config_matches_dataclass(self):
         assert DEFAULT_RETRY_CONFIG == RetryConfig().to_dict()

--- a/tests/test_interactive_discovery_coverage.py
+++ b/tests/test_interactive_discovery_coverage.py
@@ -724,6 +724,20 @@ class TestInteractiveSelectDataviews:
 
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "mock", None))
+    def test_error_shaped_dataview_listing_is_treated_as_failure(self, _cfg, mock_cjapy, capsys):
+        """A returned error payload should fail the interactive flow instead of looking empty."""
+        mock_cja = Mock()
+        mock_cja.getDataViews.return_value = {"statusCode": 503, "message": "backend timeout"}
+        mock_cjapy.CJA.return_value = mock_cja
+
+        result = interactive_select_dataviews("config.json")
+        assert result == []
+        out = capsys.readouterr().out
+        assert "Failed to connect to CJA API: Unexpected getDataViews() payload" in out
+        assert "HTTP 503" in out
+
+    @patch("cja_auto_sdr.generator.cjapy")
+    @patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "mock", None))
     def test_hint_stays_on_stdout_for_interactive_select(self, _cfg, mock_cjapy, capsys):
         """Hint-bearing interactive selection failures should not split streams."""
         mock_cja = Mock()

--- a/tests/test_list_command_edge_cases.py
+++ b/tests/test_list_command_edge_cases.py
@@ -7,6 +7,7 @@ Lines targeted: 168, 281, 430-431, 450, 497-498, 537, 623, 626, 632,
 
 from __future__ import annotations
 
+import json
 from io import StringIO
 from unittest.mock import MagicMock, patch
 
@@ -247,6 +248,21 @@ class TestFetchDataviewsEmpty:
         fetcher = _fetch_dataviews(output_format="table")
         result = fetcher(cja, is_machine_readable=False)
         assert "No data views" in result
+
+    def test_error_payload_is_treated_as_empty_with_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Error-shaped getDataViews payloads should not be iterated like real listings."""
+        cja = MagicMock()
+        cja.getDataViews.return_value = {"statusCode": 500, "message": "backend timeout"}
+
+        fetcher = _fetch_dataviews(output_format="json")
+        with caplog.at_level("WARNING"):
+            result = fetcher(cja, is_machine_readable=True)
+
+        parsed = json.loads(result)
+        assert parsed["count"] == 0
+        assert parsed["dataViews"] == []
+        assert "unexpected getDataViews() payload" in caplog.text
+        assert "statusCode=500" in caplog.text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_list_command_edge_cases.py
+++ b/tests/test_list_command_edge_cases.py
@@ -31,6 +31,7 @@ from cja_auto_sdr.cli.commands.list import (
     _fetch_datasets,
     _fetch_dataviews,
 )
+from cja_auto_sdr.core.exceptions import APIError
 
 # ---------------------------------------------------------------------------
 # _approved_display edge cases (lines 623, 626, 632)
@@ -230,8 +231,6 @@ class TestFetchDataviewsEmpty:
 
     def test_empty_json_format_returns_empty_json(self) -> None:
         """JSON format returns empty JSON response (not the CSV branch)."""
-        import json
-
         cja = MagicMock()
         cja.getDataViews.return_value = []
 
@@ -249,20 +248,14 @@ class TestFetchDataviewsEmpty:
         result = fetcher(cja, is_machine_readable=False)
         assert "No data views" in result
 
-    def test_error_payload_is_treated_as_empty_with_warning(self, caplog: pytest.LogCaptureFixture) -> None:
-        """Error-shaped getDataViews payloads should not be iterated like real listings."""
+    def test_error_payload_raises_api_error(self) -> None:
+        """Error-shaped getDataViews payloads must fail discovery instead of masquerading as empty."""
         cja = MagicMock()
         cja.getDataViews.return_value = {"statusCode": 500, "message": "backend timeout"}
 
         fetcher = _fetch_dataviews(output_format="json")
-        with caplog.at_level("WARNING"):
-            result = fetcher(cja, is_machine_readable=True)
-
-        parsed = json.loads(result)
-        assert parsed["count"] == 0
-        assert parsed["dataViews"] == []
-        assert "unexpected getDataViews() payload" in caplog.text
-        assert "statusCode=500" in caplog.text
+        with pytest.raises(APIError, match="Unexpected getDataViews\\(\\) payload"):
+            fetcher(cja, is_machine_readable=True)
 
 
 # ---------------------------------------------------------------------------
@@ -293,8 +286,6 @@ class TestBuildComponentListFetcherEmpty:
 
     def test_empty_metrics_json_returns_empty_json(self) -> None:
         """Empty components + JSON + machine_readable preserve dataview metadata."""
-        import json
-
         from cja_auto_sdr.cli.commands.list import _fetch_metrics_list
 
         cja = self._make_cja(
@@ -395,6 +386,16 @@ class TestFetchConnectionsDataFramePath:
         fetcher = _fetch_connections(output_format="csv")
         result = fetcher(cja, is_machine_readable=True)
         assert result == "connection_id,connection_name,owner,dataset_id,dataset_name\n"
+
+    def test_empty_connections_invalid_dataview_payload_raises(self) -> None:
+        """Fallback to getDataViews should fail loudly on error-shaped listing payloads."""
+        cja = MagicMock()
+        cja.getConnections.return_value = []
+        cja.getDataViews.return_value = {"statusCode": 503, "message": "backend timeout"}
+
+        fetcher = _fetch_connections(output_format="table")
+        with pytest.raises(APIError, match="Unexpected getDataViews\\(\\) payload"):
+            fetcher(cja, is_machine_readable=False)
 
 
 # ---------------------------------------------------------------------------
@@ -518,6 +519,16 @@ class TestFetchDatasetsEdgeCases:
         fetcher = _fetch_datasets(output_format="table")
         result = fetcher(cja, is_machine_readable=False)
         assert "DV1" in result
+
+    def test_invalid_dataview_payload_raises(self) -> None:
+        """Dataset listing should not downgrade an API error payload into an empty result."""
+        cja = MagicMock()
+        cja.getConnections.return_value = []
+        cja.getDataViews.return_value = {"statusCode": 500, "message": "backend timeout"}
+
+        fetcher = _fetch_datasets(output_format="table")
+        with pytest.raises(APIError, match="Unexpected getDataViews\\(\\) payload"):
+            fetcher(cja, is_machine_readable=False)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_org_analyzer_coverage.py
+++ b/tests/test_org_analyzer_coverage.py
@@ -1268,6 +1268,16 @@ class TestExceptionHandlers:
         result = analyzer._quick_check_empty_org()
         assert result is None
 
+    def test_quick_check_empty_org_ignores_error_payload(self, mock_cja, logger, caplog):
+        """Error-shaped getDataViews payloads must not be mistaken for an empty org."""
+        mock_cja.getDataViews.return_value = {"statusCode": 503, "message": "backend timeout"}
+        analyzer = _make_analyzer(mock_cja, logger)
+        with caplog.at_level(logging.WARNING):
+            result = analyzer._quick_check_empty_org()
+        assert result is None
+        assert "unexpected getDataViews() payload" in caplog.text
+        assert "statusCode=503" in caplog.text
+
 
 # ===================================================================
 # 13. Cache paths

--- a/tests/test_org_analyzer_coverage.py
+++ b/tests/test_org_analyzer_coverage.py
@@ -18,7 +18,7 @@ from unittest.mock import Mock, patch
 import pandas as pd
 import pytest
 
-from cja_auto_sdr.core.exceptions import MemoryLimitExceeded
+from cja_auto_sdr.core.exceptions import APIError, MemoryLimitExceeded
 from cja_auto_sdr.org.analyzer import OrgComponentAnalyzer
 from cja_auto_sdr.org.models import (
     ComponentDistribution,
@@ -1277,6 +1277,13 @@ class TestExceptionHandlers:
         assert result is None
         assert "unexpected getDataViews() payload" in caplog.text
         assert "statusCode=503" in caplog.text
+
+    def test_list_and_filter_data_views_raises_on_error_payload(self, mock_cja, logger):
+        """Main org-report listing path must fail on error-shaped getDataViews payloads."""
+        mock_cja.getDataViews.return_value = {"statusCode": 500, "message": "backend timeout"}
+        analyzer = _make_analyzer(mock_cja, logger)
+        with pytest.raises(APIError, match="Unexpected getDataViews\\(\\) payload"):
+            analyzer._list_and_filter_data_views()
 
 
 # ===================================================================

--- a/tests/test_output_content_validation.py
+++ b/tests/test_output_content_validation.py
@@ -38,7 +38,7 @@ def rich_data_dict():
         "Metadata": pd.DataFrame(
             {
                 "Property": ["Generated At", "Data View ID", "Tool Version", "Total Metrics"],
-                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.5.13", 3],
+                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.5.14", 3],
             },
         ),
         "Data Quality": pd.DataFrame(
@@ -104,7 +104,7 @@ def rich_metadata_dict():
         "Generated At": "2025-01-15 10:30:00 PST",
         "Data View ID": "dv_content_test",
         "Data View Name": "Test DataView",
-        "Tool Version": "3.5.13",
+        "Tool Version": "3.5.14",
         "Metrics Count": "3",
         "Dimensions Count": "4",
     }
@@ -224,7 +224,7 @@ class TestJSONContentValidation:
             data = json.load(f)
 
         assert data["metadata"]["Data View ID"] == "dv_content_test"
-        assert data["metadata"]["Tool Version"] == "3.5.13"
+        assert data["metadata"]["Tool Version"] == "3.5.14"
 
     def test_json_metadata_preserves_partial_markers(self, tmp_path, rich_data_dict, rich_metadata_dict):
         logger = logging.getLogger("json_test")

--- a/tests/test_parallel_api_fetcher.py
+++ b/tests/test_parallel_api_fetcher.py
@@ -142,6 +142,50 @@ class TestParallelAPIFetcherInit:
         assert stats["scale_ups"] >= 1
         assert fetcher.max_workers == 2
 
+    @patch("cja_auto_sdr.api.fetch.make_api_call_with_retry")
+    @patch("cja_auto_sdr.api.fetch.tqdm")
+    def test_auto_tune_ignores_adapter_exhausted_error_payloads(
+        self,
+        mock_tqdm,
+        mock_api_call,
+        mock_cja,
+        mock_logger,
+        mock_perf_tracker,
+    ):
+        """Adapter-exhausted upstream payloads must not count as successful timing samples."""
+        mock_pbar = MagicMock()
+        mock_tqdm.return_value.__enter__ = Mock(return_value=mock_pbar)
+        mock_tqdm.return_value.__exit__ = Mock(return_value=False)
+        mock_api_call.return_value = {"statusCode": 503, "message": "upstream exhausted"}
+
+        tuning_config = APITuningConfig(
+            min_workers=1,
+            max_workers=4,
+            scale_up_threshold_ms=1_000_000.0,
+            sample_window=1,
+            cooldown_seconds=0.0,
+        )
+        fetcher = ParallelAPIFetcher(
+            mock_cja,
+            mock_logger,
+            mock_perf_tracker,
+            max_workers=1,
+            tuning_config=tuning_config,
+            quiet=True,
+        )
+
+        metrics, dimensions, dataview = fetcher.fetch_all_data("dv_test_12345")
+        stats = fetcher.get_tuner_statistics()
+
+        assert metrics.empty
+        assert dimensions.empty
+        assert dataview["lookup_failed"] is True
+        assert dataview["lookup_failure_reason"] == "error_shape"
+        assert stats is not None
+        assert stats["total_requests"] == 0
+        assert stats["scale_ups"] == 0
+        assert fetcher.max_workers == 1
+
 
 class TestParallelAPIFetcherFetchAllData:
     """Tests for fetch_all_data method"""

--- a/tests/test_parallel_api_fetcher.py
+++ b/tests/test_parallel_api_fetcher.py
@@ -806,3 +806,102 @@ class TestParallelAPIFetcherLogging:
         # Verify completion logged
         calls = [str(c) for c in mock_logger.info.call_args_list]
         assert any("complete" in c.lower() for c in calls)
+
+
+class TestCjapyErrorPayloadContract:
+    """Component fetches must classify cjapy-style error dicts as failures, not success."""
+
+    @patch("cja_auto_sdr.api.fetch.make_api_call_with_retry")
+    def test_fetch_metrics_rejects_statusCode_error_payload(
+        self,
+        mock_api_call,
+        mock_cja,
+        mock_logger,
+        mock_perf_tracker,
+    ):
+        mock_api_call.return_value = {"statusCode": 500, "message": "backend timeout"}
+
+        fetcher = ParallelAPIFetcher(mock_cja, mock_logger, mock_perf_tracker)
+        result = fetcher._fetch_metrics("dv_test_12345")
+
+        assert isinstance(result, pd.DataFrame)
+        assert result.empty
+        status = fetcher.get_fetch_statuses()["metrics"]
+        assert status.status == "failed"
+        assert status.item_count is None
+        detail = (status.error_message or "") + " " + (status.reason or "")
+        assert "backend timeout" in detail or "error" in detail.lower()
+
+    @patch("cja_auto_sdr.api.fetch.make_api_call_with_retry")
+    def test_fetch_dimensions_rejects_statusCode_error_payload(
+        self,
+        mock_api_call,
+        mock_cja,
+        mock_logger,
+        mock_perf_tracker,
+    ):
+        mock_api_call.return_value = {"statusCode": 502, "message": "bad gateway"}
+
+        fetcher = ParallelAPIFetcher(mock_cja, mock_logger, mock_perf_tracker)
+        result = fetcher._fetch_dimensions("dv_test_12345")
+
+        assert isinstance(result, pd.DataFrame)
+        assert result.empty
+        status = fetcher.get_fetch_statuses()["dimensions"]
+        assert status.status == "failed"
+        assert status.item_count is None
+
+    @patch("cja_auto_sdr.api.fetch.make_api_call_with_retry")
+    def test_fetch_metrics_accepts_list_of_rows(
+        self,
+        mock_api_call,
+        mock_cja,
+        mock_logger,
+        mock_perf_tracker,
+    ):
+        """cjapy may return a list of row dicts — we must normalize to DataFrame."""
+        mock_api_call.return_value = [
+            {"id": "m1", "name": "M1", "type": "standard", "description": "x"},
+            {"id": "m2", "name": "M2", "type": "calculated", "description": "y"},
+        ]
+
+        fetcher = ParallelAPIFetcher(mock_cja, mock_logger, mock_perf_tracker)
+        result = fetcher._fetch_metrics("dv_test_12345")
+
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == 2
+        status = fetcher.get_fetch_statuses()["metrics"]
+        assert status.status == "success"
+        assert status.item_count == 2
+
+    @patch("cja_auto_sdr.api.fetch.make_api_call_with_retry")
+    @patch("cja_auto_sdr.api.fetch.tqdm")
+    def test_fetch_all_data_reports_failed_metrics_for_error_payload(
+        self,
+        mock_tqdm,
+        mock_api_call,
+        mock_cja,
+        mock_logger,
+        mock_perf_tracker,
+    ):
+        mock_pbar = MagicMock()
+        mock_tqdm.return_value.__enter__ = Mock(return_value=mock_pbar)
+        mock_tqdm.return_value.__exit__ = Mock(return_value=False)
+
+        def _side_effect(api_func, *args, **kwargs):
+            operation = kwargs.get("operation_name", "")
+            if operation == "getMetrics":
+                return {"statusCode": 500, "message": "backend timeout"}
+            if operation == "getDimensions":
+                return pd.DataFrame([{"id": "x", "name": "x", "type": "string", "description": "x"}])
+            return {"id": "dv_test_12345", "name": "T", "description": "d"}
+
+        mock_api_call.side_effect = _side_effect
+
+        fetcher = ParallelAPIFetcher(mock_cja, mock_logger, mock_perf_tracker)
+        metrics, _dimensions, _dataview = fetcher.fetch_all_data("dv_test_12345")
+
+        # After normalization: error dict must not surface as metrics; status is failed.
+        assert isinstance(metrics, pd.DataFrame)
+        assert metrics.empty
+        assert fetcher.get_fetch_statuses()["metrics"].status == "failed"

--- a/tests/test_profile_management.py
+++ b/tests/test_profile_management.py
@@ -613,6 +613,32 @@ class TestTestProfile:
         assert "no data views found" in captured.out
         assert "Profile test: PASSED" in captured.out
 
+    def test_api_connection_with_error_payload_fails(self, tmp_path, capsys):
+        """Error-shaped getDataViews payloads must not be reported as profile-test success."""
+        profile_dir = tmp_path / "orgs" / "error-dv"
+        _write_config_json(profile_dir)
+
+        mock_cja_instance = MagicMock()
+        mock_cja_instance.getDataViews.return_value = {"statusCode": 500, "message": "backend timeout"}
+
+        with (
+            patch("cja_auto_sdr.generator.get_profile_path", return_value=profile_dir),
+            patch("cja_auto_sdr.generator.cjapy") as mock_cjapy,
+            patch("cja_auto_sdr.generator.ConfigValidator") as mock_validator,
+            patch("cja_auto_sdr.generator._config_from_env") as mock_config_from_env,
+        ):
+            mock_cjapy.CJA.return_value = mock_cja_instance
+            mock_validator.validate_all.return_value = []
+            result = run_test_profile("error-dv")
+
+        assert result is False
+        mock_config_from_env.assert_called_once()
+        captured = capsys.readouterr()
+        assert "API connection: FAILED" in captured.err
+        assert "Unexpected getDataViews() payload" in captured.err
+        assert "statusCode=500" in captured.err
+        assert "Profile test: FAILED" in captured.err
+
     def test_api_connection_failure(self, tmp_path, capsys):
         """API connection failure should return False with helpful message."""
         profile_dir = tmp_path / "orgs" / "api-fail"

--- a/tests/test_ux_features.py
+++ b/tests/test_ux_features.py
@@ -344,11 +344,11 @@ class TestCombinedFeatures:
 class TestVersionUpdated:
     """Test that version is correct"""
 
-    def test_version_is_3_5_13(self):
-        """Test that version is 3.5.13"""
+    def test_version_is_3_5_14(self):
+        """Test that version is 3.5.14"""
         from cja_auto_sdr.generator import __version__
 
-        assert __version__ == "3.5.13"
+        assert __version__ == "3.5.14"
 
 
 class TestFormatAutoDetection:


### PR DESCRIPTION
## Summary

Fixes a real blind spot introduced by `cjapy 0.3.1`'s response shape, then narrows the project retry layer so it no longer stacks with `cjapy`'s urllib3 adapter. Follow-up review passes also fixed breaker/log signaling, harmonized the sibling `retry_with_backoff` decorator, closed the remaining `getDataViews()` caller contracts (fail-closed on invalid listings), and excluded upstream failures from API auto-tuning telemetry.

## Correctness

- `make_api_call_with_retry()` normalizes camelCase `statusCode`, nested `error.statusCode`, and `response.statusCode` alongside legacy `status_code`.
- `RETRYABLE_STATUS_CODES` narrowed to `{408}`; `cjapy 0.3.1` already handles 429/500/502/503/504 via its urllib3 retry adapter, so the project layer no longer stacks retries on top.
- Adapter-exhausted 429/5xx payloads pass through unchanged but now record a circuit-breaker failure and suppress the success-after-retry log; non-upstream-failure 4xx (401/403/404/400/422) stay breaker-neutral.
- `retry_with_backoff` uses the same shared `_is_upstream_failure_payload()` predicate so the log-suppression rule is canonical across both retry forms.
- `ParallelAPIFetcher` classifies component payloads via `assess_component_payload()` before recording fetch status, and API auto-tuning no longer treats adapter-exhausted error payloads as successful response-time samples.
- `initialize_cja()` and dry-run probes only report connection success for list/tuple/DataFrame `getDataViews()` payloads.
- Operational `getDataViews()` callers now normalize or fail closed on invalid/error-shaped payloads instead of silently treating them as an empty organization or empty list.

## Docs

- Adds `docs/RESILIENCE_LAYERING.md` documenting upstream vs. project retry ownership, breaker signaling (including the non-contradictory 4xx wording), and the non-overlap rules; signaling-set section extended to cover both the wrapper and the decorator.
- Updates changelog/release docs and the generated test-count inventory.

## Test Plan

- [x] `uv run pytest -q tests/test_parallel_api_fetcher.py tests/test_cjapy_retry_interaction.py`
- [x] `uv run pytest -q tests/test_api_client.py tests/test_cja_initialization.py tests/test_list_command_edge_cases.py tests/test_interactive_discovery_coverage.py tests/test_org_analyzer_coverage.py tests/test_profile_management.py tests/test_config_and_resolution.py`
- [x] `uv run python scripts/update_test_counts.py --check`
- [x] `uv run python scripts/check_version_sync.py`
- [x] `uv run ruff check src/ tests/`
- [x] `uv run ruff format --check src/ tests/`

Spec: `docs/superpowers/specs/2026-04-23-v3.5.14-cjapy-retry-stacking-audit.md`
Plan: `docs/superpowers/plans/2026-04-23-v3.5.14-cjapy-retry-stacking-audit.md`