### PR TITLE
release: v3.5.17 post-normalization cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ All notable changes to the CJA SDR Generator project will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.17] — 2026-04-24
+
+### Refactored
+
+- **`TOLERATED_LEGACY_LOOKUP_REASONS` hoisted to `core/discovery_payloads.py`.**
+  The three operational callers that tolerate legacy `getDataView` error-shape
+  payloads (`diff/snapshot.py:create_snapshot`, `generator.py:inventory_summary`,
+  `org/analyzer.py:_fetch_data_view_components`) now share one canonical
+  tolerance set instead of three duplicated inline literals.
+- **`PayloadKind` comparison in `org/analyzer.py` normalized to identity.**
+  `metadata_assessment.kind is PayloadKind.ERROR` now matches the spelling
+  already used at `diff/snapshot.py` and `generator.py`. Behavior-equivalent
+  — Enum members are singletons.
+- **Inline `classify_component_payload` imports promoted to module scope** in
+  `diff/snapshot.py` and `generator.py`, now that v3.5.15 has cemented the
+  classify-before-consume contract.
+
+### Fixed
+
+- **Test coverage for `OrgAnalyzer` metadata-enrichment exception branch.**
+  `tests/test_org_analyzer_metadata_enrichment.py` gains a characterization
+  test for the `except Exception` branch that handles `cja.getDataView`
+  raising instead of returning an error-shape dict. Locks in the
+  warning-level log emission so a silent downgrade to `debug` would now be
+  caught by CI.
+
+### Documentation
+
+- Inline comments on two deliberately legacy-tolerant branches
+  (`generator.py` non-mapping `getDataView` pass-through; `diff/snapshot.py`
+  DataFrame duck-typing shim in `create_snapshot`) document the pre-v3.5.14
+  compatibility intent so future readers do not mistake them for dead code.
+
 ## [3.5.16] — 2026-04-24
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Package manager: **uv**
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
-- Current version: v3.5.16
+- Current version: v3.5.17
 - Tests: **7,884** across 131 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
 - Current version: v3.5.17
-- Tests: **7,884** across 131 files at **95% coverage gate**
+- Tests: **7,885** across 131 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)
 

--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (7,884+ tests)
+├── tests/                     # Test suite (7,885+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -924,7 +924,7 @@ cja_auto_sdr --list-dataviews --log-level DEBUG
 At launch, the tool logs diagnostic lines containing the tool version, Python version, platform, active log level, inferred run mode (batch, single, or discovery), and dependency versions. These appear automatically at `INFO` level and are useful for troubleshooting environment issues in CI/CD logs or support requests:
 
 ```text
-CJA SDR Generator v3.5.16 | Python 3.14.2 | darwin | log_level=INFO | mode=single
+CJA SDR Generator v3.5.17 | Python 3.14.2 | darwin | log_level=INFO | mode=single
 Dependencies: cjapy=0.3.0, pandas=2.3.3, numpy=2.2.1, xlsxwriter=3.2.9, tqdm=4.67.0
 ```
 

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -190,7 +190,7 @@ This command:
 
 ```bash
 $ uv run cja_auto_sdr -V
-cja_auto_sdr 3.5.16
+cja_auto_sdr 3.5.17
 ```
 
 > **Important:** All commands in this guide assume you're in the `cja_auto_sdr` directory. If you see "command not found", make sure you're in the right directory and have run `uv sync`.

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Quick Reference Card
 
-Single-page command cheat sheet for CJA SDR Generator v3.5.16.
+Single-page command cheat sheet for CJA SDR Generator v3.5.17.
 
 ## Four Main Modes
 

--- a/src/cja_auto_sdr/core/discovery_payloads.py
+++ b/src/cja_auto_sdr/core/discovery_payloads.py
@@ -411,7 +411,7 @@ def _coerce_lookup_scalar_text(value: Any) -> str | None:
     if isinstance(value, bytes):
         try:
             return value.decode("utf-8", errors="ignore")
-        except AttributeError, TypeError, ValueError:
+        except (AttributeError, TypeError, ValueError):
             return None
     if isinstance(value, (int, float)) and not isinstance(value, bool):
         return str(value)

--- a/src/cja_auto_sdr/core/discovery_payloads.py
+++ b/src/cja_auto_sdr/core/discovery_payloads.py
@@ -48,6 +48,18 @@ DATAVIEW_METADATA_HINT_KEYS = frozenset(
         "modified_date",
     },
 )
+# Legacy getDataView payloads from pre-v3.5.14 cjapy paths can classify as ERROR
+# because they lack the expected identity fields, yet still carry usable metadata.
+# Three operational call sites (diff snapshot, SDR inventory summary, org-report
+# metadata enrichment) tolerate these specific reasons to preserve backward
+# compatibility. Keep this set in one place so the three sites stay in lockstep.
+TOLERATED_LEGACY_LOOKUP_REASONS: frozenset[str] = frozenset(
+    {
+        "missing_expected_id",
+        "missing_identity",
+        "insufficient_metadata",
+    },
+)
 _DIAGNOSTIC_KEY_PREFIXES = ("error", "lookup_", "status")
 _LOOKUP_MISSING_VALUE = object()
 _LOOKUP_CANONICAL_KEY_ALIASES = {

--- a/src/cja_auto_sdr/core/discovery_payloads.py
+++ b/src/cja_auto_sdr/core/discovery_payloads.py
@@ -411,7 +411,7 @@ def _coerce_lookup_scalar_text(value: Any) -> str | None:
     if isinstance(value, bytes):
         try:
             return value.decode("utf-8", errors="ignore")
-        except (AttributeError, TypeError, ValueError):
+        except AttributeError, TypeError, ValueError:
             return None
     if isinstance(value, (int, float)) and not isinstance(value, bool):
         return str(value)

--- a/src/cja_auto_sdr/core/version.py
+++ b/src/cja_auto_sdr/core/version.py
@@ -1,3 +1,3 @@
 """Version information for CJA Auto SDR."""
 
-__version__ = "3.5.16"
+__version__ = "3.5.17"

--- a/src/cja_auto_sdr/diff/snapshot.py
+++ b/src/cja_auto_sdr/diff/snapshot.py
@@ -162,6 +162,7 @@ class SnapshotManager:
             raise _annotate_snapshot_failure(exc, stage="metrics_fetch") from exc
 
         metrics_outcome = classify_component_payload(raw_metrics)
+        # Duck-typing shim for pre-classification cjapy DataFrame returns; unwrap without the classifier.
         legacy_metrics_like_frame = (
             metrics_outcome.status == "failed"
             and metrics_outcome.reason == "unsupported_payload_type"

--- a/src/cja_auto_sdr/diff/snapshot.py
+++ b/src/cja_auto_sdr/diff/snapshot.py
@@ -7,20 +7,17 @@ from datetime import UTC, datetime, timedelta
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from cja_auto_sdr.core.colors import ConsoleColors
-from cja_auto_sdr.core.discovery_payloads import PayloadKind, assess_dataview_lookup_payload
+from cja_auto_sdr.core.discovery_payloads import (
+    PayloadKind,
+    TOLERATED_LEGACY_LOOKUP_REASONS,
+    assess_dataview_lookup_payload,
+)
 from cja_auto_sdr.core.error_policies import RECOVERABLE_OPTIONAL_ENRICHMENT_EXCEPTIONS
 from cja_auto_sdr.core.exceptions import attach_api_connection_hint_context
 from cja_auto_sdr.core.json_io import write_json_atomic
 from cja_auto_sdr.diff.models import DataViewSnapshot
 
 _SNAPSHOT_FAILURE_STAGE_ATTR = "_cja_snapshot_failure_stage"
-_TOLERATED_LEGACY_LOOKUP_REASONS = frozenset(
-    {
-        "missing_expected_id",
-        "missing_identity",
-        "insufficient_metadata",
-    }
-)
 
 
 def _annotate_snapshot_failure(exc: Exception, *, stage: str, api_hint_context: str | None = None) -> Exception:
@@ -132,7 +129,7 @@ class SnapshotManager:
         legacy_acceptable_dict = (
             isinstance(raw_dv_info, dict)
             and lookup_assessment.kind is PayloadKind.ERROR
-            and lookup_assessment.reason in _TOLERATED_LEGACY_LOOKUP_REASONS
+            and lookup_assessment.reason in TOLERATED_LEGACY_LOOKUP_REASONS
         )
         if not lookup_assessment.is_valid and not legacy_acceptable_dict:
             detail = ""

--- a/src/cja_auto_sdr/diff/snapshot.py
+++ b/src/cja_auto_sdr/diff/snapshot.py
@@ -9,8 +9,8 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from cja_auto_sdr.api.fetch import classify_component_payload
 from cja_auto_sdr.core.colors import ConsoleColors
 from cja_auto_sdr.core.discovery_payloads import (
-    PayloadKind,
     TOLERATED_LEGACY_LOOKUP_REASONS,
+    PayloadKind,
     assess_dataview_lookup_payload,
 )
 from cja_auto_sdr.core.error_policies import RECOVERABLE_OPTIONAL_ENRICHMENT_EXCEPTIONS

--- a/src/cja_auto_sdr/diff/snapshot.py
+++ b/src/cja_auto_sdr/diff/snapshot.py
@@ -6,6 +6,7 @@ import os
 from datetime import UTC, datetime, timedelta
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
+from cja_auto_sdr.api.fetch import classify_component_payload
 from cja_auto_sdr.core.colors import ConsoleColors
 from cja_auto_sdr.core.discovery_payloads import (
     PayloadKind,
@@ -159,7 +160,6 @@ class SnapshotManager:
             raw_metrics = cja.getMetrics(data_view_id, inclType=True, full=True)
         except Exception as exc:
             raise _annotate_snapshot_failure(exc, stage="metrics_fetch") from exc
-        from cja_auto_sdr.api.fetch import classify_component_payload
 
         metrics_outcome = classify_component_payload(raw_metrics)
         legacy_metrics_like_frame = (

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -2717,6 +2717,7 @@ def process_inventory_summary(
         and lookup_assessment.kind is _PayloadKind.ERROR
         and lookup_assessment.reason in _TOLERATED_LEGACY_LOOKUP_REASONS
     )
+    # Preserves pre-v3.5.14 tolerance of non-dict getDataView returns from legacy cjapy paths.
     tolerated_legacy_non_mapping = raw_lookup is not None and not isinstance(raw_lookup, dict)
     if not lookup_assessment.is_valid and not tolerated_legacy_lookup and not tolerated_legacy_non_mapping:
         detail = ""

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -149,6 +149,9 @@ from cja_auto_sdr.core.discovery_payloads import (
     PayloadKind as _PayloadKind,
 )
 from cja_auto_sdr.core.discovery_payloads import (
+    TOLERATED_LEGACY_LOOKUP_REASONS as _TOLERATED_LEGACY_LOOKUP_REASONS,
+)
+from cja_auto_sdr.core.discovery_payloads import (
     assess_component_payload as _assess_component_payload,
 )
 from cja_auto_sdr.core.discovery_payloads import (
@@ -2711,7 +2714,7 @@ def process_inventory_summary(
     tolerated_legacy_lookup = (
         isinstance(raw_lookup, dict)
         and lookup_assessment.kind is _PayloadKind.ERROR
-        and lookup_assessment.reason in {"missing_expected_id", "missing_identity", "insufficient_metadata"}
+        and lookup_assessment.reason in _TOLERATED_LEGACY_LOOKUP_REASONS
     )
     tolerated_legacy_non_mapping = raw_lookup is not None and not isinstance(raw_lookup, dict)
     if not lookup_assessment.is_valid and not tolerated_legacy_lookup and not tolerated_legacy_non_mapping:

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -32,6 +32,7 @@ import cjapy
 import pandas as pd
 from tqdm import tqdm
 
+from cja_auto_sdr.api.fetch import classify_component_payload as _classify_component_payload
 from cja_auto_sdr.api.quality_policy import (
     QUALITY_POLICY_ALLOWED_KEYS,
     QUALITY_REPORT_PREFERRED_COLUMNS,
@@ -2744,18 +2745,17 @@ def process_inventory_summary(
     if include_derived:
 
         def _build_derived_inventory_summary() -> Any:
-            from cja_auto_sdr.api.fetch import classify_component_payload
             from cja_auto_sdr.inventory.derived_fields import DerivedFieldInventoryBuilder
 
             raw_metrics = cja.getMetrics(data_view_id, inclType=True, full=True)
-            metrics_outcome = classify_component_payload(raw_metrics)
+            metrics_outcome = _classify_component_payload(raw_metrics)
             if metrics_outcome.status == "failed":
                 raise RuntimeError(
                     f"metrics fetch returned error payload ({metrics_outcome.reason}): {metrics_outcome.error_message}"
                 )
 
             raw_dimensions = cja.getDimensions(data_view_id, inclType=True, full=True)
-            dimensions_outcome = classify_component_payload(raw_dimensions)
+            dimensions_outcome = _classify_component_payload(raw_dimensions)
             if dimensions_outcome.status == "failed":
                 raise RuntimeError(
                     f"dimensions fetch returned error payload "

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -147,10 +147,10 @@ from cja_auto_sdr.core.discovery_normalization import (
     pick_first_present_text as _pick_first_present_text,
 )
 from cja_auto_sdr.core.discovery_payloads import (
-    PayloadKind as _PayloadKind,
+    TOLERATED_LEGACY_LOOKUP_REASONS as _TOLERATED_LEGACY_LOOKUP_REASONS,
 )
 from cja_auto_sdr.core.discovery_payloads import (
-    TOLERATED_LEGACY_LOOKUP_REASONS as _TOLERATED_LEGACY_LOOKUP_REASONS,
+    PayloadKind as _PayloadKind,
 )
 from cja_auto_sdr.core.discovery_payloads import (
     assess_component_payload as _assess_component_payload,

--- a/src/cja_auto_sdr/org/analyzer.py
+++ b/src/cja_auto_sdr/org/analyzer.py
@@ -32,7 +32,11 @@ from cja_auto_sdr.core.constants import (
     GOVERNANCE_MAX_OVERLAP_THRESHOLD,
     effective_governance_overlap_threshold,
 )
-from cja_auto_sdr.core.discovery_payloads import assess_dataview_lookup_payload
+from cja_auto_sdr.core.discovery_payloads import (
+    PayloadKind,
+    TOLERATED_LEGACY_LOOKUP_REASONS,
+    assess_dataview_lookup_payload,
+)
 from cja_auto_sdr.core.exceptions import LockOwnershipLostError
 from cja_auto_sdr.inventory.utils import extract_owner
 from cja_auto_sdr.org.models import (
@@ -945,8 +949,7 @@ class OrgComponentAnalyzer:
                     tolerated_legacy_metadata = (
                         isinstance(raw_dv_details, dict)
                         and metadata_assessment.kind.value == "error"
-                        and metadata_assessment.reason
-                        in {"missing_expected_id", "missing_identity", "insufficient_metadata"}
+                        and metadata_assessment.reason in TOLERATED_LEGACY_LOOKUP_REASONS
                     )
                     if metadata_assessment.is_valid or tolerated_legacy_metadata:
                         dv_details = metadata_assessment.payload or raw_dv_details

--- a/src/cja_auto_sdr/org/analyzer.py
+++ b/src/cja_auto_sdr/org/analyzer.py
@@ -33,8 +33,8 @@ from cja_auto_sdr.core.constants import (
     effective_governance_overlap_threshold,
 )
 from cja_auto_sdr.core.discovery_payloads import (
-    PayloadKind,
     TOLERATED_LEGACY_LOOKUP_REASONS,
+    PayloadKind,
     assess_dataview_lookup_payload,
 )
 from cja_auto_sdr.core.exceptions import LockOwnershipLostError

--- a/src/cja_auto_sdr/org/analyzer.py
+++ b/src/cja_auto_sdr/org/analyzer.py
@@ -948,7 +948,7 @@ class OrgComponentAnalyzer:
                     metadata_assessment = assess_dataview_lookup_payload(raw_dv_details, expected_data_view_id=dv_id)
                     tolerated_legacy_metadata = (
                         isinstance(raw_dv_details, dict)
-                        and metadata_assessment.kind.value == "error"
+                        and metadata_assessment.kind is PayloadKind.ERROR
                         and metadata_assessment.reason in TOLERATED_LEGACY_LOOKUP_REASONS
                     )
                     if metadata_assessment.is_valid or tolerated_legacy_metadata:

--- a/tests/README.md
+++ b/tests/README.md
@@ -147,7 +147,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 7,884 comprehensive tests**
+**Total: 7,885 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -156,16 +156,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,778 | 129 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,779 | 129 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 0 | 0 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **7,884** | **135** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **7,885** | **135** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,778 | 129 | `-m "unit and not slow"` |
+| `test-unit` | 7,779 | 129 | `-m "unit and not slow"` |
 | `test-integration` | 96 | 5 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -240,7 +240,7 @@ tests/
 | `test_lock_backend_edge_cases.py` | 165 | Lock backend metadata I/O, stale detection, legacy parsing |
 | `test_derived_fields_coverage.py` | 161 | Derived field complexity scoring, logic summary, predicates |
 | `test_org_analyzer_coverage.py` | 162 | Org analyzer governance, naming audit, sampling, memory, drift, clustering |
-| `test_org_analyzer_metadata_enrichment.py` | 2 | Org analyzer metadata enrichment payload handling |
+| `test_org_analyzer_metadata_enrichment.py` | 3 | Org analyzer metadata enrichment payload handling |
 | `test_api_coverage.py` | 98 | API cache, quality, fetch, resilience exception paths |
 | `test_diff_coverage.py` | 72 | Diff comparator, models, git integration edge cases |
 | `test_generator_coverage.py` | 143 | Generator utility functions — coercion, normalization, diff formatting |
@@ -310,7 +310,7 @@ tests/
 | `test_agent_workflows.py` | 69 | Agent workflow shell script validation tests |
 | `test_manifest_agent_contract.py` | 16 | Manifest vs runtime capability drift tests |
 | `test_tool_manifests.py` | 40 | Tool manifest schema and content tests |
-| **Total** | **7,884** | **Collected via pytest --collect-only** |
+| **Total** | **7,885** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -768,7 +768,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (7,884 tests total)
+- [x] Comprehensive test coverage (7,885 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 78 tests

--- a/tests/test_org_analyzer_metadata_enrichment.py
+++ b/tests/test_org_analyzer_metadata_enrichment.py
@@ -61,3 +61,29 @@ def test_metadata_enrichment_populates_fields_on_valid_payload(analyzer_with_met
     assert summary.owner == "Alice"
     assert summary.created == "2026-04-20T00:00:00Z"
     assert summary.has_description is True
+
+
+def test_metadata_enrichment_logs_warning_on_getdataview_exception(
+    analyzer_with_metadata_enabled,
+    caplog,
+):
+    analyzer, cja = analyzer_with_metadata_enabled
+    cja.getDataView.side_effect = RuntimeError("backend timeout")
+
+    dv = {"id": "dv_abc123", "name": "Test DV"}
+    with caplog.at_level(logging.WARNING, logger="cja_auto_sdr.org.analyzer"):
+        summary = analyzer._fetch_data_view_components(dv)
+
+    assert summary.data_view_id == "dv_abc123"
+    assert summary.owner is None
+    assert summary.owner_id is None
+    assert summary.created is None
+    assert summary.modified is None
+    assert summary.description is None
+    assert summary.has_description is False
+    assert any(
+        "metadata fetch raised" in record.message.lower()
+        and "dv_abc123" in record.message
+        and "backend timeout" in record.message
+        for record in caplog.records
+    ), f"expected raised-exception warning for dv_abc123, got: {[r.message for r in caplog.records]}"

--- a/tests/test_output_content_validation.py
+++ b/tests/test_output_content_validation.py
@@ -38,7 +38,7 @@ def rich_data_dict():
         "Metadata": pd.DataFrame(
             {
                 "Property": ["Generated At", "Data View ID", "Tool Version", "Total Metrics"],
-                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.5.16", 3],
+                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.5.17", 3],
             },
         ),
         "Data Quality": pd.DataFrame(
@@ -104,7 +104,7 @@ def rich_metadata_dict():
         "Generated At": "2025-01-15 10:30:00 PST",
         "Data View ID": "dv_content_test",
         "Data View Name": "Test DataView",
-        "Tool Version": "3.5.16",
+        "Tool Version": "3.5.17",
         "Metrics Count": "3",
         "Dimensions Count": "4",
     }
@@ -224,7 +224,7 @@ class TestJSONContentValidation:
             data = json.load(f)
 
         assert data["metadata"]["Data View ID"] == "dv_content_test"
-        assert data["metadata"]["Tool Version"] == "3.5.16"
+        assert data["metadata"]["Tool Version"] == "3.5.17"
 
     def test_json_metadata_preserves_partial_markers(self, tmp_path, rich_data_dict, rich_metadata_dict):
         logger = logging.getLogger("json_test")

--- a/tests/test_ux_features.py
+++ b/tests/test_ux_features.py
@@ -344,11 +344,11 @@ class TestCombinedFeatures:
 class TestVersionUpdated:
     """Test that version is correct"""
 
-    def test_version_is_3_5_16(self):
-        """Test that version is 3.5.16"""
+    def test_version_is_3_5_17(self):
+        """Test that version is 3.5.17"""
         from cja_auto_sdr.generator import __version__
 
-        assert __version__ == "3.5.16"
+        assert __version__ == "3.5.17"
 
 
 class TestFormatAutoDetection:


### PR DESCRIPTION
## Summary

Patch release that lands the six non-blocking follow-ups surfaced during PR #70's review of the v3.5.15 operational payload normalization.

**Refactor (no behavior change):**
- Hoist `TOLERATED_LEGACY_LOOKUP_REASONS` to `core/discovery_payloads.py` so `diff/snapshot.py`, `generator.py`, and `org/analyzer.py` share one canonical tolerance set instead of three inline duplicates.
- Normalize `org/analyzer.py` `PayloadKind` comparison from `.value == "error"` to `is PayloadKind.ERROR` — matches spelling at the other two sites (Enum singletons are behavior-equivalent).
- Promote the two inline `classify_component_payload` imports out of method bodies (`diff/snapshot.py:create_snapshot` and `generator.py:_build_derived_inventory_summary`) now that v3.5.15 has cemented the classify-before-consume contract.

**Test gap closed:**
- `tests/test_org_analyzer_metadata_enrichment.py` gains `test_metadata_enrichment_logs_warning_on_getdataview_exception`, mirroring the existing error-shape-payload test with a raised-exception case so the warning-level log at `analyzer.py:940` is locked in by CI.

**Docs:**
- One-line intent comments on two deliberately legacy-tolerant branches (`generator.py:2716` non-mapping pass-through; `diff/snapshot.py:165` DataFrame duck-typing shim) to prevent future readers from mistaking them for dead code.

Version bumped to `3.5.17` across the 8 canonical files validated by `scripts/check_version_sync.py`. Test count: 7,884 → 7,885.

Spec: [`docs/superpowers/specs/2026-04-24-v3.5.17-post-normalization-cleanup.md`](docs/superpowers/specs/2026-04-24-v3.5.17-post-normalization-cleanup.md)
Plan: [`docs/superpowers/plans/2026-04-24-v3.5.17-post-normalization-cleanup.md`](docs/superpowers/plans/2026-04-24-v3.5.17-post-normalization-cleanup.md)

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — 250 files already formatted
- [x] `uv run python scripts/check_version_sync.py` — all 8 canonical refs at 3.5.17
- [x] `uv run python scripts/update_test_counts.py --check` — counts up to date
- [x] `uv run pytest -q tests/test_generator_mock_contract.py tests/test_backwards_compat.py tests/test_lazy_forwarding.py` — 109 passed
- [x] `uv run pytest tests/ -x -q` — 7,869 passed, 16 skipped (~63s)
- [x] New exception-branch test verified load-bearing (fails if `analyzer.py:940` warning is downgraded to `debug`)
- [x] Final greps: only canonical definition of tolerated-reasons set; no `.value == "error"` in analyzer; exactly 2 module-scope `classify_component_payload` imports