### PR TITLE
chore: promote PyPI classifier to Production/Stable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.14"
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",


### PR DESCRIPTION
## Summary
- Update the single `Development Status` trove classifier in `pyproject.toml` from `4 - Beta` to `5 - Production/Stable` to reflect project maturity.

## Test plan
- [x] CI lint passes
- [x] CI tests pass
- [x] Package build workflow succeeds