### PR TITLE
v3.5.19: Tier 1 cleanup (falsy collapse, levenshtein)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,21 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   check is the falsy form. Sits in the same fuzzy-match path as v3.5.18's
   keys-list hoist.
 
-### Investigated and reverted
-
-- **Inline-import promotion of `cja_auto_sdr.inventory.*` builders in
-  `generator.py` was attempted and reverted.** Six inline imports of
-  `DerivedFieldInventoryBuilder`, `CalculatedMetricsInventoryBuilder`, and
-  `SegmentsInventoryBuilder` looked like a candidate for the same v3.5.17
-  pattern that promoted `classify_component_payload`. Promotion broke tests
-  in `test_cli_command_handlers.py`, `test_process_single_dataview.py`,
-  `test_main_impl_coverage.py`, `test_snapshot.py`, and
-  `test_generator_remaining_coverage.py` that use `patch.dict("sys.modules",
-  ...)` or `patch("cja_auto_sdr.inventory.X.Builder")` to inject failure
-  modes — both patterns rely on the inline import resolving at call time.
-  Documented here so future hygiene scans don't re-attempt the promotion
-  without first redesigning the test mocks.
-
 ## [3.5.18] — 2026-04-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ All notable changes to the CJA SDR Generator project will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.19] — 2026-04-25
+
+### Refactored
+
+- **`len(x) > 0` collapsed to falsy form on two more confirmed-list sites:**
+  `inventory/utils.py:321` (`self.errors` initialized as `list[str] = []`,
+  only mutated via `.append()` — uses `bool(self.errors)` to preserve the
+  `has_issues -> bool` annotation) and `org/analyzer.py:1726`
+  (`audit["stale_patterns"]` initialized as `[]`, only mutated via `.append()`).
+  Continues the pattern shipped in v3.5.18. Pandas `Series`/`DataFrame`/`Index`
+  sites left as-is. Count expressions in the same block (e.g.
+  `org/analyzer.py:1731`) preserved as-is.
+
+- **`len(s2) == 0` → `not s2` in `levenshtein_distance`** at
+  `generator.py:4203`. `s2` is annotated `str`, so the canonical empty-string
+  check is the falsy form. Sits in the same fuzzy-match path as v3.5.18's
+  keys-list hoist.
+
+### Investigated and reverted
+
+- **Inline-import promotion of `cja_auto_sdr.inventory.*` builders in
+  `generator.py` was attempted and reverted.** Six inline imports of
+  `DerivedFieldInventoryBuilder`, `CalculatedMetricsInventoryBuilder`, and
+  `SegmentsInventoryBuilder` looked like a candidate for the same v3.5.17
+  pattern that promoted `classify_component_payload`. Promotion broke tests
+  in `test_cli_command_handlers.py`, `test_process_single_dataview.py`,
+  `test_main_impl_coverage.py`, `test_snapshot.py`, and
+  `test_generator_remaining_coverage.py` that use `patch.dict("sys.modules",
+  ...)` or `patch("cja_auto_sdr.inventory.X.Builder")` to inject failure
+  modes — both patterns rely on the inline import resolving at call time.
+  Documented here so future hygiene scans don't re-attempt the promotion
+  without first redesigning the test mocks.
+
 ## [3.5.18] — 2026-04-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   check is the falsy form. Sits in the same fuzzy-match path as v3.5.18's
   keys-list hoist.
 
+### Investigated and reverted
+
+- **Inline-import promotion of `cja_auto_sdr.inventory.*` builders in
+  `generator.py` was attempted and reverted.** Six inline imports of
+  `DerivedFieldInventoryBuilder`, `CalculatedMetricsInventoryBuilder`, and
+  `SegmentsInventoryBuilder` looked like a candidate for the same v3.5.17
+  pattern that promoted `classify_component_payload`. Promotion broke tests
+  in `test_cli_command_handlers.py`, `test_process_single_dataview.py`,
+  `test_main_impl_coverage.py`, `test_snapshot.py`, and
+  `test_generator_remaining_coverage.py` that use `patch.dict("sys.modules",
+  ...)` or `patch("cja_auto_sdr.inventory.X.Builder")` to inject failure
+  modes — both patterns rely on the inline import resolving at call time.
+  Documented here so future hygiene scans don't re-attempt the promotion
+  without first redesigning the test mocks.
+
 ## [3.5.18] — 2026-04-25
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Package manager: **uv**
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
-- Current version: v3.5.18
+- Current version: v3.5.19
 - Tests: **7,885** across 131 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -924,7 +924,7 @@ cja_auto_sdr --list-dataviews --log-level DEBUG
 At launch, the tool logs diagnostic lines containing the tool version, Python version, platform, active log level, inferred run mode (batch, single, or discovery), and dependency versions. These appear automatically at `INFO` level and are useful for troubleshooting environment issues in CI/CD logs or support requests:
 
 ```text
-CJA SDR Generator v3.5.18 | Python 3.14.2 | darwin | log_level=INFO | mode=single
+CJA SDR Generator v3.5.19 | Python 3.14.2 | darwin | log_level=INFO | mode=single
 Dependencies: cjapy=0.3.0, pandas=2.3.3, numpy=2.2.1, xlsxwriter=3.2.9, tqdm=4.67.0
 ```
 

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -190,7 +190,7 @@ This command:
 
 ```bash
 $ uv run cja_auto_sdr -V
-cja_auto_sdr 3.5.18
+cja_auto_sdr 3.5.19
 ```
 
 > **Important:** All commands in this guide assume you're in the `cja_auto_sdr` directory. If you see "command not found", make sure you're in the right directory and have run `uv sync`.

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Quick Reference Card
 
-Single-page command cheat sheet for CJA SDR Generator v3.5.18.
+Single-page command cheat sheet for CJA SDR Generator v3.5.19.
 
 ## Four Main Modes
 

--- a/src/cja_auto_sdr/core/version.py
+++ b/src/cja_auto_sdr/core/version.py
@@ -1,3 +1,3 @@
 """Version information for CJA Auto SDR."""
 
-__version__ = "3.5.18"
+__version__ = "3.5.19"

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -4200,7 +4200,7 @@ def levenshtein_distance(s1: str, s2: str) -> int:
     if len(s1) < len(s2):
         return levenshtein_distance(s2, s1)
 
-    if len(s2) == 0:
+    if not s2:
         return len(s1)
 
     previous_row = range(len(s2) + 1)

--- a/src/cja_auto_sdr/inventory/utils.py
+++ b/src/cja_auto_sdr/inventory/utils.py
@@ -318,7 +318,7 @@ class BatchProcessingStats:
     @property
     def has_issues(self) -> bool:
         """Check if any items were skipped or had errors."""
-        return self.skipped > 0 or len(self.errors) > 0
+        return self.skipped > 0 or bool(self.errors)
 
 
 # ==================== VALIDATION HELPERS ====================

--- a/src/cja_auto_sdr/org/analyzer.py
+++ b/src/cja_auto_sdr/org/analyzer.py
@@ -1723,7 +1723,7 @@ class OrgComponentAnalyzer:
                 },
             )
 
-        if len(audit["stale_patterns"]) > 0:
+        if audit["stale_patterns"]:
             audit["recommendations"].append(
                 {
                     "type": "stale_naming_patterns",

--- a/tests/test_output_content_validation.py
+++ b/tests/test_output_content_validation.py
@@ -38,7 +38,7 @@ def rich_data_dict():
         "Metadata": pd.DataFrame(
             {
                 "Property": ["Generated At", "Data View ID", "Tool Version", "Total Metrics"],
-                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.5.18", 3],
+                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.5.19", 3],
             },
         ),
         "Data Quality": pd.DataFrame(
@@ -104,7 +104,7 @@ def rich_metadata_dict():
         "Generated At": "2025-01-15 10:30:00 PST",
         "Data View ID": "dv_content_test",
         "Data View Name": "Test DataView",
-        "Tool Version": "3.5.18",
+        "Tool Version": "3.5.19",
         "Metrics Count": "3",
         "Dimensions Count": "4",
     }
@@ -224,7 +224,7 @@ class TestJSONContentValidation:
             data = json.load(f)
 
         assert data["metadata"]["Data View ID"] == "dv_content_test"
-        assert data["metadata"]["Tool Version"] == "3.5.18"
+        assert data["metadata"]["Tool Version"] == "3.5.19"
 
     def test_json_metadata_preserves_partial_markers(self, tmp_path, rich_data_dict, rich_metadata_dict):
         logger = logging.getLogger("json_test")

--- a/tests/test_ux_features.py
+++ b/tests/test_ux_features.py
@@ -344,11 +344,11 @@ class TestCombinedFeatures:
 class TestVersionUpdated:
     """Test that version is correct"""
 
-    def test_version_is_3_5_18(self):
-        """Test that version is 3.5.18"""
+    def test_version_is_3_5_19(self):
+        """Test that version is 3.5.19"""
         from cja_auto_sdr.generator import __version__
 
-        assert __version__ == "3.5.18"
+        assert __version__ == "3.5.19"
 
 
 class TestFormatAutoDetection:


### PR DESCRIPTION
## Summary

Two surgical cleanups continuing the v3.5.18 pattern:

- **Collapse `len(x) > 0` → falsy on two more confirmed-list sites:** `inventory/utils.py:321` (`self.errors`, initialized as `list[str] = []`, only mutated via `.append()` — uses `bool(self.errors)` to preserve the `has_issues -> bool` annotation) and `org/analyzer.py:1726` (`audit["stale_patterns"]`, initialized as `[]`, only mutated via `.append()`). Pandas Series/DataFrame/Index sites and intentional count expressions left as-is.
- **`len(s2) == 0` → `not s2` in `levenshtein_distance`** at `generator.py:4203`. `s2` is annotated `str`, so the canonical empty-string check is the falsy form. Sits in the same fuzzy-match path as v3.5.18's keys-list hoist.

Zero behavior change. No new tests. Existing 7,885-test suite stays green.

## Test plan

- [x] `uv run pytest tests/ --collect-only -q` reports 7,885 tests
- [x] `uv run pytest tests/ -x -q` passes (7869 passed, 16 skipped)
- [x] `uv run pytest -q tests/test_generator_mock_contract.py tests/test_backwards_compat.py tests/test_lazy_forwarding.py` passes (109 passed)
- [x] `uv run ruff check src/ tests/ examples/` passes
- [x] `uv run ruff format --check src/ tests/` passes (250 files already formatted)
- [x] `uv run python scripts/check_version_sync.py` passes
- [x] CHANGELOG.md updated with v3.5.19 entry