### PR TITLE
v3.5.20: friendly error-line summaries for known API failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ All notable changes to the CJA SDR Generator project will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.20] — 2026-05-06
+
+### Fixed
+
+- **Friendlier error-line summaries for known API failures** — the `✗ API
+  connection failed:` line in `--validate-config`, `--dry-run`, and
+  `--profile-test` now displays a human-readable summary instead of the raw
+  exception repr for recognised error patterns:
+  - `KeyError('content')` → `"empty or malformed API response"` (with existing
+    AEP API / product-profile hint below)
+  - HTTP 401 → `"HTTP 401 — authentication failed"`
+  - HTTP 403 → `"HTTP 403 — authorization failed or resource not accessible"`
+    (or `"HTTP 403 — data view not accessible"` for per-data-view lookups)
+  - Unrecognised exceptions fall back to `str(exc)` unchanged.
+
 ## [3.5.19] — 2026-04-25
 
 ### Refactored

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,8 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Package manager: **uv**
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
-- Current version: v3.5.19
-- Tests: **7,885** across 131 files at **95% coverage gate**
+- Current version: v3.5.20
+- Tests: **7,895** across 135 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)
 

--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (7,885+ tests)
+├── tests/                     # Test suite (7,895+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -924,7 +924,7 @@ cja_auto_sdr --list-dataviews --log-level DEBUG
 At launch, the tool logs diagnostic lines containing the tool version, Python version, platform, active log level, inferred run mode (batch, single, or discovery), and dependency versions. These appear automatically at `INFO` level and are useful for troubleshooting environment issues in CI/CD logs or support requests:
 
 ```text
-CJA SDR Generator v3.5.19 | Python 3.14.2 | darwin | log_level=INFO | mode=single
+CJA SDR Generator v3.5.20 | Python 3.14.2 | darwin | log_level=INFO | mode=single
 Dependencies: cjapy=0.3.0, pandas=2.3.3, numpy=2.2.1, xlsxwriter=3.2.9, tqdm=4.67.0
 ```
 

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -190,7 +190,7 @@ This command:
 
 ```bash
 $ uv run cja_auto_sdr -V
-cja_auto_sdr 3.5.19
+cja_auto_sdr 3.5.20
 ```
 
 > **Important:** All commands in this guide assume you're in the `cja_auto_sdr` directory. If you see "command not found", make sure you're in the right directory and have run `uv sync`.

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Quick Reference Card
 
-Single-page command cheat sheet for CJA SDR Generator v3.5.19.
+Single-page command cheat sheet for CJA SDR Generator v3.5.20.
 
 ## Four Main Modes
 

--- a/src/cja_auto_sdr/cli/commands/config.py
+++ b/src/cja_auto_sdr/cli/commands/config.py
@@ -45,9 +45,12 @@ def _print_api_connection_failure(
     unexpected: bool = False,
 ) -> None:
     """Render validate-config API failures with consistent hint handling."""
+    from cja_auto_sdr.core.exceptions import api_connection_error_summary
+
     hint = _api_connection_hint(exc)
     label = "API connection failed (unexpected)" if unexpected and hint is None else "API connection failed"
-    print(generator.ConsoleColors.error(f"  \u2717 {label}: {exc!s}"))
+    summary = api_connection_error_summary(exc) or str(exc)
+    print(generator.ConsoleColors.error(f"  \u2717 {label}: {summary}"))
     if hint:
         print()
         for line in hint.splitlines():

--- a/src/cja_auto_sdr/core/exceptions.py
+++ b/src/cja_auto_sdr/core/exceptions.py
@@ -368,3 +368,32 @@ def api_connection_hint(exc: Exception, *, context: str | None = None) -> str | 
             "      access it."
         )
     return None
+
+
+def api_connection_error_summary(exc: Exception, *, context: str | None = None) -> str | None:
+    """Return a short human-readable summary for the error-line display.
+
+    Complements :func:`api_connection_hint`: when a hint is available, this
+    returns a one-liner suitable for the ``✗ … : <summary>`` part of a failure
+    message so callers do not display the raw exception repr.
+
+    Returns ``None`` when no known summary applies — callers should fall back
+    to ``str(exc)`` in that case.
+    """
+    if isinstance(exc, KeyError):
+        if str(exc).strip("'\"") == "content":
+            return "empty or malformed API response"
+        return None
+
+    status = _api_connection_hint_status(exc)
+    normalized_context = _normalize_api_connection_hint_context(
+        context if context is not None else _exception_api_connection_hint_context(exc),
+    )
+
+    if status == 401:
+        return "HTTP 401 — authentication failed"
+    if status == 403 and normalized_context == _DATAVIEW_LOOKUP_HINT_CONTEXT:
+        return "HTTP 403 — data view not accessible"
+    if status == 403:
+        return "HTTP 403 — authorization failed or resource not accessible"
+    return None

--- a/src/cja_auto_sdr/core/profiles.py
+++ b/src/cja_auto_sdr/core/profiles.py
@@ -672,7 +672,8 @@ def test_profile(profile_name: str) -> bool:
     def _print_profile_test_failure(exc: Exception) -> bool:
         """Render a controlled profile-test failure with optional remediation hint."""
         print(ConsoleColors.error("   API connection: FAILED"), file=sys.stderr)
-        print(ConsoleColors.error(f"   Error: {api_connection_error_summary(exc) or str(exc)}"), file=sys.stderr)
+        summary = api_connection_error_summary(exc) or str(exc)
+        print(ConsoleColors.error(f"   Error: {summary}"), file=sys.stderr)
         print(file=sys.stderr)
         print(ConsoleColors.error("Profile test: FAILED"), file=sys.stderr)
         print(file=sys.stderr)

--- a/src/cja_auto_sdr/core/profiles.py
+++ b/src/cja_auto_sdr/core/profiles.py
@@ -17,7 +17,12 @@ from cja_auto_sdr.api.quality_policy import _canonical_quality_policy_key
 from cja_auto_sdr.core.colors import ConsoleColors
 from cja_auto_sdr.core.constants import BANNER_WIDTH, CREDENTIAL_FIELDS, ENV_VAR_MAPPING
 from cja_auto_sdr.core.credentials import filter_credentials
-from cja_auto_sdr.core.exceptions import ProfileConfigError, ProfileNotFoundError, api_connection_hint
+from cja_auto_sdr.core.exceptions import (
+    ProfileConfigError,
+    ProfileNotFoundError,
+    api_connection_error_summary,
+    api_connection_hint,
+)
 from cja_auto_sdr.core.json_io import write_json_atomic
 
 __all__ = [
@@ -667,7 +672,7 @@ def test_profile(profile_name: str) -> bool:
     def _print_profile_test_failure(exc: Exception) -> bool:
         """Render a controlled profile-test failure with optional remediation hint."""
         print(ConsoleColors.error("   API connection: FAILED"), file=sys.stderr)
-        print(ConsoleColors.error(f"   Error: {exc}"), file=sys.stderr)
+        print(ConsoleColors.error(f"   Error: {api_connection_error_summary(exc) or str(exc)}"), file=sys.stderr)
         print(file=sys.stderr)
         print(ConsoleColors.error("Profile test: FAILED"), file=sys.stderr)
         print(file=sys.stderr)

--- a/src/cja_auto_sdr/core/version.py
+++ b/src/cja_auto_sdr/core/version.py
@@ -1,3 +1,3 @@
 """Version information for CJA Auto SDR."""
 
-__version__ = "3.5.19"
+__version__ = "3.5.20"

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -175,6 +175,7 @@ from cja_auto_sdr.core.exceptions import (
     ProfileNotFoundError,
     RetryableHTTPError,
     ValidationError,
+    api_connection_error_summary,
     api_connection_hint,
 )
 from cja_auto_sdr.core.locks.manager import normalize_lock_stale_threshold_seconds
@@ -3912,7 +3913,8 @@ def run_dry_run(data_views: list[str], config_file: str, logger: logging.Logger,
 
     def _fail_dry_run_api_connection(error: Exception) -> bool:
         """Print a consistent step-[2/3] API probe failure and stop the dry-run."""
-        print(f"  ✗ API connection failed: {_dry_run_error_text(error)}")
+        summary = api_connection_error_summary(error) or _dry_run_error_text(error)
+        print(f"  ✗ API connection failed: {summary}")
         _print_api_hint(error, file=sys.stdout)
         print()
         print("=" * BANNER_WIDTH)
@@ -3922,7 +3924,8 @@ def run_dry_run(data_views: list[str], config_file: str, logger: logging.Logger,
 
     def _print_dry_run_data_view_error(error: Exception, *, context: str | None = None) -> None:
         """Print a consistent per-data-view validation error and optional remediation hint."""
-        print(f"  ✗ {dv_id}: Error - {_dry_run_error_text(error)}")
+        summary = api_connection_error_summary(error, context=context) or _dry_run_error_text(error)
+        print(f"  ✗ {dv_id}: Error - {summary}")
         _print_api_hint(error, file=sys.stdout, context=context)
 
     # Step 1: Validate credentials

--- a/tests/README.md
+++ b/tests/README.md
@@ -147,7 +147,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 7,885 comprehensive tests**
+**Total: 7,895 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -156,16 +156,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,779 | 129 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,789 | 129 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 0 | 0 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **7,885** | **135** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **7,895** | **135** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,779 | 129 | `-m "unit and not slow"` |
+| `test-unit` | 7,789 | 129 | `-m "unit and not slow"` |
 | `test-integration` | 96 | 5 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -210,7 +210,7 @@ tests/
 | `test_shared_cache.py` | 28 | Shared validation cache |
 | `test_logging_optimization.py` | 17 | Logging performance optimizations |
 | `test_env_credentials.py` | 15 | Environment variable credentials |
-| `test_dry_run.py` | 15 | Dry-run mode functionality |
+| `test_dry_run.py` | 16 | Dry-run mode functionality |
 | `test_early_exit.py` | 11 | Early exit optimizations |
 | `test_data_quality.py` | 10 | Data quality validation logic |
 | `test_parallel_validation.py` | 9 | Parallel validation operations |
@@ -281,7 +281,7 @@ tests/
 | `test_org_trending_adversarial.py` | 51 | Adversarial and stress tests for trending |
 | `test_cli_diff_contracts.py` | 70 | CLI/diff public API contract tests |
 | `test_list_command_edge_cases.py` | 61 | List command edge cases and coverage |
-| `test_cli_commands_config_coverage.py` | 37 | Config command edge cases and coverage |
+| `test_cli_commands_config_coverage.py` | 46 | Config command edge cases and coverage |
 | `test_cli_execution.py` | 27 | CLI execution edge cases and coverage |
 | `test_diff_git_coverage.py` | 27 | Diff/git subprocess error path coverage |
 | `test_generator_trending_coverage.py` | 19 | Generator trending integration coverage |
@@ -310,7 +310,7 @@ tests/
 | `test_agent_workflows.py` | 69 | Agent workflow shell script validation tests |
 | `test_manifest_agent_contract.py` | 16 | Manifest vs runtime capability drift tests |
 | `test_tool_manifests.py` | 40 | Tool manifest schema and content tests |
-| **Total** | **7,885** | **Collected via pytest --collect-only** |
+| **Total** | **7,895** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -768,7 +768,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (7,885 tests total)
+- [x] Comprehensive test coverage (7,895 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 78 tests

--- a/tests/test_cli_commands_config_coverage.py
+++ b/tests/test_cli_commands_config_coverage.py
@@ -819,6 +819,33 @@ class TestValidateConfigHintOutput:
 
         assert result is False
         captured = capsys.readouterr()
-        assert "API connection failed: HTTP 403 Forbidden" in captured.out
+        assert "API connection failed: HTTP 403 — authorization failed or resource not accessible" in captured.out
         assert "authentication or authorization failed" in captured.out
         assert "unexpected" not in captured.out
+
+    def test_key_error_content_shows_friendly_summary_on_error_line(self, capsys):
+        """KeyError('content') error line must say 'empty or malformed' not \"'content'\"."""
+        from cja_auto_sdr.cli.commands.config import validate_config_only
+
+        gen = _make_generator_mock(
+            python_version_info=(3, 14, 0),
+            recoverable_exceptions=(KeyError,),
+        )
+        gen.load_credentials_from_env.return_value = {
+            "org_id": "org@AdobeOrg",
+            "client_id": "cid12345678",
+            "secret": "sec12345678",
+            "scopes": "openid",
+        }
+        gen.validate_env_credentials.return_value = True
+        gen.cjapy.CJA.return_value.getDataViews.side_effect = KeyError("content")
+
+        with patch("cja_auto_sdr.cli.commands.config._generator_module", return_value=gen):
+            with patch("cja_auto_sdr.cli.commands.config._check_output_dir_access"):
+                result = validate_config_only()
+
+        assert result is False
+        captured = capsys.readouterr()
+        assert "API connection failed: empty or malformed API response" in captured.out
+        assert "'content'" not in captured.out
+        assert "AEP API" in captured.out

--- a/tests/test_cli_commands_config_coverage.py
+++ b/tests/test_cli_commands_config_coverage.py
@@ -707,6 +707,64 @@ class TestApiConnectionHint:
 
 
 # ---------------------------------------------------------------------------
+# api_connection_error_summary — short summary for the error line
+# ---------------------------------------------------------------------------
+
+
+class TestApiConnectionErrorSummary:
+    """Tests for api_connection_error_summary in core.exceptions."""
+
+    def test_key_error_content_returns_malformed_summary(self):
+        from cja_auto_sdr.core.exceptions import api_connection_error_summary
+
+        assert api_connection_error_summary(KeyError("content")) == "empty or malformed API response"
+
+    def test_key_error_other_key_returns_none(self):
+        from cja_auto_sdr.core.exceptions import api_connection_error_summary
+
+        assert api_connection_error_summary(KeyError("globalCompanyId")) is None
+
+    def test_http_401_returns_auth_summary(self):
+        from cja_auto_sdr.core.exceptions import api_connection_error_summary
+
+        exc = Exception("Unauthorized")
+        exc.status_code = 401
+        assert api_connection_error_summary(exc) == "HTTP 401 — authentication failed"
+
+    def test_http_403_generic_returns_auth_summary(self):
+        from cja_auto_sdr.core.exceptions import api_connection_error_summary
+
+        exc = Exception("Forbidden")
+        exc.status_code = 403
+        assert api_connection_error_summary(exc) == "HTTP 403 — authorization failed or resource not accessible"
+
+    def test_http_403_data_view_lookup_returns_access_summary(self):
+        from cja_auto_sdr.core.exceptions import api_connection_error_summary
+
+        exc = Exception("Forbidden")
+        exc.status_code = 403
+        assert api_connection_error_summary(exc, context="data_view_lookup") == "HTTP 403 — data view not accessible"
+
+    def test_runtime_http_403_text_returns_auth_summary(self):
+        from cja_auto_sdr.core.exceptions import api_connection_error_summary
+
+        assert (
+            api_connection_error_summary(RuntimeError("HTTP 403 Forbidden"))
+            == "HTTP 403 — authorization failed or resource not accessible"
+        )
+
+    def test_generic_exception_returns_none(self):
+        from cja_auto_sdr.core.exceptions import api_connection_error_summary
+
+        assert api_connection_error_summary(ValueError("something else")) is None
+
+    def test_unrelated_numeric_runtime_text_returns_none(self):
+        from cja_auto_sdr.core.exceptions import api_connection_error_summary
+
+        assert api_connection_error_summary(RuntimeError("expected 403 columns in export")) is None
+
+
+# ---------------------------------------------------------------------------
 # validate_config_only — hint output in step [4/5]
 # ---------------------------------------------------------------------------
 

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -66,6 +66,20 @@ class TestDryRunMode:
         assert result is False
 
     @patch("cja_auto_sdr.generator.cjapy")
+    def test_dry_run_key_error_content_shows_friendly_summary(self, mock_cjapy, valid_config_file, logger, capsys):
+        """KeyError('content') in dry-run API probe must show friendly summary, not \"'content'\"."""
+        mock_cja_instance = MagicMock()
+        mock_cjapy.CJA.return_value = mock_cja_instance
+        mock_cja_instance.getDataViews.side_effect = KeyError("content")
+
+        result = run_dry_run(data_views=["dv_12345"], config_file=valid_config_file, logger=logger)
+
+        assert result is False
+        captured = capsys.readouterr()
+        assert "API connection failed: empty or malformed API response" in captured.out
+        assert "'content'" not in captured.out
+
+    @patch("cja_auto_sdr.generator.cjapy")
     def test_dry_run_success_with_valid_data_views(self, mock_cjapy, valid_config_file, logger):
         """Test dry-run succeeds with valid configuration and data views"""
         # Mock CJA instance

--- a/tests/test_main_impl_coverage.py
+++ b/tests/test_main_impl_coverage.py
@@ -1829,7 +1829,8 @@ class TestRunDryRunAPIValidation:
             result = run_dry_run(["dv_test"], "config.json", logger)
         assert result is False
         captured = capsys.readouterr()
-        assert "API connection failed: 'content'" in captured.out
+        assert "API connection failed: empty or malformed API response" in captured.out
+        assert "'content'" not in captured.out
         assert "AEP API" in captured.out
 
     def test_api_connection_runtime_auth_error_shows_hint(self, capsys):
@@ -1845,7 +1846,7 @@ class TestRunDryRunAPIValidation:
             result = run_dry_run(["dv_test"], "config.json", logger)
         assert result is False
         captured = capsys.readouterr()
-        assert "API connection failed: HTTP 403 Forbidden" in captured.out
+        assert "API connection failed: HTTP 403 — authorization failed or resource not accessible" in captured.out
         assert "authentication or authorization failed" in captured.out
 
     def test_api_connection_plain_exception_auth_error_shows_hint(self, capsys):
@@ -1861,7 +1862,7 @@ class TestRunDryRunAPIValidation:
             result = run_dry_run(["dv_test"], "config.json", logger)
         assert result is False
         captured = capsys.readouterr()
-        assert "API connection failed: HTTP 403 Forbidden" in captured.out
+        assert "API connection failed: HTTP 403 — authorization failed or resource not accessible" in captured.out
         assert "authentication or authorization failed" in captured.out
 
     def test_api_connection_unexpected_runtime_exception(self, capsys):
@@ -2021,7 +2022,7 @@ class TestRunDryRunAPIValidation:
             result = run_dry_run(["dv_forbidden"], "config.json", logger)
         assert result is False
         captured = capsys.readouterr()
-        assert "dv_forbidden: Error - HTTP 403 Forbidden" in captured.out
+        assert "dv_forbidden: Error - HTTP 403 — data view not accessible" in captured.out
         assert "accessing this data view" in captured.out
         assert "have access to it" in captured.out
 
@@ -2045,7 +2046,7 @@ class TestRunDryRunAPIValidation:
             result = run_dry_run(["dv_forbidden"], "config.json", logger)
         assert result is False
         captured = capsys.readouterr()
-        assert "dv_forbidden: Error - HTTP 403 Forbidden" in captured.out
+        assert "dv_forbidden: Error - HTTP 403 — data view not accessible" in captured.out
         assert "accessing this data view" in captured.out
         assert "have access to it" in captured.out
 
@@ -2073,7 +2074,7 @@ class TestRunDryRunAPIValidation:
             result = run_dry_run(["dv_components"], "config.json", logger)
         assert result is False
         captured = capsys.readouterr()
-        assert "dv_components: Error - HTTP 403 Forbidden" in captured.out
+        assert "dv_components: Error - HTTP 403 — authorization failed or resource not accessible" in captured.out
         assert "authentication or authorization failed" in captured.out
         assert "accessing this data view" not in captured.out
 
@@ -2101,7 +2102,7 @@ class TestRunDryRunAPIValidation:
             result = run_dry_run(["dv_components"], "config.json", logger)
         assert result is False
         captured = capsys.readouterr()
-        assert "dv_components: Error - HTTP 403 Forbidden" in captured.out
+        assert "dv_components: Error - HTTP 403 — authorization failed or resource not accessible" in captured.out
         assert "authentication or authorization failed" in captured.out
         assert "accessing this data view" not in captured.out
 

--- a/tests/test_output_content_validation.py
+++ b/tests/test_output_content_validation.py
@@ -38,7 +38,7 @@ def rich_data_dict():
         "Metadata": pd.DataFrame(
             {
                 "Property": ["Generated At", "Data View ID", "Tool Version", "Total Metrics"],
-                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.5.19", 3],
+                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.5.20", 3],
             },
         ),
         "Data Quality": pd.DataFrame(
@@ -104,7 +104,7 @@ def rich_metadata_dict():
         "Generated At": "2025-01-15 10:30:00 PST",
         "Data View ID": "dv_content_test",
         "Data View Name": "Test DataView",
-        "Tool Version": "3.5.19",
+        "Tool Version": "3.5.20",
         "Metrics Count": "3",
         "Dimensions Count": "4",
     }
@@ -224,7 +224,7 @@ class TestJSONContentValidation:
             data = json.load(f)
 
         assert data["metadata"]["Data View ID"] == "dv_content_test"
-        assert data["metadata"]["Tool Version"] == "3.5.19"
+        assert data["metadata"]["Tool Version"] == "3.5.20"
 
     def test_json_metadata_preserves_partial_markers(self, tmp_path, rich_data_dict, rich_metadata_dict):
         logger = logging.getLogger("json_test")

--- a/tests/test_profile_management.py
+++ b/tests/test_profile_management.py
@@ -677,7 +677,7 @@ class TestTestProfile:
         assert result is False
         captured = capsys.readouterr()
         assert "Profile test: FAILED" in captured.err
-        assert "HTTP 403 Forbidden" in captured.err
+        assert "HTTP 403 — authorization failed or resource not accessible" in captured.err
         assert "authentication or authorization failed" in captured.out
 
     def test_plain_constructor_failure_returns_controlled_failure(self, tmp_path, capsys):

--- a/tests/test_ux_features.py
+++ b/tests/test_ux_features.py
@@ -344,11 +344,11 @@ class TestCombinedFeatures:
 class TestVersionUpdated:
     """Test that version is correct"""
 
-    def test_version_is_3_5_19(self):
-        """Test that version is 3.5.19"""
+    def test_version_is_3_5_20(self):
+        """Test that version is 3.5.20"""
         from cja_auto_sdr.generator import __version__
 
-        assert __version__ == "3.5.19"
+        assert __version__ == "3.5.20"
 
 
 class TestFormatAutoDetection:


### PR DESCRIPTION
## Summary

- Replaces raw `str(exc)` / `KeyError` repr on the `✗ … failed:` error line with a concise human-readable summary across `--validate-config`, `--dry-run` (both API probe and per-data-view), and `--profile-test`.
- Adds `api_connection_error_summary()` in `core/exceptions.py` that mirrors `api_connection_hint()` and reuses the same status/context detection helpers.
- Falls back to `str(exc)` / `_dry_run_error_text()` for unrecognised exceptions — zero behaviour change outside known patterns.

## Test plan
- [x] `TestApiConnectionErrorSummary` covers KeyError('content'), KeyError(other), 401, 403 generic, 403 + data_view_lookup, RuntimeError 403 text, ValueError, and false-positive numeric "403" text — **8/8 pass**
- [x] Validate-config summary-line test asserts friendly message and absence of `'content'` — **`test_key_error_content_shows_friendly_summary_on_error_line` passes**
- [x] Dry-run summary-line test asserts friendly message and absence of `'content'` — **`test_dry_run_key_error_content_shows_friendly_summary` passes**
- [x] Profile-test assertion updated to expect new summary — **`test_runtime_auth_failure_shows_hint` passes against `HTTP 403 — authorization failed or resource not accessible`**
- [x] Full suite green, ruff clean, version-sync clean, test-count sync clean — **7,879 passed / 16 skipped; ruff `All checks passed!`; version sync at 3.5.20; test counts up to date**