### PR TITLE
docs: v3.8.0 Notion SDR Registry docs (follow-up to #85)

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,11 @@ cja_auto_sdr "Production Analytics"
 | Export as HTML | `cja_auto_sdr dv_12345 --format html` |
 | Export as Markdown | `cja_auto_sdr dv_12345 --format markdown` |
 | Generate all formats | `cja_auto_sdr dv_12345 --format all` |
+| **Notion SDR Registry (v3.8.0)** | |
+| Bootstrap registry database (one-time) | `cja_auto_sdr --notion-create-database` |
+| Publish detail page + registry row | `cja_auto_sdr dv_12345 --format notion` (with `NOTION_DATABASE_ID` set) |
+| Batch publish with complete rows | `cja_auto_sdr --batch dv_1 dv_2 dv_3 --format notion` |
+| Org-report lightweight catalog | `cja_auto_sdr --org-report --format notion` (counts only; no detail pages) |
 | **Quick Stats & Discovery** | |
 | Quick stats (no full report) | `cja_auto_sdr dv_12345 --stats` |
 | Stats as JSON | `cja_auto_sdr dv_12345 --stats --format json` |

--- a/docs/AGENT_AUTOMATION.md
+++ b/docs/AGENT_AUTOMATION.md
@@ -428,7 +428,7 @@ The run summary includes an `advisories` rollup key when advisories are present 
 
 ### Publishing to Notion
 
-Notion is supported as a first-class output destination for SDR generation. Install the optional extra and set the two required env vars:
+Notion is supported as a first-class output destination for SDR generation and org-report catalog publishing. Install the optional extra and set the required env vars:
 
 ```bash
 uv pip install 'cja-auto-sdr[notion]'
@@ -441,11 +441,43 @@ export NOTION_PARENT_PAGE_ID=<page-id>
 uv run cja_auto_sdr dv_12345 --format json --output-dir ./artifacts
 uv run cja_auto_sdr --push-to-notion ./artifacts/dv_12345_sdr.json
 
-# Single-step: generate and publish in one command
+# Single-step: generate detail page and publish
 uv run cja_auto_sdr dv_12345 --format notion
 ```
 
 Page IDs are tracked in `.notion_pages.json` so re-runs update the existing page rather than accumulating duplicates. Use `--notion-force-new` to override.
+
+**SDR Registry database pattern (v3.8.0):**
+
+The registry database maintains one row per data view in a "CJA SDR Registry" Notion database, keyed by Data View ID. It has 14 properties covering counts, data quality, timezone, currency, and a link to the detail page.
+
+```bash
+# One-time: bootstrap the registry database
+uv run cja_auto_sdr --notion-create-database
+# Prints: notion://databases/<id>  ← save this
+
+export NOTION_DATABASE_ID=<id-from-above>
+
+# Per-data-view: publish detail page + upsert complete registry row
+uv run cja_auto_sdr dv_12345 --format notion
+
+# Batch: multiple data views with complete rows
+uv run cja_auto_sdr --batch dv_12345 dv_67890 dv_abcde --format notion
+```
+
+**Org-report catalog pattern (v3.8.0 — lightweight):**
+
+`--org-report --format notion` writes a lightweight catalog row per data view from the org report summary. This is fast (serial, no extra API calls) but only fills Name, Data View ID, Metrics Count, Dimensions Count, owner/dates, and an SDR Page link where a detail page already exists. Segments, Calculated Metrics, Derived Fields counts, and Data Quality are not populated.
+
+```bash
+# Lightweight catalog from org report (fast, counts only)
+uv run cja_auto_sdr --org-report --format notion
+
+# Follow up with batch for complete rows on key data views
+uv run cja_auto_sdr --batch dv_12345 dv_67890 --format notion
+```
+
+Use `--org-report --format notion` for a quick high-level view; use `--batch --format notion` when you need complete rows with all 14 properties.
 
 Pattern:
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -167,7 +167,7 @@ cja-auto-sdr [OPTIONS] DATA_VIEW_ID_OR_NAME [...]
 | `json` | ✓ | ✓ | ✓ | ✓ |
 | `html` | ✓ | ✓ | ✓ | ✗ |
 | `markdown` | ✓ | ✓ | ✓ | ✗ |
-| `notion` | ✓ | ✗ | ✗ | ✗ |
+| `notion` | ✓ | ✗ | ✓ (catalog only — see note) | ✗ |
 | `console` | ✗ | ✓ (default) | ✓ (default) | ✓ (default) |
 | `all` | ✓ | ✓ | ✓ | ✗ |
 
@@ -176,6 +176,8 @@ cja-auto-sdr [OPTIONS] DATA_VIEW_ID_OR_NAME [...]
 > **Note:** Console format is supported for diff comparison, org-wide analysis, and discovery. Using `--format console` with SDR generation will show an error with suggested alternatives.
 >
 > **Note:** In diff and org-wide modes, `--format all` includes console output (displayed in terminal) in addition to all file formats.
+>
+> **Note:** `--org-report --format notion` publishes a **lightweight catalog** only — one registry row per data view from the org report summary. It fills Name, Data View ID, Metrics Count, Dimensions Count, owner/dates, and an SDR Page link where a detail page already exists. It does **not** fetch segments, calculated metrics, or derived fields; does **not** run data-quality validation (those columns are left empty, Data Quality shows `unknown`); does **not** create detail pages; and runs serially. For complete rows with all counts and detail pages, use `--batch <ids> --format notion` instead.
 
 ### Configuration
 
@@ -493,7 +495,7 @@ Cache is stored in `~/.cja_auto_sdr/cache/org_report_cache.json`.
 
 ### Notion Integration
 
-Publish SDRs directly to a Notion page, or push a previously-generated JSON artifact to Notion without re-calling the CJA API. Requires `NOTION_TOKEN` and `NOTION_PARENT_PAGE_ID` environment variables. Install the extra first:
+Publish SDRs directly to a Notion page, maintain a registry database of all published data views, or push a previously-generated JSON artifact to Notion without re-calling the CJA API. Requires `NOTION_TOKEN` and `NOTION_PARENT_PAGE_ID` environment variables. Install the extra first:
 
 ```bash
 uv pip install 'cja-auto-sdr[notion]'
@@ -504,6 +506,8 @@ uv pip install 'cja-auto-sdr[notion]'
 | `--format notion` | Publish SDR to a Notion page as part of generation | - |
 | `--push-to-notion JSON_FILE` | Push an existing SDR JSON artifact to Notion (standalone mode; no CJA API call) | - |
 | `--notion-force-new` | Force a new Notion page instead of updating the existing one for this data view | False |
+| `--notion-database-id ID` | ID of the "CJA SDR Registry" database to upsert a row into after publishing. Falls back to the `NOTION_DATABASE_ID` env var. When neither is set, no row is written | - |
+| `--notion-create-database` | Bootstrap a new "CJA SDR Registry" database under `NOTION_PARENT_PAGE_ID`, print its ID to stdout, and exit. Use this ID as `NOTION_DATABASE_ID` for subsequent runs | - |
 
 ```bash
 # Publish SDR directly to Notion
@@ -515,11 +519,41 @@ cja_auto_sdr --push-to-notion ./reports/dv_12345_sdr.json
 # Force a new Notion page even if one already exists
 cja_auto_sdr dv_12345 --format notion --notion-force-new
 cja_auto_sdr --push-to-notion ./reports/dv_12345_sdr.json --notion-force-new
+
+# --- SDR Registry Database (v3.8.0) ---
+
+# Step 1: Bootstrap the registry database once (prints the database ID)
+cja_auto_sdr --notion-create-database
+# Output: notion://databases/<id>  ← capture this
+
+# Step 2: Set the database ID in your environment
+export NOTION_DATABASE_ID=<id-from-step-1>
+
+# Step 3: Publish a detail page AND upsert a complete registry row
+cja_auto_sdr dv_12345 --format notion
+
+# Equivalently, pass the database ID explicitly
+cja_auto_sdr dv_12345 --format notion --notion-database-id <id>
+
+# Publish batch of data views with complete registry rows
+cja_auto_sdr --batch dv_12345 dv_67890 --format notion
+
+# Org-report Notion catalog (lightweight — counts only, no detail pages)
+# Fills Name, Data View ID, Metrics/Dimensions Count, and SDR Page link
+# where a detail page already exists. Segments/CM/DF counts, and Data Quality
+# are NOT populated (those columns are empty). Runs serially.
+cja_auto_sdr --org-report --format notion
 ```
 
 > **Idempotency:** Page IDs are tracked in `.notion_pages.json` in the output directory so re-runs update the existing page rather than creating duplicates. Use `--notion-force-new` to override.
 >
+> **Registry file (v2):** `.notion_pages.json` now stores `{"page_id": "...", "database_row_id": "..."}` per data view. Legacy v1 string entries (just a page ID) are read transparently and rewritten to v2 format on the next sync — no manual migration needed.
+>
+> **`--workers > 1` and `--watch` are rejected with `--format notion`** (exit 1). For multiple data views, use `--batch <ids> --format notion` (serial within the Notion writer).
+>
 > **Stdout:** `--push-to-notion` prints the resulting `notion://pages/<id>` identifier to stdout on success. Avoid combining with `--run-summary-json -` / `--output -` if you need to consume stdout machine-readably, since the two outputs will be interleaved.
+>
+> **Org-report catalog limitations:** `--org-report --format notion` creates one registry row per data view from the org report summary. Segments count, Calculated Metrics count, Derived Fields count, and Data Quality columns remain empty because the org report does not fetch those details. Detail pages are not created. For complete rows with all counts and a linked detail page, use `--batch <ids> --format notion` (or run `cja_auto_sdr <dv_id> --format notion` per data view). Full org-report detail pages are planned for a future release.
 
 ### Watch Mode
 
@@ -678,6 +712,14 @@ Preset flag for running CJA SDR Generator from AI agents, scripts, and automatio
 | `MAX_RETRIES` | Maximum API retry attempts (overridden by --max-retries) |
 | `RETRY_BASE_DELAY` | Initial retry delay in seconds (overridden by --retry-base-delay) |
 | `RETRY_MAX_DELAY` | Maximum retry delay in seconds (overridden by --retry-max-delay) |
+
+**Notion Integration:**
+
+| Variable | Description |
+|----------|-------------|
+| `NOTION_TOKEN` | Notion integration token (required for `--format notion` and related flags) |
+| `NOTION_PARENT_PAGE_ID` | Notion page ID under which SDR pages and databases are created |
+| `NOTION_DATABASE_ID` | ID of the "CJA SDR Registry" database; when set, every `--format notion` run upserts a registry row. Falls back to `--notion-database-id`. Unset = no row written |
 
 **Console & CI Integration:**
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -218,6 +218,20 @@ cja_auto_sdr --sample-config
 | `LOG_FORMAT` | Log output format: `text` (human-readable) or `json` (structured) | text |
 | `OUTPUT_DIR` | Default output directory for generated files | Current directory |
 
+### Notion Integration Environment Variables
+
+These variables are used when publishing SDRs to Notion (`--format notion`, `--push-to-notion`, or `--notion-create-database`).
+
+| Variable | Description | Required |
+|----------|-------------|----------|
+| `NOTION_TOKEN` | Notion integration token (starts with `secret_`) | **Yes** (for any Notion output) |
+| `NOTION_PARENT_PAGE_ID` | ID of the Notion page under which SDR detail pages are created. Also used as the parent when bootstrapping a new registry database with `--notion-create-database` | **Yes** (for any Notion output) |
+| `NOTION_DATABASE_ID` | ID of an existing "CJA SDR Registry" database. When set, every `--format notion` run upserts the data view's row in the registry with all counts and Data Quality. Unset = no database row written (v3.7.0 behavior preserved). Can also be supplied via `--notion-database-id` | No |
+
+> **Bootstrapping `NOTION_DATABASE_ID`:** Run `cja_auto_sdr --notion-create-database` once. It creates a new "CJA SDR Registry" database under `NOTION_PARENT_PAGE_ID` and prints the new database ID to stdout. Copy that value into your environment or `.env` file as `NOTION_DATABASE_ID`, then use it on subsequent runs.
+>
+> **Unset behavior:** If `NOTION_DATABASE_ID` is not set (and `--notion-database-id` is not passed), `--format notion` runs exactly as in v3.7.0 — the SDR detail page is created or updated, but no registry row is written.
+
 ### Setting Environment Variables
 
 **macOS/Linux (current session):**

--- a/docs/ORG_WIDE_ANALYSIS.md
+++ b/docs/ORG_WIDE_ANALYSIS.md
@@ -335,7 +335,7 @@ If `scipy` is not installed and `--cluster` is used, a warning is logged and clu
 
 | Option | Description |
 |--------|-------------|
-| `--format FORMAT` | Output format: `console`, `json`, `excel`, `markdown`, `html`, `csv`, `all`, or aliases |
+| `--format FORMAT` | Output format: `console`, `json`, `excel`, `markdown`, `html`, `csv`, `notion`, `all`, or aliases |
 | `--output PATH` | Specific output file path |
 | `--output-dir DIR` | Output directory (default: current) |
 
@@ -352,6 +352,9 @@ cja_auto_sdr --org-report --format reports
 
 # Generate CSV + JSON for data pipelines
 cja_auto_sdr --org-report --format data
+
+# Publish a lightweight Notion catalog (counts only; no detail pages)
+cja_auto_sdr --org-report --format notion
 ```
 
 ## Output Formats
@@ -446,6 +449,30 @@ Multiple CSV files in a directory:
 - `org_report_distribution.csv`
 - `org_report_similarity.csv`
 - `org_report_recommendations.csv`
+
+### Notion (v3.8.0 — lightweight catalog)
+
+`--org-report --format notion` writes one row to the "CJA SDR Registry" database per data view in the org report summary. Requires `NOTION_TOKEN`, `NOTION_PARENT_PAGE_ID`, and `NOTION_DATABASE_ID` (or `--notion-database-id`).
+
+**What is populated:**
+- Name, Data View ID, Metrics Count, Dimensions Count, owner, dates
+- SDR Page link (`notion://pages/<id>`) where a previously published detail page exists
+
+**What is NOT populated (catalog limitations):**
+- Segments Count, Calculated Metrics Count, Derived Fields Count — the org report does not fetch these
+- Data Quality — not run in org-report mode; shows `unknown`
+
+**Detail pages are not created.** The org-report catalog is a read-only summary pass over existing registry rows and org-summary data. For complete rows with all 14 properties and linked detail pages, use `--batch <ids> --format notion` (or per-data-view `cja_auto_sdr <dv_id> --format notion`).
+
+> **Full org-report detail-page generation** (writing a complete Notion page per data view directly from org-report mode) is planned for a future release. For now, the recommended pattern is: run `--org-report --format notion` to populate a quick catalog, then run `--batch <ids> --format notion` for any data views that need complete rows and detail pages.
+
+```bash
+# Lightweight catalog from org report
+cja_auto_sdr --org-report --format notion
+
+# Follow up with batch for complete rows on specific data views
+cja_auto_sdr --batch dv_12345 dv_67890 --format notion
+```
 
 ## Use Cases
 

--- a/docs/OUTPUT_FORMATS.md
+++ b/docs/OUTPUT_FORMATS.md
@@ -24,11 +24,13 @@ The tool supports multiple output formats beyond Excel, providing flexible integ
 | JSON | ✓ | ✓ | ✓ | ✓ |
 | HTML | ✓ | ✓ | ✓ | ✗ |
 | Markdown | ✓ | ✓ | ✓ | ✗ |
-| Notion | ✓ | ✗ | ✗ | ✗ |
+| Notion | ✓ | ✗ | ✓ (catalog only) | ✗ |
 | Console/Table | ✗ | ✓ (default) | ✓ (default) | ✓ (default) |
 | All | ✓ | ✓ | ✓ | ✗ |
 
 > The Discovery column covers both discovery commands (`--list-dataviews`, `--list-connections`, `--list-datasets`) and discovery inspection commands (`--describe-dataview`, `--list-metrics`, `--list-dimensions`, `--list-segments`, `--list-calculated-metrics`). All output console (table), JSON, or CSV. They do not generate file-based formats like Excel, HTML, or Markdown.
+>
+> **Notion + Org-Wide Analysis:** `--org-report --format notion` writes a lightweight catalog row per data view (Name, Data View ID, Metrics/Dimensions Count, SDR Page link). Segments, Calculated Metrics, Derived Fields counts, and Data Quality are not populated. No detail pages are created. For complete rows, use `--batch <ids> --format notion`.
 
 ### Format Aliases (introduced in v3.2.0)
 
@@ -393,7 +395,7 @@ pandoc CJA_DataView_myview_dv_12345_SDR.md -o report.pdf
 
 ### 6. Notion Format
 
-Publishes the SDR directly to a Notion page. Requires `NOTION_TOKEN` and `NOTION_PARENT_PAGE_ID` environment variables and the `notion` optional extra (`uv pip install 'cja-auto-sdr[notion]'`).
+Publishes the SDR directly to a Notion page and (optionally) upserts a row in a "CJA SDR Registry" database. Requires `NOTION_TOKEN` and `NOTION_PARENT_PAGE_ID` environment variables and the `notion` optional extra (`uv pip install 'cja-auto-sdr[notion]'`).
 
 Each run creates or updates a single page under the configured parent. Page IDs are tracked in `.notion_pages.json` in the output directory so re-runs update in place rather than accumulating duplicates.
 
@@ -407,6 +409,13 @@ cja_auto_sdr dv_12345 --format notion --notion-force-new
 
 # Push an existing JSON artifact to Notion (no CJA API call)
 cja_auto_sdr --push-to-notion ./reports/dv_12345_sdr.json
+
+# Publish and upsert a registry row (requires NOTION_DATABASE_ID)
+export NOTION_DATABASE_ID=<database-id>
+cja_auto_sdr dv_12345 --format notion
+
+# Bootstrap a new registry database and capture its ID
+cja_auto_sdr --notion-create-database
 ```
 
 **Block layout:**
@@ -421,6 +430,60 @@ cja_auto_sdr --push-to-notion ./reports/dv_12345_sdr.json
 - **`--push-to-notion` is mutually exclusive with all other generation flags.** Combining it with `--org-report`, `--diff`, `--snapshot`, `--batch`, `--watch`, `--inventory-summary`, `--dry-run`, or positional data view IDs exits with an actionable error (rather than silently dropping `--push-to-notion`).
 - **Large sections split into sibling tables.** Notion caps a block's children array at 100. Sections with more than 99 data rows are split into multiple sibling tables under the same heading, preserving row order.
 - **API failures surface as friendly messages.** Missing/invalid `NOTION_TOKEN`, deleted parent pages, and rate-limit errors print a one-line summary and exit 1; 429 responses are retried with exponential backoff (or `Retry-After` if Notion provides it) before giving up.
+- **`--workers > 1` and `--watch` are rejected** with exit 1 when `--format notion` is active. Use `--batch <ids> --format notion` for multiple data views.
+
+#### Notion Registry Database (v3.8.0)
+
+When `NOTION_DATABASE_ID` is set (or `--notion-database-id` is passed), every `--format notion` run upserts a row in the "CJA SDR Registry" database, keyed by Data View ID. If the env var and flag are both unset, no row is written (v3.7.0 behavior preserved).
+
+**Registry properties (14 total):**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| Name | Title | Data view display name |
+| Data View ID | Text | CJA data view ID (e.g. `dv_abc123`) — primary key for upsert |
+| SDR Page | URL | `notion://pages/<page_id>` string pointing to the detail page (NOT a Notion relation) |
+| Last Updated | Date | Timestamp of the most recent upsert |
+| Tool Version | Text | `cja-auto-sdr` version that wrote the row |
+| Captured At | Date | When the data was captured from the CJA API |
+| Currency | Text | Data view currency setting |
+| Timezone | Text | Data view timezone setting |
+| Metrics Count | Number | Total metrics in the data view |
+| Dimensions Count | Number | Total dimensions in the data view |
+| Segments Count | Number | Total segments scoped to the data view |
+| Calculated Metrics Count | Number | Total calculated metrics for the data view |
+| Derived Fields Count | Number | Total derived fields in the data view |
+| Data Quality | Select | Summary of data quality status (`passed`, `issues_found`, `skipped`, `unknown`) |
+
+> **`SDR Page` is a URL string, not a Notion relation.** The property holds `notion://pages/<id>` as plain text. This avoids permission constraints that would prevent cross-database relations in most Notion workspace configurations.
+>
+> **Registry file v1 → v2 migration:** `.notion_pages.json` previously stored a plain page ID string per data view. From v3.8.0 it stores `{"page_id": "...", "database_row_id": "..."}`. Legacy v1 entries are read transparently and rewritten to v2 format on the next sync — no manual migration is needed.
+
+**Bootstrap workflow:**
+
+```bash
+# 1. Create the registry database (one-time setup)
+cja_auto_sdr --notion-create-database
+# Prints: notion://databases/<id>
+
+# 2. Add the database ID to your environment
+export NOTION_DATABASE_ID=<id>  # or add to .env
+
+# 3. Publish data views — detail page + complete registry row
+cja_auto_sdr dv_12345 --format notion
+cja_auto_sdr --batch dv_12345 dv_67890 dv_abcde --format notion
+```
+
+**Org-report catalog (lightweight):**
+
+`--org-report --format notion` writes one registry row per data view from the org report summary. It fills Name, Data View ID, Metrics Count, Dimensions Count, owner/dates, and an SDR Page link where a detail page already exists. The following columns are **not** populated because the org report does not fetch that data:
+
+- Segments Count
+- Calculated Metrics Count
+- Derived Fields Count
+- Data Quality (shows `unknown`)
+
+Detail pages are not created. For complete rows with all counts and linked detail pages, use `--batch <ids> --format notion` instead. Full org-report detail-page generation is planned for a future release.
 
 ---
 

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -402,6 +402,8 @@ cja_auto_sdr --list-dataviews  # Uses client-a
 | `--format notion` | Publish SDR directly to Notion (requires `NOTION_TOKEN` + `NOTION_PARENT_PAGE_ID`) |
 | `--push-to-notion JSON_FILE` | Push existing JSON artifact to Notion (no CJA API call) |
 | `--notion-force-new` | Force a new Notion page instead of updating existing |
+| `--notion-database-id ID` | ID of the "CJA SDR Registry" database; upserts a row after publishing. Falls back to `NOTION_DATABASE_ID` env var |
+| `--notion-create-database` | Bootstrap a new "CJA SDR Registry" database under `NOTION_PARENT_PAGE_ID`, print its ID, and exit |
 
 > **Retention precedence:** Explicit values are preserved in both forms: `--keep-last 0` / `--keep-last=0` and `--keep-since 90d` / `--keep-since=90d`.
 
@@ -414,11 +416,13 @@ cja_auto_sdr --list-dataviews  # Uses client-a
 | `json` | ✅ | ✅ | ✅ | ✅ | JSON for integrations |
 | `html` | ✅ | ✅ | ✅ | ❌ | Browser-viewable |
 | `markdown` | ✅ | ✅ | ✅ | ❌ | Documentation-ready |
-| `notion` | ✅ | ❌ | ❌ | ❌ | Publish SDR to Notion page |
+| `notion` | ✅ | ❌ | ✅ (catalog only) | ❌ | Publish SDR to Notion page; org-report writes lightweight catalog rows (counts only, no detail pages) |
 | `console` | ❌ | ✅ (default) | ✅ (default) | ✅ (default) | Terminal output |
 | `all` | ✅ | ✅ | ✅ | ❌ | All formats |
 
 > Discovery column covers both discovery commands (`--list-dataviews`, etc.) and inspection commands (`--describe-dataview`, `--list-metrics`, etc.).
+>
+> **Org-report Notion catalog:** `--org-report --format notion` writes one registry row per data view (Name, Data View ID, Metrics Count, Dimensions Count, SDR Page link if available). Segments, Calculated Metrics, Derived Fields counts and Data Quality are not populated. No detail pages are created. For full rows and detail pages use `--batch <ids> --format notion`.
 
 ### Format Aliases (Shortcuts)
 
@@ -544,6 +548,26 @@ cja_auto_sdr dv_12345 --snapshot ./baseline.json --include-all-inventory
 
 # Compare against snapshot with inventory (same behavior)
 cja_auto_sdr dv_12345 --diff-snapshot ./baseline.json --include-all-inventory
+
+# --- Notion SDR Registry (v3.8.0) ---
+
+# Bootstrap the registry database (one-time; prints the database ID)
+cja_auto_sdr --notion-create-database
+
+# Publish a detail page AND upsert a complete registry row (all 14 properties)
+export NOTION_DATABASE_ID=<id-from-bootstrap>
+cja_auto_sdr dv_12345 --format notion
+
+# Or pass the database ID explicitly
+cja_auto_sdr dv_12345 --format notion --notion-database-id <id>
+
+# Batch: publish multiple data views with complete registry rows
+cja_auto_sdr --batch dv_12345 dv_67890 --format notion
+
+# Org-report catalog (lightweight rows — counts only, no detail pages)
+# Populates Name, Data View ID, Metrics/Dimensions Count, SDR Page link
+# Segments/CM/DF counts and Data Quality are NOT filled in
+cja_auto_sdr --org-report --format notion
 ```
 
 ## Environment Variables

--- a/tools/cja_sdr_generate.json
+++ b/tools/cja_sdr_generate.json
@@ -11,7 +11,7 @@
       "format": {
         "type": "string",
         "enum": ["excel", "csv", "json", "html", "markdown", "notion", "all", "reports", "data", "ci"],
-        "description": "Output format for the SDR artifact. Supports direct formats plus aliases: 'all' (all formats + console), 'reports' (excel + markdown), 'data' (csv + json), and 'ci' (json + markdown). Use 'notion' to publish directly to a Notion page (requires NOTION_TOKEN and NOTION_PARENT_PAGE_ID env vars and the 'notion' optional extra). JSON is recommended for machine-readable downstream processing."
+        "description": "Output format for the SDR artifact. Supports direct formats plus aliases: 'all' (all formats + console), 'reports' (excel + markdown), 'data' (csv + json), and 'ci' (json + markdown). Use 'notion' to publish directly to a Notion page (requires NOTION_TOKEN and NOTION_PARENT_PAGE_ID env vars and the 'notion' optional extra). When NOTION_DATABASE_ID or notion_database_id is set, also upserts a complete 14-property row in the CJA SDR Registry database. JSON is recommended for machine-readable downstream processing."
       },
       "output": {
         "type": "string",
@@ -68,6 +68,18 @@
         "type": "string",
         "enum": ["text", "json"],
         "description": "Log output format. Use 'json' when ingesting logs programmatically."
+      },
+      "notion_database_id": {
+        "type": "string",
+        "description": "ID of the CJA SDR Registry Notion database. When provided (or set via NOTION_DATABASE_ID env var), upserts a 14-property row after publishing the detail page. Falls back to the NOTION_DATABASE_ID env var. Unset = no row written."
+      },
+      "notion_create_database": {
+        "type": "boolean",
+        "description": "Bootstrap a new CJA SDR Registry database under NOTION_PARENT_PAGE_ID, print the new database ID to stdout, and exit. Use the printed ID as notion_database_id or NOTION_DATABASE_ID for subsequent runs."
+      },
+      "notion_force_new": {
+        "type": "boolean",
+        "description": "Force creation of a new Notion page even if one already exists for this data view. Breaks the .notion_pages.json link (old page is left as an orphan)."
       }
     },
     "required": ["data_view_id"]

--- a/tools/cja_sdr_governance.json
+++ b/tools/cja_sdr_governance.json
@@ -26,8 +26,8 @@
       },
       "format": {
         "type": "string",
-        "enum": ["console", "json", "csv", "html", "markdown", "excel"],
-        "description": "Output format for the org report. Use 'json' for agent/machine-readable output."
+        "enum": ["console", "json", "csv", "html", "markdown", "excel", "notion"],
+        "description": "Output format for the org report. Use 'json' for agent/machine-readable output. Use 'notion' to publish a lightweight catalog row per data view to the CJA SDR Registry database (requires NOTION_TOKEN, NOTION_PARENT_PAGE_ID, and NOTION_DATABASE_ID or notion_database_id). The org-report Notion catalog fills Name, Data View ID, Metrics/Dimensions Count, owner/dates, and SDR Page link — it does NOT populate Segments, Calculated Metrics, Derived Fields counts or Data Quality, and does NOT create detail pages. Runs serially."
       },
       "output": {
         "type": "string",
@@ -69,6 +69,10 @@
         "type": "integer",
         "description": "Maximum number of data views to process. Useful for testing or sampling large orgs.",
         "minimum": 1
+      },
+      "notion_database_id": {
+        "type": "string",
+        "description": "ID of the CJA SDR Registry Notion database. Required when format is 'notion'. Falls back to the NOTION_DATABASE_ID env var. The org-report writes lightweight catalog rows only — no detail pages, and Segments/CM/DF counts and Data Quality are not populated."
       }
     },
     "required": []


### PR DESCRIPTION
## Summary

Docs-only follow-up to **#85**. The v3.8.0 documentation commit was authored in a subagent git worktree and never merged into #85 (the code, tests, CHANGELOG, and version bump all landed; only the doc commit was orphaned). This brings those docs to main.

**No version bump** — stays v3.8.0; no code changes.

## What's added
- `docs/CLI_REFERENCE.md` — `--notion-database-id`, `--notion-create-database`, recipes
- `docs/CONFIGURATION.md` — `NOTION_DATABASE_ID` env var
- `docs/OUTPUT_FORMATS.md` — Notion registry database (14-property schema, data sources, forward-compat)
- `docs/ORG_WIDE_ANALYSIS.md` — `--org-report --format notion` lightweight catalog (counts only; limitations)
- `docs/QUICK_REFERENCE.md` — new flags + recipe
- `docs/AGENT_AUTOMATION.md` — Notion-as-destination patterns
- `README.md` — registry use-case rows (badge kept at current 8196)
- `tools/cja_sdr_generate.json`, `tools/cja_sdr_governance.json` — new flags / format enum

## Verification
- `check_version_sync.py` OK at 3.8.0 (no version change); `update_test_counts.py --check` up to date; ruff clean; tool JSON valid.

Cherry-picked the orphaned doc commit; the only conflict was the README test badge (resolved to main's current 8196).

https://claude.ai/code/session_011to9ekGpfJUaGGWKmUxhTA