### PR TITLE
v3.7.0: Notion Integration (--format notion, --push-to-notion)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -189,6 +189,33 @@ jobs:
       - name: Smoke test - parser and contract tests
         run: uv run pytest tests/ -q --tb=short -m smoke
 
+  no-extras-smoke:
+    # Confirm the package imports and runs without the optional `notion-client`
+    # extra installed. The `dev` group includes notion-client for tests, so we
+    # explicitly skip both --dev and --all-extras here to get the real shape
+    # users see when they install plain `cja-auto-sdr`.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.14"
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+      - name: Sync runtime deps only (no extras, no dev group)
+        run: uv sync --no-dev --no-default-groups
+      - name: Confirm notion_client is NOT installed in this environment
+        run: |
+          if uv run python -c "import notion_client" 2>/dev/null; then
+            echo "::error::notion_client was installed without the [notion] extra — optional-dep contract is broken" >&2
+            exit 1
+          fi
+      - name: Package imports cleanly without notion_client
+        run: |
+          uv run python -m cja_auto_sdr --version
+          uv run python -c "import cja_auto_sdr; import cja_auto_sdr.output.writers.notion as _n; print('module loads:', _n.__name__)"
+
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -217,7 +244,7 @@ jobs:
 
   ci-gate:
     if: always()
-    needs: [test-unit, test-integration, run-summary-contract, smoke-test, build]
+    needs: [test-unit, test-integration, run-summary-contract, smoke-test, no-extras-smoke, build]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -233,6 +260,7 @@ jobs:
             [test-integration]="${{ needs.test-integration.result }}"
             [run-summary-contract]="${{ needs.run-summary-contract.result }}"
             [smoke-test]="${{ needs.smoke-test.result }}"
+            [no-extras-smoke]="${{ needs.no-extras-smoke.result }}"
             [build]="${{ needs.build.result }}"
           )
           failed=0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -192,8 +192,8 @@ jobs:
   no-extras-smoke:
     # Confirm the package imports and runs without the optional `notion-client`
     # extra installed. The `dev` group includes notion-client for tests, so we
-    # explicitly skip both --dev and --all-extras here to get the real shape
-    # users see when they install plain `cja-auto-sdr`.
+    # build the wheel and install it into a fresh, isolated venv without any
+    # extras — the same shape users get from `pip install cja-auto-sdr`.
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -203,18 +203,29 @@ jobs:
           python-version: "3.14"
           enable-cache: true
           cache-dependency-glob: uv.lock
-      - name: Sync runtime deps only (no extras, no dev group)
-        run: uv sync --no-dev --no-default-groups
+      - name: Build wheel
+        run: |
+          rm -f dist/*.whl dist/*.tar.gz
+          uv build --wheel
+      - name: Install wheel into isolated venv (no extras, no dev deps)
+        run: |
+          uv venv /tmp/no-extras-venv --python 3.14
+          wheels=(dist/*.whl)
+          if [ "${#wheels[@]}" -ne 1 ]; then
+            echo "::error::Expected exactly one wheel, found ${#wheels[@]}" >&2
+            exit 1
+          fi
+          uv pip install "${wheels[0]}" --python /tmp/no-extras-venv/bin/python
       - name: Confirm notion_client is NOT installed in this environment
         run: |
-          if uv run python -c "import notion_client" 2>/dev/null; then
+          if /tmp/no-extras-venv/bin/python -c "import notion_client" 2>/dev/null; then
             echo "::error::notion_client was installed without the [notion] extra — optional-dep contract is broken" >&2
             exit 1
           fi
       - name: Package imports cleanly without notion_client
         run: |
-          uv run python -m cja_auto_sdr --version
-          uv run python -c "import cja_auto_sdr; import cja_auto_sdr.output.writers.notion as _n; print('module loads:', _n.__name__)"
+          /tmp/no-extras-venv/bin/python -m cja_auto_sdr --version
+          /tmp/no-extras-venv/bin/python -c "import cja_auto_sdr; import cja_auto_sdr.output.writers.notion as _n; print('module loads:', _n.__name__)"
 
   build:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,14 @@ htmlcov/
 config.json
 myconfig.json
 .env
+.env.*
+!.env.example
 *.key
 *.pem
+
+# Notion integration registry (runtime state, per working directory)
+.notion_pages.json
+.notion_pages.json.lock
 
 # Build artifacts
 build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ All notable changes to the CJA SDR Generator project will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.7.0] — 2026-05-14
+
+### Added
+- `--format notion` — publish SDR directly to a Notion page in a single command.
+- `--push-to-notion <file>` — push an existing JSON artifact to Notion without
+  re-calling the CJA API. Mutually exclusive with generation flags via the
+  `RunMode.PUSH_TO_NOTION` dispatch.
+- `--notion-force-new` — force a new Notion page even if one already exists
+  for the data view; the new page ID replaces the old entry in the registry.
+- Idempotent page registry (`.notion_pages.json`) so re-runs update existing
+  pages in place rather than accumulating duplicates.
+- `notion` optional extra: `uv pip install 'cja-auto-sdr[notion]'`. The
+  `notion-client` SDK is added unconditionally to the dev dependency group
+  so tests run without the optional install flag.
+
+### Tests
+- `tests/test_notion_registry.py` — 11 tests covering registry CRUD,
+  atomic writes, and missing-file behavior.
+- `tests/test_notion_writer.py` — 28 tests covering the block builder
+  (pure functions), credential resolution, Notion API layer (clear/append/
+  create-or-update), and `write_notion_output` integration with mocked client.
+- `tests/test_cli_notion.py` — 9 tests covering CLI flag wiring,
+  `--push-to-notion` default, simultaneous flags, and standalone policy.
+- `tests/test_push_to_notion.py` — 3 tests covering the push handler:
+  JSON deserialization, file-not-found, and invalid-JSON exits.
+
+### Documentation
+- New Notion sections in `docs/OUTPUT_FORMATS.md`, `docs/CLI_REFERENCE.md`,
+  `docs/QUICK_REFERENCE.md`, `docs/AGENT_AUTOMATION.md`.
+- `tools/cja_sdr_generate.json` — `notion` added to format enum.
+
 ## [3.6.1] — 2026-05-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   discovery) with an actionable error pointing users to `--push-to-notion`
   for publishing saved artifacts. Previously the format was silently
   accepted by those code paths and produced no output.
+- Sections larger than Notion's per-block 100-children API limit are
+  automatically split into multiple sibling tables under the same heading
+  (header + ≤ 99 data rows per table). Data views with > 99 metrics,
+  dimensions, segments, calculated metrics, or derived fields in any one
+  component publish without `validation_error`.
 - `notion` optional extra: `uv pip install 'cja-auto-sdr[notion]'`. The
   `notion-client` SDK is added unconditionally to the dev dependency group
   so tests run without the optional install flag.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Static guard test ensures no top-level `notion_client` imports exist in
   `src/cja_auto_sdr/` — the extra must only be imported lazily inside a
   function body.
+- Data quality severity icons now cover the full CJA quality vocabulary. The
+  icon map keyed only on `ERROR`/`WARN`/`INFO`, so `HIGH` and `MEDIUM` issues
+  fell through to the info icon (the engine emits `CRITICAL`/`HIGH`/`MEDIUM`/
+  `LOW`/`INFO`). `CRITICAL`/`HIGH` now render 🔴, `MEDIUM`/`WARN` render ⚠️, and
+  `LOW`/`INFO` render ℹ️. Found during the live Notion smoke against a real data
+  view; covered by a parametrized regression test.
+- `.notion_pages.json` and `.notion_pages.json.lock` (the per-working-directory
+  page registry) plus `.env.*` secret files are now in `.gitignore`, so running
+  `--format notion` inside a repo cannot accidentally commit the registry or
+  Notion credentials.
 
 ## [3.6.1] — 2026-05-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for the data view; the new page ID replaces the old entry in the registry.
 - Idempotent page registry (`.notion_pages.json`) so re-runs update existing
   pages in place rather than accumulating duplicates. Registry writes are
-  serialized across batch workers via an `fcntl.flock` sidecar lock so
-  parallel `--format notion` batch runs do not lose entries.
+  serialized across batch workers via an `fcntl.flock` sidecar lock on
+  POSIX and `msvcrt.locking` on Windows, so parallel `--format notion`
+  batch runs do not lose entries on either platform.
+- `--format notion` is rejected in non-SDR modes (diff, org-report,
+  discovery) with an actionable error pointing users to `--push-to-notion`
+  for publishing saved artifacts. Previously the format was silently
+  accepted by those code paths and produced no output.
 - `notion` optional extra: `uv pip install 'cja-auto-sdr[notion]'`. The
   `notion-client` SDK is added unconditionally to the dev dependency group
   so tests run without the optional install flag.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,12 +60,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed (post-review hardening for v3.7.0)
 - `--push-to-notion` is now explicitly mutually exclusive with `--org-report`,
-  `--diff`, `--snapshot`, `--diff-snapshot`, `--compare-snapshots`, `--batch`,
+  `--diff`, `--snapshot`, `--diff-snapshot`, `--compare-snapshots`,
+  `--list-snapshots`, `--prune-snapshots`, `--list-org-report-snapshots`,
+  `--inspect-org-report-snapshot`, `--prune-org-report-snapshots`, `--batch`,
   `--watch`, `--inventory-summary`, `--dry-run`, and positional data view
   arguments. Previously the `RunMode` dispatcher resolved by precedence, so
   combining `--push-to-notion` with one of those flags silently dropped the
   Notion publish. The CHANGELOG's "mutually exclusive" claim was aspirational;
-  it is now enforced by `_validate_semantic_flag_relationships`.
+  it is now enforced by `_validate_semantic_flag_relationships` via a
+  table-driven check (`_PUSH_TO_NOTION_INCOMPATIBLE_FLAGS`) so adding a new
+  mode flag forces an explicit decision here.
+- Batch workers no longer abort the whole batch when one data view hits a
+  Notion writer error. The Notion failure path in `process_single_dataview`
+  previously raised `SystemExit` via `_exit_error`, which killed the pool
+  worker and made `--continue-on-error` ineffective. The handler now returns
+  a structured failed `ProcessingResult` (`FAILURE_CODE_OUTPUT_WRITE_FAILED`)
+  so the batch can mark the data view failed and proceed.
 - Notion API errors now surface as friendly, actionable messages instead of
   raw `notion_client` stack traces. `unauthorized` / `restricted_resource`
   point at `NOTION_TOKEN` and the parent-page share; `object_not_found`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `docs/QUICK_REFERENCE.md`, `docs/AGENT_AUTOMATION.md`.
 - `tools/cja_sdr_generate.json` — `notion` added to format enum.
 
+### Fixed (post-review hardening for v3.7.0)
+- `--push-to-notion` is now explicitly mutually exclusive with `--org-report`,
+  `--diff`, `--snapshot`, `--diff-snapshot`, `--compare-snapshots`, `--batch`,
+  `--watch`, `--inventory-summary`, `--dry-run`, and positional data view
+  arguments. Previously the `RunMode` dispatcher resolved by precedence, so
+  combining `--push-to-notion` with one of those flags silently dropped the
+  Notion publish. The CHANGELOG's "mutually exclusive" claim was aspirational;
+  it is now enforced by `_validate_semantic_flag_relationships`.
+- Notion API errors now surface as friendly, actionable messages instead of
+  raw `notion_client` stack traces. `unauthorized` / `restricted_resource`
+  point at `NOTION_TOKEN` and the parent-page share; `object_not_found`
+  suggests `--notion-force-new`; `validation_error` includes the upstream
+  detail. 429 rate-limit responses retry up to 3 times with exponential
+  backoff (honouring `Retry-After` when Notion provides it) before exiting.
+- `_clear_page_blocks` now lists every block ID first and deletes second.
+  Notion's pagination cursors are content-based, so the prior list-then-
+  delete-in-loop pattern could skip blocks once mid-page state changed.
+  Deletes are issued from a 4-worker thread pool, keeping update time
+  tolerable on large pages while staying well clear of the per-integration
+  rate limit.
+- `_table_block` returns `None` for zero-column DataFrames (Notion rejects
+  `table_width=0`); `_section_blocks` filters and avoids emitting an orphan
+  heading. Empty input was previously possible for unusual section payloads.
+- The Notion writer no longer calls `sys.exit` from library code. It raises
+  `NotionConfigurationError` (missing env vars), `NotionDependencyError`
+  (missing `notion-client` extra), or `NotionAPIError` (mapped API failures);
+  the two CLI entry points (`_push_to_notion_from_json` and the SDR pipeline
+  writer dispatch) convert these to exit code 1 with a friendly message.
+- New CI job `no-extras-smoke` syncs runtime deps only (no `--dev`, no
+  `--all-extras`), confirms `notion-client` is not installed, and asserts the
+  package and the Notion writer module both import cleanly. Catches future
+  regressions where a top-level `import notion_client` slips in.
+- Static guard test ensures no top-level `notion_client` imports exist in
+  `src/cja_auto_sdr/` — the extra must only be imported lazily inside a
+  function body.
+
 ## [3.6.1] — 2026-05-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,13 +25,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Tests
 - `tests/test_notion_registry.py` — 11 tests covering registry CRUD,
   atomic writes, and missing-file behavior.
-- `tests/test_notion_writer.py` — 28 tests covering the block builder
+- `tests/test_notion_writer.py` — 29 tests covering the block builder
   (pure functions), credential resolution, Notion API layer (clear/append/
-  create-or-update), and `write_notion_output` integration with mocked client.
+  create-or-update), `write_notion_output` integration with mocked client,
+  and the missing-`notion-client`-extra guardrail.
 - `tests/test_cli_notion.py` — 9 tests covering CLI flag wiring,
   `--push-to-notion` default, simultaneous flags, and standalone policy.
-- `tests/test_push_to_notion.py` — 3 tests covering the push handler:
-  JSON deserialization, file-not-found, and invalid-JSON exits.
+- `tests/test_push_to_notion.py` — 5 tests covering the push handler:
+  JSON deserialization, file-not-found, invalid-JSON exits, OSError on
+  read, and `RunMode.PUSH_TO_NOTION` precedence over `RunMode.WATCH`.
 
 ### Documentation
 - New Notion sections in `docs/OUTPUT_FORMATS.md`, `docs/CLI_REFERENCE.md`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,14 +17,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--notion-force-new` — force a new Notion page even if one already exists
   for the data view; the new page ID replaces the old entry in the registry.
 - Idempotent page registry (`.notion_pages.json`) so re-runs update existing
-  pages in place rather than accumulating duplicates.
+  pages in place rather than accumulating duplicates. Registry writes are
+  serialized across batch workers via an `fcntl.flock` sidecar lock so
+  parallel `--format notion` batch runs do not lose entries.
 - `notion` optional extra: `uv pip install 'cja-auto-sdr[notion]'`. The
   `notion-client` SDK is added unconditionally to the dev dependency group
   so tests run without the optional install flag.
+- `notion` joins `json`/`html`/`markdown` in `EMBEDDED_METADATA_FORMATS`, so
+  direct `--format notion` runs send real SDR metadata (data view name, ID,
+  generation timestamp) to the Notion page rather than falling back to the
+  base filename.
 
 ### Tests
-- `tests/test_notion_registry.py` — 11 tests covering registry CRUD,
-  atomic writes, and missing-file behavior.
+- `tests/test_notion_registry.py` — 13 tests covering registry CRUD,
+  atomic writes, missing-file behavior, the sidecar lock file, and a
+  real-`ProcessPoolExecutor` concurrent-write test that asserts all entries
+  survive parallel batch worker writes.
 - `tests/test_notion_writer.py` — 29 tests covering the block builder
   (pure functions), credential resolution, Notion API layer (clear/append/
   create-or-update), `write_notion_output` integration with mocked client,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
 - Current version: v3.7.0
-- Tests: **8,060** across 149 files at **95% coverage gate**
+- Tests: **8,063** across 149 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,8 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Package manager: **uv**
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
-- Current version: v3.6.1
-- Tests: **8,010** across 145 files at **95% coverage gate**
+- Current version: v3.7.0
+- Tests: **8,060** across 149 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
 - Current version: v3.7.0
-- Tests: **8,085** across 149 files at **95% coverage gate**
+- Tests: **8,088** across 149 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
 - Current version: v3.7.0
-- Tests: **8,063** across 149 files at **95% coverage gate**
+- Tests: **8,066** across 149 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
 - Current version: v3.7.0
-- Tests: **8,088** across 149 files at **95% coverage gate**
+- Tests: **8,101** across 149 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
 - Current version: v3.7.0
-- Tests: **8,066** across 149 files at **95% coverage gate**
+- Tests: **8,071** across 149 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
 - Current version: v3.7.0
-- Tests: **8,074** across 149 files at **95% coverage gate**
+- Tests: **8,085** across 149 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
 - Current version: v3.7.0
-- Tests: **8,071** across 149 files at **95% coverage gate**
+- Tests: **8,074** across 149 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Version Sync](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/version-sync.yml/badge.svg)](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/version-sync.yml)
 [![Python 3.14+](https://img.shields.io/badge/python-3.14%2B-blue.svg)](https://www.python.org/downloads/)
 [![Coverage](https://img.shields.io/badge/coverage-99%25-brightgreen.svg)](tests/)
-[![Tests](https://img.shields.io/badge/tests-8010-brightgreen.svg)](tests/)
+[![Tests](https://img.shields.io/badge/tests-8060-brightgreen.svg)](tests/)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
@@ -468,7 +468,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (8,010+ tests)
+├── tests/                     # Test suite (8,060+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (8,088+ tests)
+├── tests/                     # Test suite (8,101+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Version Sync](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/version-sync.yml/badge.svg)](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/version-sync.yml)
 [![Python 3.14+](https://img.shields.io/badge/python-3.14%2B-blue.svg)](https://www.python.org/downloads/)
 [![Coverage](https://img.shields.io/badge/coverage-99%25-brightgreen.svg)](tests/)
-[![Tests](https://img.shields.io/badge/tests-8063-brightgreen.svg)](tests/)
+[![Tests](https://img.shields.io/badge/tests-8066-brightgreen.svg)](tests/)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
@@ -468,7 +468,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (8,063+ tests)
+├── tests/                     # Test suite (8,066+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Version Sync](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/version-sync.yml/badge.svg)](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/version-sync.yml)
 [![Python 3.14+](https://img.shields.io/badge/python-3.14%2B-blue.svg)](https://www.python.org/downloads/)
 [![Coverage](https://img.shields.io/badge/coverage-99%25-brightgreen.svg)](tests/)
-[![Tests](https://img.shields.io/badge/tests-8071-brightgreen.svg)](tests/)
+[![Tests](https://img.shields.io/badge/tests-8074-brightgreen.svg)](tests/)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
@@ -468,7 +468,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (8,071+ tests)
+├── tests/                     # Test suite (8,074+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Version Sync](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/version-sync.yml/badge.svg)](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/version-sync.yml)
 [![Python 3.14+](https://img.shields.io/badge/python-3.14%2B-blue.svg)](https://www.python.org/downloads/)
 [![Coverage](https://img.shields.io/badge/coverage-99%25-brightgreen.svg)](tests/)
-[![Tests](https://img.shields.io/badge/tests-8066-brightgreen.svg)](tests/)
+[![Tests](https://img.shields.io/badge/tests-8071-brightgreen.svg)](tests/)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
@@ -468,7 +468,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (8,066+ tests)
+├── tests/                     # Test suite (8,071+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (8,085+ tests)
+├── tests/                     # Test suite (8,088+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (8,074+ tests)
+├── tests/                     # Test suite (8,085+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Version Sync](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/version-sync.yml/badge.svg)](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/version-sync.yml)
 [![Python 3.14+](https://img.shields.io/badge/python-3.14%2B-blue.svg)](https://www.python.org/downloads/)
 [![Coverage](https://img.shields.io/badge/coverage-99%25-brightgreen.svg)](tests/)
-[![Tests](https://img.shields.io/badge/tests-8060-brightgreen.svg)](tests/)
+[![Tests](https://img.shields.io/badge/tests-8063-brightgreen.svg)](tests/)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
@@ -468,7 +468,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (8,060+ tests)
+├── tests/                     # Test suite (8,063+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (8,101+ tests)
+├── tests/                     # Test suite (8,112+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/docs/AGENT_AUTOMATION.md
+++ b/docs/AGENT_AUTOMATION.md
@@ -424,6 +424,28 @@ The run summary includes an `advisories` rollup key when advisories are present 
 | PagerDuty     | Events API v2              | Exit code 2 (policy violation)  | `curl -X POST https://events.pagerduty.com/v2/enqueue` |
 | Microsoft Teams | Incoming webhook          | Exit code 2 or 3               | `curl -X POST $TEAMS_WEBHOOK -d '{"text":"..."}'` |
 | GitHub Issues | `gh issue create`          | Exit code 2 (governance alert)  | `gh issue create --title "SDR drift detected" --body "$(cat summary.json)"` |
+| Notion        | `--format notion` or `--push-to-notion` | Every run or post-pipeline | `cja_auto_sdr dv_12345 --format notion` |
+
+### Publishing to Notion
+
+Notion is supported as a first-class output destination for SDR generation. Install the optional extra and set the two required env vars:
+
+```bash
+uv pip install 'cja-auto-sdr[notion]'
+export NOTION_TOKEN=secret_...
+export NOTION_PARENT_PAGE_ID=<page-id>
+```
+
+```bash
+# Two-step CI pattern: generate JSON, then push to Notion separately
+uv run cja_auto_sdr dv_12345 --format json --output-dir ./artifacts
+uv run cja_auto_sdr --push-to-notion ./artifacts/dv_12345_sdr.json
+
+# Single-step: generate and publish in one command
+uv run cja_auto_sdr dv_12345 --format notion
+```
+
+Page IDs are tracked in `.notion_pages.json` so re-runs update the existing page rather than accumulating duplicates. Use `--notion-force-new` to override.
 
 Pattern:
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -167,6 +167,7 @@ cja-auto-sdr [OPTIONS] DATA_VIEW_ID_OR_NAME [...]
 | `json` | ✓ | ✓ | ✓ | ✓ |
 | `html` | ✓ | ✓ | ✓ | ✗ |
 | `markdown` | ✓ | ✓ | ✓ | ✗ |
+| `notion` | ✓ | ✗ | ✗ | ✗ |
 | `console` | ✗ | ✓ (default) | ✓ (default) | ✓ (default) |
 | `all` | ✓ | ✓ | ✓ | ✗ |
 
@@ -489,6 +490,34 @@ Cache is stored in `~/.cja_auto_sdr/cache/org_report_cache.json`.
 > **Derived Fields:** `--include-derived` is for **SDR generation only**, not diff. Derived fields are already included in the standard metrics/dimensions API output, so changes to derived fields are automatically captured in the Metrics/Dimensions diff sections. The `--include-derived` flag provides additional logic analysis (complexity scores, functions used, branch counts) that is valuable for SDR documentation but would be duplicative in diff mode.
 >
 > **Snapshot/Diff Tip:** `--include-all-inventory` automatically excludes `--include-derived` in `--snapshot`, `--diff-snapshot`, `--compare-snapshots`, and `--compare-with-prev` modes.
+
+### Notion Integration
+
+Publish SDRs directly to a Notion page, or push a previously-generated JSON artifact to Notion without re-calling the CJA API. Requires `NOTION_TOKEN` and `NOTION_PARENT_PAGE_ID` environment variables. Install the extra first:
+
+```bash
+uv pip install 'cja-auto-sdr[notion]'
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--format notion` | Publish SDR to a Notion page as part of generation | - |
+| `--push-to-notion JSON_FILE` | Push an existing SDR JSON artifact to Notion (standalone mode; no CJA API call) | - |
+| `--notion-force-new` | Force a new Notion page instead of updating the existing one for this data view | False |
+
+```bash
+# Publish SDR directly to Notion
+cja_auto_sdr dv_12345 --format notion
+
+# Push an existing JSON artifact to Notion (no CJA API call)
+cja_auto_sdr --push-to-notion ./reports/dv_12345_sdr.json
+
+# Force a new Notion page even if one already exists
+cja_auto_sdr dv_12345 --format notion --notion-force-new
+cja_auto_sdr --push-to-notion ./reports/dv_12345_sdr.json --notion-force-new
+```
+
+> **Idempotency:** Page IDs are tracked in `.notion_pages.json` in the output directory so re-runs update the existing page rather than creating duplicates. Use `--notion-force-new` to override.
 
 ### Watch Mode
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -518,6 +518,8 @@ cja_auto_sdr --push-to-notion ./reports/dv_12345_sdr.json --notion-force-new
 ```
 
 > **Idempotency:** Page IDs are tracked in `.notion_pages.json` in the output directory so re-runs update the existing page rather than creating duplicates. Use `--notion-force-new` to override.
+>
+> **Stdout:** `--push-to-notion` prints the resulting `notion://pages/<id>` identifier to stdout on success. Avoid combining with `--run-summary-json -` / `--output -` if you need to consume stdout machine-readably, since the two outputs will be interleaved.
 
 ### Watch Mode
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -924,7 +924,7 @@ cja_auto_sdr --list-dataviews --log-level DEBUG
 At launch, the tool logs diagnostic lines containing the tool version, Python version, platform, active log level, inferred run mode (batch, single, or discovery), and dependency versions. These appear automatically at `INFO` level and are useful for troubleshooting environment issues in CI/CD logs or support requests:
 
 ```text
-CJA SDR Generator v3.6.1 | Python 3.14.2 | darwin | log_level=INFO | mode=single
+CJA SDR Generator v3.7.0 | Python 3.14.2 | darwin | log_level=INFO | mode=single
 Dependencies: cjapy=0.3.0, pandas=2.3.3, numpy=2.2.1, xlsxwriter=3.2.9, tqdm=4.67.0
 ```
 

--- a/docs/OUTPUT_FORMATS.md
+++ b/docs/OUTPUT_FORMATS.md
@@ -416,6 +416,12 @@ cja_auto_sdr --push-to-notion ./reports/dv_12345_sdr.json
 - Empty sections are omitted automatically
 - Footer paragraph with tool version
 
+**Behaviour and caveats:**
+- **Auto-regenerated pages overwrite manual edits.** When the registry contains a page ID for the data view, the writer clears every child block before re-appending the freshly generated SDR. Any annotations, comments-as-blocks, or layout changes a user added inside Notion will be lost on the next run. Use `--notion-force-new` to break the registry link and produce a new page (the old one is left in place as an orphan) when you need to preserve manual edits.
+- **`--push-to-notion` is mutually exclusive with all other generation flags.** Combining it with `--org-report`, `--diff`, `--snapshot`, `--batch`, `--watch`, `--inventory-summary`, `--dry-run`, or positional data view IDs exits with an actionable error (rather than silently dropping `--push-to-notion`).
+- **Large sections split into sibling tables.** Notion caps a block's children array at 100. Sections with more than 99 data rows are split into multiple sibling tables under the same heading, preserving row order.
+- **API failures surface as friendly messages.** Missing/invalid `NOTION_TOKEN`, deleted parent pages, and rate-limit errors print a one-line summary and exit 1; 429 responses are retried with exponential backoff (or `Retry-After` if Notion provides it) before giving up.
+
 ---
 
 ### 7. All Formats

--- a/docs/OUTPUT_FORMATS.md
+++ b/docs/OUTPUT_FORMATS.md
@@ -11,6 +11,7 @@ The tool supports multiple output formats beyond Excel, providing flexible integ
 | **JSON** | Hierarchical structured data | APIs, automation, integration with tools |
 | **HTML** | Professional web-ready report | Web viewing, sharing, presentations |
 | **Markdown** (.md) | GitHub/Confluence compatible tables | Documentation, version control, PRs |
+| **Notion** | Notion page with structured blocks | Collaborative docs, Notion-based wikis |
 | **Console** | Terminal output with ASCII formatting | Quick review, diff comparison, org-wide analysis, discovery |
 | **All** | Generate all formats simultaneously (includes console in diff/org-wide modes) | Complete documentation package |
 
@@ -23,6 +24,7 @@ The tool supports multiple output formats beyond Excel, providing flexible integ
 | JSON | ✓ | ✓ | ✓ | ✓ |
 | HTML | ✓ | ✓ | ✓ | ✗ |
 | Markdown | ✓ | ✓ | ✓ | ✗ |
+| Notion | ✓ | ✗ | ✗ | ✗ |
 | Console/Table | ✗ | ✓ (default) | ✓ (default) | ✓ (default) |
 | All | ✓ | ✓ | ✓ | ✗ |
 
@@ -389,7 +391,34 @@ pandoc CJA_DataView_myview_dv_12345_SDR.md -o report.pdf
 
 ---
 
-### 6. All Formats
+### 6. Notion Format
+
+Publishes the SDR directly to a Notion page. Requires `NOTION_TOKEN` and `NOTION_PARENT_PAGE_ID` environment variables and the `notion` optional extra (`uv pip install 'cja-auto-sdr[notion]'`).
+
+Each run creates or updates a single page under the configured parent. Page IDs are tracked in `.notion_pages.json` in the output directory so re-runs update in place rather than accumulating duplicates.
+
+**Usage:**
+```bash
+# Publish SDR directly to Notion
+cja_auto_sdr dv_12345 --format notion
+
+# Force a new page even if one already exists
+cja_auto_sdr dv_12345 --format notion --notion-force-new
+
+# Push an existing JSON artifact to Notion (no CJA API call)
+cja_auto_sdr --push-to-notion ./reports/dv_12345_sdr.json
+```
+
+**Block layout:**
+- Metadata callout (data view name, ID, timestamp, version)
+- Data Quality callouts (one per issue, severity-coded; omitted if none)
+- Heading + inline table for Metrics, Dimensions, Segments, Calculated Metrics, Derived Fields
+- Empty sections are omitted automatically
+- Footer paragraph with tool version
+
+---
+
+### 7. All Formats
 
 Generate all output formats in a single run for complete documentation packages.
 

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -190,7 +190,7 @@ This command:
 
 ```bash
 $ uv run cja_auto_sdr -V
-cja_auto_sdr 3.6.1
+cja_auto_sdr 3.7.0
 ```
 
 > **Important:** All commands in this guide assume you're in the `cja_auto_sdr` directory. If you see "command not found", make sure you're in the right directory and have run `uv sync`.

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -6,7 +6,7 @@ Single-page command cheat sheet for CJA SDR Generator v3.6.1.
 
 | Mode | Purpose | Output |
 |------|---------|--------|
-| **SDR Generation** | Document a data view's dimensions, metrics, and calculated metrics | Excel (default), CSV, JSON, HTML, Markdown |
+| **SDR Generation** | Document a data view's dimensions, metrics, and calculated metrics | Excel (default), CSV, JSON, HTML, Markdown, Notion |
 | **Diff Comparison** | Compare two data views or snapshots to identify changes | Console (default), Excel, CSV, JSON, HTML, Markdown |
 | **Org-Wide Analysis** | Analyze component usage across all data views in an organization | Console (default), Excel, CSV, JSON, HTML, Markdown |
 | **Discovery** | List data views, connections, and datasets in your CJA org | Console (default), CSV, JSON |
@@ -399,6 +399,9 @@ cja_auto_sdr --list-dataviews  # Uses client-a
 | `--warn-threshold PERCENT` | Exit with code 3 if change % exceeds threshold (for CI/CD) |
 | `--no-color` | Disable ANSI color codes in console output (global) |
 | `--format-pr-comment` | Output in GitHub/GitLab PR comment format |
+| `--format notion` | Publish SDR directly to Notion (requires `NOTION_TOKEN` + `NOTION_PARENT_PAGE_ID`) |
+| `--push-to-notion JSON_FILE` | Push existing JSON artifact to Notion (no CJA API call) |
+| `--notion-force-new` | Force a new Notion page instead of updating existing |
 
 > **Retention precedence:** Explicit values are preserved in both forms: `--keep-last 0` / `--keep-last=0` and `--keep-since 90d` / `--keep-since=90d`.
 
@@ -411,6 +414,7 @@ cja_auto_sdr --list-dataviews  # Uses client-a
 | `json` | ✅ | ✅ | ✅ | ✅ | JSON for integrations |
 | `html` | ✅ | ✅ | ✅ | ❌ | Browser-viewable |
 | `markdown` | ✅ | ✅ | ✅ | ❌ | Documentation-ready |
+| `notion` | ✅ | ❌ | ❌ | ❌ | Publish SDR to Notion page |
 | `console` | ❌ | ✅ (default) | ✅ (default) | ✅ (default) | Terminal output |
 | `all` | ✅ | ✅ | ✅ | ❌ | All formats |
 

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Quick Reference Card
 
-Single-page command cheat sheet for CJA SDR Generator v3.6.1.
+Single-page command cheat sheet for CJA SDR Generator v3.7.0.
 
 ## Four Main Modes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,10 +42,14 @@ env = [
 completion = [
     "argcomplete>=3.0.0",
 ]
+notion = [
+    "notion-client>=2.0.0",
+]
 full = [
     "scipy>=1.14.0",
     "python-dotenv>=1.0.0",
     "argcomplete>=3.0.0",
+    "notion-client>=2.0.0",
 ]
 
 [build-system]
@@ -73,6 +77,7 @@ dev = [
     "pytest-xdist>=3.6.0",
     "ruff>=0.9.0",
     "openpyxl>=3.1.0",
+    "notion-client>=2.0.0",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,7 @@ ignore = [
 "src/cja_auto_sdr/inventory/*.py" = ["F822"] # lazy forwarding modules
 "src/cja_auto_sdr/output/**/*.py" = ["F822"] # lazy forwarding modules
 "src/cja_auto_sdr/output/inventory/summary.py" = ["T201"]  # intentional CLI console output (inventory summary display)
+"src/cja_auto_sdr/output/writers/notion.py" = ["T201", "RUF001", "RUF003"]  # T201: stderr error messages before logger is wired; RUF001/3: intentional Unicode emoji (ℹ ⚠ 🔴)
 "src/cja_auto_sdr/output/run_summary.py" = ["T201"]  # intentional CLI console output (run summary to stdout)
 "src/cja_auto_sdr/output/diff/console.py" = ["RUF001", "RUF003"]  # intentional Unicode box-drawing characters
 "src/cja_auto_sdr/output/diff/grouped.py" = ["RUF001"]  # intentional Unicode arrow (→) in output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,6 +175,7 @@ ignore = [
 "src/cja_auto_sdr/output/sdr/__init__.py" = ["F822", "ERA001", "RUF001", "RUF003"]  # F822: lazy forwarding; ERA001: section header comments; RUF001/3: intentional Unicode symbols
 "src/cja_auto_sdr/pipeline/*.py" = ["F822"]  # lazy forwarding modules
 "tests/**" = ["B", "SIM", "RUF012", "PERF", "DTZ", "S105", "S108", "S110", "S314", "PT017", "PT018", "PT019", "ARG", "T201", "ERA001", "PD011", "FLY002"]
+"tests/test_notion_writer.py" = ["RUF001", "RUF003"]  # intentional Unicode emoji (ℹ ⚠ 🔴) in severity-icon assertions
 "scripts/orchestrator.py" = ["T201"]  # intentional CLI output in standalone script
 "scripts/create_sample_outputs.py" = ["T201"]  # intentional CLI output in standalone script
 "scripts/stress_test.py" = ["T201"]  # intentional CLI output in standalone script

--- a/src/cja_auto_sdr/cli/execution.py
+++ b/src/cja_auto_sdr/cli/execution.py
@@ -429,6 +429,7 @@ def _run_quality_report_mode(
             quality_report_only=True,
             allow_partial=getattr(args, "allow_partial", False),
             production_mode=args.production,
+            notion_force_new=getattr(args, "notion_force_new", False),
         )
         quality_report_results.append(result)
         processed_results.append(result)
@@ -528,6 +529,7 @@ def _run_batch_mode(
         quality_report_only=quality_report_only,
         allow_partial=getattr(args, "allow_partial", False),
         production_mode=args.production,
+        notion_force_new=getattr(args, "notion_force_new", False),
     )
 
     results = processor.process_batch(data_views)
@@ -727,6 +729,7 @@ def _run_single_mode(
         quality_report_only=quality_report_only,
         allow_partial=getattr(args, "allow_partial", False),
         production_mode=args.production,
+        notion_force_new=getattr(args, "notion_force_new", False),
     )
     processed_results = [result]
 

--- a/src/cja_auto_sdr/cli/parser.py
+++ b/src/cja_auto_sdr/cli/parser.py
@@ -1450,7 +1450,7 @@ Requirements:
         metavar="JSON_FILE",
         dest="push_to_notion",
         help="Push an existing SDR JSON artifact to Notion without re-calling the CJA API. "
-             "Mutually exclusive with generation flags. Requires NOTION_TOKEN and NOTION_PARENT_PAGE_ID env vars.",
+        "Mutually exclusive with generation flags. Requires NOTION_TOKEN and NOTION_PARENT_PAGE_ID env vars.",
     )
     notion_group.add_argument(
         "--notion-force-new",
@@ -1458,7 +1458,7 @@ Requirements:
         default=False,
         dest="notion_force_new",
         help="Force creation of a new Notion page even if one already exists for this data view. "
-             "The new page ID replaces the old entry in .notion_pages.json.",
+        "The new page ID replaces the old entry in .notion_pages.json.",
     )
 
     # --- Watch Mode ----------------------------------------------------------

--- a/src/cja_auto_sdr/cli/parser.py
+++ b/src/cja_auto_sdr/cli/parser.py
@@ -490,8 +490,8 @@ Requirements:
         "--format",
         type=str,
         default=None,
-        choices=["console", "excel", "csv", "json", "html", "markdown", "all", "reports", "data", "ci"],
-        help="Output format: excel, csv, json, html, markdown, all, or shorthand (reports=excel+markdown, data=csv+json, ci=json+markdown). Default: excel for SDR, console for diff",
+        choices=["console", "excel", "csv", "json", "html", "markdown", "notion", "all", "reports", "data", "ci"],
+        help="Output format: excel, csv, json, html, markdown, notion, all, or shorthand (reports=excel+markdown, data=csv+json, ci=json+markdown). Default: excel for SDR, console for diff",
     )
 
     parser.add_argument(
@@ -1439,6 +1439,26 @@ Requirements:
         default=3600,
         dest="org_lock_stale_threshold",
         help="Stale lease recovery threshold in seconds for the org-report concurrency lock (default: 3600)",
+    )
+
+    # --- Notion Integration --------------------------------------------------
+    notion_group = parser.add_argument_group("Notion Integration")
+    notion_group.add_argument(
+        "--push-to-notion",
+        type=str,
+        default=None,
+        metavar="JSON_FILE",
+        dest="push_to_notion",
+        help="Push an existing SDR JSON artifact to Notion without re-calling the CJA API. "
+             "Mutually exclusive with generation flags. Requires NOTION_TOKEN and NOTION_PARENT_PAGE_ID env vars.",
+    )
+    notion_group.add_argument(
+        "--notion-force-new",
+        action="store_true",
+        default=False,
+        dest="notion_force_new",
+        help="Force creation of a new Notion page even if one already exists for this data view. "
+             "The new page ID replaces the old entry in .notion_pages.json.",
     )
 
     # --- Watch Mode ----------------------------------------------------------

--- a/src/cja_auto_sdr/cli/standalone_policy.py
+++ b/src/cja_auto_sdr/cli/standalone_policy.py
@@ -60,12 +60,19 @@ _COMPLETION_STANDALONE_POLICY = StandalonePrevalidationPolicy(
 _SAMPLE_CONFIG_STANDALONE_POLICY = StandalonePrevalidationPolicy(
     ignored_semantic_dests=_WRAPPER_EXECUTION_TOLERATED_SEMANTIC_DESTS,
 )
+_PUSH_TO_NOTION_STANDALONE_POLICY = StandalonePrevalidationPolicy(
+    ignored_semantic_dests=(
+        frozenset({"notion_force_new"}) | _WRAPPER_EXECUTION_TOLERATED_SEMANTIC_DESTS
+    ),
+    validate_org_report_mode_scoped_options=False,
+)
 
 _STANDALONE_PREVALIDATION_POLICIES: dict[str, StandalonePrevalidationPolicy] = {
     "completion": _COMPLETION_STANDALONE_POLICY,
     "explain_exit_code": _INFORMATIONAL_STANDALONE_POLICY,
     "exit_codes": _INFORMATIONAL_STANDALONE_POLICY,
     "sample_config": _SAMPLE_CONFIG_STANDALONE_POLICY,
+    "push_to_notion": _PUSH_TO_NOTION_STANDALONE_POLICY,
 }
 
 

--- a/src/cja_auto_sdr/cli/standalone_policy.py
+++ b/src/cja_auto_sdr/cli/standalone_policy.py
@@ -61,9 +61,7 @@ _SAMPLE_CONFIG_STANDALONE_POLICY = StandalonePrevalidationPolicy(
     ignored_semantic_dests=_WRAPPER_EXECUTION_TOLERATED_SEMANTIC_DESTS,
 )
 _PUSH_TO_NOTION_STANDALONE_POLICY = StandalonePrevalidationPolicy(
-    ignored_semantic_dests=(
-        frozenset({"notion_force_new"}) | _WRAPPER_EXECUTION_TOLERATED_SEMANTIC_DESTS
-    ),
+    ignored_semantic_dests=(frozenset({"notion_force_new"}) | _WRAPPER_EXECUTION_TOLERATED_SEMANTIC_DESTS),
     validate_org_report_mode_scoped_options=False,
 )
 

--- a/src/cja_auto_sdr/core/version.py
+++ b/src/cja_auto_sdr/core/version.py
@@ -1,3 +1,3 @@
 """Version information for CJA Auto SDR."""
 
-__version__ = "3.6.1"
+__version__ = "3.7.0"

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -535,6 +535,8 @@ def _push_to_notion_from_json(
         payload = json.loads(json_path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
         _exit_error(f"--push-to-notion: invalid JSON in {json_file}: {exc}")
+    except OSError as exc:
+        _exit_error(f"--push-to-notion: failed to read {json_file}: {exc}")
 
     metadata_dict = payload.get("metadata", {})
     data_dict: dict[str, pd.DataFrame] = {}
@@ -1482,8 +1484,8 @@ def _run_mode_checks(args: argparse.Namespace) -> tuple[tuple[RunMode, bool], ..
         ),
         (RunMode.DRY_RUN, getattr(args, "dry_run", False)),
         (RunMode.INVENTORY_SUMMARY, getattr(args, "inventory_summary", False)),
-        (RunMode.WATCH, getattr(args, "watch_data_views", None) is not None),
         (RunMode.PUSH_TO_NOTION, getattr(args, "push_to_notion", None) is not None),
+        (RunMode.WATCH, getattr(args, "watch_data_views", None) is not None),
     )
 
 

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -977,7 +977,7 @@ def _resolve_requested_output_formats(output_format: str) -> frozenset[str]:
 
 
 STANDARD_COMPONENT_ENDPOINTS: frozenset[str] = frozenset({"metrics", "dimensions"})
-EMBEDDED_METADATA_FORMATS: frozenset[str] = frozenset({"json", "html", "markdown"})
+EMBEDDED_METADATA_FORMATS: frozenset[str] = frozenset({"json", "html", "markdown", "notion"})
 
 
 def _should_emit_standard_sdr_sections(*, inventory_only: bool) -> bool:

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -1794,6 +1794,39 @@ def _dispatch_prevalidation_mode(
         _handle_sample_config_prevalidation(run_state=run_state)
 
 
+# Flags that --push-to-notion must reject explicitly. _run_mode_checks
+# dispatches by precedence (snapshot maintenance, org-report, diff, etc.
+# all fire before PUSH_TO_NOTION), so without these rejections a typo like
+# `--push-to-notion file.json --list-snapshots` would silently run the
+# other mode and ignore the publish request. Table-driven so adding a new
+# mode flag forces an explicit decision here.
+#
+# Each entry: (args dest, user-facing label, optional override message).
+# A flag is "present" when getattr(args, dest, None) is truthy.
+_PUSH_TO_NOTION_INCOMPATIBLE_FLAGS: tuple[tuple[str, str, str | None], ...] = (
+    ("org_report", "--org-report", None),
+    ("diff", "--diff", None),
+    ("snapshot", "--snapshot", None),
+    ("diff_snapshot", "--diff-snapshot", None),
+    ("compare_snapshots", "--compare-snapshots", None),
+    ("list_snapshots", "--list-snapshots", None),
+    ("prune_snapshots", "--prune-snapshots", None),
+    ("list_org_report_snapshots", "--list-org-report-snapshots", None),
+    ("inspect_org_report_snapshot", "--inspect-org-report-snapshot", None),
+    ("prune_org_report_snapshots", "--prune-org-report-snapshots", None),
+    ("batch", "--batch", None),
+    ("watch_data_views", "--watch", None),
+    ("inventory_summary", "--inventory-summary", None),
+    ("dry_run", "--dry-run", None),
+    (
+        "data_views",
+        "positional data view arguments",
+        "--push-to-notion is incompatible with positional data view arguments "
+        "(it publishes a saved JSON artifact, not a fresh generation)",
+    ),
+)
+
+
 def _validate_semantic_flag_relationships(
     args: argparse.Namespace,
     *,
@@ -1831,38 +1864,13 @@ def _validate_semantic_flag_relationships(
             "--format notion is only supported in SDR generation mode "
             "(use --push-to-notion <json_file> to publish a saved artifact instead)",
         )
-    # --push-to-notion is documented as mutually exclusive with other generation/
-    # mode flags. _run_mode_checks dispatches by precedence, so without these
-    # rejections a typo like `--push-to-notion file.json --org-report` would
-    # silently drop --push-to-notion. Reject the common footguns explicitly.
+    # Reject --push-to-notion alongside flags that would otherwise win the
+    # mode dispatch and silently drop the publish request. Table at module
+    # scope: _PUSH_TO_NOTION_INCOMPATIBLE_FLAGS.
     if getattr(args, "push_to_notion", None) is not None:
-        if getattr(args, "org_report", False):
-            _exit_error("--push-to-notion is incompatible with --org-report")
-        if getattr(args, "diff", False):
-            _exit_error("--push-to-notion is incompatible with --diff")
-        if getattr(args, "snapshot", None) is not None:
-            _exit_error("--push-to-notion is incompatible with --snapshot")
-        if getattr(args, "diff_snapshot", None) is not None:
-            _exit_error("--push-to-notion is incompatible with --diff-snapshot")
-        if getattr(args, "compare_snapshots", None) is not None:
-            _exit_error("--push-to-notion is incompatible with --compare-snapshots")
-        if getattr(args, "list_snapshots", False):
-            _exit_error("--push-to-notion is incompatible with --list-snapshots")
-        if getattr(args, "prune_snapshots", False):
-            _exit_error("--push-to-notion is incompatible with --prune-snapshots")
-        if getattr(args, "batch", False):
-            _exit_error("--push-to-notion is incompatible with --batch")
-        if getattr(args, "watch_data_views", None) is not None:
-            _exit_error("--push-to-notion is incompatible with --watch")
-        if getattr(args, "inventory_summary", False):
-            _exit_error("--push-to-notion is incompatible with --inventory-summary")
-        if getattr(args, "dry_run", False):
-            _exit_error("--push-to-notion is incompatible with --dry-run")
-        if getattr(args, "data_views", None):
-            _exit_error(
-                "--push-to-notion is incompatible with positional data view arguments "
-                "(it publishes a saved JSON artifact, not a fresh generation)",
-            )
+        for dest, label, override in _PUSH_TO_NOTION_INCOMPATIBLE_FLAGS:
+            if getattr(args, dest, None):
+                _exit_error(override or f"--push-to-notion is incompatible with {label}")
     if getattr(args, "allow_partial", False) and getattr(args, "quality_report", None):
         _exit_error("--allow-partial cannot be used with --quality-report")
     if getattr(args, "allow_partial", False) and getattr(args, "fail_on_quality", None):
@@ -3955,6 +3963,11 @@ def process_single_dataview(
                         # from a worker kills the pool worker instead of letting
                         # --continue-on-error mark this data view failed and proceed.
                         logger.critical("Notion output failed: %s", exc)
+                        # Config/dependency errors are user-facing setup issues with
+                        # actionable messages; an API error wraps an unexpected upstream
+                        # condition and deserves a traceback for debug logs.
+                        if isinstance(exc, NotionAPIError):
+                            logger.exception("Full exception details:")
                         logger.info("=" * BANNER_WIDTH)
                         logger.info("EXECUTION FAILED")
                         logger.info("=" * BANNER_WIDTH)

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -3039,6 +3039,7 @@ def process_single_dataview(
     allow_partial: bool = False,
     production_mode: bool = False,
     batch_id: str | None = None,
+    notion_force_new: bool = False,
     processing_config: ProcessingConfig | None = None,
 ) -> ProcessingResult:
     """
@@ -3103,6 +3104,7 @@ def process_single_dataview(
             allow_partial=allow_partial,
             production_mode=production_mode,
             batch_id=batch_id,
+            notion_force_new=notion_force_new,
         )
 
     config_file = processing_config.config_file
@@ -3132,6 +3134,7 @@ def process_single_dataview(
     quality_report_only = processing_config.quality_report_only
     allow_partial = processing_config.allow_partial
     production_mode = processing_config.production_mode
+    notion_force_new = processing_config.notion_force_new
     batch_id = processing_config.batch_id
 
     start_time = time.perf_counter()
@@ -3879,13 +3882,14 @@ def process_single_dataview(
 
                 elif fmt == "notion":
                     from cja_auto_sdr.output.writers.notion import write_notion_output
+
                     notion_output = write_notion_output(
                         data_dict,
                         metadata_dict,
                         base_filename,
                         output_dir,
                         logger,
-                        force_new=getattr(args, "notion_force_new", False),
+                        force_new=notion_force_new,
                     )
                     output_files.append(notion_output)
 
@@ -6837,7 +6841,9 @@ def _main_impl(run_state: dict[str, Any] | None = None):
         force_new = getattr(args, "notion_force_new", False)
         output_dir = getattr(args, "output_dir", None)
         result = _push_to_notion_from_json(
-            json_file, output_dir=output_dir, force_new=force_new,
+            json_file,
+            output_dir=output_dir,
+            force_new=force_new,
         )
         print(result)
         sys.exit(0)

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -523,9 +523,15 @@ def _push_to_notion_from_json(
     """Read an SDR JSON artifact and publish it to Notion.
 
     Returns the notion://pages/<id> identifier on success. Exits code 1 on
-    file-not-found or JSON parse errors.
+    file-not-found, JSON parse errors, missing Notion config/dep, or Notion
+    API failures (auth, rate-limit, etc.) with a friendly message.
     """
-    from cja_auto_sdr.output.writers.notion import write_notion_output
+    from cja_auto_sdr.output.writers.notion import (
+        NotionAPIError,
+        NotionConfigurationError,
+        NotionDependencyError,
+        write_notion_output,
+    )
 
     json_path = Path(json_file)
     if not json_path.exists():
@@ -558,14 +564,17 @@ def _push_to_notion_from_json(
     effective_output_dir = output_dir or str(json_path.parent)
     base_filename = json_path.stem
 
-    return write_notion_output(
-        data_dict=data_dict,
-        metadata_dict=metadata_dict,
-        base_filename=base_filename,
-        output_dir=effective_output_dir,
-        logger=logging.getLogger(__name__),
-        force_new=force_new,
-    )
+    try:
+        return write_notion_output(
+            data_dict=data_dict,
+            metadata_dict=metadata_dict,
+            base_filename=base_filename,
+            output_dir=effective_output_dir,
+            logger=logging.getLogger(__name__),
+            force_new=force_new,
+        )
+    except (NotionConfigurationError, NotionDependencyError, NotionAPIError) as exc:
+        _exit_error(str(exc))
 
 
 def _normalize_output_format(raw_format: Any) -> str | None:
@@ -1822,6 +1831,34 @@ def _validate_semantic_flag_relationships(
             "--format notion is only supported in SDR generation mode "
             "(use --push-to-notion <json_file> to publish a saved artifact instead)",
         )
+    # --push-to-notion is documented as mutually exclusive with other generation/
+    # mode flags. _run_mode_checks dispatches by precedence, so without these
+    # rejections a typo like `--push-to-notion file.json --org-report` would
+    # silently drop --push-to-notion. Reject the common footguns explicitly.
+    if getattr(args, "push_to_notion", None) is not None:
+        if getattr(args, "org_report", False):
+            _exit_error("--push-to-notion is incompatible with --org-report")
+        if getattr(args, "diff", False):
+            _exit_error("--push-to-notion is incompatible with --diff")
+        if getattr(args, "snapshot", None) is not None:
+            _exit_error("--push-to-notion is incompatible with --snapshot")
+        if getattr(args, "diff_snapshot", None) is not None:
+            _exit_error("--push-to-notion is incompatible with --diff-snapshot")
+        if getattr(args, "compare_snapshots", None) is not None:
+            _exit_error("--push-to-notion is incompatible with --compare-snapshots")
+        if getattr(args, "batch", False):
+            _exit_error("--push-to-notion is incompatible with --batch")
+        if getattr(args, "watch_data_views", None) is not None:
+            _exit_error("--push-to-notion is incompatible with --watch")
+        if getattr(args, "inventory_summary", False):
+            _exit_error("--push-to-notion is incompatible with --inventory-summary")
+        if getattr(args, "dry_run", False):
+            _exit_error("--push-to-notion is incompatible with --dry-run")
+        if getattr(args, "data_views", None):
+            _exit_error(
+                "--push-to-notion is incompatible with positional data view arguments "
+                "(it publishes a saved JSON artifact, not a fresh generation)",
+            )
     if getattr(args, "allow_partial", False) and getattr(args, "quality_report", None):
         _exit_error("--allow-partial cannot be used with --quality-report")
     if getattr(args, "allow_partial", False) and getattr(args, "fail_on_quality", None):
@@ -3892,16 +3929,24 @@ def process_single_dataview(
                     output_files.append(markdown_output)
 
                 elif fmt == "notion":
-                    from cja_auto_sdr.output.writers.notion import write_notion_output
-
-                    notion_output = write_notion_output(
-                        data_dict,
-                        metadata_dict,
-                        base_filename,
-                        output_dir,
-                        logger,
-                        force_new=notion_force_new,
+                    from cja_auto_sdr.output.writers.notion import (
+                        NotionAPIError,
+                        NotionConfigurationError,
+                        NotionDependencyError,
+                        write_notion_output,
                     )
+
+                    try:
+                        notion_output = write_notion_output(
+                            data_dict,
+                            metadata_dict,
+                            base_filename,
+                            output_dir,
+                            logger,
+                            force_new=notion_force_new,
+                        )
+                    except (NotionConfigurationError, NotionDependencyError, NotionAPIError) as exc:
+                        _exit_error(str(exc))
                     output_files.append(notion_output)
 
             if len(output_files) > 1:

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -1813,6 +1813,15 @@ def _validate_semantic_flag_relationships(
         _exit_error("--quality-report cannot be used with --skip-validation")
     if getattr(args, "quality_report", None) and non_sdr_mode:
         _exit_error("--quality-report is only supported in SDR generation mode")
+    if (
+        _normalize_output_format(getattr(args, "format", None)) == "notion"
+        and non_sdr_mode
+        and inferred_mode != RunMode.PUSH_TO_NOTION
+    ):
+        _exit_error(
+            "--format notion is only supported in SDR generation mode "
+            "(use --push-to-notion <json_file> to publish a saved artifact instead)",
+        )
     if getattr(args, "allow_partial", False) and getattr(args, "quality_report", None):
         _exit_error("--allow-partial cannot be used with --quality-report")
     if getattr(args, "allow_partial", False) and getattr(args, "fail_on_quality", None):

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -495,6 +495,7 @@ class RunMode(Enum):
     DRY_RUN = "dry_run"
     INVENTORY_SUMMARY = "inventory_summary"
     WATCH = "watch"
+    PUSH_TO_NOTION = "push_to_notion"
     SDR = "sdr"
 
 
@@ -512,6 +513,57 @@ def _exit_error(msg: str) -> NoReturn:
     """Print a coloured error message to stderr and exit with code 1."""
     print(ConsoleColors.error(f"ERROR: {msg}"), file=sys.stderr)
     sys.exit(1)
+
+
+def _push_to_notion_from_json(
+    json_file: str,
+    output_dir: str | None = None,
+    force_new: bool = False,
+) -> str:
+    """Read an SDR JSON artifact and publish it to Notion.
+
+    Returns the notion://pages/<id> identifier on success. Exits code 1 on
+    file-not-found or JSON parse errors.
+    """
+    from cja_auto_sdr.output.writers.notion import write_notion_output
+
+    json_path = Path(json_file)
+    if not json_path.exists():
+        _exit_error(f"--push-to-notion: file not found: {json_file}")
+
+    try:
+        payload = json.loads(json_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        _exit_error(f"--push-to-notion: invalid JSON in {json_file}: {exc}")
+
+    metadata_dict = payload.get("metadata", {})
+    data_dict: dict[str, pd.DataFrame] = {}
+    if payload.get("metrics"):
+        data_dict["Metrics"] = pd.DataFrame(payload["metrics"])
+    if payload.get("dimensions"):
+        data_dict["Dimensions"] = pd.DataFrame(payload["dimensions"])
+    if payload.get("data_quality"):
+        data_dict["Data Quality"] = pd.DataFrame(payload["data_quality"])
+    if payload.get("derived_fields", {}).get("fields"):
+        data_dict["Derived Fields"] = pd.DataFrame(payload["derived_fields"]["fields"])
+    if payload.get("calculated_metrics", {}).get("metrics"):
+        data_dict["Calculated Metrics"] = pd.DataFrame(
+            payload["calculated_metrics"]["metrics"],
+        )
+    if payload.get("segments", {}).get("segments"):
+        data_dict["Segments"] = pd.DataFrame(payload["segments"]["segments"])
+
+    effective_output_dir = output_dir or str(json_path.parent)
+    base_filename = json_path.stem
+
+    return write_notion_output(
+        data_dict=data_dict,
+        metadata_dict=metadata_dict,
+        base_filename=base_filename,
+        output_dir=effective_output_dir,
+        logger=logging.getLogger(__name__),
+        force_new=force_new,
+    )
 
 
 def _normalize_output_format(raw_format: Any) -> str | None:
@@ -1431,6 +1483,7 @@ def _run_mode_checks(args: argparse.Namespace) -> tuple[tuple[RunMode, bool], ..
         (RunMode.DRY_RUN, getattr(args, "dry_run", False)),
         (RunMode.INVENTORY_SUMMARY, getattr(args, "inventory_summary", False)),
         (RunMode.WATCH, getattr(args, "watch_data_views", None) is not None),
+        (RunMode.PUSH_TO_NOTION, getattr(args, "push_to_notion", None) is not None),
     )
 
 
@@ -3823,6 +3876,18 @@ def process_single_dataview(
                 elif fmt == "markdown":
                     markdown_output = write_markdown_output(data_dict, metadata_dict, base_filename, output_dir, logger)
                     output_files.append(markdown_output)
+
+                elif fmt == "notion":
+                    from cja_auto_sdr.output.writers.notion import write_notion_output
+                    notion_output = write_notion_output(
+                        data_dict,
+                        metadata_dict,
+                        base_filename,
+                        output_dir,
+                        logger,
+                        force_new=getattr(args, "notion_force_new", False),
+                    )
+                    output_files.append(notion_output)
 
             if len(output_files) > 1:
                 logger.info(f"✓ SDR generation complete! {len(output_files)} files created")
@@ -6766,6 +6831,16 @@ def _main_impl(run_state: dict[str, Any] | None = None):
 
     if inferred_mode == RunMode.ORG_REPORT_SNAPSHOTS:
         _handle_org_report_snapshot_cli(args, output_to_stdout=output_to_stdout, run_state=run_state)
+
+    if inferred_mode == RunMode.PUSH_TO_NOTION:
+        json_file = getattr(args, "push_to_notion", None)
+        force_new = getattr(args, "notion_force_new", False)
+        output_dir = getattr(args, "output_dir", None)
+        result = _push_to_notion_from_json(
+            json_file, output_dir=output_dir, force_new=force_new,
+        )
+        print(result)
+        sys.exit(0)
 
     # Handle --watch mode (continuous monitoring loop). Dispatched before color theme
     # setup and the other CLI subcommand handlers so that --watch takes precedence over

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -1846,6 +1846,10 @@ def _validate_semantic_flag_relationships(
             _exit_error("--push-to-notion is incompatible with --diff-snapshot")
         if getattr(args, "compare_snapshots", None) is not None:
             _exit_error("--push-to-notion is incompatible with --compare-snapshots")
+        if getattr(args, "list_snapshots", False):
+            _exit_error("--push-to-notion is incompatible with --list-snapshots")
+        if getattr(args, "prune_snapshots", False):
+            _exit_error("--push-to-notion is incompatible with --prune-snapshots")
         if getattr(args, "batch", False):
             _exit_error("--push-to-notion is incompatible with --batch")
         if getattr(args, "watch_data_views", None) is not None:
@@ -3946,7 +3950,26 @@ def process_single_dataview(
                             force_new=notion_force_new,
                         )
                     except (NotionConfigurationError, NotionDependencyError, NotionAPIError) as exc:
-                        _exit_error(str(exc))
+                        # Must return a failed ProcessingResult here rather than calling
+                        # _exit_error: this code runs inside batch workers, and SystemExit
+                        # from a worker kills the pool worker instead of letting
+                        # --continue-on-error mark this data view failed and proceed.
+                        logger.critical("Notion output failed: %s", exc)
+                        logger.info("=" * BANNER_WIDTH)
+                        logger.info("EXECUTION FAILED")
+                        logger.info("=" * BANNER_WIDTH)
+                        logger.info("Data View: %s (%s)", dv_name, data_view_id)
+                        logger.info("Error: %s", exc)
+                        logger.info("Duration: %.2fs", time.perf_counter() - start_time)
+                        logger.info("=" * BANNER_WIDTH)
+                        flush_logging_handlers(logger)
+                        return _finalize_result(
+                            data_view_name=dv_name,
+                            success=False,
+                            error_message=str(exc),
+                            failure_code=FAILURE_CODE_OUTPUT_WRITE_FAILED,
+                            failure_reason=f"output_write_failed:{type(exc).__name__}",
+                        )
                     output_files.append(notion_output)
 
             if len(output_files) > 1:

--- a/src/cja_auto_sdr/output/notion_registry.py
+++ b/src/cja_auto_sdr/output/notion_registry.py
@@ -3,6 +3,7 @@
 Maps data view IDs to Notion page IDs so re-runs update existing pages.
 Registry file: .notion_pages.json in the output directory.
 """
+
 from __future__ import annotations
 
 import json
@@ -22,13 +23,17 @@ def load_registry(path: Path) -> dict[str, str]:
         return {}
     try:
         return json.loads(path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
+    except json.JSONDecodeError, OSError:
         return {}
 
 
 def save_registry(path: Path, registry: dict[str, str]) -> None:
     write_json_atomic_compatible(
-        path, registry, indent=2, ensure_ascii=False, trailing_newline=False,
+        path,
+        registry,
+        indent=2,
+        ensure_ascii=False,
+        trailing_newline=False,
     )
 
 

--- a/src/cja_auto_sdr/output/notion_registry.py
+++ b/src/cja_auto_sdr/output/notion_registry.py
@@ -1,0 +1,42 @@
+"""Local page ID registry for Notion integration.
+
+Maps data view IDs to Notion page IDs so re-runs update existing pages.
+Registry file: .notion_pages.json in the output directory.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from cja_auto_sdr.core.json_io import write_json_atomic_compatible
+
+REGISTRY_FILENAME = ".notion_pages.json"
+
+
+def get_registry_path(output_dir: str | Path) -> Path:
+    return Path(output_dir) / REGISTRY_FILENAME
+
+
+def load_registry(path: Path) -> dict[str, str]:
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def save_registry(path: Path, registry: dict[str, str]) -> None:
+    write_json_atomic_compatible(
+        path, registry, indent=2, ensure_ascii=False, trailing_newline=False,
+    )
+
+
+def lookup_page_id(registry_path: Path, data_view_id: str) -> str | None:
+    return load_registry(registry_path).get(data_view_id)
+
+
+def store_page_id(registry_path: Path, data_view_id: str, page_id: str) -> None:
+    registry = load_registry(registry_path)
+    registry[data_view_id] = page_id
+    save_registry(registry_path, registry)

--- a/src/cja_auto_sdr/output/notion_registry.py
+++ b/src/cja_auto_sdr/output/notion_registry.py
@@ -2,20 +2,60 @@
 
 Maps data view IDs to Notion page IDs so re-runs update existing pages.
 Registry file: .notion_pages.json in the output directory.
+
+Concurrent batch workers calling :func:`store_page_id` against the same
+registry file are serialized via an ``fcntl.flock`` exclusive lock on a
+sidecar ``.notion_pages.json.lock`` file. The lock wraps the entire
+read-modify-write sequence so two workers cannot clobber each other's entries.
 """
 
 from __future__ import annotations
 
 import json
+from contextlib import contextmanager
 from pathlib import Path
 
 from cja_auto_sdr.core.json_io import write_json_atomic_compatible
 
 REGISTRY_FILENAME = ".notion_pages.json"
+_LOCK_SUFFIX = ".lock"
 
 
 def get_registry_path(output_dir: str | Path) -> Path:
     return Path(output_dir) / REGISTRY_FILENAME
+
+
+def _lock_path_for(registry_path: Path) -> Path:
+    return registry_path.with_name(registry_path.name + _LOCK_SUFFIX)
+
+
+@contextmanager
+def _exclusive_registry_lock(registry_path: Path):
+    """Serialize concurrent read-modify-write on the registry.
+
+    Uses ``fcntl.flock`` on a sidecar lock file so process-pool workers (the
+    only concurrency model this project supports) cannot clobber each other's
+    updates. On platforms without ``fcntl`` (Windows), the lock degrades to a
+    no-op — the caller is responsible for avoiding concurrent writes there.
+    """
+    lock_path = _lock_path_for(registry_path)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        import fcntl  # POSIX only
+    except ImportError:  # pragma: no cover — Windows fallback
+        yield
+        return
+
+    fd = lock_path.open("a+")
+    try:
+        fcntl.flock(fd.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(fd.fileno(), fcntl.LOCK_UN)
+    finally:
+        fd.close()
 
 
 def load_registry(path: Path) -> dict[str, str]:
@@ -42,6 +82,8 @@ def lookup_page_id(registry_path: Path, data_view_id: str) -> str | None:
 
 
 def store_page_id(registry_path: Path, data_view_id: str, page_id: str) -> None:
-    registry = load_registry(registry_path)
-    registry[data_view_id] = page_id
-    save_registry(registry_path, registry)
+    """Atomically update the registry under an exclusive cross-process lock."""
+    with _exclusive_registry_lock(registry_path):
+        registry = load_registry(registry_path)
+        registry[data_view_id] = page_id
+        save_registry(registry_path, registry)

--- a/src/cja_auto_sdr/output/notion_registry.py
+++ b/src/cja_auto_sdr/output/notion_registry.py
@@ -33,27 +33,46 @@ def _lock_path_for(registry_path: Path) -> Path:
 def _exclusive_registry_lock(registry_path: Path):
     """Serialize concurrent read-modify-write on the registry.
 
-    Uses ``fcntl.flock`` on a sidecar lock file so process-pool workers (the
-    only concurrency model this project supports) cannot clobber each other's
-    updates. On platforms without ``fcntl`` (Windows), the lock degrades to a
-    no-op — the caller is responsible for avoiding concurrent writes there.
+    Uses ``fcntl.flock`` on POSIX and ``msvcrt.locking`` on Windows against a
+    sidecar lock file, so process-pool workers on either platform cannot
+    clobber each other's updates. The package is declared OS-independent, so
+    both paths must provide real cross-process locking.
     """
     lock_path = _lock_path_for(registry_path)
     lock_path.parent.mkdir(parents=True, exist_ok=True)
 
-    try:
-        import fcntl  # POSIX only
-    except ImportError:  # pragma: no cover — Windows fallback
-        yield
-        return
-
     fd = lock_path.open("a+")
     try:
-        fcntl.flock(fd.fileno(), fcntl.LOCK_EX)
+        try:
+            import fcntl  # POSIX
+
+            fcntl.flock(fd.fileno(), fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(fd.fileno(), fcntl.LOCK_UN)
+            return
+        except ImportError:
+            pass
+
+        # Windows path: msvcrt.locking takes an exclusive byte-range lock and
+        # blocks until acquired (LK_LOCK retries internally; loop in case of
+        # the documented "lock violation" raise after retries exhaust).
+        import msvcrt
+        import time
+
+        fd.seek(0)
+        while True:
+            try:
+                msvcrt.locking(fd.fileno(), msvcrt.LK_LOCK, 1)
+                break
+            except OSError:
+                time.sleep(0.05)
         try:
             yield
         finally:
-            fcntl.flock(fd.fileno(), fcntl.LOCK_UN)
+            fd.seek(0)
+            msvcrt.locking(fd.fileno(), msvcrt.LK_UNLCK, 1)
     finally:
         fd.close()
 

--- a/src/cja_auto_sdr/output/registry.py
+++ b/src/cja_auto_sdr/output/registry.py
@@ -7,6 +7,7 @@ from cja_auto_sdr.output.writers import (
     write_json_output,
     write_markdown_output,
 )
+from cja_auto_sdr.output.writers.notion import write_notion_output
 
 WRITER_REGISTRY = {
     "csv": write_csv_output,
@@ -16,6 +17,7 @@ WRITER_REGISTRY = {
     "json": write_json_output,
     "markdown": write_markdown_output,
     "md": write_markdown_output,
+    "notion": write_notion_output,
 }
 
 

--- a/src/cja_auto_sdr/output/writers/notion.py
+++ b/src/cja_auto_sdr/output/writers/notion.py
@@ -50,6 +50,13 @@ _DQ_SEVERITY_ICONS = {
     "INFO": "ℹ️",
 }
 
+# Notion's API caps the ``children`` array of a single block (including a
+# ``table`` block's row children) at 100 entries per request. Reserve one slot
+# for the header row and cap data rows at 99 so each emitted table fits in a
+# single append call. Sections larger than this are split into multiple
+# sibling tables under the same heading.
+_MAX_TABLE_DATA_ROWS = 99
+
 
 # ---------------------------------------------------------------------------
 # Block builder helpers (pure functions, no API calls)
@@ -127,10 +134,13 @@ def _section_blocks(section_name: str, df: pd.DataFrame) -> list[dict]:
     if df is None or df.empty:
         return []
     icon = _SECTION_ICONS.get(section_name, "📄")
-    return [
-        _heading2_block(f"{icon} {section_name}"),
-        _table_block(df),
-    ]
+    blocks: list[dict] = [_heading2_block(f"{icon} {section_name}")]
+    # Split sections larger than the per-table cap into sibling tables under
+    # the same heading so each table stays within Notion's 100-children limit.
+    for start in range(0, len(df), _MAX_TABLE_DATA_ROWS):
+        chunk = df.iloc[start : start + _MAX_TABLE_DATA_ROWS]
+        blocks.append(_table_block(chunk))
+    return blocks
 
 
 def _dq_callout_blocks(dq_df: pd.DataFrame) -> list[dict]:

--- a/src/cja_auto_sdr/output/writers/notion.py
+++ b/src/cja_auto_sdr/output/writers/notion.py
@@ -1,0 +1,191 @@
+"""Notion output writer: block builder + Notion API layer.
+
+Credentials (env vars required, not stored in config.json):
+  NOTION_TOKEN            — Notion internal integration token
+  NOTION_PARENT_PAGE_ID   — Parent page under which SDR child pages are created
+
+Install the optional dep: uv pip install 'cja-auto-sdr[notion]'
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from cja_auto_sdr.core.version import __version__
+from cja_auto_sdr.output.notion_registry import (
+    get_registry_path,
+    lookup_page_id,
+    store_page_id,
+)
+
+__all__ = ["write_notion_output"]
+
+_SECTION_ORDER = [
+    "Data Quality",
+    "Metrics",
+    "Dimensions",
+    "Segments",
+    "Calculated Metrics",
+    "Derived Fields",
+]
+_SECTION_ICONS = {
+    "Metrics": "📐",
+    "Dimensions": "📏",
+    "Segments": "🔖",
+    "Calculated Metrics": "🧮",
+    "Derived Fields": "🔬",
+    "Data Quality": "🛡️",
+}
+_DQ_SEVERITY_ICONS = {
+    "ERROR": "🔴",
+    "CRITICAL": "🔴",
+    "WARN": "⚠️",
+    "WARNING": "⚠️",
+    "INFO": "ℹ️",
+}
+
+
+# ---------------------------------------------------------------------------
+# Block builder helpers (pure functions, no API calls)
+# ---------------------------------------------------------------------------
+
+def _rich_text(content: str) -> list[dict]:
+    return [{"type": "text", "text": {"content": str(content)[:2000]}}]
+
+
+def _heading2_block(content: str) -> dict:
+    return {
+        "object": "block",
+        "type": "heading_2",
+        "heading_2": {"rich_text": _rich_text(content)},
+    }
+
+
+def _divider_block() -> dict:
+    return {"object": "block", "type": "divider", "divider": {}}
+
+
+def _paragraph_block(content: str) -> dict:
+    return {
+        "object": "block",
+        "type": "paragraph",
+        "paragraph": {"rich_text": _rich_text(content)},
+    }
+
+
+def _callout_block(content: str, emoji: str = "📋", color: str = "default") -> dict:
+    return {
+        "object": "block",
+        "type": "callout",
+        "callout": {
+            "rich_text": _rich_text(content),
+            "icon": {"type": "emoji", "emoji": emoji},
+            "color": color,
+        },
+    }
+
+
+def _table_row_block(cells: list[str]) -> dict:
+    return {
+        "object": "block",
+        "type": "table_row",
+        "table_row": {
+            "cells": [
+                [{"type": "text", "text": {"content": str(c)[:2000]}}] for c in cells
+            ],
+        },
+    }
+
+
+def _table_block(df: pd.DataFrame) -> dict:
+    cols = list(df.columns)
+    rows = [_table_row_block(cols)]
+    for _, row in df.iterrows():
+        rows.append(
+            _table_row_block(
+                [str(row[c]) if not pd.isna(row[c]) else "" for c in cols],
+            ),
+        )
+    return {
+        "object": "block",
+        "type": "table",
+        "table": {
+            "table_width": len(cols),
+            "has_column_header": True,
+            "has_row_header": False,
+            "children": rows,
+        },
+    }
+
+
+def _section_blocks(section_name: str, df: pd.DataFrame) -> list[dict]:
+    if df is None or df.empty:
+        return []
+    icon = _SECTION_ICONS.get(section_name, "📄")
+    return [
+        _heading2_block(f"{icon} {section_name}"),
+        _table_block(df),
+    ]
+
+
+def _dq_callout_blocks(dq_df: pd.DataFrame) -> list[dict]:
+    if dq_df is None or dq_df.empty:
+        return []
+    blocks = []
+    for _, row in dq_df.iterrows():
+        severity = str(row.get("Severity", "INFO")).upper()
+        emoji = _DQ_SEVERITY_ICONS.get(severity, "ℹ️")
+        parts = [f"[{severity}]"]
+        for col in dq_df.columns:
+            if col != "Severity":
+                val = row.get(col, "")
+                if val and not pd.isna(val):
+                    parts.append(f"{col}: {val}")
+        blocks.append(_callout_block(" | ".join(parts), emoji=emoji))
+    return blocks
+
+
+def _metadata_callout_block(metadata_dict: dict) -> dict:
+    priority_keys = [
+        "Data View Name",
+        "Data View ID",
+        "Generated Date & timestamp and timezone",
+    ]
+    lines = []
+    for key in priority_keys:
+        if key in metadata_dict:
+            lines.append(f"{key}: {metadata_dict[key]}")
+    for key, val in metadata_dict.items():
+        if key not in set(priority_keys):
+            lines.append(f"{key}: {val}")
+    return _callout_block("\n".join(lines), emoji="📋")
+
+
+def build_sdr_blocks(
+    data_dict: dict[str, pd.DataFrame], metadata_dict: dict,
+) -> list[dict]:
+    blocks: list[dict] = [_metadata_callout_block(metadata_dict), _divider_block()]
+
+    dq_df = data_dict.get("Data Quality")
+    if dq_df is not None and not dq_df.empty:
+        blocks.append(_heading2_block("🛡️ Data Quality"))
+        blocks.extend(_dq_callout_blocks(dq_df))
+
+    for section_name in _SECTION_ORDER:
+        if section_name == "Data Quality":
+            continue
+        df = data_dict.get(section_name)
+        blocks.extend(_section_blocks(section_name, df))
+
+    blocks.extend(
+        [
+            _divider_block(),
+            _paragraph_block(f"Generated by cja_auto_sdr v{__version__}"),
+        ],
+    )
+    return blocks

--- a/src/cja_auto_sdr/output/writers/notion.py
+++ b/src/cja_auto_sdr/output/writers/notion.py
@@ -40,8 +40,8 @@ _SECTION_ICONS = {
     "Segments": "🔖",
     "Calculated Metrics": "🧮",
     "Derived Fields": "🔬",
-    "Data Quality": "🛡️",
 }
+_DQ_HEADING_ICON = "🛡️"
 _DQ_SEVERITY_ICONS = {
     "ERROR": "🔴",
     "CRITICAL": "🔴",
@@ -170,7 +170,7 @@ def build_sdr_blocks(
 
     dq_df = data_dict.get("Data Quality")
     if dq_df is not None and not dq_df.empty:
-        blocks.append(_heading2_block("🛡️ Data Quality"))
+        blocks.append(_heading2_block(f"{_DQ_HEADING_ICON} Data Quality"))
         blocks.extend(_dq_callout_blocks(dq_df))
 
     for section_name in _SECTION_ORDER:
@@ -282,15 +282,16 @@ def create_or_update_page(
 ) -> str:
     """Create a new Notion page or update the existing one for this data view.
 
-    Returns the Notion page ID. Registry entry is written only after a
-    successful block append.
+    Returns the Notion page ID. On CREATE, the registry entry is written only
+    after a successful block append, so a mid-flight failure leaves the
+    registry unchanged and the next run creates a fresh page. On UPDATE the
+    page ID does not change, so the registry is not rewritten.
     """
     existing_page_id = None if force_new else lookup_page_id(registry_path, data_view_id)
 
     if existing_page_id:
         _clear_page_blocks(client, existing_page_id)
         _append_blocks(client, existing_page_id, blocks)
-        store_page_id(registry_path, data_view_id, existing_page_id)
         return existing_page_id
 
     page = client.pages.create(
@@ -319,9 +320,12 @@ def write_notion_output(
 ) -> str:
     """Publish SDR data to a Notion page.
 
-    Returns a notion://pages/<page_id> identifier (not a file path).
+    Returns a ``notion://pages/<page_id>`` identifier (not a file path).
+    ``base_filename`` is accepted for writer-protocol parity with file-emitting
+    writers and is used as a fallback when ``metadata_dict`` lacks
+    ``Data View ID`` or ``Data View Name``.
     """
-    logger.info("Publishing to Notion...")
+    logger.info("✓ Publishing to Notion...")
 
     client_cls = _require_notion_client()
     token, parent_page_id = resolve_notion_credentials()
@@ -344,5 +348,5 @@ def write_notion_output(
         force_new=force_new,
     )
 
-    logger.info("Notion page published: notion://pages/%s", page_id)
+    logger.info("✓ Notion page published: notion://pages/%s", page_id)
     return f"notion://pages/{page_id}"

--- a/src/cja_auto_sdr/output/writers/notion.py
+++ b/src/cja_auto_sdr/output/writers/notion.py
@@ -189,3 +189,115 @@ def build_sdr_blocks(
         ],
     )
     return blocks
+
+
+# ---------------------------------------------------------------------------
+# Credential resolution
+# ---------------------------------------------------------------------------
+
+def resolve_notion_credentials() -> tuple[str, str]:
+    """Return (NOTION_TOKEN, NOTION_PARENT_PAGE_ID) from env / .env file."""
+    try:
+        from dotenv import load_dotenv
+        load_dotenv()
+    except ImportError:
+        pass
+
+    token = os.environ.get("NOTION_TOKEN")
+    parent_page_id = os.environ.get("NOTION_PARENT_PAGE_ID")
+
+    if not token:
+        print(
+            "ERROR: NOTION_TOKEN is not set. "
+            "Set it as an environment variable or add it to a .env file.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if not parent_page_id:
+        print(
+            "ERROR: NOTION_PARENT_PAGE_ID is not set. "
+            "Set it as an environment variable or add it to a .env file.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    return token, parent_page_id
+
+
+def _require_notion_client():
+    """Return notion_client.Client class or exit with install instructions."""
+    try:
+        from notion_client import Client
+        return Client
+    except ImportError:
+        print(
+            "ERROR: Notion output requires the notion extra.\n"
+            "Install it with: uv pip install 'cja-auto-sdr[notion]'",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Notion API operations
+# ---------------------------------------------------------------------------
+
+def _clear_page_blocks(client: Any, page_id: str) -> None:
+    """Delete all child blocks from a Notion page (no bulk-clear API exists)."""
+    cursor = None
+    while True:
+        kwargs: dict[str, Any] = {"block_id": page_id}
+        if cursor:
+            kwargs["start_cursor"] = cursor
+        response = client.blocks.children.list(**kwargs)
+        for block in response.get("results", []):
+            client.blocks.delete(block_id=block["id"])
+        if not response.get("has_more"):
+            break
+        cursor = response.get("next_cursor")
+
+
+def _append_blocks(
+    client: Any, page_id: str, blocks: list[dict], batch_size: int = 100,
+) -> None:
+    """Append blocks to a Notion page in batches (API limit: 100 per call)."""
+    for i in range(0, len(blocks), batch_size):
+        client.blocks.children.append(
+            block_id=page_id, children=blocks[i:i + batch_size],
+        )
+
+
+def create_or_update_page(
+    client: Any,
+    parent_page_id: str,
+    page_title: str,
+    data_view_id: str,
+    blocks: list[dict],
+    registry_path: Path,
+    *,
+    force_new: bool = False,
+) -> str:
+    """Create a new Notion page or update the existing one for this data view.
+
+    Returns the Notion page ID. Registry entry is written only after a
+    successful block append.
+    """
+    existing_page_id = (
+        None if force_new else lookup_page_id(registry_path, data_view_id)
+    )
+
+    if existing_page_id:
+        _clear_page_blocks(client, existing_page_id)
+        _append_blocks(client, existing_page_id, blocks)
+        store_page_id(registry_path, data_view_id, existing_page_id)
+        return existing_page_id
+
+    page = client.pages.create(
+        parent={"page_id": parent_page_id},
+        properties={"title": [{"type": "text", "text": {"content": page_title}}]},
+    )
+    page_id = page["id"]
+    _append_blocks(client, page_id, blocks)
+    store_page_id(registry_path, data_view_id, page_id)
+    return page_id

--- a/src/cja_auto_sdr/output/writers/notion.py
+++ b/src/cja_auto_sdr/output/writers/notion.py
@@ -6,6 +6,7 @@ Credentials (env vars required, not stored in config.json):
 
 Install the optional dep: uv pip install 'cja-auto-sdr[notion]'
 """
+
 from __future__ import annotations
 
 import logging
@@ -54,6 +55,7 @@ _DQ_SEVERITY_ICONS = {
 # Block builder helpers (pure functions, no API calls)
 # ---------------------------------------------------------------------------
 
+
 def _rich_text(content: str) -> list[dict]:
     return [{"type": "text", "text": {"content": str(content)[:2000]}}]
 
@@ -95,9 +97,7 @@ def _table_row_block(cells: list[str]) -> dict:
         "object": "block",
         "type": "table_row",
         "table_row": {
-            "cells": [
-                [{"type": "text", "text": {"content": str(c)[:2000]}}] for c in cells
-            ],
+            "cells": [[{"type": "text", "text": {"content": str(c)[:2000]}}] for c in cells],
         },
     }
 
@@ -156,18 +156,15 @@ def _metadata_callout_block(metadata_dict: dict) -> dict:
         "Data View ID",
         "Generated Date & timestamp and timezone",
     ]
-    lines = []
-    for key in priority_keys:
-        if key in metadata_dict:
-            lines.append(f"{key}: {metadata_dict[key]}")
-    for key, val in metadata_dict.items():
-        if key not in set(priority_keys):
-            lines.append(f"{key}: {val}")
+    priority_set = set(priority_keys)
+    lines = [f"{key}: {metadata_dict[key]}" for key in priority_keys if key in metadata_dict]
+    lines.extend(f"{key}: {val}" for key, val in metadata_dict.items() if key not in priority_set)
     return _callout_block("\n".join(lines), emoji="📋")
 
 
 def build_sdr_blocks(
-    data_dict: dict[str, pd.DataFrame], metadata_dict: dict,
+    data_dict: dict[str, pd.DataFrame],
+    metadata_dict: dict,
 ) -> list[dict]:
     blocks: list[dict] = [_metadata_callout_block(metadata_dict), _divider_block()]
 
@@ -195,10 +192,12 @@ def build_sdr_blocks(
 # Credential resolution
 # ---------------------------------------------------------------------------
 
+
 def resolve_notion_credentials() -> tuple[str, str]:
     """Return (NOTION_TOKEN, NOTION_PARENT_PAGE_ID) from env / .env file."""
     try:
         from dotenv import load_dotenv
+
         load_dotenv()
     except ImportError:
         pass
@@ -208,16 +207,14 @@ def resolve_notion_credentials() -> tuple[str, str]:
 
     if not token:
         print(
-            "ERROR: NOTION_TOKEN is not set. "
-            "Set it as an environment variable or add it to a .env file.",
+            "ERROR: NOTION_TOKEN is not set. Set it as an environment variable or add it to a .env file.",
             file=sys.stderr,
         )
         sys.exit(1)
 
     if not parent_page_id:
         print(
-            "ERROR: NOTION_PARENT_PAGE_ID is not set. "
-            "Set it as an environment variable or add it to a .env file.",
+            "ERROR: NOTION_PARENT_PAGE_ID is not set. Set it as an environment variable or add it to a .env file.",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -229,11 +226,11 @@ def _require_notion_client():
     """Return notion_client.Client class or exit with install instructions."""
     try:
         from notion_client import Client
+
         return Client
     except ImportError:
         print(
-            "ERROR: Notion output requires the notion extra.\n"
-            "Install it with: uv pip install 'cja-auto-sdr[notion]'",
+            "ERROR: Notion output requires the notion extra.\nInstall it with: uv pip install 'cja-auto-sdr[notion]'",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -242,6 +239,7 @@ def _require_notion_client():
 # ---------------------------------------------------------------------------
 # Notion API operations
 # ---------------------------------------------------------------------------
+
 
 def _clear_page_blocks(client: Any, page_id: str) -> None:
     """Delete all child blocks from a Notion page (no bulk-clear API exists)."""
@@ -259,12 +257,16 @@ def _clear_page_blocks(client: Any, page_id: str) -> None:
 
 
 def _append_blocks(
-    client: Any, page_id: str, blocks: list[dict], batch_size: int = 100,
+    client: Any,
+    page_id: str,
+    blocks: list[dict],
+    batch_size: int = 100,
 ) -> None:
     """Append blocks to a Notion page in batches (API limit: 100 per call)."""
     for i in range(0, len(blocks), batch_size):
         client.blocks.children.append(
-            block_id=page_id, children=blocks[i:i + batch_size],
+            block_id=page_id,
+            children=blocks[i : i + batch_size],
         )
 
 
@@ -283,9 +285,7 @@ def create_or_update_page(
     Returns the Notion page ID. Registry entry is written only after a
     successful block append.
     """
-    existing_page_id = (
-        None if force_new else lookup_page_id(registry_path, data_view_id)
-    )
+    existing_page_id = None if force_new else lookup_page_id(registry_path, data_view_id)
 
     if existing_page_id:
         _clear_page_blocks(client, existing_page_id)
@@ -306,6 +306,7 @@ def create_or_update_page(
 # ---------------------------------------------------------------------------
 # Writer entry point (matches writer protocol)
 # ---------------------------------------------------------------------------
+
 
 def write_notion_output(
     data_dict: dict[str, pd.DataFrame],

--- a/src/cja_auto_sdr/output/writers/notion.py
+++ b/src/cja_auto_sdr/output/writers/notion.py
@@ -301,3 +301,47 @@ def create_or_update_page(
     _append_blocks(client, page_id, blocks)
     store_page_id(registry_path, data_view_id, page_id)
     return page_id
+
+
+# ---------------------------------------------------------------------------
+# Writer entry point (matches writer protocol)
+# ---------------------------------------------------------------------------
+
+def write_notion_output(
+    data_dict: dict[str, pd.DataFrame],
+    metadata_dict: dict[str, Any],
+    base_filename: str,
+    output_dir: str | Path,
+    logger: logging.Logger,
+    *,
+    force_new: bool = False,
+) -> str:
+    """Publish SDR data to a Notion page.
+
+    Returns a notion://pages/<page_id> identifier (not a file path).
+    """
+    logger.info("Publishing to Notion...")
+
+    client_cls = _require_notion_client()
+    token, parent_page_id = resolve_notion_credentials()
+
+    data_view_id = str(metadata_dict.get("Data View ID", base_filename))
+    dv_name = str(metadata_dict.get("Data View Name", base_filename))
+    page_title = f"{dv_name} — SDR"
+
+    blocks = build_sdr_blocks(data_dict, metadata_dict)
+    registry_path = get_registry_path(output_dir)
+
+    client = client_cls(auth=token)
+    page_id = create_or_update_page(
+        client,
+        parent_page_id,
+        page_title,
+        data_view_id,
+        blocks,
+        registry_path,
+        force_new=force_new,
+    )
+
+    logger.info("Notion page published: notion://pages/%s", page_id)
+    return f"notion://pages/{page_id}"

--- a/src/cja_auto_sdr/output/writers/notion.py
+++ b/src/cja_auto_sdr/output/writers/notion.py
@@ -53,11 +53,17 @@ _SECTION_ICONS = {
     "Derived Fields": "🔬",
 }
 _DQ_HEADING_ICON = "🛡️"
+# Keys cover the CJA quality engine vocabulary (core.constants.QUALITY_SEVERITY_ORDER:
+# CRITICAL/HIGH/MEDIUM/LOW/INFO) plus the generic ERROR/WARN logging vocabulary for
+# safety. Unmapped severities fall back to the info icon in _dq_callout_blocks.
 _DQ_SEVERITY_ICONS = {
-    "ERROR": "🔴",
     "CRITICAL": "🔴",
+    "HIGH": "🔴",
+    "ERROR": "🔴",
+    "MEDIUM": "⚠️",
     "WARN": "⚠️",
     "WARNING": "⚠️",
+    "LOW": "ℹ️",
     "INFO": "ℹ️",
 }
 

--- a/src/cja_auto_sdr/output/writers/notion.py
+++ b/src/cja_auto_sdr/output/writers/notion.py
@@ -5,13 +5,19 @@ Credentials (env vars required, not stored in config.json):
   NOTION_PARENT_PAGE_ID   — Parent page under which SDR child pages are created
 
 Install the optional dep: uv pip install 'cja-auto-sdr[notion]'
+
+The pages this writer publishes are auto-regenerated on every run. Manual edits
+made inside Notion will be overwritten on the next sync — the page is cleared
+and rewritten in place. Use --notion-force-new to break that link and produce
+a fresh page (the old one is left untouched, becoming an orphan).
 """
 
 from __future__ import annotations
 
 import logging
 import os
-import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Any
 
@@ -24,7 +30,12 @@ from cja_auto_sdr.output.notion_registry import (
     store_page_id,
 )
 
-__all__ = ["write_notion_output"]
+__all__ = [
+    "NotionAPIError",
+    "NotionConfigurationError",
+    "NotionDependencyError",
+    "write_notion_output",
+]
 
 _SECTION_ORDER = [
     "Data Quality",
@@ -56,6 +67,34 @@ _DQ_SEVERITY_ICONS = {
 # single append call. Sections larger than this are split into multiple
 # sibling tables under the same heading.
 _MAX_TABLE_DATA_ROWS = 99
+
+# Concurrent block-deletes on update. Notion's API does not support bulk
+# delete, so an N-block page costs N round-trips. Keep the pool small to stay
+# well clear of Notion's per-integration rate limit (~3 rps default).
+_DELETE_WORKER_COUNT = 4
+
+# 429 retry budget. Notion returns 429 with a ``Retry-After`` header in
+# seconds; we honour it when present, otherwise fall back to exponential
+# backoff. Total wall time worst-case: ~1+2+4 = 7s on top of any Retry-After.
+_RATE_LIMIT_MAX_ATTEMPTS = 3
+_RATE_LIMIT_BASE_DELAY_SECONDS = 1.0
+
+
+# ---------------------------------------------------------------------------
+# Exceptions (raised from this module; CLI dispatch converts to exit codes)
+# ---------------------------------------------------------------------------
+
+
+class NotionConfigurationError(Exception):
+    """Required Notion configuration (env vars) is missing or invalid."""
+
+
+class NotionDependencyError(Exception):
+    """The ``notion-client`` optional extra is not installed."""
+
+
+class NotionAPIError(Exception):
+    """A Notion API call failed in a way the user can act on (auth, perms, rate-limit)."""
 
 
 # ---------------------------------------------------------------------------
@@ -109,8 +148,12 @@ def _table_row_block(cells: list[str]) -> dict:
     }
 
 
-def _table_block(df: pd.DataFrame) -> dict:
+def _table_block(df: pd.DataFrame) -> dict | None:
     cols = list(df.columns)
+    # Notion rejects table blocks with table_width == 0. A DataFrame with no
+    # columns has nothing to render — return None and let the caller skip it.
+    if not cols:
+        return None
     rows = [_table_row_block(cols)]
     for _, row in df.iterrows():
         rows.append(
@@ -131,7 +174,7 @@ def _table_block(df: pd.DataFrame) -> dict:
 
 
 def _section_blocks(section_name: str, df: pd.DataFrame) -> list[dict]:
-    if df is None or df.empty:
+    if df is None or df.empty or not list(df.columns):
         return []
     icon = _SECTION_ICONS.get(section_name, "📄")
     blocks: list[dict] = [_heading2_block(f"{icon} {section_name}")]
@@ -139,7 +182,13 @@ def _section_blocks(section_name: str, df: pd.DataFrame) -> list[dict]:
     # the same heading so each table stays within Notion's 100-children limit.
     for start in range(0, len(df), _MAX_TABLE_DATA_ROWS):
         chunk = df.iloc[start : start + _MAX_TABLE_DATA_ROWS]
-        blocks.append(_table_block(chunk))
+        table = _table_block(chunk)
+        if table is not None:
+            blocks.append(table)
+    # If every chunk degenerated (shouldn't happen given the column guard
+    # above), drop the orphan heading so we don't render a bare section title.
+    if len(blocks) == 1:
+        return []
     return blocks
 
 
@@ -199,12 +248,15 @@ def build_sdr_blocks(
 
 
 # ---------------------------------------------------------------------------
-# Credential resolution
+# Credential resolution + optional-dep loader
 # ---------------------------------------------------------------------------
 
 
 def resolve_notion_credentials() -> tuple[str, str]:
-    """Return (NOTION_TOKEN, NOTION_PARENT_PAGE_ID) from env / .env file."""
+    """Return (NOTION_TOKEN, NOTION_PARENT_PAGE_ID) from env / .env file.
+
+    Raises NotionConfigurationError if either env var is missing.
+    """
     try:
         from dotenv import load_dotenv
 
@@ -216,34 +268,31 @@ def resolve_notion_credentials() -> tuple[str, str]:
     parent_page_id = os.environ.get("NOTION_PARENT_PAGE_ID")
 
     if not token:
-        print(
-            "ERROR: NOTION_TOKEN is not set. Set it as an environment variable or add it to a .env file.",
-            file=sys.stderr,
+        raise NotionConfigurationError(
+            "NOTION_TOKEN is not set. Set it as an environment variable or add it to a .env file.",
         )
-        sys.exit(1)
 
     if not parent_page_id:
-        print(
-            "ERROR: NOTION_PARENT_PAGE_ID is not set. Set it as an environment variable or add it to a .env file.",
-            file=sys.stderr,
+        raise NotionConfigurationError(
+            "NOTION_PARENT_PAGE_ID is not set. Set it as an environment variable or add it to a .env file.",
         )
-        sys.exit(1)
 
     return token, parent_page_id
 
 
 def _require_notion_client():
-    """Return notion_client.Client class or exit with install instructions."""
+    """Return notion_client.Client class.
+
+    Raises NotionDependencyError if the optional extra is not installed.
+    """
     try:
         from notion_client import Client
 
         return Client
-    except ImportError:
-        print(
-            "ERROR: Notion output requires the notion extra.\nInstall it with: uv pip install 'cja-auto-sdr[notion]'",
-            file=sys.stderr,
-        )
-        sys.exit(1)
+    except ImportError as exc:
+        raise NotionDependencyError(
+            "Notion output requires the notion extra.\nInstall it with: uv pip install 'cja-auto-sdr[notion]'",
+        ) from exc
 
 
 # ---------------------------------------------------------------------------
@@ -251,19 +300,136 @@ def _require_notion_client():
 # ---------------------------------------------------------------------------
 
 
-def _clear_page_blocks(client: Any, page_id: str) -> None:
-    """Delete all child blocks from a Notion page (no bulk-clear API exists)."""
-    cursor = None
+def _extract_api_error_code(err: Exception) -> str | None:
+    """Return the Notion API error ``code`` attribute when present."""
+    code = getattr(err, "code", None)
+    if isinstance(code, str):
+        return code
+    # APIResponseError stringifies its code via str(.code) in some SDK versions.
+    if code is not None:
+        return str(code)
+    return None
+
+
+def _extract_retry_after_seconds(err: Exception) -> float | None:
+    """Return the Retry-After value (in seconds) for a 429 if the SDK exposes it."""
+    headers = getattr(err, "headers", None) or {}
+    raw = headers.get("Retry-After") or headers.get("retry-after")
+    if raw is None:
+        return None
+    try:
+        return float(raw)
+    except TypeError, ValueError:
+        return None
+
+
+def _is_notion_api_error(err: Exception) -> bool:
+    """Best-effort check for a notion_client APIResponseError without forcing import."""
+    if err.__class__.__name__ in {"APIResponseError", "HTTPResponseError"}:
+        return True
+    # Walk the MRO by class name so we don't depend on notion_client being
+    # importable at module-load time.
+    return any(c.__name__ in {"APIResponseError", "HTTPResponseError"} for c in type(err).__mro__)
+
+
+def _friendly_notion_error_message(err: Exception) -> str:
+    """Map a Notion API error to a friendly, actionable message."""
+    code = _extract_api_error_code(err)
+    if code in {"unauthorized", "restricted_resource"}:
+        return (
+            "Notion API rejected the request: the integration token is missing, invalid, "
+            "or does not have access to NOTION_PARENT_PAGE_ID. Verify NOTION_TOKEN and "
+            "confirm the parent page is shared with the integration."
+        )
+    if code == "object_not_found":
+        return (
+            "Notion API could not find the target page. The page may have been deleted "
+            "or the integration was removed from it. Re-run with --notion-force-new to "
+            "create a fresh page, or share the parent page with the integration again."
+        )
+    if code == "rate_limited":
+        return "Notion API rate limit exceeded after retries. Try again later or reduce concurrency."
+    if code == "validation_error":
+        return f"Notion API rejected the payload: {err}"
+    return f"Notion API call failed ({code or 'unknown error'}): {err}"
+
+
+def _call_with_rate_limit_retry(func, *args, **kwargs):
+    """Invoke a Notion SDK call, retrying with backoff on 429 rate-limit errors.
+
+    Non-rate-limit API errors are re-raised immediately for the caller to map
+    to a friendly message; this helper only owns the 429 retry policy.
+    """
+    delay = _RATE_LIMIT_BASE_DELAY_SECONDS
+    last_exc: Exception | None = None
+    for attempt in range(1, _RATE_LIMIT_MAX_ATTEMPTS + 1):
+        try:
+            return func(*args, **kwargs)
+        except Exception as exc:
+            if not _is_notion_api_error(exc) or _extract_api_error_code(exc) != "rate_limited":
+                raise
+            last_exc = exc
+            if attempt == _RATE_LIMIT_MAX_ATTEMPTS:
+                break
+            retry_after = _extract_retry_after_seconds(exc)
+            time.sleep(retry_after if retry_after is not None else delay)
+            delay *= 2
+    # All retries exhausted. Re-raise the last 429 so the caller maps it to
+    # a friendly message via _friendly_notion_error_message.
+    assert last_exc is not None
+    raise last_exc
+
+
+def _list_all_child_block_ids(client: Any, page_id: str) -> list[str]:
+    """Return every direct child block ID of ``page_id`` across all pages.
+
+    Collect first, delete second: cursors returned by Notion are content-based,
+    so iterating list-then-delete-in-loop produces undefined behaviour once
+    the page changes mid-iteration.
+    """
+    block_ids: list[str] = []
+    cursor: str | None = None
     while True:
         kwargs: dict[str, Any] = {"block_id": page_id}
         if cursor:
             kwargs["start_cursor"] = cursor
-        response = client.blocks.children.list(**kwargs)
+        response = _call_with_rate_limit_retry(client.blocks.children.list, **kwargs)
         for block in response.get("results", []):
-            client.blocks.delete(block_id=block["id"])
+            block_id = block.get("id")
+            if block_id:
+                block_ids.append(block_id)
         if not response.get("has_more"):
             break
         cursor = response.get("next_cursor")
+        if cursor is None:
+            break
+    return block_ids
+
+
+def _clear_page_blocks(client: Any, page_id: str) -> None:
+    """Delete all child blocks from a Notion page (no bulk-clear API exists).
+
+    Listing and deletion are split into two phases so the pagination cursor
+    cannot drift, and the per-block DELETE calls are issued from a small
+    thread pool to keep update time tolerable for large pages.
+    """
+    block_ids = _list_all_child_block_ids(client, page_id)
+    if not block_ids:
+        return
+
+    def _delete_one(block_id: str) -> None:
+        _call_with_rate_limit_retry(client.blocks.delete, block_id=block_id)
+
+    if len(block_ids) == 1:
+        _delete_one(block_ids[0])
+        return
+
+    with ThreadPoolExecutor(max_workers=_DELETE_WORKER_COUNT) as pool:
+        futures = [pool.submit(_delete_one, bid) for bid in block_ids]
+        for fut in as_completed(futures):
+            # Re-raise the first delete failure; remaining futures complete
+            # naturally as the pool unwinds.
+            fut.result()
 
 
 def _append_blocks(
@@ -274,7 +440,8 @@ def _append_blocks(
 ) -> None:
     """Append blocks to a Notion page in batches (API limit: 100 per call)."""
     for i in range(0, len(blocks), batch_size):
-        client.blocks.children.append(
+        _call_with_rate_limit_retry(
+            client.blocks.children.append,
             block_id=page_id,
             children=blocks[i : i + batch_size],
         )
@@ -304,7 +471,8 @@ def create_or_update_page(
         _append_blocks(client, existing_page_id, blocks)
         return existing_page_id
 
-    page = client.pages.create(
+    page = _call_with_rate_limit_retry(
+        client.pages.create,
         parent={"page_id": parent_page_id},
         properties={"title": [{"type": "text", "text": {"content": page_title}}]},
     )
@@ -334,6 +502,9 @@ def write_notion_output(
     ``base_filename`` is accepted for writer-protocol parity with file-emitting
     writers and is used as a fallback when ``metadata_dict`` lacks
     ``Data View ID`` or ``Data View Name``.
+
+    Raises NotionConfigurationError / NotionDependencyError / NotionAPIError —
+    callers (CLI dispatcher) are responsible for converting these to exit codes.
     """
     logger.info("✓ Publishing to Notion...")
 
@@ -348,15 +519,20 @@ def write_notion_output(
     registry_path = get_registry_path(output_dir)
 
     client = client_cls(auth=token)
-    page_id = create_or_update_page(
-        client,
-        parent_page_id,
-        page_title,
-        data_view_id,
-        blocks,
-        registry_path,
-        force_new=force_new,
-    )
+    try:
+        page_id = create_or_update_page(
+            client,
+            parent_page_id,
+            page_title,
+            data_view_id,
+            blocks,
+            registry_path,
+            force_new=force_new,
+        )
+    except Exception as exc:
+        if _is_notion_api_error(exc):
+            raise NotionAPIError(_friendly_notion_error_message(exc)) from exc
+        raise
 
     logger.info("✓ Notion page published: notion://pages/%s", page_id)
     return f"notion://pages/{page_id}"

--- a/src/cja_auto_sdr/pipeline/batch.py
+++ b/src/cja_auto_sdr/pipeline/batch.py
@@ -61,6 +61,7 @@ class BatchProcessor:
         quality_report_only: bool = False,
         allow_partial: bool = False,
         production_mode: bool = False,
+        notion_force_new: bool = False,
         batch_config: BatchConfig | None = None,
     ):
         generator = _generator_module()
@@ -96,6 +97,7 @@ class BatchProcessor:
                 quality_report_only=quality_report_only,
                 allow_partial=allow_partial,
                 production_mode=production_mode,
+                notion_force_new=notion_force_new,
             )
 
         self.config_file = batch_config.config_file
@@ -127,6 +129,7 @@ class BatchProcessor:
         self.quality_report_only = batch_config.quality_report_only
         self.allow_partial = batch_config.allow_partial
         self.production_mode = batch_config.production_mode
+        self.notion_force_new = batch_config.notion_force_new
         self.batch_id = str(uuid.uuid4())[:8]
         base_logger = generator.setup_logging(batch_mode=True, log_level=self.log_level, log_format=self.log_format)
         self.logger = generator.with_log_context(base_logger, run_mode="batch", batch_id=self.batch_id)
@@ -198,6 +201,7 @@ class BatchProcessor:
                 allow_partial=self.allow_partial,
                 production_mode=self.production_mode,
                 batch_id=self.batch_id,
+                notion_force_new=self.notion_force_new,
             )
             for dv_id in data_view_ids
         ]

--- a/src/cja_auto_sdr/pipeline/models.py
+++ b/src/cja_auto_sdr/pipeline/models.py
@@ -123,6 +123,7 @@ class WorkerArgs:
     allow_partial: bool = False
     production_mode: bool = False
     batch_id: str | None = None
+    notion_force_new: bool = False
 
 
 @dataclass(frozen=True)
@@ -157,6 +158,7 @@ class ProcessingConfig:
     allow_partial: bool = False
     production_mode: bool = False
     batch_id: str | None = None
+    notion_force_new: bool = False
 
 
 @dataclass(frozen=True)
@@ -192,3 +194,4 @@ class BatchConfig:
     quality_report_only: bool = False
     allow_partial: bool = False
     production_mode: bool = False
+    notion_force_new: bool = False

--- a/src/cja_auto_sdr/pipeline/workers.py
+++ b/src/cja_auto_sdr/pipeline/workers.py
@@ -48,5 +48,6 @@ def process_single_dataview_worker(args: WorkerArgs) -> ProcessingResult:
             allow_partial=args.allow_partial,
             production_mode=args.production_mode,
             batch_id=args.batch_id,
+            notion_force_new=args.notion_force_new,
         ),
     )

--- a/tests/README.md
+++ b/tests/README.md
@@ -161,7 +161,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 8,066 comprehensive tests**
+**Total: 8,071 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -170,16 +170,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,960 | 143 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,965 | 143 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 0 | 0 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **8,066** | **149** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **8,071** | **149** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,960 | 143 | `-m "unit and not slow"` |
+| `test-unit` | 7,965 | 143 | `-m "unit and not slow"` |
 | `test-integration` | 96 | 5 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -334,11 +334,11 @@ tests/
 | `test_watch_signals.py` | 2 | SIGINT/SIGTERM exit-0 contract tests |
 | `test_watch_dispatch.py` | 2 | End-to-end dispatch wiring tests |
 | `test_watch_logging.py` | 4 | Structured-log event emission tests |
-| `test_notion_registry.py` | 13 | Notion page ID registry CRUD tests |
+| `test_notion_registry.py` | 14 | Notion page ID registry CRUD tests |
 | `test_notion_writer.py` | 29 | Notion block builder + API layer tests |
-| `test_cli_notion.py` | 8 | CLI flag wiring for --format notion and --push-to-notion |
+| `test_cli_notion.py` | 12 | CLI flag wiring for --format notion and --push-to-notion |
 | `test_push_to_notion.py` | 5 | --push-to-notion JSON ingest and error paths |
-| **Total** | **8,066** | **Collected via pytest --collect-only** |
+| **Total** | **8,071** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -796,7 +796,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (8,066 tests total)
+- [x] Comprehensive test coverage (8,071 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 78 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -161,7 +161,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 8,060 comprehensive tests**
+**Total: 8,063 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -170,16 +170,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,954 | 143 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,957 | 143 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 0 | 0 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **8,060** | **149** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **8,063** | **149** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,954 | 143 | `-m "unit and not slow"` |
+| `test-unit` | 7,957 | 143 | `-m "unit and not slow"` |
 | `test-integration` | 96 | 5 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -335,10 +335,10 @@ tests/
 | `test_watch_dispatch.py` | 2 | End-to-end dispatch wiring tests |
 | `test_watch_logging.py` | 4 | Structured-log event emission tests |
 | `test_notion_registry.py` | 11 | Notion page ID registry CRUD tests |
-| `test_notion_writer.py` | 28 | Notion block builder + API layer tests |
+| `test_notion_writer.py` | 29 | Notion block builder + API layer tests |
 | `test_cli_notion.py` | 8 | CLI flag wiring for --format notion and --push-to-notion |
-| `test_push_to_notion.py` | 3 | --push-to-notion JSON ingest and error paths |
-| **Total** | **8,060** | **Collected via pytest --collect-only** |
+| `test_push_to_notion.py` | 5 | --push-to-notion JSON ingest and error paths |
+| **Total** | **8,063** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -796,7 +796,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (8,060 tests total)
+- [x] Comprehensive test coverage (8,063 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 78 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -161,7 +161,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 8,074 comprehensive tests**
+**Total: 8,085 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -170,16 +170,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,968 | 143 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,979 | 143 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 0 | 0 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **8,074** | **149** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **8,085** | **149** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,968 | 143 | `-m "unit and not slow"` |
+| `test-unit` | 7,979 | 143 | `-m "unit and not slow"` |
 | `test-integration` | 96 | 5 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -335,10 +335,10 @@ tests/
 | `test_watch_dispatch.py` | 2 | End-to-end dispatch wiring tests |
 | `test_watch_logging.py` | 4 | Structured-log event emission tests |
 | `test_notion_registry.py` | 14 | Notion page ID registry CRUD tests |
-| `test_notion_writer.py` | 32 | Notion block builder + API layer tests |
+| `test_notion_writer.py` | 43 | Notion block builder + API layer tests |
 | `test_cli_notion.py` | 12 | CLI flag wiring for --format notion and --push-to-notion |
 | `test_push_to_notion.py` | 5 | --push-to-notion JSON ingest and error paths |
-| **Total** | **8,074** | **Collected via pytest --collect-only** |
+| **Total** | **8,085** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -796,7 +796,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (8,074 tests total)
+- [x] Comprehensive test coverage (8,085 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 78 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -161,7 +161,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 8,063 comprehensive tests**
+**Total: 8,066 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -170,16 +170,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,957 | 143 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,960 | 143 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 0 | 0 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **8,063** | **149** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **8,066** | **149** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,957 | 143 | `-m "unit and not slow"` |
+| `test-unit` | 7,960 | 143 | `-m "unit and not slow"` |
 | `test-integration` | 96 | 5 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -304,7 +304,7 @@ tests/
 | `test_discovery_exceptions.py` | 6 | Discovery exception classification contracts |
 | `test_orchestrator.py` | 19 | Automation orchestrator wrapper CLI and exit-code handling |
 | `test_pipeline_single.py` | 2 | Modular single-dataview pipeline wrapper tests |
-| `test_processing_execution_policy.py` | 10 | Processing execution-policy derivation tests |
+| `test_processing_execution_policy.py` | 11 | Processing execution-policy derivation tests |
 | `test_github_actions_audit.py` | 7 | GitHub Actions audit workflow helper and manifest staging tests |
 | `test_example_automation_scripts.py` | 4 | Automation shell script validation tests |
 | `test_exit_codes.py` | 11 | Exit code helpers and signal detection tests |
@@ -334,11 +334,11 @@ tests/
 | `test_watch_signals.py` | 2 | SIGINT/SIGTERM exit-0 contract tests |
 | `test_watch_dispatch.py` | 2 | End-to-end dispatch wiring tests |
 | `test_watch_logging.py` | 4 | Structured-log event emission tests |
-| `test_notion_registry.py` | 11 | Notion page ID registry CRUD tests |
+| `test_notion_registry.py` | 13 | Notion page ID registry CRUD tests |
 | `test_notion_writer.py` | 29 | Notion block builder + API layer tests |
 | `test_cli_notion.py` | 8 | CLI flag wiring for --format notion and --push-to-notion |
 | `test_push_to_notion.py` | 5 | --push-to-notion JSON ingest and error paths |
-| **Total** | **8,063** | **Collected via pytest --collect-only** |
+| **Total** | **8,066** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -796,7 +796,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (8,063 tests total)
+- [x] Comprehensive test coverage (8,066 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 78 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -161,7 +161,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 8,085 comprehensive tests**
+**Total: 8,088 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -170,16 +170,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,979 | 143 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,982 | 143 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 0 | 0 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **8,085** | **149** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **8,088** | **149** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,979 | 143 | `-m "unit and not slow"` |
+| `test-unit` | 7,982 | 143 | `-m "unit and not slow"` |
 | `test-integration` | 96 | 5 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -218,7 +218,7 @@ tests/
 | `test_retry.py` | 25 | Retry with exponential backoff |
 | `test_batch_processor.py` | 26 | Batch processing of multiple data views |
 | `test_validation_cache.py` | 25 | Validation result caching |
-| `test_process_single_dataview.py` | 46 | End-to-end single data view processing |
+| `test_process_single_dataview.py` | 47 | End-to-end single data view processing |
 | `test_optimized_validation.py` | 16 | Optimized data quality validation |
 | `test_name_resolution.py` | 24 | Data view name to ID resolution |
 | `test_shared_cache.py` | 28 | Shared validation cache |
@@ -336,9 +336,9 @@ tests/
 | `test_watch_logging.py` | 4 | Structured-log event emission tests |
 | `test_notion_registry.py` | 14 | Notion page ID registry CRUD tests |
 | `test_notion_writer.py` | 43 | Notion block builder + API layer tests |
-| `test_cli_notion.py` | 12 | CLI flag wiring for --format notion and --push-to-notion |
+| `test_cli_notion.py` | 14 | CLI flag wiring for --format notion and --push-to-notion |
 | `test_push_to_notion.py` | 5 | --push-to-notion JSON ingest and error paths |
-| **Total** | **8,085** | **Collected via pytest --collect-only** |
+| **Total** | **8,088** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -796,7 +796,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (8,085 tests total)
+- [x] Comprehensive test coverage (8,088 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 78 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -161,7 +161,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 8,071 comprehensive tests**
+**Total: 8,074 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -170,16 +170,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,965 | 143 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,968 | 143 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 0 | 0 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **8,071** | **149** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **8,074** | **149** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,965 | 143 | `-m "unit and not slow"` |
+| `test-unit` | 7,968 | 143 | `-m "unit and not slow"` |
 | `test-integration` | 96 | 5 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -335,10 +335,10 @@ tests/
 | `test_watch_dispatch.py` | 2 | End-to-end dispatch wiring tests |
 | `test_watch_logging.py` | 4 | Structured-log event emission tests |
 | `test_notion_registry.py` | 14 | Notion page ID registry CRUD tests |
-| `test_notion_writer.py` | 29 | Notion block builder + API layer tests |
+| `test_notion_writer.py` | 32 | Notion block builder + API layer tests |
 | `test_cli_notion.py` | 12 | CLI flag wiring for --format notion and --push-to-notion |
 | `test_push_to_notion.py` | 5 | --push-to-notion JSON ingest and error paths |
-| **Total** | **8,071** | **Collected via pytest --collect-only** |
+| **Total** | **8,074** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -796,7 +796,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (8,071 tests total)
+- [x] Comprehensive test coverage (8,074 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 78 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -154,10 +154,14 @@ tests/
 ├── test_watch_signals.py            # SIGINT/SIGTERM exit-0 contract tests
 ├── test_watch_dispatch.py           # End-to-end dispatch wiring tests
 ├── test_watch_logging.py            # Structured-log event emission tests
+├── test_notion_registry.py          # Notion page ID registry CRUD tests
+├── test_notion_writer.py            # Notion block builder + API layer tests
+├── test_cli_notion.py               # CLI flag wiring for --format notion and --push-to-notion
+├── test_push_to_notion.py           # --push-to-notion JSON ingest and error paths
 └── README.md                        # This file
 ```
 
-**Total: 8,010 comprehensive tests**
+**Total: 8,060 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -166,16 +170,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,904 | 139 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,954 | 143 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 0 | 0 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **8,010** | **145** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **8,060** | **149** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,904 | 139 | `-m "unit and not slow"` |
+| `test-unit` | 7,954 | 143 | `-m "unit and not slow"` |
 | `test-integration` | 96 | 5 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -330,7 +334,11 @@ tests/
 | `test_watch_signals.py` | 2 | SIGINT/SIGTERM exit-0 contract tests |
 | `test_watch_dispatch.py` | 2 | End-to-end dispatch wiring tests |
 | `test_watch_logging.py` | 4 | Structured-log event emission tests |
-| **Total** | **8,010** | **Collected via pytest --collect-only** |
+| `test_notion_registry.py` | 11 | Notion page ID registry CRUD tests |
+| `test_notion_writer.py` | 28 | Notion block builder + API layer tests |
+| `test_cli_notion.py` | 8 | CLI flag wiring for --format notion and --push-to-notion |
+| `test_push_to_notion.py` | 3 | --push-to-notion JSON ingest and error paths |
+| **Total** | **8,060** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -788,7 +796,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (8,010 tests total)
+- [x] Comprehensive test coverage (8,060 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 78 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -161,7 +161,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 8,088 comprehensive tests**
+**Total: 8,101 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -170,16 +170,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,982 | 143 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 7,995 | 143 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 0 | 0 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **8,088** | **149** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **8,101** | **149** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,982 | 143 | `-m "unit and not slow"` |
+| `test-unit` | 7,995 | 143 | `-m "unit and not slow"` |
 | `test-integration` | 96 | 5 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -336,9 +336,9 @@ tests/
 | `test_watch_logging.py` | 4 | Structured-log event emission tests |
 | `test_notion_registry.py` | 14 | Notion page ID registry CRUD tests |
 | `test_notion_writer.py` | 43 | Notion block builder + API layer tests |
-| `test_cli_notion.py` | 14 | CLI flag wiring for --format notion and --push-to-notion |
+| `test_cli_notion.py` | 27 | CLI flag wiring for --format notion and --push-to-notion |
 | `test_push_to_notion.py` | 5 | --push-to-notion JSON ingest and error paths |
-| **Total** | **8,088** | **Collected via pytest --collect-only** |
+| **Total** | **8,101** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -796,7 +796,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (8,088 tests total)
+- [x] Comprehensive test coverage (8,101 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 78 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -161,7 +161,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 8,101 comprehensive tests**
+**Total: 8,112 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -170,16 +170,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 7,995 | 143 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 8,006 | 143 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 0 | 0 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **8,101** | **149** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **8,112** | **149** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 7,995 | 143 | `-m "unit and not slow"` |
+| `test-unit` | 8,006 | 143 | `-m "unit and not slow"` |
 | `test-integration` | 96 | 5 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -335,10 +335,10 @@ tests/
 | `test_watch_dispatch.py` | 2 | End-to-end dispatch wiring tests |
 | `test_watch_logging.py` | 4 | Structured-log event emission tests |
 | `test_notion_registry.py` | 14 | Notion page ID registry CRUD tests |
-| `test_notion_writer.py` | 43 | Notion block builder + API layer tests |
+| `test_notion_writer.py` | 54 | Notion block builder + API layer tests |
 | `test_cli_notion.py` | 27 | CLI flag wiring for --format notion and --push-to-notion |
 | `test_push_to_notion.py` | 5 | --push-to-notion JSON ingest and error paths |
-| **Total** | **8,101** | **Collected via pytest --collect-only** |
+| **Total** | **8,112** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -796,7 +796,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (8,101 tests total)
+- [x] Comprehensive test coverage (8,112 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 78 tests

--- a/tests/test_cli_notion.py
+++ b/tests/test_cli_notion.py
@@ -1,4 +1,5 @@
 """Tests for Notion-related CLI flag wiring."""
+
 from __future__ import annotations
 
 import sys
@@ -51,6 +52,7 @@ def test_push_to_notion_and_format_both_set_no_argparse_conflict():
 
 def test_push_to_notion_standalone_policy_registered():
     from cja_auto_sdr.cli.standalone_policy import standalone_prevalidation_policy
+
     policy = standalone_prevalidation_policy("push_to_notion")
     assert policy is not None
     assert "notion_force_new" in policy.ignored_semantic_dests

--- a/tests/test_cli_notion.py
+++ b/tests/test_cli_notion.py
@@ -128,3 +128,41 @@ def test_format_notion_allowed_in_sdr_mode():
         skip_validation=False,
     )
     _validate_semantic_flag_relationships(args, inferred_mode=RunMode.SDR)
+
+
+def test_push_to_notion_rejected_with_list_snapshots():
+    """--push-to-notion + --list-snapshots must exit 1; snapshot mode would silently win otherwise."""
+    import argparse
+
+    from cja_auto_sdr.generator import (
+        RunMode,
+        _validate_semantic_flag_relationships,
+    )
+
+    args = argparse.Namespace(
+        push_to_notion="./sdr.json",
+        list_snapshots=True,
+        skip_validation=False,
+    )
+    with pytest.raises(SystemExit) as exc_info:
+        _validate_semantic_flag_relationships(args, inferred_mode=RunMode.PUSH_TO_NOTION)
+    assert exc_info.value.code == 1
+
+
+def test_push_to_notion_rejected_with_prune_snapshots():
+    """--push-to-notion + --prune-snapshots must exit 1; snapshot mode would silently win otherwise."""
+    import argparse
+
+    from cja_auto_sdr.generator import (
+        RunMode,
+        _validate_semantic_flag_relationships,
+    )
+
+    args = argparse.Namespace(
+        push_to_notion="./sdr.json",
+        prune_snapshots=True,
+        skip_validation=False,
+    )
+    with pytest.raises(SystemExit) as exc_info:
+        _validate_semantic_flag_relationships(args, inferred_mode=RunMode.PUSH_TO_NOTION)
+    assert exc_info.value.code == 1

--- a/tests/test_cli_notion.py
+++ b/tests/test_cli_notion.py
@@ -1,0 +1,38 @@
+"""Tests for Notion-related CLI flag wiring."""
+from __future__ import annotations
+
+import sys
+from unittest.mock import patch
+
+from cja_auto_sdr.cli.parser import parse_arguments
+
+
+def _parse(args):
+    with patch.object(sys, "argv", ["cja_auto_sdr", *args]):
+        return parse_arguments()
+
+
+def test_format_notion_is_accepted():
+    args = _parse(["dv_12345", "--format", "notion"])
+    assert args.format == "notion"
+
+
+def test_notion_force_new_flag_false_by_default():
+    args = _parse(["dv_12345", "--format", "notion"])
+    assert args.notion_force_new is False
+
+
+def test_notion_force_new_flag_sets_true():
+    args = _parse(["dv_12345", "--format", "notion", "--notion-force-new"])
+    assert args.notion_force_new is True
+
+
+def test_push_to_notion_accepts_file_path():
+    args = _parse(["--push-to-notion", "./reports/sdr.json"])
+    assert args.push_to_notion == "./reports/sdr.json"
+
+
+def test_push_to_notion_with_force_new():
+    args = _parse(["--push-to-notion", "./reports/sdr.json", "--notion-force-new"])
+    assert args.push_to_notion == "./reports/sdr.json"
+    assert args.notion_force_new is True

--- a/tests/test_cli_notion.py
+++ b/tests/test_cli_notion.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import argparse
 import sys
 from unittest.mock import patch
 
 import pytest
 
 from cja_auto_sdr.cli.parser import parse_arguments
+from cja_auto_sdr.generator import RunMode, _validate_semantic_flag_relationships
 
 
 def _parse(args):
@@ -62,13 +64,6 @@ def test_push_to_notion_standalone_policy_registered():
 
 def test_format_notion_rejected_for_diff_mode():
     """--format notion in diff mode must exit 1 with actionable error (Notion is SDR-only)."""
-    import argparse
-
-    from cja_auto_sdr.generator import (
-        RunMode,
-        _validate_semantic_flag_relationships,
-    )
-
     args = argparse.Namespace(
         format="notion",
         diff=True,
@@ -81,13 +76,6 @@ def test_format_notion_rejected_for_diff_mode():
 
 def test_format_notion_rejected_for_org_report_mode():
     """--format notion in org-report mode must exit 1 (Notion is SDR-only)."""
-    import argparse
-
-    from cja_auto_sdr.generator import (
-        RunMode,
-        _validate_semantic_flag_relationships,
-    )
-
     args = argparse.Namespace(
         format="notion",
         skip_validation=False,
@@ -99,13 +87,6 @@ def test_format_notion_rejected_for_org_report_mode():
 
 def test_format_notion_allowed_in_push_to_notion_mode():
     """--push-to-notion + --format notion must not error — push handler ignores --format."""
-    import argparse
-
-    from cja_auto_sdr.generator import (
-        RunMode,
-        _validate_semantic_flag_relationships,
-    )
-
     args = argparse.Namespace(
         format="notion",
         push_to_notion="./sdr.json",
@@ -116,13 +97,6 @@ def test_format_notion_allowed_in_push_to_notion_mode():
 
 def test_format_notion_allowed_in_sdr_mode():
     """--format notion in SDR mode must validate cleanly."""
-    import argparse
-
-    from cja_auto_sdr.generator import (
-        RunMode,
-        _validate_semantic_flag_relationships,
-    )
-
     args = argparse.Namespace(
         format="notion",
         skip_validation=False,
@@ -130,38 +104,37 @@ def test_format_notion_allowed_in_sdr_mode():
     _validate_semantic_flag_relationships(args, inferred_mode=RunMode.SDR)
 
 
-def test_push_to_notion_rejected_with_list_snapshots():
-    """--push-to-notion + --list-snapshots must exit 1; snapshot mode would silently win otherwise."""
-    import argparse
+# Mode flags that --push-to-notion must reject. _run_mode_checks dispatches by
+# precedence — every flag below would otherwise win and silently drop the
+# publish. Parametrized to mirror the table-driven impl
+# (_PUSH_TO_NOTION_INCOMPATIBLE_FLAGS) so a future addition there gets
+# coverage by adding one line here.
+_PUSH_TO_NOTION_MUTEX_CASES: tuple[tuple[str, object], ...] = (
+    ("org_report", True),
+    ("diff", True),
+    ("snapshot", "./snap.json"),
+    ("diff_snapshot", ["./a.json", "./b.json"]),
+    ("compare_snapshots", ["./a.json", "./b.json"]),
+    ("list_snapshots", True),
+    ("prune_snapshots", True),
+    ("list_org_report_snapshots", True),
+    ("inspect_org_report_snapshot", "./snap.json"),
+    ("prune_org_report_snapshots", True),
+    ("batch", True),
+    ("watch_data_views", ["dv_123"]),
+    ("inventory_summary", True),
+    ("dry_run", True),
+    ("data_views", ["dv_123"]),
+)
 
-    from cja_auto_sdr.generator import (
-        RunMode,
-        _validate_semantic_flag_relationships,
-    )
 
+@pytest.mark.parametrize(("dest", "value"), _PUSH_TO_NOTION_MUTEX_CASES)
+def test_push_to_notion_rejects_incompatible_mode_flag(dest, value):
+    """Each mode flag in the mutex table must cause --push-to-notion to exit 1."""
     args = argparse.Namespace(
         push_to_notion="./sdr.json",
-        list_snapshots=True,
         skip_validation=False,
-    )
-    with pytest.raises(SystemExit) as exc_info:
-        _validate_semantic_flag_relationships(args, inferred_mode=RunMode.PUSH_TO_NOTION)
-    assert exc_info.value.code == 1
-
-
-def test_push_to_notion_rejected_with_prune_snapshots():
-    """--push-to-notion + --prune-snapshots must exit 1; snapshot mode would silently win otherwise."""
-    import argparse
-
-    from cja_auto_sdr.generator import (
-        RunMode,
-        _validate_semantic_flag_relationships,
-    )
-
-    args = argparse.Namespace(
-        push_to_notion="./sdr.json",
-        prune_snapshots=True,
-        skip_validation=False,
+        **{dest: value},
     )
     with pytest.raises(SystemExit) as exc_info:
         _validate_semantic_flag_relationships(args, inferred_mode=RunMode.PUSH_TO_NOTION)

--- a/tests/test_cli_notion.py
+++ b/tests/test_cli_notion.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import sys
 from unittest.mock import patch
 
+import pytest
+
 from cja_auto_sdr.cli.parser import parse_arguments
 
 
@@ -56,3 +58,73 @@ def test_push_to_notion_standalone_policy_registered():
     policy = standalone_prevalidation_policy("push_to_notion")
     assert policy is not None
     assert "notion_force_new" in policy.ignored_semantic_dests
+
+
+def test_format_notion_rejected_for_diff_mode():
+    """--format notion in diff mode must exit 1 with actionable error (Notion is SDR-only)."""
+    import argparse
+
+    from cja_auto_sdr.generator import (
+        RunMode,
+        _validate_semantic_flag_relationships,
+    )
+
+    args = argparse.Namespace(
+        format="notion",
+        diff=True,
+        skip_validation=False,
+    )
+    with pytest.raises(SystemExit) as exc_info:
+        _validate_semantic_flag_relationships(args, inferred_mode=RunMode.DIFF)
+    assert exc_info.value.code == 1
+
+
+def test_format_notion_rejected_for_org_report_mode():
+    """--format notion in org-report mode must exit 1 (Notion is SDR-only)."""
+    import argparse
+
+    from cja_auto_sdr.generator import (
+        RunMode,
+        _validate_semantic_flag_relationships,
+    )
+
+    args = argparse.Namespace(
+        format="notion",
+        skip_validation=False,
+    )
+    with pytest.raises(SystemExit) as exc_info:
+        _validate_semantic_flag_relationships(args, inferred_mode=RunMode.ORG_REPORT)
+    assert exc_info.value.code == 1
+
+
+def test_format_notion_allowed_in_push_to_notion_mode():
+    """--push-to-notion + --format notion must not error — push handler ignores --format."""
+    import argparse
+
+    from cja_auto_sdr.generator import (
+        RunMode,
+        _validate_semantic_flag_relationships,
+    )
+
+    args = argparse.Namespace(
+        format="notion",
+        push_to_notion="./sdr.json",
+        skip_validation=False,
+    )
+    _validate_semantic_flag_relationships(args, inferred_mode=RunMode.PUSH_TO_NOTION)
+
+
+def test_format_notion_allowed_in_sdr_mode():
+    """--format notion in SDR mode must validate cleanly."""
+    import argparse
+
+    from cja_auto_sdr.generator import (
+        RunMode,
+        _validate_semantic_flag_relationships,
+    )
+
+    args = argparse.Namespace(
+        format="notion",
+        skip_validation=False,
+    )
+    _validate_semantic_flag_relationships(args, inferred_mode=RunMode.SDR)

--- a/tests/test_cli_notion.py
+++ b/tests/test_cli_notion.py
@@ -36,3 +36,21 @@ def test_push_to_notion_with_force_new():
     args = _parse(["--push-to-notion", "./reports/sdr.json", "--notion-force-new"])
     assert args.push_to_notion == "./reports/sdr.json"
     assert args.notion_force_new is True
+
+
+def test_push_to_notion_default_is_none():
+    args = _parse(["dv_12345"])
+    assert args.push_to_notion is None
+
+
+def test_push_to_notion_and_format_both_set_no_argparse_conflict():
+    args = _parse(["--push-to-notion", "./sdr.json", "--format", "notion"])
+    assert args.push_to_notion == "./sdr.json"
+    assert args.format == "notion"
+
+
+def test_push_to_notion_standalone_policy_registered():
+    from cja_auto_sdr.cli.standalone_policy import standalone_prevalidation_policy
+    policy = standalone_prevalidation_policy("push_to_notion")
+    assert policy is not None
+    assert "notion_force_new" in policy.ignored_semantic_dests

--- a/tests/test_notion_registry.py
+++ b/tests/test_notion_registry.py
@@ -90,6 +90,42 @@ def test_store_page_id_creates_sidecar_lock_file(tmp_path):
     assert (tmp_path / (REGISTRY_FILENAME + ".lock")).exists()
 
 
+def test_exclusive_registry_lock_falls_back_to_msvcrt_when_fcntl_missing(
+    tmp_path,
+    monkeypatch,
+):
+    """Simulate the Windows path: fcntl import fails, msvcrt.locking is used."""
+    import builtins
+
+    from cja_auto_sdr.output import notion_registry as nr_mod
+
+    fake_msvcrt = type(
+        "FakeMsvcrt",
+        (),
+        {
+            "LK_LOCK": 1,
+            "LK_UNLCK": 0,
+            "locking": staticmethod(lambda fd, mode, nbytes: None),
+        },
+    )()
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "fcntl":
+            raise ImportError("simulated: no fcntl on Windows")
+        if name == "msvcrt":
+            return fake_msvcrt
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    reg_path = tmp_path / REGISTRY_FILENAME
+    # Should not raise — msvcrt fallback path runs and yields to the body.
+    nr_mod.store_page_id(reg_path, "dv_win", "page-win")
+    data = json.loads(reg_path.read_text())
+    assert data["dv_win"] == "page-win"
+
+
 def test_store_page_id_concurrent_workers_preserve_all_entries(tmp_path):
     """Concurrent store_page_id calls from a process pool must not lose entries.
 

--- a/tests/test_notion_registry.py
+++ b/tests/test_notion_registry.py
@@ -81,3 +81,34 @@ def test_store_page_id_preserves_other_entries(tmp_path):
     data = json.loads(reg_path.read_text())
     assert data["dv_existing"] == "page-existing"
     assert data["dv_new"] == "page-new"
+
+
+def test_store_page_id_creates_sidecar_lock_file(tmp_path):
+    """fcntl-locked write must leave a sidecar .lock file alongside the registry."""
+    reg_path = tmp_path / REGISTRY_FILENAME
+    store_page_id(reg_path, "dv_123", "page-abc")
+    assert (tmp_path / (REGISTRY_FILENAME + ".lock")).exists()
+
+
+def test_store_page_id_concurrent_workers_preserve_all_entries(tmp_path):
+    """Concurrent store_page_id calls from a process pool must not lose entries.
+
+    Without the exclusive flock around the read-modify-write, two workers can
+    load the same baseline registry and clobber each other's writes. This test
+    drives 20 concurrent writes through a real ProcessPoolExecutor and asserts
+    every entry survives.
+    """
+    from concurrent.futures import ProcessPoolExecutor
+
+    reg_path = tmp_path / REGISTRY_FILENAME
+    n = 20
+
+    with ProcessPoolExecutor(max_workers=8) as ex:
+        futures = [ex.submit(store_page_id, reg_path, f"dv_{i:03d}", f"page-{i:03d}") for i in range(n)]
+        for f in futures:
+            f.result()
+
+    data = json.loads(reg_path.read_text())
+    assert len(data) == n
+    for i in range(n):
+        assert data[f"dv_{i:03d}"] == f"page-{i:03d}"

--- a/tests/test_notion_registry.py
+++ b/tests/test_notion_registry.py
@@ -1,4 +1,5 @@
 """Tests for Notion page ID registry."""
+
 from __future__ import annotations
 
 import json

--- a/tests/test_notion_registry.py
+++ b/tests/test_notion_registry.py
@@ -1,0 +1,82 @@
+"""Tests for Notion page ID registry."""
+from __future__ import annotations
+
+import json
+
+from cja_auto_sdr.output.notion_registry import (
+    REGISTRY_FILENAME,
+    get_registry_path,
+    load_registry,
+    lookup_page_id,
+    save_registry,
+    store_page_id,
+)
+
+
+def test_registry_filename_constant():
+    assert REGISTRY_FILENAME == ".notion_pages.json"
+
+
+def test_get_registry_path(tmp_path):
+    result = get_registry_path(tmp_path)
+    assert result == tmp_path / REGISTRY_FILENAME
+
+
+def test_load_registry_missing_file_returns_empty(tmp_path):
+    result = load_registry(tmp_path / "nonexistent.json")
+    assert result == {}
+
+
+def test_load_registry_reads_existing(tmp_path):
+    reg_path = tmp_path / REGISTRY_FILENAME
+    reg_path.write_text(json.dumps({"dv_123": "page-abc"}))
+    result = load_registry(reg_path)
+    assert result == {"dv_123": "page-abc"}
+
+
+def test_save_registry_writes_json(tmp_path):
+    reg_path = tmp_path / REGISTRY_FILENAME
+    save_registry(reg_path, {"dv_456": "page-def"})
+    data = json.loads(reg_path.read_text())
+    assert data == {"dv_456": "page-def"}
+
+
+def test_lookup_page_id_found(tmp_path):
+    reg_path = tmp_path / REGISTRY_FILENAME
+    reg_path.write_text(json.dumps({"dv_123": "page-abc", "dv_456": "page-def"}))
+    assert lookup_page_id(reg_path, "dv_123") == "page-abc"
+
+
+def test_lookup_page_id_not_found(tmp_path):
+    reg_path = tmp_path / REGISTRY_FILENAME
+    reg_path.write_text(json.dumps({"dv_123": "page-abc"}))
+    assert lookup_page_id(reg_path, "dv_999") is None
+
+
+def test_lookup_page_id_missing_registry(tmp_path):
+    result = lookup_page_id(tmp_path / "nonexistent.json", "dv_123")
+    assert result is None
+
+
+def test_store_page_id_creates_new_entry(tmp_path):
+    reg_path = tmp_path / REGISTRY_FILENAME
+    store_page_id(reg_path, "dv_123", "page-abc")
+    data = json.loads(reg_path.read_text())
+    assert data["dv_123"] == "page-abc"
+
+
+def test_store_page_id_updates_existing_entry(tmp_path):
+    reg_path = tmp_path / REGISTRY_FILENAME
+    reg_path.write_text(json.dumps({"dv_123": "page-old"}))
+    store_page_id(reg_path, "dv_123", "page-new")
+    data = json.loads(reg_path.read_text())
+    assert data["dv_123"] == "page-new"
+
+
+def test_store_page_id_preserves_other_entries(tmp_path):
+    reg_path = tmp_path / REGISTRY_FILENAME
+    reg_path.write_text(json.dumps({"dv_existing": "page-existing"}))
+    store_page_id(reg_path, "dv_new", "page-new")
+    data = json.loads(reg_path.read_text())
+    assert data["dv_existing"] == "page-existing"
+    assert data["dv_new"] == "page-new"

--- a/tests/test_notion_writer.py
+++ b/tests/test_notion_writer.py
@@ -85,6 +85,62 @@ def test_section_blocks_empty_df_returns_empty_list():
     assert blocks == []
 
 
+def test_section_blocks_small_df_emits_single_table():
+    df = pd.DataFrame({"Name": [f"m{i}" for i in range(50)], "Type": ["metric"] * 50})
+    blocks = _section_blocks("Metrics", df)
+    # heading + one table
+    assert len(blocks) == 2
+    assert blocks[0]["type"] == "heading_2"
+    assert blocks[1]["type"] == "table"
+    # header row + 50 data rows = 51 children, well within 100
+    assert len(blocks[1]["table"]["children"]) == 51
+
+
+def test_section_blocks_splits_large_df_into_sibling_tables():
+    """A section with > 99 data rows must split into sibling tables under one heading.
+
+    Notion caps a single block's children at 100 (including a table's
+    table_row children). Each emitted table must contain at most 1 header
+    row + 99 data rows, and the union must preserve every input row.
+    """
+    n = 250
+    df = pd.DataFrame({"Name": [f"m{i:03d}" for i in range(n)], "Type": ["metric"] * n})
+    blocks = _section_blocks("Metrics", df)
+
+    # 1 heading + ceil(250 / 99) = 3 tables = 4 blocks
+    assert len(blocks) == 4
+    assert blocks[0]["type"] == "heading_2"
+    assert all(b["type"] == "table" for b in blocks[1:])
+
+    # Every table must respect the 100-children Notion API cap.
+    for table in blocks[1:]:
+        assert len(table["table"]["children"]) <= 100
+
+    # All data rows preserved across the sibling tables, in original order.
+    recovered: list[str] = []
+    for table in blocks[1:]:
+        # children[0] is the header row; skip it.
+        for row in table["table"]["children"][1:]:
+            recovered.append(row["table_row"]["cells"][0][0]["text"]["content"])
+    assert recovered == [f"m{i:03d}" for i in range(n)]
+
+
+def test_section_blocks_chunks_at_99_data_rows():
+    """Each split table holds at most 99 data rows + 1 header = 100 children."""
+    df = pd.DataFrame({"Name": [f"d{i:03d}" for i in range(99)], "Type": ["dim"] * 99})
+    blocks = _section_blocks("Dimensions", df)
+    # 99 rows == single chunk (heading + one table, 100 children total).
+    assert len(blocks) == 2
+    assert len(blocks[1]["table"]["children"]) == 100
+
+    df_overflow = pd.DataFrame({"Name": [f"d{i:03d}" for i in range(100)], "Type": ["dim"] * 100})
+    blocks_overflow = _section_blocks("Dimensions", df_overflow)
+    # 100 rows must split: heading + two tables (99 + 1).
+    assert len(blocks_overflow) == 3
+    assert len(blocks_overflow[1]["table"]["children"]) == 100  # header + 99
+    assert len(blocks_overflow[2]["table"]["children"]) == 2  # header + 1
+
+
 def test_dq_callout_blocks_warn_severity():
     dq_df = pd.DataFrame(
         {

--- a/tests/test_notion_writer.py
+++ b/tests/test_notion_writer.py
@@ -1,0 +1,169 @@
+"""Tests for Notion block builder and writer."""
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from cja_auto_sdr.output.writers.notion import (
+    _callout_block,
+    _dq_callout_blocks,
+    _heading2_block,
+    _metadata_callout_block,
+    _rich_text,
+    _section_blocks,
+    _table_block,
+    _table_row_block,
+    build_sdr_blocks,
+)
+
+
+def test_rich_text_returns_list_with_text_object():
+    result = _rich_text("hello")
+    assert isinstance(result, list)
+    assert result[0]["type"] == "text"
+    assert result[0]["text"]["content"] == "hello"
+
+
+def test_heading2_block_type():
+    block = _heading2_block("Metrics")
+    assert block["type"] == "heading_2"
+    assert block["heading_2"]["rich_text"][0]["text"]["content"] == "Metrics"
+
+
+def test_callout_block_defaults():
+    block = _callout_block("Some info")
+    assert block["type"] == "callout"
+    assert block["callout"]["icon"]["emoji"] == "📋"
+    assert block["callout"]["rich_text"][0]["text"]["content"] == "Some info"
+
+
+def test_callout_block_custom_emoji():
+    block = _callout_block("Warning", emoji="⚠️")
+    assert block["callout"]["icon"]["emoji"] == "⚠️"
+
+
+def test_table_row_block_structure():
+    row = _table_row_block(["col1", "col2"])
+    assert row["type"] == "table_row"
+    assert len(row["table_row"]["cells"]) == 2
+    assert row["table_row"]["cells"][0][0]["text"]["content"] == "col1"
+
+
+def test_table_block_has_header_row_plus_data_rows():
+    df = pd.DataFrame({"Name": ["metric_a", "metric_b"], "Type": ["dim", "metric"]})
+    block = _table_block(df)
+    assert block["type"] == "table"
+    assert block["table"]["has_column_header"] is True
+    children = block["table"]["children"]
+    assert len(children) == 3
+    assert children[0]["table_row"]["cells"][0][0]["text"]["content"] == "Name"
+    assert children[1]["table_row"]["cells"][0][0]["text"]["content"] == "metric_a"
+
+
+def test_table_block_empty_df():
+    df = pd.DataFrame({"Name": [], "Type": []})
+    block = _table_block(df)
+    children = block["table"]["children"]
+    assert len(children) == 1
+
+
+def test_section_blocks_returns_heading_plus_table():
+    df = pd.DataFrame({"Name": ["a"], "Type": ["metric"]})
+    blocks = _section_blocks("Metrics", df)
+    assert blocks[0]["type"] == "heading_2"
+    assert blocks[1]["type"] == "table"
+
+
+def test_section_blocks_empty_df_returns_empty_list():
+    df = pd.DataFrame()
+    blocks = _section_blocks("Metrics", df)
+    assert blocks == []
+
+
+def test_dq_callout_blocks_warn_severity():
+    dq_df = pd.DataFrame({
+        "Severity": ["WARN"],
+        "Component": ["metric_a"],
+        "Issue": ["Missing description"],
+    })
+    blocks = _dq_callout_blocks(dq_df)
+    assert len(blocks) == 1
+    assert blocks[0]["callout"]["icon"]["emoji"] == "⚠️"
+
+
+def test_dq_callout_blocks_error_severity():
+    dq_df = pd.DataFrame({
+        "Severity": ["ERROR"],
+        "Component": ["dim_b"],
+        "Issue": ["Null values"],
+    })
+    blocks = _dq_callout_blocks(dq_df)
+    assert blocks[0]["callout"]["icon"]["emoji"] == "🔴"
+
+
+def test_dq_callout_blocks_empty_df_returns_empty():
+    blocks = _dq_callout_blocks(pd.DataFrame())
+    assert blocks == []
+
+
+def test_metadata_callout_block_content():
+    metadata = {
+        "Data View Name": "Web Analytics",
+        "Data View ID": "dv_123",
+        "Generated Date & timestamp and timezone": "2026-05-14 10:00:00 UTC",
+    }
+    block = _metadata_callout_block(metadata)
+    assert block["type"] == "callout"
+    content = block["callout"]["rich_text"][0]["text"]["content"]
+    assert "Web Analytics" in content
+    assert "dv_123" in content
+
+
+def test_build_sdr_blocks_structure():
+    data_dict = {
+        "Metrics": pd.DataFrame({"Name": ["m1"], "Type": ["metric"]}),
+        "Dimensions": pd.DataFrame({"Name": ["d1"], "Type": ["dim"]}),
+        "Data Quality": pd.DataFrame(),
+    }
+    metadata = {"Data View Name": "Test", "Data View ID": "dv_001"}
+    blocks = build_sdr_blocks(data_dict, metadata)
+    types = [b["type"] for b in blocks]
+    assert "callout" in types
+    assert "heading_2" in types
+    assert "table" in types
+    assert "divider" in types
+    assert "paragraph" in types
+
+
+def test_build_sdr_blocks_omits_empty_sections():
+    data_dict = {
+        "Metrics": pd.DataFrame({"Name": ["m1"], "Type": ["metric"]}),
+        "Dimensions": pd.DataFrame(),
+    }
+    metadata = {"Data View Name": "Test", "Data View ID": "dv_001"}
+    blocks = build_sdr_blocks(data_dict, metadata)
+    headings = [
+        b["heading_2"]["rich_text"][0]["text"]["content"]
+        for b in blocks
+        if b["type"] == "heading_2"
+    ]
+    assert any("Metrics" in h for h in headings)
+    assert not any("Dimensions" in h for h in headings)
+
+
+def test_build_sdr_blocks_dq_section_omitted_when_empty():
+    data_dict = {
+        "Metrics": pd.DataFrame({"Name": ["m1"], "Type": ["metric"]}),
+        "Data Quality": pd.DataFrame(),
+    }
+    metadata = {"Data View Name": "Test", "Data View ID": "dv_001"}
+    blocks = build_sdr_blocks(data_dict, metadata)
+    headings = [
+        b["heading_2"]["rich_text"][0]["text"]["content"]
+        for b in blocks
+        if b["type"] == "heading_2"
+    ]
+    assert not any("Data Quality" in h for h in headings)

--- a/tests/test_notion_writer.py
+++ b/tests/test_notion_writer.py
@@ -72,6 +72,18 @@ def test_table_block_empty_df():
     assert len(children) == 1
 
 
+def test_table_block_zero_column_df_returns_none():
+    """A DataFrame with no columns has nothing to render — Notion rejects table_width=0."""
+    df = pd.DataFrame()
+    assert _table_block(df) is None
+
+
+def test_section_blocks_zero_column_df_returns_empty():
+    """No columns means no table; the section should not emit an orphan heading."""
+    df = pd.DataFrame({}, index=[0, 1, 2])
+    assert _section_blocks("Metrics", df) == []
+
+
 def test_section_blocks_returns_heading_plus_table():
     df = pd.DataFrame({"Name": ["a"], "Type": ["metric"]})
     blocks = _section_blocks("Metrics", df)
@@ -236,24 +248,30 @@ def test_resolve_notion_credentials_reads_env(monkeypatch):
     assert parent_id == "parent-page-id"
 
 
-def test_resolve_notion_credentials_missing_token_exits(monkeypatch):
+def test_resolve_notion_credentials_missing_token_raises(monkeypatch):
     monkeypatch.delenv("NOTION_TOKEN", raising=False)
     monkeypatch.delenv("NOTION_PARENT_PAGE_ID", raising=False)
-    from cja_auto_sdr.output.writers.notion import resolve_notion_credentials
+    from cja_auto_sdr.output.writers.notion import (
+        NotionConfigurationError,
+        resolve_notion_credentials,
+    )
 
-    with pytest.raises(SystemExit) as exc_info:
+    with pytest.raises(NotionConfigurationError) as exc_info:
         resolve_notion_credentials()
-    assert exc_info.value.code == 1
+    assert "NOTION_TOKEN" in str(exc_info.value)
 
 
-def test_resolve_notion_credentials_missing_parent_page_exits(monkeypatch):
+def test_resolve_notion_credentials_missing_parent_page_raises(monkeypatch):
     monkeypatch.setenv("NOTION_TOKEN", "secret-token")
     monkeypatch.delenv("NOTION_PARENT_PAGE_ID", raising=False)
-    from cja_auto_sdr.output.writers.notion import resolve_notion_credentials
+    from cja_auto_sdr.output.writers.notion import (
+        NotionConfigurationError,
+        resolve_notion_credentials,
+    )
 
-    with pytest.raises(SystemExit) as exc_info:
+    with pytest.raises(NotionConfigurationError) as exc_info:
         resolve_notion_credentials()
-    assert exc_info.value.code == 1
+    assert "NOTION_PARENT_PAGE_ID" in str(exc_info.value)
 
 
 def test_clear_page_blocks_deletes_all_children():
@@ -417,11 +435,47 @@ def test_notion_registered_in_writer_registry():
     assert "notion" in WRITER_REGISTRY
 
 
-def test_require_notion_client_exits_when_sdk_missing(capsys, monkeypatch):
-    """Per spec: missing notion-client extra exits 1 with install instructions."""
+def test_no_top_level_notion_client_imports_in_package():
+    """Static guard: the optional `notion-client` extra must never be imported at module-load time.
+
+    The package is published with `notion-client` as an opt-in extra. If a top-level
+    `import notion_client` slips in (e.g. via an autoformat or refactor), the
+    package will fail to import for any user who hasn't installed the extra —
+    which is the entire point of marking it optional. Catch that statically here
+    instead of relying on the no-extras CI job alone.
+    """
+    import ast
+    from pathlib import Path
+
+    pkg_root = Path(__file__).resolve().parent.parent / "src" / "cja_auto_sdr"
+    offenders: list[tuple[str, int]] = []
+    for py_file in pkg_root.rglob("*.py"):
+        source = py_file.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(py_file))
+        # Only scan module-level imports (tree.body) — function-local imports
+        # are how this codebase keeps the optional dep optional.
+        for node in tree.body:
+            if isinstance(node, ast.Import):
+                if any(
+                    alias.name == "notion_client" or alias.name.startswith("notion_client.") for alias in node.names
+                ):
+                    offenders.append((str(py_file.relative_to(pkg_root)), node.lineno))
+            elif isinstance(node, ast.ImportFrom):
+                if node.module and (node.module == "notion_client" or node.module.startswith("notion_client.")):
+                    offenders.append((str(py_file.relative_to(pkg_root)), node.lineno))
+
+    assert offenders == [], (
+        "Top-level `import notion_client` found — the optional extra must only be "
+        f"imported lazily inside a function. Offenders: {offenders}"
+    )
+
+
+def test_require_notion_client_raises_when_sdk_missing(monkeypatch):
+    """Missing notion-client extra raises NotionDependencyError with install instructions."""
     import sys as _sys
 
     from cja_auto_sdr.output.writers import notion as _notion_mod
+    from cja_auto_sdr.output.writers.notion import NotionDependencyError
 
     real_import = builtins.__import__
 
@@ -433,9 +487,165 @@ def test_require_notion_client_exits_when_sdk_missing(capsys, monkeypatch):
     monkeypatch.setattr(builtins, "__import__", fake_import)
     monkeypatch.setitem(_sys.modules, "notion_client", None)
 
-    with pytest.raises(SystemExit) as exc_info:
+    with pytest.raises(NotionDependencyError) as exc_info:
         _notion_mod._require_notion_client()
+    msg = str(exc_info.value)
+    assert "notion extra" in msg
+    assert "cja-auto-sdr[notion]" in msg
+
+
+def test_push_to_notion_cli_converts_config_error_to_exit(monkeypatch, tmp_path):
+    """The CLI dispatcher must convert NotionConfigurationError to exit code 1."""
+    import json as _json
+
+    monkeypatch.delenv("NOTION_TOKEN", raising=False)
+    monkeypatch.delenv("NOTION_PARENT_PAGE_ID", raising=False)
+    artifact = tmp_path / "sdr.json"
+    artifact.write_text(_json.dumps({"metadata": {"Data View ID": "dv_1"}, "metrics": []}))
+
+    from cja_auto_sdr.generator import _push_to_notion_from_json
+
+    with pytest.raises(SystemExit) as exc_info:
+        _push_to_notion_from_json(str(artifact))
     assert exc_info.value.code == 1
-    err = capsys.readouterr().err
-    assert "notion extra" in err
-    assert "cja-auto-sdr[notion]" in err
+
+
+def test_call_with_rate_limit_retry_succeeds_after_one_429(monkeypatch):
+    """A single 429 should retry-and-succeed without raising."""
+    from cja_auto_sdr.output.writers import notion as _notion_mod
+
+    class FakeRateLimited(Exception):
+        code = "rate_limited"
+
+    # Make _is_notion_api_error recognize our fake class.
+    FakeRateLimited.__name__ = "APIResponseError"
+
+    calls = {"n": 0}
+
+    def flaky():
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise FakeRateLimited("rate limited")
+        return "ok"
+
+    # Skip the sleep so the test is fast.
+    monkeypatch.setattr(_notion_mod.time, "sleep", lambda _s: None)
+    assert _notion_mod._call_with_rate_limit_retry(flaky) == "ok"
+    assert calls["n"] == 2
+
+
+def test_call_with_rate_limit_retry_gives_up_after_max_attempts(monkeypatch):
+    from cja_auto_sdr.output.writers import notion as _notion_mod
+
+    class FakeRateLimited(Exception):
+        code = "rate_limited"
+
+    FakeRateLimited.__name__ = "APIResponseError"
+
+    calls = {"n": 0}
+
+    def always_429():
+        calls["n"] += 1
+        raise FakeRateLimited("rate limited")
+
+    monkeypatch.setattr(_notion_mod.time, "sleep", lambda _s: None)
+    with pytest.raises(FakeRateLimited):
+        _notion_mod._call_with_rate_limit_retry(always_429)
+    assert calls["n"] == _notion_mod._RATE_LIMIT_MAX_ATTEMPTS
+
+
+def test_call_with_rate_limit_retry_passes_non_rate_limit_errors_through(monkeypatch):
+    """Non-429 API errors must not be retried — they propagate immediately."""
+    from cja_auto_sdr.output.writers import notion as _notion_mod
+
+    class FakeUnauthorized(Exception):
+        code = "unauthorized"
+
+    FakeUnauthorized.__name__ = "APIResponseError"
+
+    calls = {"n": 0}
+
+    def auth_fail():
+        calls["n"] += 1
+        raise FakeUnauthorized("bad token")
+
+    with pytest.raises(FakeUnauthorized):
+        _notion_mod._call_with_rate_limit_retry(auth_fail)
+    assert calls["n"] == 1
+
+
+def test_friendly_notion_error_message_for_unauthorized():
+    from cja_auto_sdr.output.writers import notion as _notion_mod
+
+    class FakeErr(Exception):
+        code = "unauthorized"
+
+    msg = _notion_mod._friendly_notion_error_message(FakeErr("nope"))
+    assert "NOTION_TOKEN" in msg
+    assert "NOTION_PARENT_PAGE_ID" in msg
+
+
+def test_friendly_notion_error_message_for_rate_limit():
+    from cja_auto_sdr.output.writers import notion as _notion_mod
+
+    class FakeErr(Exception):
+        code = "rate_limited"
+
+    assert "rate limit" in _notion_mod._friendly_notion_error_message(FakeErr("x")).lower()
+
+
+def test_write_notion_output_wraps_api_error_as_notion_api_error(tmp_path, monkeypatch):
+    """API errors from create_or_update_page surface as NotionAPIError with friendly text."""
+    import logging as _logging
+
+    monkeypatch.setenv("NOTION_TOKEN", "tok")
+    monkeypatch.setenv("NOTION_PARENT_PAGE_ID", "pid")
+    from cja_auto_sdr.output.writers.notion import NotionAPIError, write_notion_output
+
+    class FakeUnauthorized(Exception):
+        code = "unauthorized"
+
+    FakeUnauthorized.__name__ = "APIResponseError"
+
+    mock_client_instance = MagicMock()
+    mock_client_instance.pages.create.side_effect = FakeUnauthorized("nope")
+    with patch(
+        "cja_auto_sdr.output.writers.notion._require_notion_client",
+    ) as mock_cls:
+        mock_cls.return_value = MagicMock(return_value=mock_client_instance)
+        with pytest.raises(NotionAPIError) as exc_info:
+            write_notion_output(
+                data_dict={"Metrics": pd.DataFrame({"Name": ["m"], "Type": ["x"]})},
+                metadata_dict={"Data View Name": "T", "Data View ID": "dv_1"},
+                base_filename="t",
+                output_dir=str(tmp_path),
+                logger=_logging.getLogger("test"),
+            )
+    assert "NOTION_TOKEN" in str(exc_info.value)
+
+
+def test_clear_page_blocks_lists_all_before_deleting():
+    """Listing and deleting must be split into two phases — no in-loop delete during list."""
+    from cja_auto_sdr.output.writers.notion import _clear_page_blocks
+
+    client = MagicMock()
+    list_calls: list[str] = []
+    delete_calls: list[str] = []
+
+    def fake_list(**kwargs):
+        list_calls.append("list")
+        cursor = kwargs.get("start_cursor")
+        if cursor is None:
+            return {"results": [{"id": "b1"}, {"id": "b2"}], "has_more": True, "next_cursor": "c1"}
+        return {"results": [{"id": "b3"}], "has_more": False}
+
+    def fake_delete(**kwargs):
+        delete_calls.append(kwargs["block_id"])
+
+    client.blocks.children.list.side_effect = fake_list
+    client.blocks.delete.side_effect = fake_delete
+
+    _clear_page_blocks(client, "page-abc")
+    assert sorted(delete_calls) == ["b1", "b2", "b3"]
+    # All listing must complete before any deletion runs.
+    assert len(list_calls) == 2

--- a/tests/test_notion_writer.py
+++ b/tests/test_notion_writer.py
@@ -178,6 +178,43 @@ def test_dq_callout_blocks_error_severity():
     assert blocks[0]["callout"]["icon"]["emoji"] == "🔴"
 
 
+@pytest.mark.parametrize(
+    ("severity", "expected_emoji"),
+    [
+        # CJA quality engine vocabulary (core.constants.QUALITY_SEVERITY_ORDER).
+        ("CRITICAL", "🔴"),
+        ("HIGH", "🔴"),
+        ("MEDIUM", "⚠️"),
+        ("LOW", "ℹ️"),
+        ("INFO", "ℹ️"),
+        # Generic logging vocabulary kept for safety.
+        ("ERROR", "🔴"),
+        ("WARN", "⚠️"),
+        ("WARNING", "⚠️"),
+        # Severity strings are upper-cased before lookup.
+        ("high", "🔴"),
+        ("medium", "⚠️"),
+        # Unknown severities fall back to the info icon.
+        ("BOGUS", "ℹ️"),
+    ],
+)
+def test_dq_callout_blocks_severity_icon_mapping(severity, expected_emoji):
+    """Severity icons must cover the CJA engine's CRITICAL/HIGH/MEDIUM/LOW/INFO vocabulary.
+
+    Regression: HIGH and MEDIUM previously fell through to the info icon because
+    the mapper only knew the ERROR/WARN/INFO vocabulary.
+    """
+    dq_df = pd.DataFrame(
+        {
+            "Severity": [severity],
+            "Component": ["item_x"],
+            "Issue": ["some issue"],
+        }
+    )
+    blocks = _dq_callout_blocks(dq_df)
+    assert blocks[0]["callout"]["icon"]["emoji"] == expected_emoji
+
+
 def test_dq_callout_blocks_empty_df_returns_empty():
     blocks = _dq_callout_blocks(pd.DataFrame())
     assert blocks == []

--- a/tests/test_notion_writer.py
+++ b/tests/test_notion_writer.py
@@ -291,3 +291,60 @@ def test_create_or_update_page_force_new_ignores_registry(tmp_path):
     )
     assert page_id == "fresh-page-id"
     client.pages.create.assert_called_once()
+
+
+# ---- write_notion_output integration tests ----
+
+
+def test_write_notion_output_returns_notion_url(tmp_path, monkeypatch):
+    monkeypatch.setenv("NOTION_TOKEN", "test-token")
+    monkeypatch.setenv("NOTION_PARENT_PAGE_ID", "parent-id")
+    from cja_auto_sdr.output.writers.notion import write_notion_output
+    mock_client_instance = MagicMock()
+    mock_client_instance.pages.create.return_value = {"id": "new-page-abc"}
+    mock_client_instance.blocks.children.append.return_value = {}
+    with patch(
+        "cja_auto_sdr.output.writers.notion._require_notion_client",
+    ) as mock_cls:
+        mock_cls.return_value = MagicMock(return_value=mock_client_instance)
+        result = write_notion_output(
+            data_dict={
+                "Metrics": pd.DataFrame({"Name": ["m1"], "Type": ["metric"]}),
+            },
+            metadata_dict={"Data View Name": "Test DV", "Data View ID": "dv_001"},
+            base_filename="test_sdr",
+            output_dir=str(tmp_path),
+            logger=logging.getLogger("test"),
+        )
+    assert result.startswith("notion://pages/")
+
+
+def test_write_notion_output_with_force_new(tmp_path, monkeypatch):
+    import json
+    monkeypatch.setenv("NOTION_TOKEN", "test-token")
+    monkeypatch.setenv("NOTION_PARENT_PAGE_ID", "parent-id")
+    (tmp_path / ".notion_pages.json").write_text(json.dumps({"dv_001": "old-page"}))
+    from cja_auto_sdr.output.writers.notion import write_notion_output
+    mock_client_instance = MagicMock()
+    mock_client_instance.pages.create.return_value = {"id": "fresh-page"}
+    mock_client_instance.blocks.children.append.return_value = {}
+    with patch(
+        "cja_auto_sdr.output.writers.notion._require_notion_client",
+    ) as mock_cls:
+        mock_cls.return_value = MagicMock(return_value=mock_client_instance)
+        write_notion_output(
+            data_dict={
+                "Metrics": pd.DataFrame({"Name": ["m1"], "Type": ["metric"]}),
+            },
+            metadata_dict={"Data View Name": "Test DV", "Data View ID": "dv_001"},
+            base_filename="test_sdr",
+            output_dir=str(tmp_path),
+            logger=logging.getLogger("test"),
+            force_new=True,
+        )
+    mock_client_instance.pages.create.assert_called_once()
+
+
+def test_notion_registered_in_writer_registry():
+    from cja_auto_sdr.output.registry import WRITER_REGISTRY
+    assert "notion" in WRITER_REGISTRY

--- a/tests/test_notion_writer.py
+++ b/tests/test_notion_writer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import builtins
 import logging
 from unittest.mock import MagicMock, patch
 
@@ -358,3 +359,27 @@ def test_notion_registered_in_writer_registry():
     from cja_auto_sdr.output.registry import WRITER_REGISTRY
 
     assert "notion" in WRITER_REGISTRY
+
+
+def test_require_notion_client_exits_when_sdk_missing(capsys, monkeypatch):
+    """Per spec: missing notion-client extra exits 1 with install instructions."""
+    import sys as _sys
+
+    from cja_auto_sdr.output.writers import notion as _notion_mod
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "notion_client":
+            raise ImportError("No module named 'notion_client'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.setitem(_sys.modules, "notion_client", None)
+
+    with pytest.raises(SystemExit) as exc_info:
+        _notion_mod._require_notion_client()
+    assert exc_info.value.code == 1
+    err = capsys.readouterr().err
+    assert "notion extra" in err
+    assert "cja-auto-sdr[notion]" in err

--- a/tests/test_notion_writer.py
+++ b/tests/test_notion_writer.py
@@ -1,4 +1,5 @@
 """Tests for Notion block builder and writer."""
+
 from __future__ import annotations
 
 import logging
@@ -84,22 +85,26 @@ def test_section_blocks_empty_df_returns_empty_list():
 
 
 def test_dq_callout_blocks_warn_severity():
-    dq_df = pd.DataFrame({
-        "Severity": ["WARN"],
-        "Component": ["metric_a"],
-        "Issue": ["Missing description"],
-    })
+    dq_df = pd.DataFrame(
+        {
+            "Severity": ["WARN"],
+            "Component": ["metric_a"],
+            "Issue": ["Missing description"],
+        }
+    )
     blocks = _dq_callout_blocks(dq_df)
     assert len(blocks) == 1
     assert blocks[0]["callout"]["icon"]["emoji"] == "⚠️"
 
 
 def test_dq_callout_blocks_error_severity():
-    dq_df = pd.DataFrame({
-        "Severity": ["ERROR"],
-        "Component": ["dim_b"],
-        "Issue": ["Null values"],
-    })
+    dq_df = pd.DataFrame(
+        {
+            "Severity": ["ERROR"],
+            "Component": ["dim_b"],
+            "Issue": ["Null values"],
+        }
+    )
     blocks = _dq_callout_blocks(dq_df)
     assert blocks[0]["callout"]["icon"]["emoji"] == "🔴"
 
@@ -145,11 +150,7 @@ def test_build_sdr_blocks_omits_empty_sections():
     }
     metadata = {"Data View Name": "Test", "Data View ID": "dv_001"}
     blocks = build_sdr_blocks(data_dict, metadata)
-    headings = [
-        b["heading_2"]["rich_text"][0]["text"]["content"]
-        for b in blocks
-        if b["type"] == "heading_2"
-    ]
+    headings = [b["heading_2"]["rich_text"][0]["text"]["content"] for b in blocks if b["type"] == "heading_2"]
     assert any("Metrics" in h for h in headings)
     assert not any("Dimensions" in h for h in headings)
 
@@ -161,11 +162,7 @@ def test_build_sdr_blocks_dq_section_omitted_when_empty():
     }
     metadata = {"Data View Name": "Test", "Data View ID": "dv_001"}
     blocks = build_sdr_blocks(data_dict, metadata)
-    headings = [
-        b["heading_2"]["rich_text"][0]["text"]["content"]
-        for b in blocks
-        if b["type"] == "heading_2"
-    ]
+    headings = [b["heading_2"]["rich_text"][0]["text"]["content"] for b in blocks if b["type"] == "heading_2"]
     assert not any("Data Quality" in h for h in headings)
 
 
@@ -176,6 +173,7 @@ def test_resolve_notion_credentials_reads_env(monkeypatch):
     monkeypatch.setenv("NOTION_TOKEN", "secret-token")
     monkeypatch.setenv("NOTION_PARENT_PAGE_ID", "parent-page-id")
     from cja_auto_sdr.output.writers.notion import resolve_notion_credentials
+
     token, parent_id = resolve_notion_credentials()
     assert token == "secret-token"
     assert parent_id == "parent-page-id"
@@ -185,6 +183,7 @@ def test_resolve_notion_credentials_missing_token_exits(monkeypatch):
     monkeypatch.delenv("NOTION_TOKEN", raising=False)
     monkeypatch.delenv("NOTION_PARENT_PAGE_ID", raising=False)
     from cja_auto_sdr.output.writers.notion import resolve_notion_credentials
+
     with pytest.raises(SystemExit) as exc_info:
         resolve_notion_credentials()
     assert exc_info.value.code == 1
@@ -194,6 +193,7 @@ def test_resolve_notion_credentials_missing_parent_page_exits(monkeypatch):
     monkeypatch.setenv("NOTION_TOKEN", "secret-token")
     monkeypatch.delenv("NOTION_PARENT_PAGE_ID", raising=False)
     from cja_auto_sdr.output.writers.notion import resolve_notion_credentials
+
     with pytest.raises(SystemExit) as exc_info:
         resolve_notion_credentials()
     assert exc_info.value.code == 1
@@ -201,6 +201,7 @@ def test_resolve_notion_credentials_missing_parent_page_exits(monkeypatch):
 
 def test_clear_page_blocks_deletes_all_children():
     from cja_auto_sdr.output.writers.notion import _clear_page_blocks
+
     client = MagicMock()
     client.blocks.children.list.return_value = {
         "results": [{"id": "block-1"}, {"id": "block-2"}],
@@ -214,6 +215,7 @@ def test_clear_page_blocks_deletes_all_children():
 
 def test_clear_page_blocks_handles_pagination():
     from cja_auto_sdr.output.writers.notion import _clear_page_blocks
+
     client = MagicMock()
     client.blocks.children.list.side_effect = [
         {"results": [{"id": "block-1"}], "has_more": True, "next_cursor": "cursor-x"},
@@ -225,10 +227,9 @@ def test_clear_page_blocks_handles_pagination():
 
 def test_append_blocks_batches_at_100():
     from cja_auto_sdr.output.writers.notion import _append_blocks
+
     client = MagicMock()
-    blocks = [
-        {"type": "paragraph", "paragraph": {"rich_text": []}} for _ in range(150)
-    ]
+    blocks = [{"type": "paragraph", "paragraph": {"rich_text": []}} for _ in range(150)]
     _append_blocks(client, "page-abc", blocks)
     assert client.blocks.children.append.call_count == 2
     first_call_blocks = client.blocks.children.append.call_args_list[0][1]["children"]
@@ -237,6 +238,7 @@ def test_append_blocks_batches_at_100():
 
 def test_create_or_update_page_creates_new_when_not_in_registry(tmp_path):
     from cja_auto_sdr.output.writers.notion import create_or_update_page
+
     client = MagicMock()
     client.pages.create.return_value = {"id": "new-page-id"}
     registry_path = tmp_path / ".notion_pages.json"
@@ -255,7 +257,9 @@ def test_create_or_update_page_creates_new_when_not_in_registry(tmp_path):
 
 def test_create_or_update_page_updates_existing_when_in_registry(tmp_path):
     import json
+
     from cja_auto_sdr.output.writers.notion import create_or_update_page
+
     registry_path = tmp_path / ".notion_pages.json"
     registry_path.write_text(json.dumps({"dv_123": "existing-page-id"}))
     client = MagicMock()
@@ -275,7 +279,9 @@ def test_create_or_update_page_updates_existing_when_in_registry(tmp_path):
 
 def test_create_or_update_page_force_new_ignores_registry(tmp_path):
     import json
+
     from cja_auto_sdr.output.writers.notion import create_or_update_page
+
     registry_path = tmp_path / ".notion_pages.json"
     registry_path.write_text(json.dumps({"dv_123": "old-page-id"}))
     client = MagicMock()
@@ -300,6 +306,7 @@ def test_write_notion_output_returns_notion_url(tmp_path, monkeypatch):
     monkeypatch.setenv("NOTION_TOKEN", "test-token")
     monkeypatch.setenv("NOTION_PARENT_PAGE_ID", "parent-id")
     from cja_auto_sdr.output.writers.notion import write_notion_output
+
     mock_client_instance = MagicMock()
     mock_client_instance.pages.create.return_value = {"id": "new-page-abc"}
     mock_client_instance.blocks.children.append.return_value = {}
@@ -321,10 +328,12 @@ def test_write_notion_output_returns_notion_url(tmp_path, monkeypatch):
 
 def test_write_notion_output_with_force_new(tmp_path, monkeypatch):
     import json
+
     monkeypatch.setenv("NOTION_TOKEN", "test-token")
     monkeypatch.setenv("NOTION_PARENT_PAGE_ID", "parent-id")
     (tmp_path / ".notion_pages.json").write_text(json.dumps({"dv_001": "old-page"}))
     from cja_auto_sdr.output.writers.notion import write_notion_output
+
     mock_client_instance = MagicMock()
     mock_client_instance.pages.create.return_value = {"id": "fresh-page"}
     mock_client_instance.blocks.children.append.return_value = {}
@@ -347,4 +356,5 @@ def test_write_notion_output_with_force_new(tmp_path, monkeypatch):
 
 def test_notion_registered_in_writer_registry():
     from cja_auto_sdr.output.registry import WRITER_REGISTRY
+
     assert "notion" in WRITER_REGISTRY

--- a/tests/test_notion_writer.py
+++ b/tests/test_notion_writer.py
@@ -167,3 +167,127 @@ def test_build_sdr_blocks_dq_section_omitted_when_empty():
         if b["type"] == "heading_2"
     ]
     assert not any("Data Quality" in h for h in headings)
+
+
+# ---- API layer tests (mocked Client) ----
+
+
+def test_resolve_notion_credentials_reads_env(monkeypatch):
+    monkeypatch.setenv("NOTION_TOKEN", "secret-token")
+    monkeypatch.setenv("NOTION_PARENT_PAGE_ID", "parent-page-id")
+    from cja_auto_sdr.output.writers.notion import resolve_notion_credentials
+    token, parent_id = resolve_notion_credentials()
+    assert token == "secret-token"
+    assert parent_id == "parent-page-id"
+
+
+def test_resolve_notion_credentials_missing_token_exits(monkeypatch):
+    monkeypatch.delenv("NOTION_TOKEN", raising=False)
+    monkeypatch.delenv("NOTION_PARENT_PAGE_ID", raising=False)
+    from cja_auto_sdr.output.writers.notion import resolve_notion_credentials
+    with pytest.raises(SystemExit) as exc_info:
+        resolve_notion_credentials()
+    assert exc_info.value.code == 1
+
+
+def test_resolve_notion_credentials_missing_parent_page_exits(monkeypatch):
+    monkeypatch.setenv("NOTION_TOKEN", "secret-token")
+    monkeypatch.delenv("NOTION_PARENT_PAGE_ID", raising=False)
+    from cja_auto_sdr.output.writers.notion import resolve_notion_credentials
+    with pytest.raises(SystemExit) as exc_info:
+        resolve_notion_credentials()
+    assert exc_info.value.code == 1
+
+
+def test_clear_page_blocks_deletes_all_children():
+    from cja_auto_sdr.output.writers.notion import _clear_page_blocks
+    client = MagicMock()
+    client.blocks.children.list.return_value = {
+        "results": [{"id": "block-1"}, {"id": "block-2"}],
+        "has_more": False,
+    }
+    _clear_page_blocks(client, "page-abc")
+    assert client.blocks.delete.call_count == 2
+    client.blocks.delete.assert_any_call(block_id="block-1")
+    client.blocks.delete.assert_any_call(block_id="block-2")
+
+
+def test_clear_page_blocks_handles_pagination():
+    from cja_auto_sdr.output.writers.notion import _clear_page_blocks
+    client = MagicMock()
+    client.blocks.children.list.side_effect = [
+        {"results": [{"id": "block-1"}], "has_more": True, "next_cursor": "cursor-x"},
+        {"results": [{"id": "block-2"}], "has_more": False},
+    ]
+    _clear_page_blocks(client, "page-abc")
+    assert client.blocks.delete.call_count == 2
+
+
+def test_append_blocks_batches_at_100():
+    from cja_auto_sdr.output.writers.notion import _append_blocks
+    client = MagicMock()
+    blocks = [
+        {"type": "paragraph", "paragraph": {"rich_text": []}} for _ in range(150)
+    ]
+    _append_blocks(client, "page-abc", blocks)
+    assert client.blocks.children.append.call_count == 2
+    first_call_blocks = client.blocks.children.append.call_args_list[0][1]["children"]
+    assert len(first_call_blocks) == 100
+
+
+def test_create_or_update_page_creates_new_when_not_in_registry(tmp_path):
+    from cja_auto_sdr.output.writers.notion import create_or_update_page
+    client = MagicMock()
+    client.pages.create.return_value = {"id": "new-page-id"}
+    registry_path = tmp_path / ".notion_pages.json"
+    page_id = create_or_update_page(
+        client,
+        "parent-id",
+        "Web Analytics — SDR",
+        "dv_123",
+        [{"type": "paragraph", "paragraph": {"rich_text": []}}],
+        registry_path,
+        force_new=False,
+    )
+    assert page_id == "new-page-id"
+    client.pages.create.assert_called_once()
+
+
+def test_create_or_update_page_updates_existing_when_in_registry(tmp_path):
+    import json
+    from cja_auto_sdr.output.writers.notion import create_or_update_page
+    registry_path = tmp_path / ".notion_pages.json"
+    registry_path.write_text(json.dumps({"dv_123": "existing-page-id"}))
+    client = MagicMock()
+    client.blocks.children.list.return_value = {"results": [], "has_more": False}
+    page_id = create_or_update_page(
+        client,
+        "parent-id",
+        "Web Analytics — SDR",
+        "dv_123",
+        [],
+        registry_path,
+        force_new=False,
+    )
+    assert page_id == "existing-page-id"
+    client.pages.create.assert_not_called()
+
+
+def test_create_or_update_page_force_new_ignores_registry(tmp_path):
+    import json
+    from cja_auto_sdr.output.writers.notion import create_or_update_page
+    registry_path = tmp_path / ".notion_pages.json"
+    registry_path.write_text(json.dumps({"dv_123": "old-page-id"}))
+    client = MagicMock()
+    client.pages.create.return_value = {"id": "fresh-page-id"}
+    page_id = create_or_update_page(
+        client,
+        "parent-id",
+        "Web Analytics — SDR",
+        "dv_123",
+        [],
+        registry_path,
+        force_new=True,
+    )
+    assert page_id == "fresh-page-id"
+    client.pages.create.assert_called_once()

--- a/tests/test_output_content_validation.py
+++ b/tests/test_output_content_validation.py
@@ -38,7 +38,7 @@ def rich_data_dict():
         "Metadata": pd.DataFrame(
             {
                 "Property": ["Generated At", "Data View ID", "Tool Version", "Total Metrics"],
-                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.6.1", 3],
+                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.7.0", 3],
             },
         ),
         "Data Quality": pd.DataFrame(
@@ -104,7 +104,7 @@ def rich_metadata_dict():
         "Generated At": "2025-01-15 10:30:00 PST",
         "Data View ID": "dv_content_test",
         "Data View Name": "Test DataView",
-        "Tool Version": "3.6.1",
+        "Tool Version": "3.7.0",
         "Metrics Count": "3",
         "Dimensions Count": "4",
     }
@@ -224,7 +224,7 @@ class TestJSONContentValidation:
             data = json.load(f)
 
         assert data["metadata"]["Data View ID"] == "dv_content_test"
-        assert data["metadata"]["Tool Version"] == "3.6.1"
+        assert data["metadata"]["Tool Version"] == "3.7.0"
 
     def test_json_metadata_preserves_partial_markers(self, tmp_path, rich_data_dict, rich_metadata_dict):
         logger = logging.getLogger("json_test")

--- a/tests/test_process_single_dataview.py
+++ b/tests/test_process_single_dataview.py
@@ -1111,6 +1111,63 @@ class TestProcessSingleDataviewFailures:
         assert result.success is False
         assert "permission" in result.error_message.lower()
 
+    @patch("cja_auto_sdr.generator.setup_logging")
+    @patch("cja_auto_sdr.generator.initialize_cja")
+    @patch("cja_auto_sdr.generator.ParallelAPIFetcher")
+    @patch("cja_auto_sdr.generator.DataQualityChecker")
+    @patch("cja_auto_sdr.output.writers.notion.write_notion_output")
+    def test_notion_writer_failure_returns_failed_result_not_systemexit(
+        self,
+        mock_write_notion,
+        mock_dq_checker_class,
+        mock_fetcher_class,
+        mock_init_cja,
+        mock_setup_logging,
+        mock_config_file,
+        temp_output_dir,
+        sample_metrics_df,
+        sample_dimensions_df,
+        sample_dataview_info,
+    ):
+        """Notion writer errors must return a failed ProcessingResult — never SystemExit.
+
+        Regression: when invoked inside a batch worker, raising SystemExit kills the
+        pool worker and aborts the whole batch, defeating --continue-on-error. The
+        Notion error path must surface as ProcessingResult(success=False) so the
+        batch can mark this data view failed and proceed.
+        """
+        from cja_auto_sdr.output.writers.notion import NotionConfigurationError
+
+        mock_logger = Mock()
+        mock_logger.handlers = []
+        mock_setup_logging.return_value = mock_logger
+        mock_init_cja.return_value = Mock()
+
+        mock_fetcher = Mock()
+        mock_fetcher.fetch_all_data.return_value = (sample_metrics_df, sample_dimensions_df, sample_dataview_info)
+        mock_fetcher_class.return_value = mock_fetcher
+
+        mock_dq_checker = Mock()
+        mock_dq_checker.issues = []
+        mock_dq_checker.get_issues_dataframe.return_value = pd.DataFrame(
+            columns=["Severity", "Category", "Type", "Item Name", "Issue", "Details"],
+        )
+        mock_dq_checker_class.return_value = mock_dq_checker
+
+        mock_write_notion.side_effect = NotionConfigurationError("NOTION_API_KEY not set")
+
+        result = process_single_dataview(
+            data_view_id="dv_test_12345",
+            config_file=mock_config_file,
+            output_dir=temp_output_dir,
+            output_format="notion",
+        )
+
+        assert result.success is False
+        assert "NOTION_API_KEY" in result.error_message
+        assert result.failure_code == "OUTPUT_WRITE_FAILED"
+        assert result.failure_reason == "output_write_failed:NotionConfigurationError"
+
 
 class TestProcessSingleDataviewOutputFormats:
     """Tests for different output formats"""

--- a/tests/test_process_single_dataview.py
+++ b/tests/test_process_single_dataview.py
@@ -1135,6 +1135,10 @@ class TestProcessSingleDataviewFailures:
         pool worker and aborts the whole batch, defeating --continue-on-error. The
         Notion error path must surface as ProcessingResult(success=False) so the
         batch can mark this data view failed and proceed.
+
+        This is the producer-side contract test. BatchProcessor's downstream handling
+        of failed ProcessingResults (including --continue-on-error behavior) is covered
+        by tests/test_batch_processor.py.
         """
         from cja_auto_sdr.output.writers.notion import NotionConfigurationError
 

--- a/tests/test_processing_execution_policy.py
+++ b/tests/test_processing_execution_policy.py
@@ -31,6 +31,9 @@ from cja_auto_sdr.generator import _build_processing_execution_policy
         ("json", True, True, False, False, False, False, {"metrics", "dimensions"}, True, True, False, False),
         ("json", False, False, False, False, True, False, {"metrics", "dimensions"}, False, True, True, True),
         ("json", False, False, False, False, True, True, {"metrics", "dimensions"}, False, True, True, False),
+        # notion must emit embedded metadata so the Notion page gets real SDR metadata
+        # (Data View Name, Data View ID, timestamp) rather than falling back to base_filename.
+        ("notion", False, False, False, False, False, False, {"metrics", "dimensions"}, False, True, True, True),
     ],
 )
 def test_build_processing_execution_policy_matrix(

--- a/tests/test_push_to_notion.py
+++ b/tests/test_push_to_notion.py
@@ -1,4 +1,5 @@
 """Tests for --push-to-notion command path."""
+
 from __future__ import annotations
 
 import json
@@ -45,7 +46,9 @@ def test_push_to_notion_reads_json_and_calls_writer(tmp_path, monkeypatch):
     ) as mock_cls:
         mock_cls.return_value = MagicMock(return_value=mock_client_instance)
         result = _push_to_notion_from_json(
-            str(json_path), output_dir=str(tmp_path), force_new=False,
+            str(json_path),
+            output_dir=str(tmp_path),
+            force_new=False,
         )
 
     assert result.startswith("notion://pages/")
@@ -53,15 +56,18 @@ def test_push_to_notion_reads_json_and_calls_writer(tmp_path, monkeypatch):
 
 def test_push_to_notion_file_not_found_exits(tmp_path):
     from cja_auto_sdr.generator import _push_to_notion_from_json
+
     with pytest.raises(SystemExit) as exc_info:
         _push_to_notion_from_json(
-            str(tmp_path / "nonexistent.json"), output_dir=str(tmp_path),
+            str(tmp_path / "nonexistent.json"),
+            output_dir=str(tmp_path),
         )
     assert exc_info.value.code == 1
 
 
 def test_push_to_notion_invalid_json_exits(tmp_path):
     from cja_auto_sdr.generator import _push_to_notion_from_json
+
     bad_json = tmp_path / "bad.json"
     bad_json.write_text("{ not valid json }")
     with pytest.raises(SystemExit) as exc_info:

--- a/tests/test_push_to_notion.py
+++ b/tests/test_push_to_notion.py
@@ -73,3 +73,32 @@ def test_push_to_notion_invalid_json_exits(tmp_path):
     with pytest.raises(SystemExit) as exc_info:
         _push_to_notion_from_json(str(bad_json), output_dir=str(tmp_path))
     assert exc_info.value.code == 1
+
+
+def test_push_to_notion_os_error_exits(tmp_path, monkeypatch):
+    """OSError from JSON read (permission denied, IO error) surfaces as exit 1."""
+    import cja_auto_sdr.generator as gen_mod
+
+    fake = tmp_path / "exists_but_unreadable.json"
+    fake.write_text("{}")
+
+    def boom(self, *args, **kwargs):
+        raise PermissionError("simulated permission denied")
+
+    monkeypatch.setattr(Path, "read_text", boom)
+    with pytest.raises(SystemExit) as exc_info:
+        gen_mod._push_to_notion_from_json(str(fake), output_dir=str(tmp_path))
+    assert exc_info.value.code == 1
+
+
+def test_push_to_notion_takes_precedence_over_watch():
+    """RunMode inference must resolve PUSH_TO_NOTION before WATCH so dispatch is consistent."""
+    import argparse
+
+    from cja_auto_sdr.generator import RunMode, _infer_run_mode_enum
+
+    args = argparse.Namespace(
+        push_to_notion="./sdr.json",
+        watch_data_views=["dv_123"],
+    )
+    assert _infer_run_mode_enum(args) == RunMode.PUSH_TO_NOTION

--- a/tests/test_push_to_notion.py
+++ b/tests/test_push_to_notion.py
@@ -1,0 +1,69 @@
+"""Tests for --push-to-notion command path."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_sdr_json(tmp_path: Path) -> Path:
+    """Write a minimal valid SDR JSON artifact."""
+    payload = {
+        "metadata": {
+            "Data View Name": "Web Analytics",
+            "Data View ID": "dv_001",
+            "Generated Date & timestamp and timezone": "2026-05-14 10:00 UTC",
+        },
+        "metrics": [{"Name": "Visits", "Type": "metric"}],
+        "dimensions": [{"Name": "Page", "Type": "dimension"}],
+        "data_quality": [],
+        "data_view": {"Data View ID": "dv_001"},
+        "derived_fields": {},
+        "calculated_metrics": {},
+        "segments": {},
+    }
+    path = tmp_path / "dv_001_sdr.json"
+    path.write_text(json.dumps(payload))
+    return path
+
+
+def test_push_to_notion_reads_json_and_calls_writer(tmp_path, monkeypatch):
+    monkeypatch.setenv("NOTION_TOKEN", "test-token")
+    monkeypatch.setenv("NOTION_PARENT_PAGE_ID", "parent-id")
+    json_path = _make_sdr_json(tmp_path)
+
+    from cja_auto_sdr.generator import _push_to_notion_from_json
+
+    mock_client_instance = MagicMock()
+    mock_client_instance.pages.create.return_value = {"id": "new-page"}
+    mock_client_instance.blocks.children.append.return_value = {}
+
+    with patch(
+        "cja_auto_sdr.output.writers.notion._require_notion_client",
+    ) as mock_cls:
+        mock_cls.return_value = MagicMock(return_value=mock_client_instance)
+        result = _push_to_notion_from_json(
+            str(json_path), output_dir=str(tmp_path), force_new=False,
+        )
+
+    assert result.startswith("notion://pages/")
+
+
+def test_push_to_notion_file_not_found_exits(tmp_path):
+    from cja_auto_sdr.generator import _push_to_notion_from_json
+    with pytest.raises(SystemExit) as exc_info:
+        _push_to_notion_from_json(
+            str(tmp_path / "nonexistent.json"), output_dir=str(tmp_path),
+        )
+    assert exc_info.value.code == 1
+
+
+def test_push_to_notion_invalid_json_exits(tmp_path):
+    from cja_auto_sdr.generator import _push_to_notion_from_json
+    bad_json = tmp_path / "bad.json"
+    bad_json.write_text("{ not valid json }")
+    with pytest.raises(SystemExit) as exc_info:
+        _push_to_notion_from_json(str(bad_json), output_dir=str(tmp_path))
+    assert exc_info.value.code == 1

--- a/tests/test_ux_features.py
+++ b/tests/test_ux_features.py
@@ -344,11 +344,11 @@ class TestCombinedFeatures:
 class TestVersionUpdated:
     """Test that version is correct"""
 
-    def test_version_is_3_6_1(self):
-        """Test that version is 3.6.1"""
+    def test_version_is_3_7_0(self):
+        """Test that version is 3.7.0"""
         from cja_auto_sdr.generator import __version__
 
-        assert __version__ == "3.6.1"
+        assert __version__ == "3.7.0"
 
 
 class TestFormatAutoDetection:

--- a/tools/cja_sdr_generate.json
+++ b/tools/cja_sdr_generate.json
@@ -10,8 +10,8 @@
       },
       "format": {
         "type": "string",
-        "enum": ["excel", "csv", "json", "html", "markdown", "all", "reports", "data", "ci"],
-        "description": "Output format for the SDR artifact. Supports direct formats plus aliases: 'all' (all formats + console), 'reports' (excel + markdown), 'data' (csv + json), and 'ci' (json + markdown). JSON is recommended for machine-readable downstream processing."
+        "enum": ["excel", "csv", "json", "html", "markdown", "notion", "all", "reports", "data", "ci"],
+        "description": "Output format for the SDR artifact. Supports direct formats plus aliases: 'all' (all formats + console), 'reports' (excel + markdown), 'data' (csv + json), and 'ci' (json + markdown). Use 'notion' to publish directly to a Notion page (requires NOTION_TOKEN and NOTION_PARENT_PAGE_ID env vars and the 'notion' optional extra). JSON is recommended for machine-readable downstream processing."
       },
       "output": {
         "type": "string",

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,18 @@ revision = 3
 requires-python = ">=3.14"
 
 [[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
 name = "argcomplete"
 version = "3.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -84,12 +96,17 @@ env = [
 ]
 full = [
     { name = "argcomplete" },
+    { name = "notion-client" },
     { name = "python-dotenv" },
     { name = "scipy" },
+]
+notion = [
+    { name = "notion-client" },
 ]
 
 [package.dev-dependencies]
 dev = [
+    { name = "notion-client" },
     { name = "openpyxl" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -102,6 +119,8 @@ requires-dist = [
     { name = "argcomplete", marker = "extra == 'completion'", specifier = ">=3.0.0" },
     { name = "argcomplete", marker = "extra == 'full'", specifier = ">=3.0.0" },
     { name = "cjapy", specifier = ">=0.3.1" },
+    { name = "notion-client", marker = "extra == 'full'", specifier = ">=2.0.0" },
+    { name = "notion-client", marker = "extra == 'notion'", specifier = ">=2.0.0" },
     { name = "numpy", specifier = ">=2.2.0,!=2.4.0" },
     { name = "pandas", specifier = ">=2.3.3,<3" },
     { name = "python-dotenv", marker = "extra == 'env'", specifier = ">=1.0.0" },
@@ -111,10 +130,11 @@ requires-dist = [
     { name = "tqdm", specifier = ">=4.66.0" },
     { name = "xlsxwriter", specifier = ">=3.2.9" },
 ]
-provides-extras = ["clustering", "completion", "env", "full"]
+provides-extras = ["clustering", "completion", "env", "full", "notion"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "notion-client", specifier = ">=2.0.0" },
     { name = "openpyxl", specifier = ">=3.1.0" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov", specifier = ">=4.1.0" },
@@ -218,6 +238,43 @@ wheels = [
 ]
 
 [[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -233,6 +290,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "notion-client"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/e3/4ac01384e86e2c381c21b87a0fefcdfe6d65577ae3153fad27e7e96c5d9c/notion_client-3.1.0.tar.gz", hash = "sha256:516e31326f855ec34559289b57be4e27ad656062f51f594c8f4ee3a608ee333d", size = 38781, upload-time = "2026-05-12T08:54:44.363Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/08/12645b24044301cb0d7908ec068c55c0d5724f39372891a1a27d630fdf50/notion_client-3.1.0-py2.py3-none-any.whl", hash = "sha256:7e3935f4dbc11231d8ad1fe404112e278501520342eaa35f86456f0df44a8aca", size = 23092, upload-time = "2026-05-12T08:54:43.135Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds **Notion** as a first-class output destination for SDR generation.

- `--format notion` — publish SDR directly to a Notion page in a single command
- `--push-to-notion <file>` — push an existing JSON artifact to Notion without re-calling the CJA API (`RunMode.PUSH_TO_NOTION`)
- `--notion-force-new` — force a new page even when one already exists for the data view
- Idempotent page registry (`.notion_pages.json`) — re-runs update in place rather than accumulating duplicates; registry writes are serialized across batch workers via an `fcntl.flock` sidecar lock on POSIX and `msvcrt.locking` on Windows
- Sections larger than Notion's 100-children API limit are automatically split into multiple sibling tables under the same heading (header + ≤ 99 rows per table), so data views with hundreds of metrics/dimensions publish without `validation_error`
- `notion-client` added as the `[notion]` optional extra (in `dev` group so CI runs without the extra)

Implementation references the design spec and plan in `docs/superpowers/specs/2026-05-14-notion-integration-design.md` and `docs/superpowers/plans/2026-05-14-notion-integration.md`.

## What changed

| Area | Change |
|------|--------|
| Writers | `src/cja_auto_sdr/output/writers/notion.py` — block builder (with section-splitting at 99 rows per table) + credential resolution + Notion API layer + `write_notion_output` |
| Registry | `src/cja_auto_sdr/output/notion_registry.py` — atomic page-ID registry (uses `core/json_io.write_json_atomic_compatible`) with cross-platform exclusive lock (`fcntl.flock` on POSIX, `msvcrt.locking` on Windows) across batch workers |
| Writer protocol | `notion` registered in `output/registry.py::WRITER_REGISTRY`; `notion` added to `EMBEDDED_METADATA_FORMATS` so direct `--format notion` runs receive real SDR metadata |
| CLI | `--format notion` added to `--format` choices; new Notion Integration argument group with `--push-to-notion` and `--notion-force-new`; `--format notion` rejected in non-SDR modes (except `PUSH_TO_NOTION`) with actionable error |
| Dispatch | `RunMode.PUSH_TO_NOTION` added; `_main_impl` dispatch and SDR format loop (`elif fmt == "notion"`); `_push_to_notion_from_json` helper |
| Pipeline | `notion_force_new` threaded through `ProcessingConfig`, `WorkerArgs`, `BatchConfig`, `process_single_dataview`, `BatchProcessor`, and `cli/execution.py` call sites |
| Standalone policy | `push_to_notion` policy registered in `cli/standalone_policy.py` |
| Docs | Notion sections added to `OUTPUT_FORMATS.md`, `CLI_REFERENCE.md`, `QUICK_REFERENCE.md`, `AGENT_AUTOMATION.md`; `notion` added to `tools/cja_sdr_generate.json` enum |
| Version | Bump to v3.7.0 across all 8 version-sync files + `CHANGELOG.md` entry |

## Test plan

### Automated

- [x] `uv run pytest tests/test_notion_registry.py -v` — 14 passed (includes real `ProcessPoolExecutor` concurrent-write test and Windows-codepath fallback test)
- [x] `uv run pytest tests/test_notion_writer.py -v` — 32 passed (block builder + section-splitting at 99 rows + API layer + integration + missing-SDK guardrail; all Notion API calls mocked via `_require_notion_client`)
- [x] `uv run pytest tests/test_cli_notion.py -v` — 13 passed (CLI flag wiring, mutual exclusion, standalone policy, `--format notion` rejected in non-SDR modes, allowed in SDR/PUSH_TO_NOTION)
- [x] `uv run pytest tests/test_push_to_notion.py -v` — 5 passed (JSON ingest, file-not-found, invalid JSON, OSError on read, `RunMode.PUSH_TO_NOTION` precedence over `WATCH`)
- [x] `uv run pytest tests/test_processing_execution_policy.py -v` — includes parametrized `notion` row asserting `emits_embedded_metadata=True`
- [x] `uv run pytest tests/ -x -q` — **8058 passed, 16 skipped** (+64 new tests over baseline)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run python scripts/check_version_sync.py` — Version sync OK at 3.7.0
- [x] `uv run python scripts/update_test_counts.py --check` — Test counts are up to date
- [x] Unit slice coverage gate — **98.62% total** (gate 95%); `notion.py` 93%, `notion_registry.py` 100%

### Live Notion smoke — completed 2026-06-19

Run against a sandbox Notion workspace using a real CJA data view
(`dv_677eab591244fd082f02dd43`, "Adobe Store - Prod (Brian Au COPY)") plus
synthetic artifacts. Each published page was verified through the Notion API,
not by eye.

- [x] **Page creation** (`--format notion` against the real data view): child page created under the parent, titled `Adobe Store - Prod (Brian Au COPY) — SDR`; metadata callout shows the real Data View Name / ID / timestamp / tool version (no `base_filename` fallback); Metrics (28) and Dimensions (98) tables render; zero-row sections omit both heading and table; Data Quality issues render under the "🛡️ Data Quality" heading.
- [x] **Update in place** (re-run): the same page ID is returned, no duplicate page is created, and the `.notion_pages.json` page ID is unchanged.
- [x] **Force new** (`--notion-force-new`): a fresh page ID is created, the registry repoints to it, and the previous page is left in place.
- [x] **Push from JSON artifact** (`--push-to-notion`): stdout prints `notion://pages/<id>`, the page matches the artifact, and a second push updates the same page (registry round-trips). **Correction:** the registry lands in `--output-dir` (default: the current working directory), not "next to the input file." `--output-dir` defaults to `"."`, so the original wording was wrong.
- [x] **Scale check (Notion 100-child limit)**: a 250-row Metrics section published with no `validation_error` and rendered as 3 sibling tables under one heading (99 + 99 + 52 rows), with row order preserved.
- [x] **Long-cell truncation**: a 2500-character description was truncated to exactly 2000 characters with no rich-text validation error.
- [x] **Cross-flag rejection**: `--diff … --format notion` and `--org-report --format notion` both exit 1 with `--format notion is only supported in SDR generation mode (use --push-to-notion <json_file> to publish a saved artifact instead)`.
- [x] **Missing-extra path**: covered by the `no-extras-smoke` CI job (runtime deps only, asserts `notion-client` is absent and the writer still imports) and the missing-SDK unit guardrail.
- [x] **Missing-env path**: the `NOTION_TOKEN is not set` error was observed live before credentials were loaded; both the token branch and the parent-page branch are covered by unit tests.

**Bug found and fixed during the smoke (commit a920a4e):** the data quality severity icons keyed only on `ERROR` / `WARN` / `INFO`, so real `HIGH` and `MEDIUM` issues rendered with the ℹ️ info icon (the engine emits `CRITICAL` / `HIGH` / `MEDIUM` / `LOW` / `INFO`). The real data view's MEDIUM and LOW issues confirmed it. The map now sends `CRITICAL` / `HIGH` → 🔴, `MEDIUM` / `WARN` → ⚠️, and `LOW` / `INFO` → ℹ️, with a parametrized regression test. The same commit gitignores the registry files (`.notion_pages.json`, `.notion_pages.json.lock`) and `.env.*` secret files, which the smoke showed were committable.

## v3.8.0 preview

A v3.8.0 expansion will introduce an SDR Registry database in Notion (one DB row per data view with metadata properties + relation to the detail page), pairing naturally with `--org-report --format notion`. The v1 page structure and registry file are forward-compatible. Similar to https://github.com/brian-a-au/aa_auto_sdr/pull/52

