### PR TITLE
release: v3.5.15 operational payload normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ All notable changes to the CJA SDR Generator project will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.15] — 2026-04-24
+
+### Fixed
+
+- **Operational callers now fail closed on cjapy 0.3.1 error payloads.**
+  `diff/snapshot.py:create_snapshot`, `process_inventory_summary`, and
+  org-report metadata enrichment now classify `getDataView` / `getMetrics` /
+  `getDimensions` payloads before consuming them. Before v3.5.15, an
+  error-shaped response could crash snapshot creation with `AttributeError` on
+  `.empty`, silently produce an "Unknown" data-view name, or drop org-report
+  metadata without a warning.
+- **Derived-fields inventory no longer masks upstream error payloads as pandas
+  construction errors.** The inventory-summary path classifies metrics and
+  dimensions responses before creating DataFrames, so scalar error dicts like
+  `{"statusCode": 503, "message": "..."}` degrade through the existing
+  optional-inventory policy with the original classified reason.
+- **Org-report metadata enrichment now logs warning-level attribution for
+  error-shaped `getDataView` returns.** The path remains best-effort and still
+  returns the surrounding data-view summary with empty metadata fields.
+
+### Refactored
+
+- Extracted `classify_component_payload` / `ComponentFetchOutcome` into
+  `cja_auto_sdr.api.fetch` module scope. `ParallelAPIFetcher` now delegates to
+  the shared helper while preserving its existing fetch-status contract.
+
+### Documentation
+
+- Extended `docs/RESILIENCE_LAYERING.md` with the operational caller
+  classify-before-consume contract beyond the main SDR fetch path.
+
 ## [3.5.14] — 2026-04-23
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Package manager: **uv**
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
-- Current version: v3.5.14
+- Current version: v3.5.15
 - Tests: **7,861** across 131 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)

--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (7,861+ tests)
+├── tests/                     # Test suite (7,883+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -924,7 +924,7 @@ cja_auto_sdr --list-dataviews --log-level DEBUG
 At launch, the tool logs diagnostic lines containing the tool version, Python version, platform, active log level, inferred run mode (batch, single, or discovery), and dependency versions. These appear automatically at `INFO` level and are useful for troubleshooting environment issues in CI/CD logs or support requests:
 
 ```text
-CJA SDR Generator v3.5.14 | Python 3.14.2 | darwin | log_level=INFO | mode=single
+CJA SDR Generator v3.5.15 | Python 3.14.2 | darwin | log_level=INFO | mode=single
 Dependencies: cjapy=0.3.0, pandas=2.3.3, numpy=2.2.1, xlsxwriter=3.2.9, tqdm=4.67.0
 ```
 

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -190,7 +190,7 @@ This command:
 
 ```bash
 $ uv run cja_auto_sdr -V
-cja_auto_sdr 3.5.14
+cja_auto_sdr 3.5.15
 ```
 
 > **Important:** All commands in this guide assume you're in the `cja_auto_sdr` directory. If you see "command not found", make sure you're in the right directory and have run `uv sync`.

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Quick Reference Card
 
-Single-page command cheat sheet for CJA SDR Generator v3.5.14.
+Single-page command cheat sheet for CJA SDR Generator v3.5.15.
 
 ## Four Main Modes
 

--- a/docs/RESILIENCE_LAYERING.md
+++ b/docs/RESILIENCE_LAYERING.md
@@ -172,3 +172,22 @@ v3.5.14 fixes all six points:
    decorator don't inherit the telemetry bug. The decorator has no
    circuit-breaker parameter, so only the log-suppression half of the rule
    applies there.
+
+## Operational callers (v3.5.15+)
+
+Beyond the main SDR fetch path, operational paths also consume cjapy payloads
+directly. They now share a classify-before-consume contract via
+`classify_component_payload` for `getMetrics` / `getDimensions` payloads and
+`assess_dataview_lookup_payload` for `getDataView` payloads.
+
+| Call site                                                | Classifier used                  | On ERROR/INVALID                                           |
+| -------------------------------------------------------- | -------------------------------- | ---------------------------------------------------------- |
+| `diff/snapshot.py:create_snapshot`                       | both helpers                     | raises annotated `_annotate_snapshot_failure`              |
+| `generator.py:process_inventory_summary` lookup          | `assess_dataview_lookup_payload` | returns `{"error": <detail>}` + stderr `_print_api_hint`   |
+| `generator.py:_build_derived_inventory_summary`          | `classify_component_payload`     | raises `RuntimeError` caught by optional-inventory policy  |
+| `org/analyzer.py:_fetch_data_view_components` metadata   | `assess_dataview_lookup_payload` | logs `WARNING`; summary still returns with empty metadata  |
+
+`ParallelAPIFetcher._normalize_component_payload` is now a thin wrapper over
+`classify_component_payload`, so the main SDR fetch path and these operational
+paths share one component-payload contract. Before v3.5.15 each path had its
+own partial guard or none at all.

--- a/src/cja_auto_sdr/api/fetch.py
+++ b/src/cja_auto_sdr/api/fetch.py
@@ -28,6 +28,72 @@ API_FETCH_TASK_COUNT = 3  # metrics + dimensions + dataview
 
 
 @dataclass(frozen=True, slots=True)
+class ComponentFetchOutcome:
+    """Pure classification result for a cjapy component payload."""
+
+    frame: pd.DataFrame
+    status: str
+    reason: str
+    error_message: str
+    item_count: int | None
+
+
+def classify_component_payload(payload: Any) -> ComponentFetchOutcome:
+    """Classify a cjapy component payload into a fetch outcome."""
+    if isinstance(payload, pd.DataFrame):
+        if payload.empty:
+            return ComponentFetchOutcome(
+                frame=pd.DataFrame(),
+                status="empty",
+                reason="empty_response",
+                error_message="",
+                item_count=0,
+            )
+        return ComponentFetchOutcome(
+            frame=payload,
+            status="success",
+            reason="dataframe",
+            error_message="",
+            item_count=len(payload),
+        )
+
+    assessment = assess_component_payload(payload)
+    if assessment.kind is PayloadKind.DATA:
+        frame = pd.DataFrame(assessment.rows)
+        return ComponentFetchOutcome(
+            frame=frame,
+            status="success",
+            reason=assessment.reason,
+            error_message="",
+            item_count=len(frame),
+        )
+
+    if assessment.kind is PayloadKind.EMPTY:
+        return ComponentFetchOutcome(
+            frame=pd.DataFrame(),
+            status="empty",
+            reason=assessment.reason or "empty_response",
+            error_message="",
+            item_count=0,
+        )
+
+    error_detail = ""
+    if isinstance(payload, dict):
+        error_detail = str(payload.get("message") or payload.get("error") or "")
+        status_code = payload.get("statusCode") or payload.get("status_code")
+        if status_code is not None:
+            error_detail = f"{status_code}: {error_detail}" if error_detail else f"status {status_code}"
+
+    return ComponentFetchOutcome(
+        frame=pd.DataFrame(),
+        status="failed",
+        reason=assessment.reason or f"{assessment.kind.value}_payload",
+        error_message=error_detail or f"{assessment.kind.value} payload shape",
+        item_count=None,
+    )
+
+
+@dataclass(frozen=True, slots=True)
 class EndpointFetchStatus:
     """Outcome metadata for a single API endpoint fetch."""
 
@@ -245,48 +311,34 @@ class ParallelAPIFetcher:
     ) -> pd.DataFrame:
         """Classify a component payload and record the correct fetch status.
 
-        cjapy 0.3.1 can return parsed JSON error dicts (e.g. ``{"statusCode": 500, ...}``)
-        for component endpoints. Treating these as successful fetches is wrong because
-        downstream SDR rendering then consumes an error shape as "data". This helper
-        delegates classification to ``assess_component_payload`` and converts the result
-        into a DataFrame + fetch-status update.
+        Delegates classification to ``classify_component_payload`` so
+        operational callers share the same cjapy payload contract as the main
+        SDR fetch path.
         """
-        # Preserve the existing DataFrame fast path: non-empty DataFrames are successes.
-        if isinstance(payload, pd.DataFrame):
-            if payload.empty:
-                self.logger.warning("No %s returned from API", label)
-                self._record_fetch_status(endpoint, "empty", reason="empty_response", item_count=0)
-                return pd.DataFrame()
-            self.logger.info("Successfully fetched %s %s", len(payload), label)
-            self._record_fetch_status(endpoint, "success", item_count=len(payload))
-            return payload
+        outcome = classify_component_payload(payload)
+        if outcome.status == "success":
+            self.logger.info("Successfully fetched %s %s", outcome.item_count, label)
+            self._record_fetch_status(endpoint, "success", item_count=outcome.item_count)
+            return outcome.frame
 
-        assessment = assess_component_payload(payload)
-        if assessment.kind is PayloadKind.DATA:
-            frame = pd.DataFrame(assessment.rows)
-            self.logger.info("Successfully fetched %s %s", len(frame), label)
-            self._record_fetch_status(endpoint, "success", item_count=len(frame))
-            return frame
-
-        if assessment.kind is PayloadKind.EMPTY:
+        if outcome.status == "empty":
             self.logger.warning("No %s returned from API", label)
-            self._record_fetch_status(endpoint, "empty", reason=assessment.reason or "empty_response", item_count=0)
-            return pd.DataFrame()
+            self._record_fetch_status(endpoint, "empty", reason=outcome.reason, item_count=0)
+            return outcome.frame
 
-        # ERROR or INVALID — record failure with a useful detail and return empty.
-        error_detail = ""
-        if isinstance(payload, dict):
-            error_detail = str(payload.get("message") or payload.get("error") or "")
         self.logger.error(
-            "%s fetch returned %s payload (%s)", label.capitalize(), assessment.kind.value, assessment.reason
+            "%s fetch returned %s payload (%s)",
+            label.capitalize(),
+            outcome.status,
+            outcome.reason,
         )
         self._record_fetch_status(
             endpoint,
             "failed",
-            reason=assessment.reason or f"{assessment.kind.value}_payload",
-            error_message=error_detail or f"{assessment.kind.value} payload shape",
+            reason=outcome.reason,
+            error_message=outcome.error_message,
         )
-        return pd.DataFrame()
+        return outcome.frame
 
     def _fetch_metrics(self, data_view_id: str) -> pd.DataFrame:
         """Fetch metrics with error handling and retry"""

--- a/src/cja_auto_sdr/core/version.py
+++ b/src/cja_auto_sdr/core/version.py
@@ -1,3 +1,3 @@
 """Version information for CJA Auto SDR."""
 
-__version__ = "3.5.14"
+__version__ = "3.5.15"

--- a/src/cja_auto_sdr/diff/snapshot.py
+++ b/src/cja_auto_sdr/diff/snapshot.py
@@ -7,12 +7,20 @@ from datetime import UTC, datetime, timedelta
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from cja_auto_sdr.core.colors import ConsoleColors
+from cja_auto_sdr.core.discovery_payloads import PayloadKind, assess_dataview_lookup_payload
 from cja_auto_sdr.core.error_policies import RECOVERABLE_OPTIONAL_ENRICHMENT_EXCEPTIONS
 from cja_auto_sdr.core.exceptions import attach_api_connection_hint_context
 from cja_auto_sdr.core.json_io import write_json_atomic
 from cja_auto_sdr.diff.models import DataViewSnapshot
 
 _SNAPSHOT_FAILURE_STAGE_ATTR = "_cja_snapshot_failure_stage"
+_TOLERATED_LEGACY_LOOKUP_REASONS = frozenset(
+    {
+        "missing_expected_id",
+        "missing_identity",
+        "insufficient_metadata",
+    }
+)
 
 
 def _annotate_snapshot_failure(exc: Exception, *, stage: str, api_hint_context: str | None = None) -> Exception:
@@ -112,20 +120,38 @@ class SnapshotManager:
         self.logger.info(f"Creating snapshot for data view: {data_view_id}")
 
         try:
-            dv_info = cja.getDataView(data_view_id)
+            raw_dv_info = cja.getDataView(data_view_id)
         except Exception as exc:
             raise _annotate_snapshot_failure(
                 exc,
                 stage="data_view_lookup",
                 api_hint_context="data_view_lookup",
             ) from exc
-        if not dv_info:
+
+        lookup_assessment = assess_dataview_lookup_payload(raw_dv_info, expected_data_view_id=data_view_id)
+        legacy_acceptable_dict = (
+            isinstance(raw_dv_info, dict)
+            and lookup_assessment.kind is PayloadKind.ERROR
+            and lookup_assessment.reason in _TOLERATED_LEGACY_LOOKUP_REASONS
+        )
+        if not lookup_assessment.is_valid and not legacy_acceptable_dict:
+            detail = ""
+            if isinstance(raw_dv_info, dict):
+                detail = str(
+                    raw_dv_info.get("message") or raw_dv_info.get("error") or raw_dv_info.get("statusCode") or ""
+                )
+            if lookup_assessment.kind is PayloadKind.EMPTY:
+                detail = f"Failed to fetch data view info for {data_view_id}"
             raise _annotate_snapshot_failure(
-                ValueError(f"Failed to fetch data view info for {data_view_id}"),
+                ValueError(
+                    f"Data view lookup returned {lookup_assessment.kind.value} payload "
+                    f"({lookup_assessment.reason}): {detail}".rstrip(": ")
+                ),
                 stage="data_view_lookup",
                 api_hint_context="data_view_lookup",
             )
 
+        dv_info = lookup_assessment.payload or {}
         dv_name = dv_info.get("name", "Unknown")
         dv_owner = dv_info.get("owner", {})
         owner_name = dv_owner.get("name", "") if isinstance(dv_owner, dict) else str(dv_owner)
@@ -133,22 +159,55 @@ class SnapshotManager:
 
         self.logger.info("Fetching metrics...")
         try:
-            metrics_df = cja.getMetrics(data_view_id, inclType=True, full=True)
+            raw_metrics = cja.getMetrics(data_view_id, inclType=True, full=True)
         except Exception as exc:
             raise _annotate_snapshot_failure(exc, stage="metrics_fetch") from exc
-        metrics_list = []
-        if metrics_df is not None and not metrics_df.empty:
-            metrics_list = metrics_df.to_dict("records")
+        from cja_auto_sdr.api.fetch import classify_component_payload
+
+        metrics_outcome = classify_component_payload(raw_metrics)
+        legacy_metrics_like_frame = (
+            metrics_outcome.status == "failed"
+            and metrics_outcome.reason == "unsupported_payload_type"
+            and hasattr(raw_metrics, "empty")
+            and hasattr(raw_metrics, "to_dict")
+        )
+        if metrics_outcome.status == "failed" and not legacy_metrics_like_frame:
+            raise _annotate_snapshot_failure(
+                ValueError(
+                    f"Metrics fetch returned error payload ({metrics_outcome.reason}): {metrics_outcome.error_message}"
+                ),
+                stage="metrics_fetch",
+            )
+        if legacy_metrics_like_frame:
+            metrics_list = raw_metrics.to_dict("records") if not raw_metrics.empty else []
+        else:
+            metrics_list = metrics_outcome.frame.to_dict("records") if not metrics_outcome.frame.empty else []
         self.logger.info(f"  Fetched {len(metrics_list)} metrics")
 
         self.logger.info("Fetching dimensions...")
         try:
-            dimensions_df = cja.getDimensions(data_view_id, inclType=True, full=True)
+            raw_dimensions = cja.getDimensions(data_view_id, inclType=True, full=True)
         except Exception as exc:
             raise _annotate_snapshot_failure(exc, stage="dimensions_fetch") from exc
-        dimensions_list = []
-        if dimensions_df is not None and not dimensions_df.empty:
-            dimensions_list = dimensions_df.to_dict("records")
+        dimensions_outcome = classify_component_payload(raw_dimensions)
+        legacy_dimensions_like_frame = (
+            dimensions_outcome.status == "failed"
+            and dimensions_outcome.reason == "unsupported_payload_type"
+            and hasattr(raw_dimensions, "empty")
+            and hasattr(raw_dimensions, "to_dict")
+        )
+        if dimensions_outcome.status == "failed" and not legacy_dimensions_like_frame:
+            raise _annotate_snapshot_failure(
+                ValueError(
+                    f"Dimensions fetch returned error payload "
+                    f"({dimensions_outcome.reason}): {dimensions_outcome.error_message}"
+                ),
+                stage="dimensions_fetch",
+            )
+        if legacy_dimensions_like_frame:
+            dimensions_list = raw_dimensions.to_dict("records") if not raw_dimensions.empty else []
+        else:
+            dimensions_list = dimensions_outcome.frame.to_dict("records") if not dimensions_outcome.frame.empty else []
         self.logger.info(f"  Fetched {len(dimensions_list)} dimensions")
 
         snapshot = DataViewSnapshot(

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -2687,10 +2687,9 @@ def process_inventory_summary(
         print(ConsoleColors.error("ERROR: Failed to initialize CJA connection"), file=sys.stderr)
         return {"error": "CJA initialization failed"}
 
-    # Get data view info
+    # Get data view info - classify the response shape before consuming.
     try:
-        lookup_data = cja.getDataView(data_view_id)
-        dv_name = lookup_data.get("name", data_view_id) if isinstance(lookup_data, dict) else data_view_id
+        raw_lookup = cja.getDataView(data_view_id)
     except RECOVERABLE_CONFIG_API_EXCEPTIONS as e:
         print(ConsoleColors.error(f"ERROR: Failed to fetch data view: {e}"), file=sys.stderr)
         _print_api_hint(e, context="data_view_lookup")
@@ -2708,6 +2707,29 @@ def process_inventory_summary(
         logger.debug("Unexpected error fetching data view", exc_info=True)
         return {"error": str(e)}
 
+    lookup_assessment = _assess_dataview_lookup_payload(raw_lookup, expected_data_view_id=data_view_id)
+    tolerated_legacy_lookup = (
+        isinstance(raw_lookup, dict)
+        and lookup_assessment.kind is _PayloadKind.ERROR
+        and lookup_assessment.reason in {"missing_expected_id", "missing_identity", "insufficient_metadata"}
+    )
+    tolerated_legacy_non_mapping = raw_lookup is not None and not isinstance(raw_lookup, dict)
+    if not lookup_assessment.is_valid and not tolerated_legacy_lookup and not tolerated_legacy_non_mapping:
+        detail = ""
+        if isinstance(raw_lookup, dict):
+            detail = str(raw_lookup.get("message") or raw_lookup.get("error") or raw_lookup.get("statusCode") or "")
+        error_message = (
+            f"Data view lookup returned {lookup_assessment.kind.value} payload "
+            f"({lookup_assessment.reason}): {detail}".rstrip(": ")
+        )
+        lookup_error = RuntimeError(error_message)
+        print(ConsoleColors.error(f"ERROR: {error_message}"), file=sys.stderr)
+        _print_api_hint(lookup_error, context="data_view_lookup")
+        return {"error": error_message}
+
+    lookup_data = lookup_assessment.payload or (raw_lookup if isinstance(raw_lookup, dict) else {})
+    dv_name = lookup_data.get("name", data_view_id)
+
     if not quiet:
         print(ConsoleColors.info(f"Fetching inventory data for: {dv_name}"))
 
@@ -2719,19 +2741,26 @@ def process_inventory_summary(
     if include_derived:
 
         def _build_derived_inventory_summary() -> Any:
+            from cja_auto_sdr.api.fetch import classify_component_payload
             from cja_auto_sdr.inventory.derived_fields import DerivedFieldInventoryBuilder
 
-            # Need full metrics/dimensions (inclType + full) for derived field detection
-            metrics_data = cja.getMetrics(data_view_id, inclType=True, full=True)
-            dimensions_data = cja.getDimensions(data_view_id, inclType=True, full=True)
+            raw_metrics = cja.getMetrics(data_view_id, inclType=True, full=True)
+            metrics_outcome = classify_component_payload(raw_metrics)
+            if metrics_outcome.status == "failed":
+                raise RuntimeError(
+                    f"metrics fetch returned error payload ({metrics_outcome.reason}): {metrics_outcome.error_message}"
+                )
 
-            metrics_df = metrics_data if isinstance(metrics_data, pd.DataFrame) else pd.DataFrame(metrics_data or [])
-            dimensions_df = (
-                dimensions_data if isinstance(dimensions_data, pd.DataFrame) else pd.DataFrame(dimensions_data or [])
-            )
+            raw_dimensions = cja.getDimensions(data_view_id, inclType=True, full=True)
+            dimensions_outcome = classify_component_payload(raw_dimensions)
+            if dimensions_outcome.status == "failed":
+                raise RuntimeError(
+                    f"dimensions fetch returned error payload "
+                    f"({dimensions_outcome.reason}): {dimensions_outcome.error_message}"
+                )
 
             builder = DerivedFieldInventoryBuilder(logger=logger)
-            derived = builder.build(metrics_df, dimensions_df, data_view_id, dv_name)
+            derived = builder.build(metrics_outcome.frame, dimensions_outcome.frame, data_view_id, dv_name)
             if not quiet:
                 print(ConsoleColors.dim(f"  Derived fields: {derived.total_derived_fields}"))
             return derived

--- a/src/cja_auto_sdr/org/analyzer.py
+++ b/src/cja_auto_sdr/org/analyzer.py
@@ -32,6 +32,7 @@ from cja_auto_sdr.core.constants import (
     GOVERNANCE_MAX_OVERLAP_THRESHOLD,
     effective_governance_overlap_threshold,
 )
+from cja_auto_sdr.core.discovery_payloads import assess_dataview_lookup_payload
 from cja_auto_sdr.core.exceptions import LockOwnershipLostError
 from cja_auto_sdr.inventory.utils import extract_owner
 from cja_auto_sdr.org.models import (
@@ -934,22 +935,33 @@ class OrgComponentAnalyzer:
 
             if self.config.include_metadata:
                 try:
-                    # Try to get detailed data view info
-                    dv_details = cja.getDataView(dv_id)
-                    if dv_details is not None and isinstance(dv_details, dict):
-                        # Extract owner using utility function
-                        owner, owner_id = extract_owner(dv_details.get("owner"))
+                    raw_dv_details = cja.getDataView(dv_id)
+                except Exception as e:  # Intentional: metadata enrichment is optional and best-effort only.
+                    self.logger.warning("Metadata fetch raised for %s: %s", dv_id, e)
+                    raw_dv_details = None
 
-                        # Extract dates
+                if raw_dv_details is not None:
+                    metadata_assessment = assess_dataview_lookup_payload(raw_dv_details, expected_data_view_id=dv_id)
+                    tolerated_legacy_metadata = (
+                        isinstance(raw_dv_details, dict)
+                        and metadata_assessment.kind.value == "error"
+                        and metadata_assessment.reason
+                        in {"missing_expected_id", "missing_identity", "insufficient_metadata"}
+                    )
+                    if metadata_assessment.is_valid or tolerated_legacy_metadata:
+                        dv_details = metadata_assessment.payload or raw_dv_details
+                        owner, owner_id = extract_owner(dv_details.get("owner"))
                         created = dv_details.get("created") or dv_details.get("createdDate")
                         modified = dv_details.get("modified") or dv_details.get("modifiedDate")
-
-                        # Extract description
                         description = dv_details.get("description", "")
                         has_description = bool(description and description.strip())
-                except Exception as e:  # Intentional: metadata enrichment is optional and best-effort only.
-                    # Metadata fetch may fail - continue without it
-                    self.logger.debug("Metadata fetch failed for %s: %s", dv_id, e)
+                    else:
+                        self.logger.warning(
+                            "Metadata fetch returned %s payload for %s (%s)",
+                            metadata_assessment.kind.value,
+                            dv_id,
+                            metadata_assessment.reason,
+                        )
 
             return DataViewSummary(
                 data_view_id=dv_id,

--- a/tests/README.md
+++ b/tests/README.md
@@ -17,9 +17,11 @@ tests/
 ├── test_circuit_breaker.py          # Circuit breaker pattern tests
 ├── test_cja_initialization.py       # CJA initialization and validation tests
 ├── test_cjapy_retry_interaction.py  # cjapy retry/status-payload normalization contract tests
+├── test_classify_component_payload.py  # Shared component payload classification tests
 ├── test_cli.py                      # Command-line interface tests
 ├── test_data_quality.py             # Data quality validation tests
 ├── test_derived_inventory.py        # Derived fields inventory tests
+├── test_diff_snapshot_cjapy_payloads.py # Diff snapshot cjapy payload classification tests
 ├── test_diff_comparison.py          # Data view diff comparison tests
 ├── test_discovery_formatters.py     # Discovery formatters and WorkerArgs tests
 ├── test_discovery_normalization.py  # Discovery normalization helpers tests
@@ -37,6 +39,7 @@ tests/
 ├── test_explain_exit_code.py        # Exit-code explainer, fast-path dispatch, and run-summary tests
 ├── test_git_integration.py          # Git integration and snapshot tests
 ├── test_inventory_pragma_coverage.py # Inventory pragma coverage hardening tests
+├── test_inventory_summary_cjapy_payloads.py # Inventory summary cjapy payload classification tests
 ├── test_inventory_utils.py          # Inventory utilities tests
 ├── test_logging_optimization.py     # Logging optimization tests
 ├── test_name_resolution.py          # Data view name resolution tests
@@ -124,6 +127,7 @@ tests/
 ├── test_discovery_exceptions.py     # Discovery exception classification contracts
 ├── test_lock_backend_edge_cases.py  # Lock backend metadata I/O, stale detection, legacy parsing
 ├── test_org_analyzer_coverage.py    # Org analyzer governance, naming audit, sampling, memory, drift, clustering
+├── test_org_analyzer_metadata_enrichment.py # Org analyzer metadata enrichment payload tests
 ├── test_orchestrator.py             # Automation orchestrator wrapper tests
 ├── test_pipeline_single.py          # Modular single-dataview pipeline wrapper tests
 ├── test_processing_execution_policy.py # Processing execution-policy derivation tests
@@ -143,7 +147,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 7,861 comprehensive tests**
+**Total: 7,883 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -152,16 +156,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,755 | 125 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,777 | 129 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 7 | 1 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **7,861** | **131** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **7,883** | **135** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,748 | 124 | `-m "unit and not slow"` |
+| `test-unit` | 7,770 | 128 | `-m "unit and not slow"` |
 | `test-integration` | 103 | 6 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -178,7 +182,9 @@ tests/
 | `test_cli.py` | 412 | Command-line interface and argument parsing |
 | `test_profiles.py` | 78 | Multi-organization profile support |
 | `test_derived_inventory.py` | 62 | Derived fields inventory feature |
+| `test_diff_snapshot_cjapy_payloads.py` | 5 | Diff snapshot cjapy payload classification |
 | `test_inventory_pragma_coverage.py` | 18 | Inventory pragma coverage hardening |
+| `test_inventory_summary_cjapy_payloads.py` | 4 | Inventory summary cjapy payload classification |
 | `test_inventory_utils.py` | 56 | Inventory utilities and helpers |
 | `test_segments_inventory.py` | 48 | Segments inventory feature |
 | `test_edge_cases.py` | 39 | Edge cases, configuration dataclasses, custom exceptions |
@@ -187,9 +193,10 @@ tests/
 | `test_output_formats.py` | 37 | CSV, JSON, HTML, Markdown output generation |
 | `test_cja_initialization.py` | 51 | CJA connection and configuration validation |
 | `test_cjapy_retry_interaction.py` | 58 | cjapy retry/status-payload normalization contract |
+| `test_classify_component_payload.py` | 10 | Shared component payload classification helper |
 | `test_utils.py` | 50 | Utility functions and helpers |
 | `test_excel_formatting.py` | 28 | Excel sheet formatting and styling |
-| `test_parallel_api_fetcher.py` | 40 | Parallel API data fetching |
+| `test_parallel_api_fetcher.py` | 41 | Parallel API data fetching |
 | `test_api_tuning.py` | 25 | API worker auto-tuning |
 | `test_error_messages.py` | 23 | Enhanced error messages and guidance |
 | `test_explain_exit_code.py` | 44 | --explain-exit-code shared explainer, parser, fast-path, and run-summary behavior |
@@ -233,6 +240,7 @@ tests/
 | `test_lock_backend_edge_cases.py` | 165 | Lock backend metadata I/O, stale detection, legacy parsing |
 | `test_derived_fields_coverage.py` | 161 | Derived field complexity scoring, logic summary, predicates |
 | `test_org_analyzer_coverage.py` | 162 | Org analyzer governance, naming audit, sampling, memory, drift, clustering |
+| `test_org_analyzer_metadata_enrichment.py` | 2 | Org analyzer metadata enrichment payload handling |
 | `test_api_coverage.py` | 98 | API cache, quality, fetch, resilience exception paths |
 | `test_diff_coverage.py` | 72 | Diff comparator, models, git integration edge cases |
 | `test_generator_coverage.py` | 143 | Generator utility functions — coercion, normalization, diff formatting |
@@ -302,7 +310,7 @@ tests/
 | `test_agent_workflows.py` | 69 | Agent workflow shell script validation tests |
 | `test_manifest_agent_contract.py` | 16 | Manifest vs runtime capability drift tests |
 | `test_tool_manifests.py` | 40 | Tool manifest schema and content tests |
-| **Total** | **7,861** | **Collected via pytest --collect-only** |
+| **Total** | **7,883** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -760,7 +768,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (7,861 tests total)
+- [x] Comprehensive test coverage (7,883 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 78 tests

--- a/tests/test_classify_component_payload.py
+++ b/tests/test_classify_component_payload.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from cja_auto_sdr.api.fetch import ComponentFetchOutcome, classify_component_payload
+
+
+def test_classify_non_empty_dataframe_is_success():
+    frame = pd.DataFrame([{"id": "a"}, {"id": "b"}])
+    outcome = classify_component_payload(frame)
+    assert isinstance(outcome, ComponentFetchOutcome)
+    assert outcome.status == "success"
+    assert outcome.item_count == 2
+    assert len(outcome.frame) == 2
+
+
+def test_classify_empty_dataframe_is_empty():
+    outcome = classify_component_payload(pd.DataFrame())
+    assert outcome.status == "empty"
+    assert outcome.reason == "empty_response"
+    assert outcome.item_count == 0
+    assert outcome.frame.empty
+
+
+def test_classify_list_of_dicts_is_success():
+    outcome = classify_component_payload([{"id": "a"}])
+    assert outcome.status == "success"
+    assert outcome.item_count == 1
+
+
+def test_classify_dict_envelope_is_success():
+    outcome = classify_component_payload({"content": [{"id": "a"}, {"id": "b"}]})
+    assert outcome.status == "success"
+    assert outcome.item_count == 2
+    assert outcome.frame["id"].tolist() == ["a", "b"]
+
+
+def test_classify_empty_sequence_is_empty():
+    outcome = classify_component_payload([])
+    assert outcome.status == "empty"
+    assert outcome.item_count == 0
+
+
+def test_classify_statuscode_error_dict_is_failed():
+    outcome = classify_component_payload({"statusCode": 500, "message": "backend timeout"})
+    assert outcome.status == "failed"
+    assert "500" in outcome.error_message
+    assert "backend timeout" in outcome.error_message
+    assert outcome.item_count is None
+    assert outcome.frame.empty
+
+
+def test_classify_explicit_error_key_is_failed():
+    outcome = classify_component_payload({"error": "auth expired"})
+    assert outcome.status == "failed"
+    assert "auth expired" in outcome.error_message
+
+
+def test_classify_none_is_empty():
+    outcome = classify_component_payload(None)
+    assert outcome.status == "empty"
+    assert outcome.item_count == 0
+
+
+def test_classify_non_mapping_sequence_rows_are_failed():
+    outcome = classify_component_payload([1, 2])
+    assert outcome.status == "failed"
+    assert "non_mapping_sequence_rows" in outcome.reason
+    assert outcome.item_count is None
+    assert outcome.frame.empty
+
+
+def test_classify_unsupported_type_is_failed():
+    outcome = classify_component_payload(42)
+    assert outcome.status == "failed"
+    assert "invalid" in outcome.reason.lower() or "unsupported" in outcome.reason.lower()

--- a/tests/test_diff_snapshot_cjapy_payloads.py
+++ b/tests/test_diff_snapshot_cjapy_payloads.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from cja_auto_sdr.diff.snapshot import SnapshotManager
+
+
+@pytest.fixture
+def mock_cja():
+    cja = MagicMock()
+    cja.getDataView.return_value = {
+        "id": "dv_abc123",
+        "name": "Test Data View",
+        "owner": {"name": "Alice"},
+        "description": "",
+    }
+    cja.getMetrics.return_value = pd.DataFrame([{"id": "metrics/pageviews", "name": "Page Views", "type": "count"}])
+    cja.getDimensions.return_value = pd.DataFrame([{"id": "variables/page", "name": "Page", "type": "string"}])
+    return cja
+
+
+@pytest.fixture
+def snapshot_manager():
+    return SnapshotManager(logger=logging.getLogger("test.diff.snapshot"))
+
+
+def test_create_snapshot_fails_closed_on_error_shape_getdataview_payload(snapshot_manager, mock_cja):
+    mock_cja.getDataView.return_value = {"statusCode": 500, "message": "backend timeout"}
+
+    with pytest.raises(Exception) as excinfo:
+        snapshot_manager.create_snapshot(mock_cja, "dv_abc123")
+
+    assert getattr(excinfo.value, "_cja_snapshot_failure_stage", None) == "data_view_lookup"
+    assert "500" in str(excinfo.value) or "backend timeout" in str(excinfo.value)
+
+
+def test_create_snapshot_fails_closed_on_error_shape_getmetrics_payload(snapshot_manager, mock_cja):
+    mock_cja.getMetrics.return_value = {"statusCode": 503, "message": "backend timeout"}
+
+    with pytest.raises(Exception) as excinfo:
+        snapshot_manager.create_snapshot(mock_cja, "dv_abc123")
+
+    assert getattr(excinfo.value, "_cja_snapshot_failure_stage", None) == "metrics_fetch"
+    assert not (
+        isinstance(excinfo.value, AttributeError)
+        and "empty" in str(excinfo.value)
+        and getattr(excinfo.value, "_cja_snapshot_failure_stage", None) is None
+    )
+
+
+def test_create_snapshot_fails_closed_on_error_shape_getdimensions_payload(snapshot_manager, mock_cja):
+    mock_cja.getDimensions.return_value = {"statusCode": 503, "message": "backend timeout"}
+
+    with pytest.raises(Exception) as excinfo:
+        snapshot_manager.create_snapshot(mock_cja, "dv_abc123")
+
+    assert getattr(excinfo.value, "_cja_snapshot_failure_stage", None) == "dimensions_fetch"
+
+
+def test_create_snapshot_succeeds_on_valid_payloads(snapshot_manager, mock_cja):
+    snapshot = snapshot_manager.create_snapshot(mock_cja, "dv_abc123")
+    assert snapshot.data_view_id == "dv_abc123"
+    assert snapshot.data_view_name == "Test Data View"
+    assert len(snapshot.metrics) == 1
+    assert len(snapshot.dimensions) == 1
+
+
+def test_create_snapshot_does_not_leak_attributeerror_on_dict_metrics(snapshot_manager, mock_cja):
+    mock_cja.getMetrics.return_value = {"statusCode": 503, "message": "backend timeout"}
+
+    with pytest.raises(Exception) as excinfo:
+        snapshot_manager.create_snapshot(mock_cja, "dv_abc123")
+
+    assert getattr(excinfo.value, "_cja_snapshot_failure_stage", None) == "metrics_fetch"
+    assert not isinstance(excinfo.value, AttributeError)

--- a/tests/test_inventory_summary_cjapy_payloads.py
+++ b/tests/test_inventory_summary_cjapy_payloads.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+
+@pytest.fixture
+def mock_cja():
+    cja = MagicMock()
+    cja.getDataView.return_value = {
+        "id": "dv_abc123",
+        "name": "Inventory Data View",
+        "owner": {"name": "Alice"},
+    }
+    cja.getMetrics.return_value = pd.DataFrame([])
+    cja.getDimensions.return_value = pd.DataFrame([])
+    return cja
+
+
+@patch("cja_auto_sdr.generator.initialize_cja")
+@patch("cja_auto_sdr.generator.setup_logging")
+def test_inventory_summary_returns_error_on_error_shape_getdataview(
+    mock_setup_logging,
+    mock_initialize_cja,
+    mock_cja,
+    capsys,
+):
+    from cja_auto_sdr.generator import process_inventory_summary
+
+    mock_setup_logging.return_value = MagicMock()
+    mock_initialize_cja.return_value = mock_cja
+    mock_cja.getDataView.return_value = {"statusCode": 500, "message": "backend timeout"}
+
+    result = process_inventory_summary(data_view_id="dv_abc123", include_derived=True)
+
+    assert "error" in result
+    assert "500" in result["error"] or "backend timeout" in result["error"]
+    stderr = capsys.readouterr().err
+    assert "ERROR" in stderr
+
+
+@patch("cja_auto_sdr.generator.initialize_cja")
+@patch("cja_auto_sdr.generator.setup_logging")
+def test_derived_inventory_step_handles_error_shape_metrics_payload(
+    mock_setup_logging,
+    mock_initialize_cja,
+    mock_cja,
+    caplog,
+):
+    from cja_auto_sdr.generator import process_inventory_summary
+
+    mock_setup_logging.return_value = logging.getLogger("test.inventory_summary")
+    mock_initialize_cja.return_value = mock_cja
+    mock_cja.getMetrics.return_value = {"statusCode": 503, "message": "backend timeout"}
+
+    with caplog.at_level(logging.WARNING, logger="test.inventory_summary"):
+        result = process_inventory_summary(data_view_id="dv_abc123", include_derived=True, quiet=True)
+
+    assert "error" not in result
+    assert "derived_fields" not in result.get("inventories", {})
+    warning_text = "\n".join(record.getMessage() for record in caplog.records)
+    assert "derived fields inventory" in warning_text
+    assert "object_error_shape" in warning_text
+    assert "503" in warning_text
+
+
+@patch("cja_auto_sdr.generator.initialize_cja")
+@patch("cja_auto_sdr.generator.setup_logging")
+def test_inventory_summary_succeeds_on_valid_lookup(mock_setup_logging, mock_initialize_cja, mock_cja):
+    from cja_auto_sdr.generator import process_inventory_summary
+
+    mock_setup_logging.return_value = MagicMock()
+    mock_initialize_cja.return_value = mock_cja
+
+    result = process_inventory_summary(data_view_id="dv_abc123", include_derived=False, quiet=True)
+
+    assert "error" not in result
+    assert result.get("data_view_id") == "dv_abc123"
+
+
+@patch("cja_auto_sdr.generator.initialize_cja")
+@patch("cja_auto_sdr.generator.setup_logging")
+def test_derived_inventory_step_does_not_raise_on_error_dimensions_payload(
+    mock_setup_logging,
+    mock_initialize_cja,
+    mock_cja,
+    caplog,
+):
+    from cja_auto_sdr.generator import process_inventory_summary
+
+    mock_setup_logging.return_value = logging.getLogger("test.inventory_summary")
+    mock_initialize_cja.return_value = mock_cja
+    mock_cja.getDimensions.return_value = {"statusCode": 500, "message": "dims down"}
+
+    with caplog.at_level(logging.WARNING, logger="test.inventory_summary"):
+        result = process_inventory_summary(data_view_id="dv_abc123", include_derived=True, quiet=True)
+
+    assert "error" not in result
+    assert "derived_fields" not in result.get("inventories", {})
+    warning_text = "\n".join(record.getMessage() for record in caplog.records)
+    assert "derived fields inventory" in warning_text
+    assert "object_error_shape" in warning_text
+    assert "500" in warning_text

--- a/tests/test_org_analyzer_metadata_enrichment.py
+++ b/tests/test_org_analyzer_metadata_enrichment.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from cja_auto_sdr.org.analyzer import OrgComponentAnalyzer
+from cja_auto_sdr.org.models import OrgReportConfig
+
+
+@pytest.fixture
+def analyzer_with_metadata_enabled(monkeypatch):
+    cja = MagicMock()
+    cja.getMetrics.return_value = pd.DataFrame([{"id": "metrics/pageviews", "name": "Page Views", "type": "count"}])
+    cja.getDimensions.return_value = pd.DataFrame([{"id": "variables/page", "name": "Page", "type": "string"}])
+    config = OrgReportConfig(include_metadata=True)
+    analyzer = OrgComponentAnalyzer(
+        cja=cja,
+        config=config,
+        logger=logging.getLogger("cja_auto_sdr.org.analyzer"),
+        org_id="test_org@AdobeOrg",
+    )
+    monkeypatch.setattr(analyzer, "_get_thread_client", lambda: cja)
+    return analyzer, cja
+
+
+def test_metadata_enrichment_logs_warning_on_error_shape_getdataview(
+    analyzer_with_metadata_enabled,
+    caplog,
+):
+    analyzer, cja = analyzer_with_metadata_enabled
+    cja.getDataView.return_value = {"statusCode": 500, "message": "backend timeout"}
+
+    dv = {"id": "dv_abc123", "name": "Test DV"}
+    with caplog.at_level(logging.WARNING, logger="cja_auto_sdr.org.analyzer"):
+        summary = analyzer._fetch_data_view_components(dv)
+
+    assert summary.data_view_id == "dv_abc123"
+    assert summary.owner is None
+    assert any("metadata" in record.message.lower() and "dv_abc123" in record.message for record in caplog.records), (
+        f"expected metadata warning for dv_abc123, got: {[r.message for r in caplog.records]}"
+    )
+
+
+def test_metadata_enrichment_populates_fields_on_valid_payload(analyzer_with_metadata_enabled):
+    analyzer, cja = analyzer_with_metadata_enabled
+    cja.getDataView.return_value = {
+        "id": "dv_abc123",
+        "name": "Test DV",
+        "owner": {"name": "Alice", "id": "user_123"},
+        "description": "hello",
+        "created": "2026-04-20T00:00:00Z",
+        "modified": "2026-04-22T00:00:00Z",
+    }
+
+    dv = {"id": "dv_abc123", "name": "Test DV"}
+    summary = analyzer._fetch_data_view_components(dv)
+
+    assert summary.owner == "Alice"
+    assert summary.created == "2026-04-20T00:00:00Z"
+    assert summary.has_description is True

--- a/tests/test_output_content_validation.py
+++ b/tests/test_output_content_validation.py
@@ -38,7 +38,7 @@ def rich_data_dict():
         "Metadata": pd.DataFrame(
             {
                 "Property": ["Generated At", "Data View ID", "Tool Version", "Total Metrics"],
-                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.5.14", 3],
+                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.5.15", 3],
             },
         ),
         "Data Quality": pd.DataFrame(
@@ -104,7 +104,7 @@ def rich_metadata_dict():
         "Generated At": "2025-01-15 10:30:00 PST",
         "Data View ID": "dv_content_test",
         "Data View Name": "Test DataView",
-        "Tool Version": "3.5.14",
+        "Tool Version": "3.5.15",
         "Metrics Count": "3",
         "Dimensions Count": "4",
     }
@@ -224,7 +224,7 @@ class TestJSONContentValidation:
             data = json.load(f)
 
         assert data["metadata"]["Data View ID"] == "dv_content_test"
-        assert data["metadata"]["Tool Version"] == "3.5.14"
+        assert data["metadata"]["Tool Version"] == "3.5.15"
 
     def test_json_metadata_preserves_partial_markers(self, tmp_path, rich_data_dict, rich_metadata_dict):
         logger = logging.getLogger("json_test")

--- a/tests/test_parallel_api_fetcher.py
+++ b/tests/test_parallel_api_fetcher.py
@@ -855,6 +855,43 @@ class TestParallelAPIFetcherLogging:
 class TestCjapyErrorPayloadContract:
     """Component fetches must classify cjapy-style error dicts as failures, not success."""
 
+    def test_normalize_component_payload_delegates_to_classify_helper(
+        self,
+        mock_cja,
+        mock_logger,
+        mock_perf_tracker,
+    ):
+        fetcher = ParallelAPIFetcher(mock_cja, mock_logger, mock_perf_tracker)
+
+        result = fetcher._normalize_component_payload(
+            pd.DataFrame([{"id": "a"}, {"id": "b"}]),
+            endpoint="metrics",
+            label="metrics",
+        )
+        assert len(result) == 2
+        assert fetcher.get_fetch_statuses()["metrics"].status == "success"
+        assert fetcher.get_fetch_statuses()["metrics"].item_count == 2
+
+        result = fetcher._normalize_component_payload(
+            pd.DataFrame(),
+            endpoint="metrics",
+            label="metrics",
+        )
+        assert result.empty
+        empty_status = fetcher.get_fetch_statuses()["metrics"]
+        assert empty_status.status == "empty"
+        assert empty_status.reason == "empty_response"
+
+        result = fetcher._normalize_component_payload(
+            {"statusCode": 500, "message": "backend timeout"},
+            endpoint="dimensions",
+            label="dimensions",
+        )
+        assert result.empty
+        status = fetcher.get_fetch_statuses()["dimensions"]
+        assert status.status == "failed"
+        assert "500" in status.error_message or "backend timeout" in status.error_message
+
     @patch("cja_auto_sdr.api.fetch.make_api_call_with_retry")
     def test_fetch_metrics_rejects_statusCode_error_payload(
         self,

--- a/tests/test_ux_features.py
+++ b/tests/test_ux_features.py
@@ -344,11 +344,11 @@ class TestCombinedFeatures:
 class TestVersionUpdated:
     """Test that version is correct"""
 
-    def test_version_is_3_5_14(self):
-        """Test that version is 3.5.14"""
+    def test_version_is_3_5_15(self):
+        """Test that version is 3.5.15"""
         from cja_auto_sdr.generator import __version__
 
-        assert __version__ == "3.5.14"
+        assert __version__ == "3.5.15"
 
 
 class TestFormatAutoDetection:


### PR DESCRIPTION
## Summary

Ships v3.5.15 operational cjapy payload normalization across the remaining direct caller paths.

- extracts `classify_component_payload` / `ComponentFetchOutcome` into `api/fetch.py` and delegates `ParallelAPIFetcher._normalize_component_payload` through it
- classifies `getDataView`, `getMetrics`, and `getDimensions` payloads in diff snapshot creation and inventory summary paths
- classifies org-report metadata enrichment `getDataView` responses and warns on error-shaped payloads while keeping metadata best-effort
- bumps version/docs/changelog/test-count inventories for v3.5.15

## Test plan

- [x] `uv run pytest tests/test_classify_component_payload.py tests/test_parallel_api_fetcher.py::TestCjapyErrorPayloadContract::test_normalize_component_payload_delegates_to_classify_helper tests/test_diff_snapshot_cjapy_payloads.py tests/test_inventory_summary_cjapy_payloads.py tests/test_org_analyzer_metadata_enrichment.py -q`
- [x] `uv run pytest tests/test_parallel_api_fetcher.py tests/ -k "snapshot or inventory or org_analyzer or org_report" -q`
- [x] `uv run pytest tests/ --collect-only -q` (7,883 collected)
- [x] `uv run pytest -q tests/test_generator_mock_contract.py tests/test_backwards_compat.py tests/test_lazy_forwarding.py`
- [x] `uv run pytest tests/ -x -q` (7,867 passed, 16 skipped)
- [x] `uv run ruff check src/ tests/`
- [x] `uv run ruff format --check src/ tests/`
- [x] `uv run python scripts/check_version_sync.py`
- [x] `uv run python scripts/update_test_counts.py --check`

Spec: `docs/superpowers/specs/2026-04-23-v3.5.15-getdataview-caller-normalization.md`
Plan: `docs/superpowers/plans/2026-04-23-v3.5.15-getdataview-caller-normalization.md`
