### PR TITLE
docs: add warning emoji to AEP API requirement callout

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ pip install -e .
 
 Get your credentials from [Adobe Developer Console](https://developer.adobe.com/console/) (see [QUICKSTART_GUIDE](docs/QUICKSTART_GUIDE.md) for detailed steps).
 
-> **Important:** Your Adobe Developer Console project must have **both** the CJA API **and** the AEP (Experience Platform) API added. The AEP API associates your service account with an Experience Platform product profile, which is required for CJA API authentication. See the [Quickstart Guide](docs/QUICKSTART_GUIDE.md#15-add-the-adobe-experience-platform-aep-api) for setup instructions.
+> ⚠ **Important:** Your Adobe Developer Console project must have **both** the CJA API **and** the AEP (Experience Platform) API added. The AEP API associates your service account with an Experience Platform product profile, which is required for CJA API authentication. See the [Quickstart Guide](docs/QUICKSTART_GUIDE.md#15-add-the-adobe-experience-platform-aep-api) for setup instructions.
 
 **Option A: Configuration File (Quickest)**
 


### PR DESCRIPTION
## Summary
- Prepend ⚠ emoji to the existing **Important** callout in README.md about requiring both CJA and AEP APIs in the Adobe Developer Console project, increasing visual prominence of a frequent setup pitfall.

## Test plan
- [x] Docs-only change — no code, no tests, no version bump
- [ ] Confirm rendered README on GitHub shows the warning emoji