### PR TITLE
v3.5.18: Tier 1 safe optimizations (encoding, falsy, keys-cache)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ All notable changes to the CJA SDR Generator project will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.18] — 2026-04-25
+
+### Fixed
+
+- **Three text-mode `open()` calls in `core/` now specify `encoding="utf-8"`.**
+  `core/config_validation.py:266` (config JSON load),
+  `core/credentials.py:160` (`JsonFileCredentialLoader._load_impl`), and
+  `core/credentials.py:183` (`DotenvCredentialLoader._load_impl`) previously
+  relied on platform default encoding. On non-UTF-8 locales (e.g. Windows
+  cp1252) this risked mis-decoding credential files containing non-ASCII
+  characters. Aligns with every other text-mode `open()` in `src/`, which
+  already specified `encoding="utf-8"`.
+
+### Refactored
+
+- **`len(x) == 0` collapsed to falsy form** on eight sites where `x` is
+  statically known to be a plain `list` or `dict` (verified by `isinstance`
+  guards, helper-function return types, or local `[]` initializers):
+  `core/config_validation.py:208`, `core/discovery_payloads.py:184`,
+  `org/analyzer.py:368`, `org/analyzer.py:601`, `cli/interactive.py:134`,
+  `cli/interactive.py:338`, `cli/commands/discovery.py:929`,
+  `inventory/calculated_metrics.py:491`. Zero behavior change on the typed
+  inputs. Pandas `Series`/`Index` sites left as-is since `not series` raises
+  "The truth value of an Index is ambiguous".
+
+### Performance
+
+- **Hoisted `list(name_to_id_lookup.keys())` out of the fuzzy-match loop
+  in `cli/commands/stats.py:resolve_data_view_names`.** The miss-path
+  branches built the same key list twice per iteration. For N identifiers
+  against M data views, drops O(N·M) list copies to O(M).
+
 ## [3.5.17] — 2026-04-24
 
 ### Refactored

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Package manager: **uv**
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
-- Current version: v3.5.17
+- Current version: v3.5.18
 - Tests: **7,885** across 131 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -924,7 +924,7 @@ cja_auto_sdr --list-dataviews --log-level DEBUG
 At launch, the tool logs diagnostic lines containing the tool version, Python version, platform, active log level, inferred run mode (batch, single, or discovery), and dependency versions. These appear automatically at `INFO` level and are useful for troubleshooting environment issues in CI/CD logs or support requests:
 
 ```text
-CJA SDR Generator v3.5.17 | Python 3.14.2 | darwin | log_level=INFO | mode=single
+CJA SDR Generator v3.5.18 | Python 3.14.2 | darwin | log_level=INFO | mode=single
 Dependencies: cjapy=0.3.0, pandas=2.3.3, numpy=2.2.1, xlsxwriter=3.2.9, tqdm=4.67.0
 ```
 

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -190,7 +190,7 @@ This command:
 
 ```bash
 $ uv run cja_auto_sdr -V
-cja_auto_sdr 3.5.17
+cja_auto_sdr 3.5.18
 ```
 
 > **Important:** All commands in this guide assume you're in the `cja_auto_sdr` directory. If you see "command not found", make sure you're in the right directory and have run `uv sync`.

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Quick Reference Card
 
-Single-page command cheat sheet for CJA SDR Generator v3.5.17.
+Single-page command cheat sheet for CJA SDR Generator v3.5.18.
 
 ## Four Main Modes
 

--- a/src/cja_auto_sdr/cli/commands/discovery.py
+++ b/src/cja_auto_sdr/cli/commands/discovery.py
@@ -926,7 +926,7 @@ def _fetch_dataviews(
             )
         )
 
-        if len(normalized_dvs) == 0:
+        if not normalized_dvs:
             if is_machine_readable:
                 if output_format == "json":
                     return json.dumps({"dataViews": [], "count": 0}, indent=2)

--- a/src/cja_auto_sdr/cli/commands/stats.py
+++ b/src/cja_auto_sdr/cli/commands/stats.py
@@ -169,9 +169,7 @@ def resolve_data_view_names(
             elif match_mode == "fuzzy":
                 matching_ids = name_to_id_lookup.get(identifier) or name_to_id_lookup_ci.get(identifier.lower())
                 if matching_ids is None:
-                    similar = generator.find_similar_names(
-                        identifier, name_lookup_keys, max_suggestions=1
-                    )
+                    similar = generator.find_similar_names(identifier, name_lookup_keys, max_suggestions=1)
                     if similar:
                         best_name, best_distance = similar[0]
                         matching_ids = name_to_id_lookup.get(best_name)

--- a/src/cja_auto_sdr/cli/commands/stats.py
+++ b/src/cja_auto_sdr/cli/commands/stats.py
@@ -150,6 +150,7 @@ def resolve_data_view_names(
             len(id_to_name_lookup),
         )
 
+        name_lookup_keys = list(name_to_id_lookup.keys())
         for identifier in identifiers:
             if generator.is_data_view_id(identifier):
                 if identifier in id_to_name_lookup:
@@ -169,7 +170,7 @@ def resolve_data_view_names(
                 matching_ids = name_to_id_lookup.get(identifier) or name_to_id_lookup_ci.get(identifier.lower())
                 if matching_ids is None:
                     similar = generator.find_similar_names(
-                        identifier, list(name_to_id_lookup.keys()), max_suggestions=1
+                        identifier, name_lookup_keys, max_suggestions=1
                     )
                     if similar:
                         best_name, best_distance = similar[0]
@@ -194,7 +195,7 @@ def resolve_data_view_names(
             unresolved_names.append(identifier)
 
             if suggest_similar:
-                similar = generator.find_similar_names(identifier, list(name_to_id_lookup.keys()))
+                similar = generator.find_similar_names(identifier, name_lookup_keys)
                 if similar:
                     case_match = [s for s in similar if s[1] == 0]
                     if case_match:

--- a/src/cja_auto_sdr/cli/interactive.py
+++ b/src/cja_auto_sdr/cli/interactive.py
@@ -131,7 +131,7 @@ def interactive_select_dataviews(config_file: str = "config.json", profile: str 
             )
         )
 
-        if len(normalized_dvs) == 0:
+        if not normalized_dvs:
             print()
             print(ConsoleColors.warning("No data views found or no access to any data views."))
             return []
@@ -335,7 +335,7 @@ def interactive_wizard(config_file: str = "config.json", profile: str | None = N
             )
         )
 
-        if len(normalized_dvs) == 0:
+        if not normalized_dvs:
             print()
             print(ConsoleColors.warning("No data views found or no access to any data views."))
             return None

--- a/src/cja_auto_sdr/core/config_validation.py
+++ b/src/cja_auto_sdr/core/config_validation.py
@@ -263,7 +263,7 @@ def validate_config_file(config_file: str | Path, logger: logging.Logger) -> boo
 
         # Validate JSON structure
         try:
-            with open(config_path) as f:
+            with open(config_path, encoding="utf-8") as f:
                 config_data = json.load(f)
         except json.JSONDecodeError as e:
             error_msg = ErrorMessageHelper.get_config_error_message(

--- a/src/cja_auto_sdr/core/config_validation.py
+++ b/src/cja_auto_sdr/core/config_validation.py
@@ -205,7 +205,7 @@ def validate_credentials(
         logger.debug("Ignoring unknown fields from %s: %s", source, ", ".join(unknown_fields))
 
     is_valid = (
-        len(issues) == 0
+        not issues
         if strict
         else all("Missing required field" not in issue and "Empty value" not in issue for issue in issues)
     )

--- a/src/cja_auto_sdr/core/credentials.py
+++ b/src/cja_auto_sdr/core/credentials.py
@@ -157,7 +157,7 @@ class JsonFileCredentialLoader(CredentialLoader):
         if not self.file_path.exists():
             return None
 
-        with open(self.file_path) as f:
+        with open(self.file_path, encoding="utf-8") as f:
             config = json.load(f)
 
         if isinstance(config, dict):
@@ -180,7 +180,7 @@ class DotenvCredentialLoader(CredentialLoader):
             return None
 
         credentials = {}
-        with open(self.file_path) as f:
+        with open(self.file_path, encoding="utf-8") as f:
             for line in f:
                 line = line.strip()
                 if not line or line.startswith("#"):

--- a/src/cja_auto_sdr/core/discovery_payloads.py
+++ b/src/cja_auto_sdr/core/discovery_payloads.py
@@ -181,7 +181,7 @@ def _lookup_value_has_substance(
         return any(_lookup_value_has_substance(child, _seen_containers=seen) for child in value.values())
 
     if isinstance(value, (list, tuple, set)):
-        if len(value) == 0:
+        if not value:
             return False
         seen = _seen_containers if _seen_containers is not None else set()
         container_id = id(value)

--- a/src/cja_auto_sdr/core/version.py
+++ b/src/cja_auto_sdr/core/version.py
@@ -1,3 +1,3 @@
 """Version information for CJA Auto SDR."""
 
-__version__ = "3.5.17"
+__version__ = "3.5.18"

--- a/src/cja_auto_sdr/inventory/calculated_metrics.py
+++ b/src/cja_auto_sdr/inventory/calculated_metrics.py
@@ -488,7 +488,7 @@ class CalculatedMetricsInventoryBuilder:
                 stats.record_skip("no formula in definition", metric_id)
             return None
 
-        if isinstance(raw_formula, (dict, list)) and len(raw_formula) == 0:
+        if isinstance(raw_formula, (dict, list)) and not raw_formula:
             self.logger.warning(f"Skipping metric '{metric_name}' ({metric_id}) - no formula in definition")
             if stats:
                 stats.record_skip("no formula in definition", metric_id)

--- a/src/cja_auto_sdr/org/analyzer.py
+++ b/src/cja_auto_sdr/org/analyzer.py
@@ -365,7 +365,7 @@ class OrgComponentAnalyzer:
                     _describe_unexpected_probe_payload(quick_check),
                 )
                 return None
-            if len(normalized_quick_check) == 0:
+            if not normalized_quick_check:
                 self.logger.warning("No data views found in organization; returning empty org report")
                 return OrgReportResult(
                     timestamp=datetime.now(UTC).isoformat(),
@@ -598,7 +598,7 @@ class OrgComponentAnalyzer:
             all_data_views,
             operation="getDataViews (org-report)",
         )
-        if len(all_data_views) == 0:
+        if not all_data_views:
             return [], False, 0
 
         filtered = all_data_views

--- a/tests/test_output_content_validation.py
+++ b/tests/test_output_content_validation.py
@@ -38,7 +38,7 @@ def rich_data_dict():
         "Metadata": pd.DataFrame(
             {
                 "Property": ["Generated At", "Data View ID", "Tool Version", "Total Metrics"],
-                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.5.17", 3],
+                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.5.18", 3],
             },
         ),
         "Data Quality": pd.DataFrame(
@@ -104,7 +104,7 @@ def rich_metadata_dict():
         "Generated At": "2025-01-15 10:30:00 PST",
         "Data View ID": "dv_content_test",
         "Data View Name": "Test DataView",
-        "Tool Version": "3.5.17",
+        "Tool Version": "3.5.18",
         "Metrics Count": "3",
         "Dimensions Count": "4",
     }
@@ -224,7 +224,7 @@ class TestJSONContentValidation:
             data = json.load(f)
 
         assert data["metadata"]["Data View ID"] == "dv_content_test"
-        assert data["metadata"]["Tool Version"] == "3.5.17"
+        assert data["metadata"]["Tool Version"] == "3.5.18"
 
     def test_json_metadata_preserves_partial_markers(self, tmp_path, rich_data_dict, rich_metadata_dict):
         logger = logging.getLogger("json_test")

--- a/tests/test_ux_features.py
+++ b/tests/test_ux_features.py
@@ -344,11 +344,11 @@ class TestCombinedFeatures:
 class TestVersionUpdated:
     """Test that version is correct"""
 
-    def test_version_is_3_5_17(self):
-        """Test that version is 3.5.17"""
+    def test_version_is_3_5_18(self):
+        """Test that version is 3.5.18"""
         from cja_auto_sdr.generator import __version__
 
-        assert __version__ == "3.5.17"
+        assert __version__ == "3.5.18"
 
 
 class TestFormatAutoDetection:


### PR DESCRIPTION
## Summary

Tier 1 safe-optimization patch — three classes of zero-behavior-change hygiene fixes plus version bump.

- **Fixed:** `encoding="utf-8"` added to three text-mode `open()` calls in `core/config_validation.py:266`, `core/credentials.py:160`, `core/credentials.py:183`. Closes drift against the rest of `src/` which uniformly specifies UTF-8. Avoids potential `UnicodeDecodeError` on non-UTF-8 platform locales (Windows cp1252 / cp932 / etc.) when credential files contain non-ASCII characters.
- **Refactored:** `len(x) == 0` collapsed to falsy form on 8 sites where `x` is statically a plain `list` or `dict` (verified by `isinstance` guards, helper-function return types, or local `[]` initializers). Pandas `Series` / `Index` sites left as-is since `not series` raises "The truth value of an Index is ambiguous". Zero behavior change on the typed inputs.
- **Performance:** Hoisted `list(name_to_id_lookup.keys())` out of the per-identifier loop in `cli/commands/stats.py:resolve_data_view_names`. The miss-path branches built the same key list twice per iteration. For N identifiers against M data views, drops O(N·M) list copies to O(M).

5 commits, 14 files modified. No new tests, no new public API, no CLI surface change. Test count unchanged at 7,885.

## Verification

- [x] `uv run pytest tests/ --collect-only -q` reports 7,885 tests
- [x] `uv run pytest tests/ -x -q` passes (7,869 passed, 16 skipped)
- [x] `uv run ruff check src/ tests/ scripts/ examples/` clean
- [x] `uv run ruff format --check src/ tests/` clean
- [x] `uv run python scripts/check_version_sync.py` passes
- [x] `CHANGELOG.md` updated with v3.5.18 entry

## Test plan

- [x] Local full suite green
- [x] CI (tests, lint, version-sync, patch-release-gate, test-counts) all green
- [x] Manual review (intentionally held open per request)

## Spec / Plan

- Spec: [`docs/superpowers/specs/2026-04-24-v3.5.18-tier1-safe-optimizations.md`](https://github.com/brian-a-au/cja_auto_sdr/blob/feature/v3.5.18-tier1-safe-optimizations/docs/superpowers/specs/2026-04-24-v3.5.18-tier1-safe-optimizations.md)
- Plan: [`docs/superpowers/plans/2026-04-24-v3.5.18-tier1-safe-optimizations.md`](https://github.com/brian-a-au/cja_auto_sdr/blob/feature/v3.5.18-tier1-safe-optimizations/docs/superpowers/plans/2026-04-24-v3.5.18-tier1-safe-optimizations.md)