### PR TITLE
v3.6.1: Watch Mode Follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ All notable changes to the CJA SDR Generator project will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.1] — 2026-05-14
+
+### Fixed
+- Watch loop now restores previous SIGINT/SIGTERM handlers when `run_watch`
+  returns — important for in-process tests and any embedded invocation.
+- `watch_loop_stop` diagnostic's `cycles_completed` field now reports only
+  cycles whose body completed in full, not cycles that started but were
+  interrupted by a signal.
+- Defensive `--interval` validation in `run_watch` now uses `_exit_error`
+  (matches the rest of the CLI's error formatting) instead of raw stderr print.
+- Duplicate `--watch DV_ID DV_ID` is now deduped at parse time with a stderr
+  warning, instead of producing a confusing baseline-then-empty-change pattern
+  in cycle 1.
+
+### Added
+- One-shot stderr note on watch entry: `note: watch holds snapshots in memory;
+  baselines reset on restart.` Suppressed under `--quiet`.
+
+### Tests
+- New `tests/test_watch_dispatch.py` — end-to-end dispatch wiring tests.
+- New `tests/test_watch_logging.py` — explicit coverage for the three
+  structured-log events.
+
+### Unchanged
+- `cja-watch-event/v1` NDJSON schema (every event payload is byte-equivalent).
+- All other CLI modes (single SDR, batch, org-report, diff, discovery).
+- Exit codes (SIGINT/SIGTERM → 0; semantic rejections → 1; argparse → 2).
+- No new flags, no new runtime dependencies.
+
 ## [3.6.0] — 2026-05-12
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,8 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Package manager: **uv**
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
-- Current version: v3.6.0
-- Tests: **7,998** across 143 files at **95% coverage gate**
+- Current version: v3.6.1
+- Tests: **8,010** across 145 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Version Sync](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/version-sync.yml/badge.svg)](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/version-sync.yml)
 [![Python 3.14+](https://img.shields.io/badge/python-3.14%2B-blue.svg)](https://www.python.org/downloads/)
 [![Coverage](https://img.shields.io/badge/coverage-99%25-brightgreen.svg)](tests/)
-[![Tests](https://img.shields.io/badge/tests-7998-brightgreen.svg)](tests/)
+[![Tests](https://img.shields.io/badge/tests-8010-brightgreen.svg)](tests/)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
@@ -468,7 +468,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (7,998+ tests)
+├── tests/                     # Test suite (8,010+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -500,6 +500,10 @@ Foreground loop that fetches, snapshots, and diffs one or more data views on a r
 | `--interval PERIOD` | Watch cycle interval. Accepts `Nh` (hours), `Nd` (days), or `Nw` (weeks). E.g. `1h`, `6h`, `1d`, `2w`. Required with `--watch`. | - |
 | `--watch-threshold N` | Minimum total change count to emit a `change` event. Pass `0` to emit every cycle including zero-change cycles (heartbeat mode). | 1 |
 
+> **Note:** watch holds snapshots in memory only; restarting the loop emits
+> a fresh baseline for every data view. Use `cja_auto_sdr <dv_id> --snapshot file.json`
+> before starting if you need durable baselines.
+
 #### NDJSON Event Schema: `cja-watch-event/v1`
 
 All events are emitted on stdout, one JSON object per line, with a trailing newline.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -924,7 +924,7 @@ cja_auto_sdr --list-dataviews --log-level DEBUG
 At launch, the tool logs diagnostic lines containing the tool version, Python version, platform, active log level, inferred run mode (batch, single, or discovery), and dependency versions. These appear automatically at `INFO` level and are useful for troubleshooting environment issues in CI/CD logs or support requests:
 
 ```text
-CJA SDR Generator v3.6.0 | Python 3.14.2 | darwin | log_level=INFO | mode=single
+CJA SDR Generator v3.6.1 | Python 3.14.2 | darwin | log_level=INFO | mode=single
 Dependencies: cjapy=0.3.0, pandas=2.3.3, numpy=2.2.1, xlsxwriter=3.2.9, tqdm=4.67.0
 ```
 

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -190,7 +190,7 @@ This command:
 
 ```bash
 $ uv run cja_auto_sdr -V
-cja_auto_sdr 3.6.0
+cja_auto_sdr 3.6.1
 ```
 
 > **Important:** All commands in this guide assume you're in the `cja_auto_sdr` directory. If you see "command not found", make sure you're in the right directory and have run `uv sync`.

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Quick Reference Card
 
-Single-page command cheat sheet for CJA SDR Generator v3.6.0.
+Single-page command cheat sheet for CJA SDR Generator v3.6.1.
 
 ## Four Main Modes
 

--- a/src/cja_auto_sdr/cli/commands/watch.py
+++ b/src/cja_auto_sdr/cli/commands/watch.py
@@ -29,15 +29,34 @@ _stop_requested = threading.Event()
 _stop_reason_holder: dict[str, str] = {}
 
 
+# Module-scope cache of previous signal handlers, populated by
+# _install_signal_handlers and consumed by _restore_signal_handlers.
+_previous_handlers: dict[int, Any] = {}
+
+
 def _install_signal_handlers() -> None:
-    """Install SIGINT/SIGTERM handlers that set _stop_requested + record the reason."""
+    """Install SIGINT/SIGTERM handlers and remember the previous values."""
+    # Defensive: clear stale state from a prior invocation whose restore
+    # didn't run (e.g. a test crashed between install and the finally block).
+    # Without this, the second install would capture the watch handler as
+    # "previous" and a subsequent restore would re-install it — silent test
+    # pollution that's hard to debug.
+    _previous_handlers.clear()
 
     def _handler(signum, _frame):
         _stop_reason_holder["reason"] = "sigint" if signum == signal.SIGINT else "sigterm"
         _stop_requested.set()
 
-    signal.signal(signal.SIGINT, _handler)
-    signal.signal(signal.SIGTERM, _handler)
+    _previous_handlers[signal.SIGINT] = signal.signal(signal.SIGINT, _handler)
+    _previous_handlers[signal.SIGTERM] = signal.signal(signal.SIGTERM, _handler)
+
+
+def _restore_signal_handlers() -> None:
+    """Restore the handlers that were in place before _install_signal_handlers."""
+    for signum, previous in _previous_handlers.items():
+        if previous is not None:
+            signal.signal(signum, previous)
+    _previous_handlers.clear()
 
 
 class _LoggingEmitter:
@@ -196,5 +215,6 @@ def run_watch(args: Any, *, cja: Any | None = None) -> int:
     finally:
         emitter.loop_stop(reason=stop_reason, cycles_completed=cycle)
         _stop_reason_holder.clear()
+        _restore_signal_handlers()
 
     return 0

--- a/src/cja_auto_sdr/cli/commands/watch.py
+++ b/src/cja_auto_sdr/cli/commands/watch.py
@@ -118,10 +118,12 @@ def _resolve_cja_client(args: Any) -> Any:
 
 def run_watch(args: Any, *, cja: Any | None = None) -> int:
     """Run the watch loop. Returns the process exit code (always 0 on clean exit)."""
+    # Imported lazily to avoid a circular import with generator → cli.commands.watch.
+    from cja_auto_sdr.generator import _exit_error
+
     interval_seconds = parse_duration_seconds(args.watch_interval)
     if interval_seconds is None:
-        print(f"ERROR: Invalid --interval value: {args.watch_interval}", file=sys.stderr)
-        return 1
+        _exit_error(f"Invalid --interval value: {args.watch_interval}")
 
     # Initialize logging so the three structured-log events (watch_loop_start,
     # watch_cycle_complete, watch_loop_stop) actually reach handlers. _main_impl's

--- a/src/cja_auto_sdr/cli/commands/watch.py
+++ b/src/cja_auto_sdr/cli/commands/watch.py
@@ -189,6 +189,7 @@ def run_watch(args: Any, *, cja: Any | None = None) -> int:
     )
 
     cycle = 0
+    cycles_completed = 0
     stop_reason = "fatal"  # overwritten if signal handler runs
     try:
         while True:
@@ -204,6 +205,7 @@ def run_watch(args: Any, *, cja: Any | None = None) -> int:
                         data_view_id=event.data_view_id,
                         total_changes=getattr(event, "total_changes", 0),
                     )
+            cycles_completed = cycle
             if _stop_requested.is_set():
                 break
             _sleep_with_stop(interval_seconds)
@@ -213,7 +215,7 @@ def run_watch(args: Any, *, cja: Any | None = None) -> int:
                 break
         stop_reason = _stop_reason_holder.get("reason", "fatal")
     finally:
-        emitter.loop_stop(reason=stop_reason, cycles_completed=cycle)
+        emitter.loop_stop(reason=stop_reason, cycles_completed=cycles_completed)
         _stop_reason_holder.clear()
         _restore_signal_handlers()
 

--- a/src/cja_auto_sdr/cli/commands/watch.py
+++ b/src/cja_auto_sdr/cli/commands/watch.py
@@ -187,6 +187,16 @@ def run_watch(args: Any, *, cja: Any | None = None) -> int:
         interval_seconds=interval_seconds,
         watch_threshold=args.watch_threshold,
     )
+    if not getattr(args, "quiet", False):
+        from cja_auto_sdr.core.colors import ConsoleColors
+
+        print(
+            ConsoleColors.info(
+                "note: watch holds snapshots in memory; baselines reset on restart. "
+                "For persistent snapshots, run `cja_auto_sdr <dv_id> --snapshot file.json` first."
+            ),
+            file=sys.stderr,
+        )
 
     cycle = 0
     cycles_completed = 0

--- a/src/cja_auto_sdr/core/version.py
+++ b/src/cja_auto_sdr/core/version.py
@@ -1,3 +1,3 @@
 """Version information for CJA Auto SDR."""
 
-__version__ = "3.6.0"
+__version__ = "3.6.1"

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -1874,9 +1874,7 @@ def _validate_semantic_flag_relationships(
         duplicates = sorted(dv for dv, n in counts.items() if n > 1)
         if duplicates:
             print(
-                ConsoleColors.warning(
-                    f"WARNING: --watch deduplicated repeat ID(s): {', '.join(duplicates)}"
-                ),
+                ConsoleColors.warning(f"WARNING: --watch deduplicated repeat ID(s): {', '.join(duplicates)}"),
                 file=sys.stderr,
             )
             # Preserve original ordering while deduping.

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -1862,6 +1862,32 @@ def _validate_semantic_flag_relationships(
             if not is_data_view_id(dv_id):
                 _exit_error(f"--watch values must be data view IDs (e.g. dv_abc123), not names. Got: {dv_id!r}")
 
+        # Dedupe watch_data_views (Issue 4): repeated IDs would produce a
+        # confusing baseline-then-empty-change pattern in cycle 1. Warn and
+        # continue with the deduped list. This is the one place in
+        # _validate_semantic_flag_relationships that MUTATES args rather than
+        # only validating — intentional because the alternative (a separate
+        # normalization pass in _main_impl) adds more surface area than it saves.
+        from collections import Counter
+
+        counts = Counter(args.watch_data_views)
+        duplicates = sorted(dv for dv, n in counts.items() if n > 1)
+        if duplicates:
+            print(
+                ConsoleColors.warning(
+                    f"WARNING: --watch deduplicated repeat ID(s): {', '.join(duplicates)}"
+                ),
+                file=sys.stderr,
+            )
+            # Preserve original ordering while deduping.
+            seen: set[str] = set()
+            deduped: list[str] = []
+            for dv in args.watch_data_views:
+                if dv not in seen:
+                    seen.add(dv)
+                    deduped.append(dv)
+            args.watch_data_views = deduped
+
 
 def _sync_run_summary_cli_metadata(
     run_state: dict[str, Any] | None,

--- a/tests/README.md
+++ b/tests/README.md
@@ -152,10 +152,12 @@ tests/
 ├── test_watch_prevalidation.py      # Watch flag semantic prevalidation tests
 ├── test_watch_command.py            # Watch command dispatch and signal handler tests
 ├── test_watch_signals.py            # SIGINT/SIGTERM exit-0 contract tests
+├── test_watch_dispatch.py           # End-to-end dispatch wiring tests
+├── test_watch_logging.py            # Structured-log event emission tests
 └── README.md                        # This file
 ```
 
-**Total: 7,998 comprehensive tests**
+**Total: 8,010 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -164,16 +166,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,892 | 137 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,904 | 139 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 0 | 0 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **7,998** | **143** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **8,010** | **145** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,892 | 137 | `-m "unit and not slow"` |
+| `test-unit` | 7,904 | 139 | `-m "unit and not slow"` |
 | `test-integration` | 96 | 5 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -323,10 +325,12 @@ tests/
 | `test_watch_events.py` | 8 | cja-watch-event/v1 NDJSON schema conformance tests |
 | `test_watch_pipeline.py` | 6 | Watch pipeline cycle orchestrator tests |
 | `test_watch_cli.py` | 11 | Watch mode argparse acceptance and rejection tests |
-| `test_watch_prevalidation.py` | 41 | Watch flag semantic prevalidation tests |
-| `test_watch_command.py` | 7 | Watch command dispatch and signal handler tests |
+| `test_watch_prevalidation.py` | 43 | Watch flag semantic prevalidation tests |
+| `test_watch_command.py` | 11 | Watch command dispatch and signal handler tests |
 | `test_watch_signals.py` | 2 | SIGINT/SIGTERM exit-0 contract tests |
-| **Total** | **7,998** | **Collected via pytest --collect-only** |
+| `test_watch_dispatch.py` | 2 | End-to-end dispatch wiring tests |
+| `test_watch_logging.py` | 4 | Structured-log event emission tests |
+| **Total** | **8,010** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -784,7 +788,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (7,998 tests total)
+- [x] Comprehensive test coverage (8,010 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 78 tests

--- a/tests/test_output_content_validation.py
+++ b/tests/test_output_content_validation.py
@@ -38,7 +38,7 @@ def rich_data_dict():
         "Metadata": pd.DataFrame(
             {
                 "Property": ["Generated At", "Data View ID", "Tool Version", "Total Metrics"],
-                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.6.0", 3],
+                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.6.1", 3],
             },
         ),
         "Data Quality": pd.DataFrame(
@@ -104,7 +104,7 @@ def rich_metadata_dict():
         "Generated At": "2025-01-15 10:30:00 PST",
         "Data View ID": "dv_content_test",
         "Data View Name": "Test DataView",
-        "Tool Version": "3.6.0",
+        "Tool Version": "3.6.1",
         "Metrics Count": "3",
         "Dimensions Count": "4",
     }
@@ -224,7 +224,7 @@ class TestJSONContentValidation:
             data = json.load(f)
 
         assert data["metadata"]["Data View ID"] == "dv_content_test"
-        assert data["metadata"]["Tool Version"] == "3.6.0"
+        assert data["metadata"]["Tool Version"] == "3.6.1"
 
     def test_json_metadata_preserves_partial_markers(self, tmp_path, rich_data_dict, rich_metadata_dict):
         logger = logging.getLogger("json_test")

--- a/tests/test_ux_features.py
+++ b/tests/test_ux_features.py
@@ -344,11 +344,11 @@ class TestCombinedFeatures:
 class TestVersionUpdated:
     """Test that version is correct"""
 
-    def test_version_is_3_6_0(self):
-        """Test that version is 3.6.0"""
+    def test_version_is_3_6_1(self):
+        """Test that version is 3.6.1"""
         from cja_auto_sdr.generator import __version__
 
-        assert __version__ == "3.6.0"
+        assert __version__ == "3.6.1"
 
 
 class TestFormatAutoDetection:

--- a/tests/test_watch_command.py
+++ b/tests/test_watch_command.py
@@ -3,8 +3,10 @@
 Signal tests are in test_watch_signals.py (subprocess-based, @pytest.mark.slow).
 """
 
-import pytest
+import signal as _signal
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from cja_auto_sdr.cli.commands.watch import (
     _LoggingEmitter,
@@ -246,3 +248,28 @@ def test_run_watch_invalid_interval_uses_exit_error(mock_parse, capsys):
     captured = capsys.readouterr()
     assert "ERROR:" in captured.err
     assert "garbage" in captured.err
+
+
+@patch("cja_auto_sdr.cli.commands.watch.WatchCycleRunner")
+def test_run_watch_restores_signal_handlers_on_exit(MockRunner):
+    """Issue 1: run_watch must restore the previous SIGINT/SIGTERM handlers
+    so calling it from a test session doesn't leave the watch handler
+    installed across subsequent SIGINT delivery."""
+    sentinel_int = _signal.getsignal(_signal.SIGINT)
+    sentinel_term = _signal.getsignal(_signal.SIGTERM)
+
+    runner = MockRunner.return_value
+    runner.run_cycle.return_value = iter([])
+    args = MagicMock()
+    args.watch_data_views = ["dv_abc"]
+    args.watch_interval = "1h"
+    args.watch_threshold = 1
+
+    _stop_requested.set()
+    try:
+        run_watch(args, cja=MagicMock())
+    finally:
+        _stop_requested.clear()
+
+    assert _signal.getsignal(_signal.SIGINT) is sentinel_int
+    assert _signal.getsignal(_signal.SIGTERM) is sentinel_term

--- a/tests/test_watch_command.py
+++ b/tests/test_watch_command.py
@@ -3,6 +3,7 @@
 Signal tests are in test_watch_signals.py (subprocess-based, @pytest.mark.slow).
 """
 
+import pytest
 from unittest.mock import MagicMock, patch
 
 from cja_auto_sdr.cli.commands.watch import (
@@ -225,3 +226,23 @@ def test_run_watch_emits_baseline_then_exits_on_stop(MockRunner, capsys):
     captured = capsys.readouterr()
     assert '"type":"baseline"' in captured.out
     assert '"data_view_id":"dv_abc"' in captured.out
+
+
+@patch("cja_auto_sdr.cli.commands.watch.parse_duration_seconds")
+def test_run_watch_invalid_interval_uses_exit_error(mock_parse, capsys):
+    """Issue 3: defensive --interval failure path now uses _exit_error
+    (ConsoleColors.error wrapper + sys.exit(1)) instead of raw print/return."""
+    mock_parse.return_value = None  # simulate invalid interval
+
+    args = MagicMock()
+    args.watch_data_views = ["dv_abc"]
+    args.watch_interval = "garbage"
+    args.watch_threshold = 1
+
+    with pytest.raises(SystemExit) as exc:
+        run_watch(args, cja=MagicMock())
+
+    assert exc.value.code == 1
+    captured = capsys.readouterr()
+    assert "ERROR:" in captured.err
+    assert "garbage" in captured.err

--- a/tests/test_watch_command.py
+++ b/tests/test_watch_command.py
@@ -273,3 +273,46 @@ def test_run_watch_restores_signal_handlers_on_exit(MockRunner):
 
     assert _signal.getsignal(_signal.SIGINT) is sentinel_int
     assert _signal.getsignal(_signal.SIGTERM) is sentinel_term
+
+
+@patch("cja_auto_sdr.cli.commands.watch.WatchCycleRunner")
+def test_run_watch_emits_in_memory_note_on_stderr(MockRunner, capsys):
+    """Issue 6: operators should be told once that watch holds snapshots in memory."""
+    runner = MockRunner.return_value
+    runner.run_cycle.return_value = iter([])
+    args = MagicMock()
+    args.watch_data_views = ["dv_abc"]
+    args.watch_interval = "1h"
+    args.watch_threshold = 1
+    args.quiet = False
+
+    _stop_requested.set()
+    try:
+        run_watch(args, cja=MagicMock())
+    finally:
+        _stop_requested.clear()
+
+    captured = capsys.readouterr()
+    assert "snapshots in memory" in captured.err
+    assert captured.err.count("snapshots in memory") == 1, "note should fire once, not per cycle"
+
+
+@patch("cja_auto_sdr.cli.commands.watch.WatchCycleRunner")
+def test_run_watch_suppresses_in_memory_note_in_quiet_mode(MockRunner, capsys):
+    """Quiet mode suppresses the in-memory note."""
+    runner = MockRunner.return_value
+    runner.run_cycle.return_value = iter([])
+    args = MagicMock()
+    args.watch_data_views = ["dv_abc"]
+    args.watch_interval = "1h"
+    args.watch_threshold = 1
+    args.quiet = True
+
+    _stop_requested.set()
+    try:
+        run_watch(args, cja=MagicMock())
+    finally:
+        _stop_requested.clear()
+
+    captured = capsys.readouterr()
+    assert "snapshots in memory" not in captured.err

--- a/tests/test_watch_dispatch.py
+++ b/tests/test_watch_dispatch.py
@@ -1,0 +1,49 @@
+"""End-to-end dispatch tests for --watch routing in _main_impl.
+
+These tests intentionally exercise the dispatch wiring without running the
+actual watch loop, by patching run_watch and asserting the call shape.
+"""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+
+@patch("cja_auto_sdr.cli.commands.watch.run_watch")
+@patch("cja_auto_sdr.cli.commands.watch._resolve_cja_client", return_value=MagicMock())
+def test_main_dispatches_to_run_watch_when_watch_arg_set(_mock_resolve, mock_run_watch):
+    """--watch routes through _main_impl into run_watch."""
+    from cja_auto_sdr import generator
+
+    mock_run_watch.return_value = 0
+
+    with patch.object(sys, "argv", ["cja_auto_sdr", "--watch", "dv_abc", "--interval", "1h"]):
+        try:
+            generator.main()
+        except SystemExit as exc:
+            assert exc.code == 0
+
+    assert mock_run_watch.called
+    args = mock_run_watch.call_args.args[0]
+    assert args.watch_data_views == ["dv_abc"]
+    assert args.watch_interval == "1h"
+
+
+@patch("cja_auto_sdr.cli.commands.watch.run_watch")
+def test_main_does_not_call_run_watch_when_watch_arg_absent(mock_run_watch):
+    """Non-watch invocation does not touch run_watch.
+
+    Uses --config-status rather than --version because --version is fast-path
+    and exits in __main__.py before _main_impl runs — we need an invocation
+    that actually reaches _main_impl so the absence of run_watch is meaningful.
+    --config-status dumps the resolved config and exits cleanly without
+    contacting the API, so it works in the test environment without creds.
+    """
+    from cja_auto_sdr import generator
+
+    with patch.object(sys, "argv", ["cja_auto_sdr", "--config-status"]):
+        try:
+            generator.main()
+        except SystemExit:
+            pass
+
+    assert not mock_run_watch.called

--- a/tests/test_watch_logging.py
+++ b/tests/test_watch_logging.py
@@ -87,12 +87,17 @@ def test_run_watch_emits_loop_stop_with_sigint_reason(MockRunner, mock_emit):
 def test_cycle_complete_fires_once_per_baseline_or_change_event(MockRunner, mock_emit):
     """One baseline → one cycle_complete."""
     runner = MockRunner.return_value
-    runner.run_cycle.return_value = iter([
-        BaselineEvent(
-            ts="t", cycle=1, data_view_id="dv_a",
-            snapshot_id="s", component_counts={},
-        ),
-    ])
+    runner.run_cycle.return_value = iter(
+        [
+            BaselineEvent(
+                ts="t",
+                cycle=1,
+                data_view_id="dv_a",
+                snapshot_id="s",
+                component_counts={},
+            ),
+        ]
+    )
     args = MagicMock()
     args.watch_data_views = ["dv_a"]
     args.watch_interval = "1h"

--- a/tests/test_watch_logging.py
+++ b/tests/test_watch_logging.py
@@ -1,0 +1,109 @@
+"""End-to-end coverage of the three watch structured-log events
+(watch_loop_start, watch_cycle_complete, watch_loop_stop) firing through
+the actual emit_diagnostic call path."""
+
+from unittest.mock import MagicMock, patch
+
+from cja_auto_sdr.cli.commands.watch import _stop_requested, run_watch
+from cja_auto_sdr.output.watch_event import BaselineEvent
+
+
+@patch("cja_auto_sdr.cli.commands.watch.emit_diagnostic")
+@patch("cja_auto_sdr.cli.commands.watch.WatchCycleRunner")
+def test_run_watch_emits_loop_start_with_correct_fields(MockRunner, mock_emit):
+    """watch_loop_start fires once at entry with the configured fields."""
+    runner = MockRunner.return_value
+    runner.run_cycle.return_value = iter([])
+    args = MagicMock()
+    args.watch_data_views = ["dv_a", "dv_b"]
+    args.watch_interval = "1h"
+    args.watch_threshold = 0
+
+    _stop_requested.set()
+    try:
+        run_watch(args, cja=MagicMock())
+    finally:
+        _stop_requested.clear()
+
+    loop_start_calls = [c for c in mock_emit.call_args_list if c.args and c.args[1] == "watch_loop_start"]
+    assert len(loop_start_calls) == 1
+    fields = loop_start_calls[0].kwargs
+    assert fields["data_view_count"] == 2
+    assert fields["interval_seconds"] == 3600
+    assert fields["watch_threshold"] == 0
+
+
+@patch("cja_auto_sdr.cli.commands.watch.emit_diagnostic")
+@patch("cja_auto_sdr.cli.commands.watch.WatchCycleRunner")
+def test_run_watch_emits_loop_stop_with_fatal_when_no_signal(MockRunner, mock_emit):
+    """watch_loop_stop reports `fatal` when the loop exits without a signal."""
+    runner = MockRunner.return_value
+    runner.run_cycle.return_value = iter([])
+    args = MagicMock()
+    args.watch_data_views = ["dv_abc"]
+    args.watch_interval = "1h"
+    args.watch_threshold = 1
+
+    _stop_requested.set()
+    try:
+        run_watch(args, cja=MagicMock())
+    finally:
+        _stop_requested.clear()
+
+    loop_stop_calls = [c for c in mock_emit.call_args_list if c.args and c.args[1] == "watch_loop_stop"]
+    assert len(loop_stop_calls) == 1
+    assert loop_stop_calls[0].kwargs["reason"] == "fatal"
+
+
+@patch("cja_auto_sdr.cli.commands.watch.emit_diagnostic")
+@patch("cja_auto_sdr.cli.commands.watch.WatchCycleRunner")
+def test_run_watch_emits_loop_stop_with_sigint_reason(MockRunner, mock_emit):
+    """watch_loop_stop reports `sigint` when the SIGINT handler ran."""
+    from cja_auto_sdr.cli.commands import watch as watch_mod
+
+    runner = MockRunner.return_value
+    runner.run_cycle.return_value = iter([])
+    args = MagicMock()
+    args.watch_data_views = ["dv_abc"]
+    args.watch_interval = "1h"
+    args.watch_threshold = 1
+
+    # Pre-populate the stop_reason_holder as the signal handler would.
+    watch_mod._stop_reason_holder["reason"] = "sigint"
+    _stop_requested.set()
+    try:
+        run_watch(args, cja=MagicMock())
+    finally:
+        _stop_requested.clear()
+        watch_mod._stop_reason_holder.clear()
+
+    loop_stop_calls = [c for c in mock_emit.call_args_list if c.args and c.args[1] == "watch_loop_stop"]
+    assert len(loop_stop_calls) == 1
+    assert loop_stop_calls[0].kwargs["reason"] == "sigint"
+
+
+@patch("cja_auto_sdr.cli.commands.watch.emit_diagnostic")
+@patch("cja_auto_sdr.cli.commands.watch.WatchCycleRunner")
+def test_cycle_complete_fires_once_per_baseline_or_change_event(MockRunner, mock_emit):
+    """One baseline → one cycle_complete."""
+    runner = MockRunner.return_value
+    runner.run_cycle.return_value = iter([
+        BaselineEvent(
+            ts="t", cycle=1, data_view_id="dv_a",
+            snapshot_id="s", component_counts={},
+        ),
+    ])
+    args = MagicMock()
+    args.watch_data_views = ["dv_a"]
+    args.watch_interval = "1h"
+    args.watch_threshold = 1
+
+    _stop_requested.set()
+    try:
+        run_watch(args, cja=MagicMock())
+    finally:
+        _stop_requested.clear()
+
+    cycle_complete_calls = [c for c in mock_emit.call_args_list if c.args and c.args[1] == "watch_cycle_complete"]
+    assert len(cycle_complete_calls) == 1
+    assert cycle_complete_calls[0].kwargs["data_view_id"] == "dv_a"

--- a/tests/test_watch_prevalidation.py
+++ b/tests/test_watch_prevalidation.py
@@ -128,3 +128,21 @@ def test_watch_rejects_positional_data_views():
     result = _run(["dv_old", "--watch", "dv_new", "--interval", "1h"])
     assert result.returncode == 1
     assert "positional data view" in result.stderr
+
+
+def test_watch_dedupes_duplicate_data_view_ids():
+    """Issue 4: duplicate --watch IDs are deduped at parse time with a
+    stderr warning. The loop should never see the same ID twice."""
+    # Use an invalid --interval value so run_watch exits via _exit_error
+    # before contacting the API. Dedup runs in _validate_semantic_flag_relationships
+    # (which happens first), so the WARNING is still emitted to stderr.
+    result = _run(["--watch", "dv_abc", "dv_abc", "dv_def", "--interval", "garbage"])
+    assert "WARNING" in result.stderr
+    assert "dv_abc" in result.stderr
+    assert "deduplicat" in result.stderr.lower()
+
+
+def test_watch_no_warning_when_no_duplicates():
+    """Sanity: distinct IDs produce no dedup warning."""
+    result = _run(["--watch", "dv_abc", "dv_def", "--interval", "garbage"])
+    assert "deduplicat" not in result.stderr.lower()


### PR DESCRIPTION
## Summary

Patch release closing the 5 minor findings deferred from v3.6.0's code reviews
plus one operator-experience improvement.

## Fixed
- Signal handler restore on `run_watch` return (Issue 1)
- `cycles_completed` now reports completed, not attempted (Issue 2)
- `--interval` validation uses `_exit_error` for consistent CLI errors (Issue 3)
- Duplicate `--watch` IDs deduped with warning (Issue 4)

## Added
- One-shot stderr note about in-memory snapshots (Issue 6)
- `tests/test_watch_dispatch.py`, `tests/test_watch_logging.py` (Issue 5)

## Unchanged
- `cja-watch-event/v1` schema is byte-equivalent
- All other CLI modes byte-equivalent to v3.6.0
- No new flags, no new dependencies

## Test plan
- [x] CI green (unit + lint + version-sync + test-counts)
- [x] Watch signal tests pass (SIGINT/SIGTERM still exit 0)
- [x] New dispatch + logging tests pass
- [ ] Live API smoke (`scripts/smoke_test_production.py --phase 11`) before merge