### PR TITLE
v3.10.0: Notion registry schema repair (--notion-repair-database + --notion-print-database-schema)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ All notable changes to the CJA SDR Generator project will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.10.0] - 2026-06-21
+
+### Added
+- **`--notion-repair-database`** — reconcile an existing CJA SDR Registry database with the canonical schema. It adds any missing properties with a single update and reports properties whose type differs, without changing or removing anything that exists. Needs only `NOTION_TOKEN` and a database id (`--notion-database-id` or `NOTION_DATABASE_ID`); combine with `--dry-run` to preview.
+- **`--notion-print-database-schema`** — print the canonical registry schema (property names and types) and exit. Needs no credentials.
+
+### Changed
+- When a normal `--format notion` run finds a schema-incomplete registry database, the error now names `--notion-repair-database` as the fix.
+
 ## [3.9.0] - 2026-06-21
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
 - Current version: v3.10.0
-- Tests: **8,248** across 153 files at **95% coverage gate**
+- Tests: **8,254** across 155 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,8 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Package manager: **uv**
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
-- Current version: v3.9.0
-- Tests: **8,214** across 153 files at **95% coverage gate**
+- Current version: v3.10.0
+- Tests: **8,248** across 153 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Version Sync](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/version-sync.yml/badge.svg)](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/version-sync.yml)
 [![Python 3.14+](https://img.shields.io/badge/python-3.14%2B-blue.svg)](https://www.python.org/downloads/)
 [![Coverage](https://img.shields.io/badge/coverage-99%25-brightgreen.svg)](tests/)
-[![Tests](https://img.shields.io/badge/tests-8249-brightgreen.svg)](tests/)
+[![Tests](https://img.shields.io/badge/tests-8251-brightgreen.svg)](tests/)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
@@ -481,7 +481,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (8,249+ tests)
+├── tests/                     # Test suite (8,251+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -283,6 +283,10 @@ cja_auto_sdr "Production Analytics"
 | **Notion Maintenance (v3.9.0)** | |
 | Preview orphan pages (dry run) | `cja_auto_sdr --notion-prune-orphans --dry-run --output-dir ./out` |
 | Archive orphan pages (Notion trash) | `cja_auto_sdr --notion-prune-orphans --output-dir ./out` |
+| **Notion Registry Repair (v3.10.0)** | |
+| Print canonical registry schema | `cja_auto_sdr --notion-print-database-schema` |
+| Preview schema repair (dry run) | `cja_auto_sdr --notion-repair-database --dry-run --notion-database-id <id>` |
+| Apply schema repair (add-only) | `cja_auto_sdr --notion-repair-database --notion-database-id <id>` |
 | **Quick Stats & Discovery** | |
 | Quick stats (no full report) | `cja_auto_sdr dv_12345 --stats` |
 | Stats as JSON | `cja_auto_sdr dv_12345 --stats --format json` |

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Version Sync](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/version-sync.yml/badge.svg)](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/version-sync.yml)
 [![Python 3.14+](https://img.shields.io/badge/python-3.14%2B-blue.svg)](https://www.python.org/downloads/)
 [![Coverage](https://img.shields.io/badge/coverage-99%25-brightgreen.svg)](tests/)
-[![Tests](https://img.shields.io/badge/tests-8251-brightgreen.svg)](tests/)
+[![Tests](https://img.shields.io/badge/tests-8252-brightgreen.svg)](tests/)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
@@ -481,7 +481,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (8,251+ tests)
+├── tests/                     # Test suite (8,252+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Version Sync](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/version-sync.yml/badge.svg)](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/version-sync.yml)
 [![Python 3.14+](https://img.shields.io/badge/python-3.14%2B-blue.svg)](https://www.python.org/downloads/)
 [![Coverage](https://img.shields.io/badge/coverage-99%25-brightgreen.svg)](tests/)
-[![Tests](https://img.shields.io/badge/tests-8252-brightgreen.svg)](tests/)
+[![Tests](https://img.shields.io/badge/tests-8254-brightgreen.svg)](tests/)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
@@ -481,7 +481,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (8,252+ tests)
+├── tests/                     # Test suite (8,254+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (8,226+ tests)
+├── tests/                     # Test suite (8,248+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Version Sync](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/version-sync.yml/badge.svg)](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/version-sync.yml)
 [![Python 3.14+](https://img.shields.io/badge/python-3.14%2B-blue.svg)](https://www.python.org/downloads/)
 [![Coverage](https://img.shields.io/badge/coverage-99%25-brightgreen.svg)](tests/)
-[![Tests](https://img.shields.io/badge/tests-8226-brightgreen.svg)](tests/)
+[![Tests](https://img.shields.io/badge/tests-8249-brightgreen.svg)](tests/)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
@@ -481,7 +481,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (8,248+ tests)
+├── tests/                     # Test suite (8,249+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/docs/AGENT_AUTOMATION.md
+++ b/docs/AGENT_AUTOMATION.md
@@ -495,6 +495,25 @@ uv run cja_auto_sdr --notion-prune-orphans --output-dir ./artifacts
 
 > **Limitation:** Only pages orphaned by `--notion-force-new` from v3.9.0 onward are tracked. Pages left behind by earlier runs are not catalogued and are unaffected by pruning.
 
+**Registry schema maintenance (v3.10.0):**
+
+Over time, schema additions may leave an existing registry database missing new properties. Two standalone commands help you inspect and repair the database schema without touching any rows or existing properties:
+
+```bash
+# Print the canonical CJA SDR Registry schema and exit (no credentials needed)
+cja_auto_sdr --notion-print-database-schema
+
+# Preview what would be added (no changes made)
+cja_auto_sdr --notion-repair-database --dry-run --notion-database-id <id>
+
+# Apply missing properties to the database
+cja_auto_sdr --notion-repair-database --notion-database-id <id>
+```
+
+`--notion-repair-database` is add-only: it adds missing properties and reports type conflicts, but never changes or removes existing properties or rows. It requires only `NOTION_TOKEN` and a database id (via `--notion-database-id` or the `NOTION_DATABASE_ID` env var). Combine with `--dry-run` to preview changes before applying. It is a standalone maintenance command and is rejected when combined with other commands.
+
+`--notion-print-database-schema` prints the canonical schema and exits immediately — no credentials or network access required.
+
 Pattern:
 
 ```bash

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -511,8 +511,24 @@ uv pip install 'cja-auto-sdr[notion]'
 | `--notion-database-id ID` | ID of the "CJA SDR Registry" database to upsert a row into after publishing. Falls back to the `NOTION_DATABASE_ID` env var. When neither is set, no row is written | - |
 | `--notion-create-database` | Bootstrap a new "CJA SDR Registry" database under `NOTION_PARENT_PAGE_ID`, print its ID to stdout, and exit. Use this ID as `NOTION_DATABASE_ID` for subsequent runs | - |
 | `--notion-prune-orphans` | Archive Notion pages that were left behind by `--notion-force-new`. The registry records the superseded page ID each time a new page is forced; this command archives those pages in Notion (moved to Notion trash — recoverable, not permanently deleted) and clears them from the registry. Requires only `NOTION_TOKEN`. Rejected when combined with `--org-report`, `--diff`, `--batch`, `--watch`, or `--push-to-notion`. Combine with `--dry-run` to preview without making changes. **Limitation:** only pages orphaned by `--notion-force-new` from v3.9.0 onward are tracked; pre-existing orphans from earlier runs are not catalogued | - |
+| `--notion-repair-database` | Reconcile an existing "CJA SDR Registry" database with the canonical schema. **Add-only:** adds missing properties and reports any type conflicts — never changes or removes existing properties or data rows. Requires only `NOTION_TOKEN` and a database ID (`--notion-database-id` or `NOTION_DATABASE_ID`). Use when the schema grows across versions instead of recreating the database. Combine with `--dry-run` to preview what would be added without making changes | - |
+| `--notion-print-database-schema` | Print the canonical "CJA SDR Registry" schema (property names and types) and exit. Requires no credentials. Use this to inspect the expected schema before bootstrapping or repairing a database | - |
 
 ```bash
+# --- Registry Schema & Repair (v3.10.0) ---
+
+# See the canonical registry schema (no credentials required)
+cja_auto_sdr --notion-print-database-schema
+
+# Preview what a repair would add, then apply it
+cja_auto_sdr --notion-repair-database --dry-run --notion-database-id <id>
+cja_auto_sdr --notion-repair-database --notion-database-id <id>
+
+# Or rely on the NOTION_DATABASE_ID env var
+export NOTION_DATABASE_ID=<id>
+cja_auto_sdr --notion-repair-database --dry-run
+cja_auto_sdr --notion-repair-database
+
 # Publish SDR directly to Notion
 cja_auto_sdr dv_12345 --format notion
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -940,7 +940,7 @@ cja_auto_sdr --list-dataviews --log-level DEBUG
 At launch, the tool logs diagnostic lines containing the tool version, Python version, platform, active log level, inferred run mode (batch, single, or discovery), and dependency versions. These appear automatically at `INFO` level and are useful for troubleshooting environment issues in CI/CD logs or support requests:
 
 ```text
-CJA SDR Generator v3.9.0 | Python 3.14.2 | darwin | log_level=INFO | mode=single
+CJA SDR Generator v3.10.0 | Python 3.14.2 | darwin | log_level=INFO | mode=single
 Dependencies: cjapy=0.3.0, pandas=2.3.3, numpy=2.2.1, xlsxwriter=3.2.9, tqdm=4.67.0
 ```
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -233,6 +233,8 @@ These variables are used when publishing SDRs to Notion (`--format notion`, `--p
 > **Bootstrapping `NOTION_DATABASE_ID`:** Run `cja_auto_sdr --notion-create-database` once. It creates a new "CJA SDR Registry" database under `NOTION_PARENT_PAGE_ID` and prints the new database ID to stdout. Copy that value into your environment or `.env` file as `NOTION_DATABASE_ID`, then use it on subsequent runs.
 >
 > **Unset behavior:** If `NOTION_DATABASE_ID` is not set (and `--notion-database-id` is not passed), `--format notion` runs exactly as in v3.7.0 — the SDR detail page is created or updated, but no registry row is written.
+>
+> **Schema drift (v3.10.0):** If the tool adds new registry properties in a later version and your database is missing those columns, run `cja_auto_sdr --notion-repair-database` to add them (add-only — never removes existing properties or rows). Use `--dry-run` to preview first. Run `cja_auto_sdr --notion-print-database-schema` to see the full canonical schema without credentials.
 
 ### Setting Environment Variables
 

--- a/docs/NOTION_SETUP.md
+++ b/docs/NOTION_SETUP.md
@@ -168,7 +168,45 @@ cja_auto_sdr --notion-prune-orphans
 
 The pages are archived, which means they move to the Notion trash and can be restored, not permanently deleted. The current detail page for each data view is never touched. This command needs only `NOTION_TOKEN`. It does not need a parent page or a database. It only cleans up pages that were orphaned by `--notion-force-new` from v3.9.0 onward.
 
-## 8. Publish a saved artifact without re-fetching
+## 8. Maintaining the registry database
+
+As `cja-auto-sdr` adds new registry properties across versions, your existing database may be missing those columns. Rather than recreating the database and losing your historical rows, use `--notion-repair-database` to bring it up to date.
+
+**Inspect the canonical schema first (no credentials required):**
+
+```bash
+cja_auto_sdr --notion-print-database-schema
+```
+
+This prints the full list of expected property names and their types. Compare it against your database in Notion to spot any gaps.
+
+**Preview, then apply the repair:**
+
+```bash
+# Dry run: see what properties would be added (no changes made)
+cja_auto_sdr --notion-repair-database --dry-run --notion-database-id <id>
+
+# Apply: add missing properties to the live database
+cja_auto_sdr --notion-repair-database --notion-database-id <id>
+```
+
+You can also set `NOTION_DATABASE_ID` in your environment so you do not need to pass the flag each time:
+
+```bash
+export NOTION_DATABASE_ID=<id>
+cja_auto_sdr --notion-repair-database --dry-run
+cja_auto_sdr --notion-repair-database
+```
+
+**What the repair does (and does not do):**
+
+- **Adds** any properties that exist in the canonical schema but are missing from the database.
+- **Reports** any property that exists in the database with a different type than the canonical schema expects (type conflicts are flagged in the output but never changed automatically).
+- **Never removes** existing properties or data rows, so historical data is preserved.
+
+After the repair, run a normal `--format notion` publish to populate the new columns for each data view.
+
+## 9. Publish a saved artifact without re-fetching
 
 If you already generated an SDR as a JSON file, you can publish it to Notion without calling the CJA API again:
 
@@ -178,7 +216,7 @@ cja_auto_sdr --push-to-notion path/to/sdr.json
 
 This reads the saved artifact and writes the detail page (and the registry row, if a database is configured).
 
-## 9. Troubleshooting
+## 10. Troubleshooting
 
 | Symptom | Likely cause | Fix |
 |---------|--------------|-----|

--- a/docs/OUTPUT_FORMATS.md
+++ b/docs/OUTPUT_FORMATS.md
@@ -475,6 +475,24 @@ cja_auto_sdr dv_12345 --format notion
 cja_auto_sdr --batch dv_12345 dv_67890 dv_abcde --format notion
 ```
 
+**Inspecting and repairing the schema (v3.10.0):**
+
+The canonical registry schema can be printed at any time without credentials:
+
+```bash
+cja_auto_sdr --notion-print-database-schema
+```
+
+When the schema grows across tool versions, use `--notion-repair-database` instead of recreating the database. It is add-only: it adds any missing properties and reports type conflicts, but never changes or removes existing properties or data rows. Requires only `NOTION_TOKEN` and a database id:
+
+```bash
+# Preview what would be added (no changes made)
+cja_auto_sdr --notion-repair-database --dry-run --notion-database-id <id>
+
+# Apply the repair
+cja_auto_sdr --notion-repair-database --notion-database-id <id>
+```
+
 **Org-report catalog (lightweight):**
 
 `--org-report --format notion` writes one registry row per data view from the org report summary. It fills Name, Data View ID, Metrics Count, Dimensions Count, owner/dates, and an SDR Page link where a detail page already exists. The following columns are **not** populated because the org report does not fetch that data:

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -190,7 +190,7 @@ This command:
 
 ```bash
 $ uv run cja_auto_sdr -V
-cja_auto_sdr 3.9.0
+cja_auto_sdr 3.10.0
 ```
 
 > **Important:** All commands in this guide assume you're in the `cja_auto_sdr` directory. If you see "command not found", make sure you're in the right directory and have run `uv sync`.

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -405,6 +405,8 @@ cja_auto_sdr --list-dataviews  # Uses client-a
 | `--notion-database-id ID` | ID of the "CJA SDR Registry" database; upserts a row after publishing. Falls back to `NOTION_DATABASE_ID` env var |
 | `--notion-create-database` | Bootstrap a new "CJA SDR Registry" database under `NOTION_PARENT_PAGE_ID`, print its ID, and exit |
 | `--notion-prune-orphans` | Archive Notion pages left behind by `--notion-force-new` (moved to Notion trash, recoverable). Combine with `--dry-run` to preview. Only tracks orphans created from v3.9.0 onward |
+| `--notion-repair-database` | Reconcile an existing registry database with the canonical schema. Add-only: adds missing properties, reports type conflicts, never removes existing properties or rows. Requires `NOTION_TOKEN` and a database id (`--notion-database-id` or `NOTION_DATABASE_ID`). Combine with `--dry-run` to preview |
+| `--notion-print-database-schema` | Print the canonical registry schema (property names + types) and exit. No credentials required |
 
 > **Retention precedence:** Explicit values are preserved in both forms: `--keep-last 0` / `--keep-last=0` and `--keep-since 90d` / `--keep-since=90d`.
 
@@ -577,6 +579,15 @@ cja_auto_sdr --notion-prune-orphans --dry-run --output-dir ./out
 
 # Archive orphaned pages (moved to Notion trash — recoverable)
 cja_auto_sdr --notion-prune-orphans --output-dir ./out
+
+# --- Registry Schema & Repair (v3.10.0) ---
+
+# See the canonical registry schema (no credentials required)
+cja_auto_sdr --notion-print-database-schema
+
+# Preview what a repair would add, then apply it
+cja_auto_sdr --notion-repair-database --dry-run --notion-database-id <id>
+cja_auto_sdr --notion-repair-database --notion-database-id <id>
 ```
 
 ## Environment Variables

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Quick Reference Card
 
-Single-page command cheat sheet for CJA SDR Generator v3.9.0.
+Single-page command cheat sheet for CJA SDR Generator v3.10.0.
 
 ## Four Main Modes
 

--- a/src/cja_auto_sdr/cli/parser.py
+++ b/src/cja_auto_sdr/cli/parser.py
@@ -1482,6 +1482,24 @@ Requirements:
         ),
     )
     notion_group.add_argument(
+        "--notion-print-database-schema",
+        action="store_true",
+        default=False,
+        dest="notion_print_database_schema",
+        help="Print the canonical CJA SDR Registry database schema and exit. Needs no credentials.",
+    )
+    notion_group.add_argument(
+        "--notion-repair-database",
+        action="store_true",
+        default=False,
+        dest="notion_repair_database",
+        help=(
+            "Reconcile an existing CJA SDR Registry database with the canonical schema "
+            "(add missing properties; never change or remove existing ones). Needs NOTION_TOKEN "
+            "and a database id (--notion-database-id or NOTION_DATABASE_ID). Combine with --dry-run to preview."
+        ),
+    )
+    notion_group.add_argument(
         "--notion-prune-orphans",
         action="store_true",
         default=False,

--- a/src/cja_auto_sdr/cli/standalone_policy.py
+++ b/src/cja_auto_sdr/cli/standalone_policy.py
@@ -76,6 +76,17 @@ _NOTION_PRUNE_ORPHANS_STANDALONE_POLICY = StandalonePrevalidationPolicy(
     ignored_semantic_dests=_WRAPPER_EXECUTION_TOLERATED_SEMANTIC_DESTS,
     validate_org_report_mode_scoped_options=False,
 )
+# NOTE: do NOT add "notion_repair_database" or "notion_print_database_schema" to
+# ignored_semantic_dests. The mode flag must stay visible to
+# _validate_semantic_flag_relationships — clearing it would skip the conflict guard.
+_NOTION_REPAIR_DATABASE_STANDALONE_POLICY = StandalonePrevalidationPolicy(
+    ignored_semantic_dests=_WRAPPER_EXECUTION_TOLERATED_SEMANTIC_DESTS,
+    validate_org_report_mode_scoped_options=False,
+)
+_NOTION_PRINT_SCHEMA_STANDALONE_POLICY = StandalonePrevalidationPolicy(
+    ignored_semantic_dests=_WRAPPER_EXECUTION_TOLERATED_SEMANTIC_DESTS,
+    validate_org_report_mode_scoped_options=False,
+)
 
 _STANDALONE_PREVALIDATION_POLICIES: dict[str, StandalonePrevalidationPolicy] = {
     "completion": _COMPLETION_STANDALONE_POLICY,
@@ -83,6 +94,8 @@ _STANDALONE_PREVALIDATION_POLICIES: dict[str, StandalonePrevalidationPolicy] = {
     "exit_codes": _INFORMATIONAL_STANDALONE_POLICY,
     "sample_config": _SAMPLE_CONFIG_STANDALONE_POLICY,
     "push_to_notion": _PUSH_TO_NOTION_STANDALONE_POLICY,
+    "notion_repair_database": _NOTION_REPAIR_DATABASE_STANDALONE_POLICY,
+    "notion_print_schema": _NOTION_PRINT_SCHEMA_STANDALONE_POLICY,
     "notion_prune_orphans": _NOTION_PRUNE_ORPHANS_STANDALONE_POLICY,
 }
 

--- a/src/cja_auto_sdr/core/version.py
+++ b/src/cja_auto_sdr/core/version.py
@@ -1,3 +1,3 @@
 """Version information for CJA Auto SDR."""
 
-__version__ = "3.9.0"
+__version__ = "3.10.0"

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -7108,13 +7108,6 @@ def _main_impl(run_state: dict[str, Any] | None = None):
             repair_notion_database,
         )
 
-        database_id = getattr(args, "notion_database_id", None) or os.environ.get("NOTION_DATABASE_ID")
-        if not database_id:
-            _exit_error(
-                "--notion-repair-database requires a database id. Pass --notion-database-id <id> or set "
-                "NOTION_DATABASE_ID (or use --notion-create-database to bootstrap a new registry).",
-            )
-
         # Same console-logger setup as the prune dispatch: this path runs before
         # setup_logging, so configure INFO output or the report would be suppressed.
         repair_logger = logging.getLogger("notion_repair_database")
@@ -7125,8 +7118,15 @@ def _main_impl(run_state: dict[str, Any] | None = None):
             repair_logger.addHandler(_repair_handler)
             repair_logger.propagate = False
 
+        # repair_notion_database loads .env, then resolves the database id from the
+        # --notion-database-id flag or NOTION_DATABASE_ID (env / .env), so a .env-only
+        # NOTION_DATABASE_ID works. It raises NotionConfigurationError if none is set.
         try:
-            repair_notion_database(database_id, repair_logger, dry_run=getattr(args, "dry_run", False))
+            repair_notion_database(
+                getattr(args, "notion_database_id", None),
+                repair_logger,
+                dry_run=getattr(args, "dry_run", False),
+            )
         except (NotionConfigurationError, NotionDependencyError, NotionAPIError) as exc:
             _exit_error(str(exc))
         sys.exit(0)

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -496,6 +496,8 @@ class RunMode(Enum):
     DIFF_SNAPSHOT = "diff_snapshot"
     DRY_RUN = "dry_run"
     INVENTORY_SUMMARY = "inventory_summary"
+    NOTION_PRINT_SCHEMA = "notion_print_schema"
+    NOTION_REPAIR_DATABASE = "notion_repair_database"
     NOTION_PRUNE_ORPHANS = "notion_prune_orphans"
     WATCH = "watch"
     PUSH_TO_NOTION = "push_to_notion"
@@ -1472,6 +1474,7 @@ def _run_mode_checks(args: argparse.Namespace) -> tuple[tuple[RunMode, bool], ..
         (RunMode.EXIT_CODES, getattr(args, "exit_codes", False)),
         (RunMode.COMPLETION, completion_shell is not None),
         (RunMode.SAMPLE_CONFIG, getattr(args, "sample_config", False)),
+        (RunMode.NOTION_PRINT_SCHEMA, getattr(args, "notion_print_database_schema", False)),
         (
             RunMode.PROFILE_MANAGEMENT,
             bool(
@@ -1518,6 +1521,7 @@ def _run_mode_checks(args: argparse.Namespace) -> tuple[tuple[RunMode, bool], ..
             RunMode.DIFF_SNAPSHOT,
             bool(getattr(args, "compare_with_prev", False) or getattr(args, "diff_snapshot", None)),
         ),
+        (RunMode.NOTION_REPAIR_DATABASE, getattr(args, "notion_repair_database", False)),
         (RunMode.NOTION_PRUNE_ORPHANS, getattr(args, "notion_prune_orphans", False)),
         (RunMode.DRY_RUN, getattr(args, "dry_run", False)),
         (RunMode.INVENTORY_SUMMARY, getattr(args, "inventory_summary", False)),
@@ -1925,6 +1929,23 @@ def _validate_semantic_flag_relationships(
             "Bootstrap the registry once (run a single data view with --notion-create-database), "
             "then pass --notion-database-id <id> for the batch.",
         )
+    if getattr(args, "notion_repair_database", False):
+        if inferred_mode != RunMode.NOTION_REPAIR_DATABASE:
+            _exit_error(
+                "--notion-repair-database is a standalone maintenance command and cannot be "
+                "combined with other commands",
+            )
+        for dest, label in (
+            ("data_views", "positional data view arguments"),
+            ("push_to_notion", "--push-to-notion"),
+            ("org_report", "--org-report"),
+            ("diff", "--diff"),
+            ("batch", "--batch"),
+            ("watch_data_views", "--watch"),
+            ("inventory_summary", "--inventory-summary"),
+        ):
+            if getattr(args, dest, None):
+                _exit_error(f"--notion-repair-database cannot be combined with {label}")
     if getattr(args, "notion_prune_orphans", False):
         # Modes that outrank NOTION_PRUNE_ORPHANS in _run_mode_checks (discovery,
         # snapshot maintenance, org-report, diff, config, stats, ...) would win the
@@ -7072,6 +7093,43 @@ def _main_impl(run_state: dict[str, Any] | None = None):
 
     if inferred_mode == RunMode.ORG_REPORT_SNAPSHOTS:
         _handle_org_report_snapshot_cli(args, output_to_stdout=output_to_stdout, run_state=run_state)
+
+    if inferred_mode == RunMode.NOTION_PRINT_SCHEMA:
+        from cja_auto_sdr.output.notion_database import describe_database_schema
+
+        print(describe_database_schema(), end="")
+        sys.exit(0)
+
+    if inferred_mode == RunMode.NOTION_REPAIR_DATABASE:
+        from cja_auto_sdr.output.writers.notion import (
+            NotionAPIError,
+            NotionConfigurationError,
+            NotionDependencyError,
+            repair_notion_database,
+        )
+
+        database_id = getattr(args, "notion_database_id", None) or os.environ.get("NOTION_DATABASE_ID")
+        if not database_id:
+            _exit_error(
+                "--notion-repair-database requires a database id. Pass --notion-database-id <id> or set "
+                "NOTION_DATABASE_ID (or use --notion-create-database to bootstrap a new registry).",
+            )
+
+        # Same console-logger setup as the prune dispatch: this path runs before
+        # setup_logging, so configure INFO output or the report would be suppressed.
+        repair_logger = logging.getLogger("notion_repair_database")
+        repair_logger.setLevel(logging.INFO)
+        if not repair_logger.handlers:
+            _repair_handler = logging.StreamHandler(sys.stdout)
+            _repair_handler.setFormatter(logging.Formatter("%(message)s"))
+            repair_logger.addHandler(_repair_handler)
+            repair_logger.propagate = False
+
+        try:
+            repair_notion_database(database_id, repair_logger, dry_run=getattr(args, "dry_run", False))
+        except (NotionConfigurationError, NotionDependencyError, NotionAPIError) as exc:
+            _exit_error(str(exc))
+        sys.exit(0)
 
     if inferred_mode == RunMode.NOTION_PRUNE_ORPHANS:
         from cja_auto_sdr.output.writers.notion import (

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -1943,6 +1943,8 @@ def _validate_semantic_flag_relationships(
             ("batch", "--batch"),
             ("watch_data_views", "--watch"),
             ("inventory_summary", "--inventory-summary"),
+            ("notion_prune_orphans", "--notion-prune-orphans"),
+            ("notion_create_database", "--notion-create-database"),
         ):
             if getattr(args, dest, None):
                 _exit_error(f"--notion-repair-database cannot be combined with {label}")

--- a/src/cja_auto_sdr/output/notion_database.py
+++ b/src/cja_auto_sdr/output/notion_database.py
@@ -30,6 +30,7 @@ __all__ = [
     "build_catalog_row_properties",
     "build_row_properties",
     "derive_data_quality_status",
+    "describe_database_schema",
     "ensure_database",
     "find_existing_row_id",
     "upsert_database_row",
@@ -59,6 +60,24 @@ DATABASE_SCHEMA: dict[str, dict[str, Any]] = {
         },
     },
 }
+
+
+def _schema_property_type(entry: dict) -> str:
+    """Return the Notion property type for a DATABASE_SCHEMA entry (its single key)."""
+    return next(iter(entry))
+
+
+def describe_database_schema() -> str:
+    """Render the canonical registry schema as a human-readable block for stdout."""
+    lines = [f"CJA SDR Registry — database schema ({len(DATABASE_SCHEMA)} properties)", ""]
+    for name, entry in DATABASE_SCHEMA.items():
+        ptype = _schema_property_type(entry)
+        if ptype == "select":
+            options = ", ".join(o["name"] for o in entry["select"].get("options", []))
+            lines.append(f"  {name:<26} {ptype} ({options})")
+        else:
+            lines.append(f"  {name:<26} {ptype}")
+    return "\n".join(lines) + "\n"
 
 
 def _rt(content: str) -> list[dict]:

--- a/src/cja_auto_sdr/output/notion_database.py
+++ b/src/cja_auto_sdr/output/notion_database.py
@@ -288,7 +288,8 @@ def ensure_database(
         missing = set(DATABASE_SCHEMA) - existing_props
         if missing:
             raise ValueError(
-                f"Database {database_id} is missing required properties: {sorted(missing)}",
+                f"Database {database_id} is missing required properties: {sorted(missing)}. "
+                "Run cja_auto_sdr --notion-repair-database to add them.",
             )
         return str(db["id"]), ds_id
 

--- a/src/cja_auto_sdr/output/notion_database.py
+++ b/src/cja_auto_sdr/output/notion_database.py
@@ -17,6 +17,7 @@ metadata.
 from __future__ import annotations
 
 import datetime as _dt
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from cja_auto_sdr.output.writers.notion import _call_with_rate_limit_retry
@@ -27,12 +28,14 @@ if TYPE_CHECKING:
 __all__ = [
     "DATABASE_SCHEMA",
     "DATA_QUALITY_OPTIONS",
+    "SchemaRepairResult",
     "build_catalog_row_properties",
     "build_row_properties",
     "derive_data_quality_status",
     "describe_database_schema",
     "ensure_database",
     "find_existing_row_id",
+    "repair_database_schema",
     "upsert_database_row",
 ]
 
@@ -78,6 +81,51 @@ def describe_database_schema() -> str:
         else:
             lines.append(f"  {name:<26} {ptype}")
     return "\n".join(lines) + "\n"
+
+
+@dataclass(frozen=True)
+class SchemaRepairResult:
+    to_add: list[str]
+    conflicts: list[tuple[str, str, str]]  # (name, expected_type, actual_type)
+    applied: bool
+
+
+def repair_database_schema(client: Any, *, database_id: str, dry_run: bool = False) -> SchemaRepairResult:
+    """Add canonical properties missing from an existing registry database.
+
+    Add-only: never changes a property's type, never removes one, never adds a
+    second title. Type mismatches are recorded as conflicts and left untouched.
+    Raises ValueError if the database has no data source.
+    """
+    db = _call_with_rate_limit_retry(client.databases.retrieve, database_id=database_id)
+    data_sources = db.get("data_sources") or []
+    if not data_sources:
+        raise ValueError(f"Database {database_id} has no data source")
+    ds_id = str(data_sources[0]["id"])
+    ds = _call_with_rate_limit_retry(client.data_sources.retrieve, data_source_id=ds_id)
+    live = ds.get("properties") or {}
+
+    to_add: list[str] = []
+    conflicts: list[tuple[str, str, str]] = []
+    payload: dict[str, Any] = {}
+    for name, entry in DATABASE_SCHEMA.items():
+        expected = _schema_property_type(entry)
+        if expected == "title":
+            # Every database already has exactly one title; never add a second.
+            if name in live and live[name].get("type") != "title":
+                conflicts.append((name, expected, str(live[name].get("type"))))
+            continue
+        if name not in live:
+            to_add.append(name)
+            payload[name] = entry
+        elif live[name].get("type") != expected:
+            conflicts.append((name, expected, str(live[name].get("type"))))
+
+    applied = False
+    if to_add and not dry_run:
+        _call_with_rate_limit_retry(client.data_sources.update, data_source_id=ds_id, properties=payload)
+        applied = True
+    return SchemaRepairResult(to_add=to_add, conflicts=conflicts, applied=applied)
 
 
 def _rt(content: str) -> list[dict]:

--- a/src/cja_auto_sdr/output/notion_database.py
+++ b/src/cja_auto_sdr/output/notion_database.py
@@ -281,7 +281,7 @@ def ensure_database(
         db = _call_with_rate_limit_retry(client.databases.retrieve, database_id=database_id)
         data_sources = db.get("data_sources") or []
         if not data_sources:
-            raise ValueError(f"Database {database_id} has no data sources")
+            raise ValueError(f"Database {database_id} has no data source")
         ds_id = str(data_sources[0]["id"])
         ds = _call_with_rate_limit_retry(client.data_sources.retrieve, data_source_id=ds_id)
         existing_props = set((ds.get("properties") or {}).keys())

--- a/src/cja_auto_sdr/output/notion_database.py
+++ b/src/cja_auto_sdr/output/notion_database.py
@@ -111,8 +111,13 @@ def repair_database_schema(client: Any, *, database_id: str, dry_run: bool = Fal
     for name, entry in DATABASE_SCHEMA.items():
         expected = _schema_property_type(entry)
         if expected == "title":
-            # Every database already has exactly one title; never add a second.
-            if name in live and live[name].get("type") != "title":
+            # A database always has exactly one title, so repair never adds the
+            # canonical title. Surface an absent/renamed title (or a wrong-typed
+            # "Name") as a conflict for manual resolution — otherwise ensure_database
+            # would later reject the database with no hint from repair.
+            if name not in live:
+                conflicts.append((name, expected, "missing"))
+            elif live[name].get("type") != "title":
                 conflicts.append((name, expected, str(live[name].get("type"))))
             continue
         if name not in live:

--- a/src/cja_auto_sdr/output/writers/notion.py
+++ b/src/cja_auto_sdr/output/writers/notion.py
@@ -35,6 +35,7 @@ __all__ = [
     "NotionAPIError",
     "NotionConfigurationError",
     "NotionDependencyError",
+    "repair_notion_database",
     "write_notion_output",
 ]
 
@@ -684,3 +685,43 @@ def prune_notion_orphans(
     suffix = f" ({already_gone} already gone)" if already_gone else ""
     logger.info("✓ Pruned %d orphan page(s)%s.", archived, suffix)
     return (archived, already_gone)
+
+
+def repair_notion_database(
+    database_id: str,
+    logger: logging.Logger,
+    *,
+    dry_run: bool = False,
+):
+    """Reconcile an existing registry database with the canonical schema.
+
+    Needs only NOTION_TOKEN. Returns the SchemaRepairResult. Raises
+    NotionConfigurationError / NotionDependencyError / NotionAPIError (the CLI
+    maps these to exit 1).
+    """
+    from cja_auto_sdr.output.notion_database import repair_database_schema
+
+    token, _ = resolve_notion_credentials(require_parent=False)
+    client = _build_client(_require_notion_client(), token)
+    try:
+        result = repair_database_schema(client, database_id=database_id, dry_run=dry_run)
+    except ValueError as exc:
+        raise NotionConfigurationError(str(exc)) from exc
+    except Exception as exc:
+        if _is_notion_api_error(exc):
+            raise NotionAPIError(_friendly_notion_error_message(exc)) from exc
+        raise
+
+    for name, expected, actual in result.conflicts:
+        logger.warning("Property %r has type %s, expected %s — left unchanged.", name, actual, expected)
+    if not result.to_add:
+        logger.info("Registry database schema is up to date.")
+    elif dry_run:
+        for name in result.to_add:
+            logger.info("[dry-run] would add property: %s", name)
+        logger.info("[dry-run] %d propert(ies) would be added.", len(result.to_add))
+    else:
+        for name in result.to_add:
+            logger.info("✓ Added property: %s", name)
+        logger.info("✓ Repaired registry database: added %d propert(ies).", len(result.to_add))
+    return result

--- a/src/cja_auto_sdr/output/writers/notion.py
+++ b/src/cja_auto_sdr/output/writers/notion.py
@@ -688,18 +688,37 @@ def prune_notion_orphans(
 
 
 def repair_notion_database(
-    database_id: str,
+    database_id: str | None,
     logger: logging.Logger,
     *,
     dry_run: bool = False,
 ):
     """Reconcile an existing registry database with the canonical schema.
 
-    Needs only NOTION_TOKEN. Returns the SchemaRepairResult. Raises
-    NotionConfigurationError / NotionDependencyError / NotionAPIError (the CLI
-    maps these to exit 1).
+    The database id may be passed explicitly or resolved from NOTION_DATABASE_ID
+    (environment or ``.env``). Needs only NOTION_TOKEN. Returns the
+    SchemaRepairResult. Raises NotionConfigurationError / NotionDependencyError /
+    NotionAPIError (the CLI maps these to exit 1).
     """
     from cja_auto_sdr.output.notion_database import repair_database_schema
+
+    # Load .env first so a NOTION_DATABASE_ID configured there is visible. The
+    # database id is resolved before the token check so the missing-database-id
+    # error wins when neither is set. resolve_notion_credentials loads .env too
+    # (idempotent), but it runs later, so do it here for the id lookup.
+    try:
+        from dotenv import load_dotenv
+
+        load_dotenv()
+    except ImportError:
+        pass
+
+    database_id = database_id or os.environ.get("NOTION_DATABASE_ID")
+    if not database_id:
+        raise NotionConfigurationError(
+            "--notion-repair-database requires a database id. Pass --notion-database-id <id> or set "
+            "NOTION_DATABASE_ID (or use --notion-create-database to bootstrap a new registry).",
+        )
 
     token, _ = resolve_notion_credentials(require_parent=False)
     client = _build_client(_require_notion_client(), token)

--- a/src/cja_auto_sdr/output/writers/notion.py
+++ b/src/cja_auto_sdr/output/writers/notion.py
@@ -713,9 +713,28 @@ def repair_notion_database(
         raise
 
     for name, expected, actual in result.conflicts:
-        logger.warning("Property %r has type %s, expected %s — left unchanged.", name, actual, expected)
+        if actual == "missing":
+            logger.warning(
+                "Property %r is absent — the database's title column has a different name. "
+                "Rename it to %r in Notion (repair cannot rename properties).",
+                name,
+                name,
+            )
+        else:
+            logger.warning(
+                "Property %r: expected %s, found %s — left unchanged (resolve manually).",
+                name,
+                expected,
+                actual,
+            )
     if not result.to_add:
-        logger.info("Registry database schema is up to date.")
+        if result.conflicts:
+            logger.info(
+                "No properties to add, but %d schema conflict(s) above need manual resolution.",
+                len(result.conflicts),
+            )
+        else:
+            logger.info("Registry database schema is up to date.")
     elif dry_run:
         for name in result.to_add:
             logger.info("[dry-run] would add property: %s", name)

--- a/tests/README.md
+++ b/tests/README.md
@@ -163,10 +163,11 @@ tests/
 ├── test_notion_org_publisher.py     # --org-report --format notion catalog publisher tests
 ├── test_notion_registry_v2.py       # Notion registry v2 schema and legacy v1 migration tests
 ├── test_cli_notion_prune.py         # CLI flag wiring for --notion-prune-orphans
+├── test_cli_notion_repair.py        # CLI flag wiring for --notion-repair-database and --notion-print-database-schema
 └── README.md                        # This file
 ```
 
-**Total: 8,226 comprehensive tests**
+**Total: 8,248 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -175,16 +176,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 8,120 | 148 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 8,142 | 149 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 0 | 0 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **8,226** | **154** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **8,248** | **155** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 8,120 | 148 | `-m "unit and not slow"` |
+| `test-unit` | 8,142 | 149 | `-m "unit and not slow"` |
 | `test-integration` | 96 | 5 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -340,15 +341,16 @@ tests/
 | `test_watch_dispatch.py` | 2 | End-to-end dispatch wiring tests |
 | `test_watch_logging.py` | 4 | Structured-log event emission tests |
 | `test_notion_registry.py` | 14 | Notion page ID registry CRUD tests |
-| `test_notion_writer.py` | 67 | Notion block builder + API layer tests |
+| `test_notion_writer.py` | 70 | Notion block builder + API layer tests |
 | `test_cli_notion.py` | 28 | CLI flag wiring for --format notion and --push-to-notion |
 | `test_push_to_notion.py` | 5 | --push-to-notion JSON ingest and error paths |
 | `test_cli_notion_database.py` | 32 | CLI flag wiring for --notion-create-database and --notion-database-id |
-| `test_notion_database.py` | 25 | Notion database creation and upsert tests |
+| `test_notion_database.py` | 32 | Notion database creation and upsert tests |
 | `test_notion_org_publisher.py` | 10 | --org-report --format notion catalog publisher tests |
 | `test_notion_registry_v2.py` | 11 | Notion registry v2 schema and legacy v1 migration tests |
 | `test_cli_notion_prune.py` | 20 | CLI flag wiring for --notion-prune-orphans |
-| **Total** | **8,226** | **Collected via pytest --collect-only** |
+| `test_cli_notion_repair.py` | 12 | CLI flag wiring for --notion-repair-database and --notion-print-database-schema |
+| **Total** | **8,248** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -806,7 +808,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (8,226 tests total)
+- [x] Comprehensive test coverage (8,248 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 78 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -167,7 +167,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 8,252 comprehensive tests**
+**Total: 8,254 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -176,16 +176,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 8,146 | 149 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 8,148 | 149 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 0 | 0 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **8,252** | **155** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **8,254** | **155** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 8,146 | 149 | `-m "unit and not slow"` |
+| `test-unit` | 8,148 | 149 | `-m "unit and not slow"` |
 | `test-integration` | 96 | 5 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -349,8 +349,8 @@ tests/
 | `test_notion_org_publisher.py` | 10 | --org-report --format notion catalog publisher tests |
 | `test_notion_registry_v2.py` | 11 | Notion registry v2 schema and legacy v1 migration tests |
 | `test_cli_notion_prune.py` | 20 | CLI flag wiring for --notion-prune-orphans |
-| `test_cli_notion_repair.py` | 12 | CLI flag wiring for --notion-repair-database and --notion-print-database-schema |
-| **Total** | **8,252** | **Collected via pytest --collect-only** |
+| `test_cli_notion_repair.py` | 14 | CLI flag wiring for --notion-repair-database and --notion-print-database-schema |
+| **Total** | **8,254** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -808,7 +808,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (8,252 tests total)
+- [x] Comprehensive test coverage (8,254 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 78 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -167,7 +167,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 8,251 comprehensive tests**
+**Total: 8,252 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -176,16 +176,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 8,145 | 149 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 8,146 | 149 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 0 | 0 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **8,251** | **155** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **8,252** | **155** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 8,145 | 149 | `-m "unit and not slow"` |
+| `test-unit` | 8,146 | 149 | `-m "unit and not slow"` |
 | `test-integration` | 96 | 5 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -341,7 +341,7 @@ tests/
 | `test_watch_dispatch.py` | 2 | End-to-end dispatch wiring tests |
 | `test_watch_logging.py` | 4 | Structured-log event emission tests |
 | `test_notion_registry.py` | 14 | Notion page ID registry CRUD tests |
-| `test_notion_writer.py` | 72 | Notion block builder + API layer tests |
+| `test_notion_writer.py` | 73 | Notion block builder + API layer tests |
 | `test_cli_notion.py` | 28 | CLI flag wiring for --format notion and --push-to-notion |
 | `test_push_to_notion.py` | 5 | --push-to-notion JSON ingest and error paths |
 | `test_cli_notion_database.py` | 32 | CLI flag wiring for --notion-create-database and --notion-database-id |
@@ -350,7 +350,7 @@ tests/
 | `test_notion_registry_v2.py` | 11 | Notion registry v2 schema and legacy v1 migration tests |
 | `test_cli_notion_prune.py` | 20 | CLI flag wiring for --notion-prune-orphans |
 | `test_cli_notion_repair.py` | 12 | CLI flag wiring for --notion-repair-database and --notion-print-database-schema |
-| **Total** | **8,251** | **Collected via pytest --collect-only** |
+| **Total** | **8,252** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -808,7 +808,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (8,251 tests total)
+- [x] Comprehensive test coverage (8,252 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 78 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -167,7 +167,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 8,249 comprehensive tests**
+**Total: 8,251 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -176,16 +176,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 8,143 | 149 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 8,145 | 149 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 0 | 0 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **8,249** | **155** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **8,251** | **155** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 8,143 | 149 | `-m "unit and not slow"` |
+| `test-unit` | 8,145 | 149 | `-m "unit and not slow"` |
 | `test-integration` | 96 | 5 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -341,16 +341,16 @@ tests/
 | `test_watch_dispatch.py` | 2 | End-to-end dispatch wiring tests |
 | `test_watch_logging.py` | 4 | Structured-log event emission tests |
 | `test_notion_registry.py` | 14 | Notion page ID registry CRUD tests |
-| `test_notion_writer.py` | 71 | Notion block builder + API layer tests |
+| `test_notion_writer.py` | 72 | Notion block builder + API layer tests |
 | `test_cli_notion.py` | 28 | CLI flag wiring for --format notion and --push-to-notion |
 | `test_push_to_notion.py` | 5 | --push-to-notion JSON ingest and error paths |
 | `test_cli_notion_database.py` | 32 | CLI flag wiring for --notion-create-database and --notion-database-id |
-| `test_notion_database.py` | 32 | Notion database creation and upsert tests |
+| `test_notion_database.py` | 33 | Notion database creation and upsert tests |
 | `test_notion_org_publisher.py` | 10 | --org-report --format notion catalog publisher tests |
 | `test_notion_registry_v2.py` | 11 | Notion registry v2 schema and legacy v1 migration tests |
 | `test_cli_notion_prune.py` | 20 | CLI flag wiring for --notion-prune-orphans |
 | `test_cli_notion_repair.py` | 12 | CLI flag wiring for --notion-repair-database and --notion-print-database-schema |
-| **Total** | **8,249** | **Collected via pytest --collect-only** |
+| **Total** | **8,251** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -808,7 +808,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (8,249 tests total)
+- [x] Comprehensive test coverage (8,251 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 78 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -167,7 +167,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 8,248 comprehensive tests**
+**Total: 8,249 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -176,16 +176,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 8,142 | 149 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 8,143 | 149 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 0 | 0 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **8,248** | **155** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **8,249** | **155** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 8,142 | 149 | `-m "unit and not slow"` |
+| `test-unit` | 8,143 | 149 | `-m "unit and not slow"` |
 | `test-integration` | 96 | 5 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -341,7 +341,7 @@ tests/
 | `test_watch_dispatch.py` | 2 | End-to-end dispatch wiring tests |
 | `test_watch_logging.py` | 4 | Structured-log event emission tests |
 | `test_notion_registry.py` | 14 | Notion page ID registry CRUD tests |
-| `test_notion_writer.py` | 70 | Notion block builder + API layer tests |
+| `test_notion_writer.py` | 71 | Notion block builder + API layer tests |
 | `test_cli_notion.py` | 28 | CLI flag wiring for --format notion and --push-to-notion |
 | `test_push_to_notion.py` | 5 | --push-to-notion JSON ingest and error paths |
 | `test_cli_notion_database.py` | 32 | CLI flag wiring for --notion-create-database and --notion-database-id |
@@ -350,7 +350,7 @@ tests/
 | `test_notion_registry_v2.py` | 11 | Notion registry v2 schema and legacy v1 migration tests |
 | `test_cli_notion_prune.py` | 20 | CLI flag wiring for --notion-prune-orphans |
 | `test_cli_notion_repair.py` | 12 | CLI flag wiring for --notion-repair-database and --notion-print-database-schema |
-| **Total** | **8,248** | **Collected via pytest --collect-only** |
+| **Total** | **8,249** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -808,7 +808,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (8,248 tests total)
+- [x] Comprehensive test coverage (8,249 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 78 tests

--- a/tests/test_cli_notion_repair.py
+++ b/tests/test_cli_notion_repair.py
@@ -1,0 +1,82 @@
+"""CLI wiring for --notion-repair-database and --notion-print-database-schema (v3.10.0)."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from cja_auto_sdr.cli.parser import parse_arguments
+from cja_auto_sdr.cli.standalone_policy import standalone_prevalidation_policy
+from cja_auto_sdr.generator import (
+    RunMode,
+    _infer_run_mode_enum,
+    _main_impl,
+    _validate_semantic_flag_relationships,
+)
+
+
+def test_flags_parse() -> None:
+    assert parse_arguments(["--notion-repair-database"]).notion_repair_database is True
+    assert parse_arguments(["--notion-print-database-schema"]).notion_print_database_schema is True
+    assert parse_arguments(["dv1"]).notion_repair_database is False
+
+
+def test_modes_inferred() -> None:
+    assert _infer_run_mode_enum(parse_arguments(["--notion-repair-database"])) is RunMode.NOTION_REPAIR_DATABASE
+    assert _infer_run_mode_enum(parse_arguments(["--notion-print-database-schema"])) is RunMode.NOTION_PRINT_SCHEMA
+
+
+def test_print_schema_wins_over_other_modes() -> None:
+    # Informational; must take precedence so it is never silently dropped.
+    args = parse_arguments(["--notion-print-database-schema", "--list-dataviews"])
+    assert _infer_run_mode_enum(args) is RunMode.NOTION_PRINT_SCHEMA
+
+
+def test_standalone_policies_registered() -> None:
+    assert standalone_prevalidation_policy("notion_repair_database") is not None
+    assert standalone_prevalidation_policy("notion_print_schema") is not None
+
+
+def test_print_schema_outputs_schema_no_creds(capsys, monkeypatch) -> None:
+    monkeypatch.delenv("NOTION_TOKEN", raising=False)
+    monkeypatch.setattr(sys, "argv", ["cja_auto_sdr", "--notion-print-database-schema"])
+    with pytest.raises(SystemExit) as exc:
+        _main_impl()
+    assert exc.value.code == 0
+    assert "CJA SDR Registry — database schema" in capsys.readouterr().out
+
+
+def test_repair_requires_database_id(capsys, monkeypatch) -> None:
+    monkeypatch.delenv("NOTION_DATABASE_ID", raising=False)
+    monkeypatch.setattr(sys, "argv", ["cja_auto_sdr", "--notion-repair-database"])
+    with pytest.raises(SystemExit) as exc:
+        _main_impl()
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "--notion-database-id" in err or "NOTION_DATABASE_ID" in err
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["--notion-repair-database", "--org-report"],
+        ["--notion-repair-database", "--list-dataviews"],
+        ["--notion-repair-database", "--batch", "dv1", "dv2"],
+        ["--notion-repair-database", "dv_123"],
+    ],
+)
+def test_repair_rejects_other_commands(argv, capsys) -> None:
+    args = parse_arguments(argv)
+    inferred = _infer_run_mode_enum(args)
+    with pytest.raises(SystemExit) as exc:
+        _validate_semantic_flag_relationships(args, inferred_mode=inferred)
+    assert exc.value.code == 1
+    assert "--notion-repair-database" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("argv", [["--notion-repair-database"], ["--notion-repair-database", "--dry-run"]])
+def test_repair_alone_passes_validation(argv) -> None:
+    args = parse_arguments(argv)
+    assert _infer_run_mode_enum(args) is RunMode.NOTION_REPAIR_DATABASE
+    _validate_semantic_flag_relationships(args, inferred_mode=RunMode.NOTION_REPAIR_DATABASE)

--- a/tests/test_cli_notion_repair.py
+++ b/tests/test_cli_notion_repair.py
@@ -64,6 +64,8 @@ def test_repair_requires_database_id(capsys, monkeypatch) -> None:
         ["--notion-repair-database", "--list-dataviews"],
         ["--notion-repair-database", "--batch", "dv1", "dv2"],
         ["--notion-repair-database", "dv_123"],
+        ["--notion-repair-database", "--notion-prune-orphans"],
+        ["--notion-repair-database", "--notion-create-database"],
     ],
 )
 def test_repair_rejects_other_commands(argv, capsys) -> None:

--- a/tests/test_notion_database.py
+++ b/tests/test_notion_database.py
@@ -365,3 +365,22 @@ def test_data_quality_schema_options_derive_from_constant() -> None:
 
     names = [o["name"] for o in DATABASE_SCHEMA["Data Quality"]["select"]["options"]]
     assert names == DATA_QUALITY_OPTIONS
+
+
+def test_schema_property_type_reads_single_type_key() -> None:
+    from cja_auto_sdr.output.notion_database import _schema_property_type
+
+    assert _schema_property_type({"rich_text": {}}) == "rich_text"
+    assert _schema_property_type({"number": {"format": "number"}}) == "number"
+    assert _schema_property_type({"select": {"options": []}}) == "select"
+
+
+def test_describe_database_schema_lists_every_property_with_type() -> None:
+    from cja_auto_sdr.output.notion_database import DATABASE_SCHEMA, _schema_property_type, describe_database_schema
+
+    text = describe_database_schema()
+    for name, entry in DATABASE_SCHEMA.items():
+        assert name in text
+        assert _schema_property_type(entry) in text
+    # select options are shown for Data Quality
+    assert "healthy" in text and "unknown" in text

--- a/tests/test_notion_database.py
+++ b/tests/test_notion_database.py
@@ -466,3 +466,17 @@ def test_repair_raises_when_no_data_source() -> None:
     client.databases.retrieve.return_value = {"id": "db1", "data_sources": []}
     with pytest.raises(ValueError, match="no data source"):
         repair_database_schema(client, database_id="db1")
+
+
+def test_repair_flags_absent_canonical_title_as_conflict() -> None:
+    """A renamed/absent title ('Name' not in live) is reported as a conflict, not silently skipped."""
+    from cja_auto_sdr.output.notion_database import DATABASE_SCHEMA, _schema_property_type, repair_database_schema
+
+    # Every canonical property present EXCEPT the title 'Name' (title was renamed).
+    existing = {n: {"type": _schema_property_type(e)} for n, e in DATABASE_SCHEMA.items() if n != "Name"}
+    existing["Report"] = {"type": "title"}  # the DB's title under a different name
+    result = repair_database_schema(_fake_repair_client(existing, capture={}), database_id="db1")
+
+    assert ("Name", "title", "missing") in result.conflicts
+    assert "Name" not in result.to_add
+    assert result.applied is False

--- a/tests/test_notion_database.py
+++ b/tests/test_notion_database.py
@@ -384,3 +384,85 @@ def test_describe_database_schema_lists_every_property_with_type() -> None:
         assert _schema_property_type(entry) in text
     # select options are shown for Data Quality
     assert "healthy" in text and "unknown" in text
+
+
+# ---------------------------------------------------------------------------
+# repair_database_schema
+# ---------------------------------------------------------------------------
+
+
+def _fake_repair_client(existing_props: dict, *, capture: dict):
+    """A MagicMock client whose data source exposes existing_props and records updates."""
+    client = MagicMock()
+    client.databases.retrieve.return_value = {"id": "db1", "data_sources": [{"id": "ds1"}]}
+    client.data_sources.retrieve.return_value = {"properties": existing_props}
+
+    def _update(*, data_source_id, properties):
+        capture["data_source_id"] = data_source_id
+        capture["properties"] = properties
+        return {"id": data_source_id}
+
+    client.data_sources.update.side_effect = _update
+    return client
+
+
+def test_repair_adds_missing_non_title_properties() -> None:
+    from cja_auto_sdr.output.notion_database import DATABASE_SCHEMA, repair_database_schema
+
+    # Live DB has only Name (title) + Data View ID; everything else is missing.
+    existing = {"Name": {"type": "title"}, "Data View ID": {"type": "rich_text"}}
+    cap: dict = {}
+    client = _fake_repair_client(existing, capture=cap)
+
+    result = repair_database_schema(client, database_id="db1")
+
+    expected_missing = [n for n in DATABASE_SCHEMA if n not in existing]  # excludes Name + Data View ID
+    assert result.to_add == expected_missing
+    assert result.applied is True
+    assert set(cap["properties"].keys()) == set(expected_missing)
+    assert "Name" not in cap["properties"]  # never re-adds the title
+
+
+def test_repair_dry_run_makes_no_update() -> None:
+    from cja_auto_sdr.output.notion_database import repair_database_schema
+
+    client = _fake_repair_client({"Name": {"type": "title"}}, capture={})
+    result = repair_database_schema(client, database_id="db1", dry_run=True)
+
+    assert result.to_add  # things are missing
+    assert result.applied is False
+    client.data_sources.update.assert_not_called()
+
+
+def test_repair_records_type_conflicts_without_changing_them() -> None:
+    from cja_auto_sdr.output.notion_database import repair_database_schema
+
+    # Metrics Count exists but as rich_text instead of number.
+    existing = {"Name": {"type": "title"}, "Metrics Count": {"type": "rich_text"}}
+    cap: dict = {}
+    client = _fake_repair_client(existing, capture=cap)
+
+    result = repair_database_schema(client, database_id="db1")
+
+    assert ("Metrics Count", "number", "rich_text") in result.conflicts
+    assert "Metrics Count" not in cap.get("properties", {})  # conflict never added/changed
+
+
+def test_repair_up_to_date_does_nothing() -> None:
+    from cja_auto_sdr.output.notion_database import DATABASE_SCHEMA, _schema_property_type, repair_database_schema
+
+    existing = {name: {"type": _schema_property_type(entry)} for name, entry in DATABASE_SCHEMA.items()}
+    client = _fake_repair_client(existing, capture={})
+    result = repair_database_schema(client, database_id="db1")
+
+    assert result.to_add == [] and result.conflicts == [] and result.applied is False
+    client.data_sources.update.assert_not_called()
+
+
+def test_repair_raises_when_no_data_source() -> None:
+    from cja_auto_sdr.output.notion_database import repair_database_schema
+
+    client = MagicMock()
+    client.databases.retrieve.return_value = {"id": "db1", "data_sources": []}
+    with pytest.raises(ValueError, match="no data source"):
+        repair_database_schema(client, database_id="db1")

--- a/tests/test_notion_writer.py
+++ b/tests/test_notion_writer.py
@@ -1101,3 +1101,22 @@ def test_repair_notion_database_maps_value_error(monkeypatch):
     with patch("cja_auto_sdr.output.writers.notion._require_notion_client", return_value=fake_cls):
         with pytest.raises(NotionConfigurationError, match="no data source"):
             repair_notion_database("db1", MagicMock())
+
+
+def test_repair_notion_database_maps_api_error(monkeypatch):
+    """databases.retrieve raising an API error surfaces as NotionAPIError."""
+    from cja_auto_sdr.output.writers.notion import NotionAPIError, repair_notion_database
+
+    monkeypatch.setenv("NOTION_TOKEN", "tok")
+
+    class FakeAPIError(Exception):
+        code = "object_not_found"
+
+    FakeAPIError.__name__ = "APIResponseError"
+
+    fake_cls = MagicMock()
+    fake_cls.return_value.databases.retrieve.side_effect = FakeAPIError("not found")
+
+    with patch("cja_auto_sdr.output.writers.notion._require_notion_client", return_value=fake_cls):
+        with pytest.raises(NotionAPIError):
+            repair_notion_database("db1", MagicMock())

--- a/tests/test_notion_writer.py
+++ b/tests/test_notion_writer.py
@@ -1120,3 +1120,29 @@ def test_repair_notion_database_maps_api_error(monkeypatch):
     with patch("cja_auto_sdr.output.writers.notion._require_notion_client", return_value=fake_cls):
         with pytest.raises(NotionAPIError):
             repair_notion_database("db1", MagicMock())
+
+
+def test_repair_notion_database_conflict_only_not_called_up_to_date(monkeypatch):
+    """Conflicts but nothing to add must NOT log 'up to date' (Codex P2): the schema is not clean."""
+    from cja_auto_sdr.output.notion_database import DATABASE_SCHEMA, _schema_property_type
+    from cja_auto_sdr.output.writers.notion import repair_notion_database
+
+    monkeypatch.setenv("NOTION_TOKEN", "tok")
+
+    live = {n: {"type": _schema_property_type(e)} for n, e in DATABASE_SCHEMA.items()}
+    live["Metrics Count"] = {"type": "rich_text"}  # conflict; nothing missing
+
+    fake_cls = MagicMock()
+    fc = fake_cls.return_value
+    fc.databases.retrieve.return_value = {"id": "db1", "data_sources": [{"id": "ds1"}]}
+    fc.data_sources.retrieve.return_value = {"properties": live}
+    logger = MagicMock()
+
+    with patch("cja_auto_sdr.output.writers.notion._require_notion_client", return_value=fake_cls):
+        result = repair_notion_database("db1", logger)
+
+    assert result.to_add == [] and result.conflicts
+    fc.data_sources.update.assert_not_called()
+    info_msgs = " ".join(str(c.args[0]) for c in logger.info.call_args_list)
+    assert "up to date" not in info_msgs
+    assert "manual resolution" in info_msgs

--- a/tests/test_notion_writer.py
+++ b/tests/test_notion_writer.py
@@ -1146,3 +1146,22 @@ def test_repair_notion_database_conflict_only_not_called_up_to_date(monkeypatch)
     info_msgs = " ".join(str(c.args[0]) for c in logger.info.call_args_list)
     assert "up to date" not in info_msgs
     assert "manual resolution" in info_msgs
+
+
+def test_repair_notion_database_resolves_db_id_from_env(monkeypatch):
+    """With no explicit id, repair falls back to NOTION_DATABASE_ID from the env/.env (Codex P2)."""
+    from cja_auto_sdr.output.writers.notion import repair_notion_database
+
+    monkeypatch.setenv("NOTION_TOKEN", "tok")
+    monkeypatch.setenv("NOTION_DATABASE_ID", "db-from-env")
+
+    fake_cls = MagicMock()
+    fc = fake_cls.return_value
+    fc.databases.retrieve.return_value = {"id": "db-from-env", "data_sources": [{"id": "ds1"}]}
+    fc.data_sources.retrieve.return_value = {"properties": {"Name": {"type": "title"}}}
+
+    with patch("cja_auto_sdr.output.writers.notion._require_notion_client", return_value=fake_cls):
+        repair_notion_database(None, MagicMock())  # no explicit id → resolved from env
+
+    fc.databases.retrieve.assert_called_once()
+    assert fc.databases.retrieve.call_args.kwargs["database_id"] == "db-from-env"

--- a/tests/test_notion_writer.py
+++ b/tests/test_notion_writer.py
@@ -1048,3 +1048,56 @@ def test_prune_orphans_object_not_found_is_cleared(tmp_path, monkeypatch):
 
     assert (archived, gone) == (0, 1)
     assert lookup_orphaned_page_ids(reg, "dv1") == []  # dead id removed anyway
+
+
+# ---------------------------------------------------------------------------
+# Task 3: repair_notion_database tests
+# ---------------------------------------------------------------------------
+
+
+def test_repair_notion_database_applies(tmp_path, monkeypatch):
+    from cja_auto_sdr.output.writers.notion import repair_notion_database
+
+    monkeypatch.setenv("NOTION_TOKEN", "tok")
+    monkeypatch.delenv("NOTION_PARENT_PAGE_ID", raising=False)  # not required
+
+    fake_cls = MagicMock()
+    fake_client = fake_cls.return_value
+    fake_client.databases.retrieve.return_value = {"id": "db1", "data_sources": [{"id": "ds1"}]}
+    fake_client.data_sources.retrieve.return_value = {"properties": {"Name": {"type": "title"}}}
+    fake_client.data_sources.update.return_value = {"id": "ds1"}
+
+    with patch("cja_auto_sdr.output.writers.notion._require_notion_client", return_value=fake_cls):
+        result = repair_notion_database("db1", MagicMock())
+
+    assert result.applied is True
+    assert fake_client.data_sources.update.call_count == 1
+
+
+def test_repair_notion_database_dry_run_no_update(tmp_path, monkeypatch):
+    from cja_auto_sdr.output.writers.notion import repair_notion_database
+
+    monkeypatch.setenv("NOTION_TOKEN", "tok")
+
+    fake_cls = MagicMock()
+    fake_client = fake_cls.return_value
+    fake_client.databases.retrieve.return_value = {"id": "db1", "data_sources": [{"id": "ds1"}]}
+    fake_client.data_sources.retrieve.return_value = {"properties": {"Name": {"type": "title"}}}
+
+    with patch("cja_auto_sdr.output.writers.notion._require_notion_client", return_value=fake_cls):
+        result = repair_notion_database("db1", MagicMock(), dry_run=True)
+
+    assert result.applied is False
+    fake_client.data_sources.update.assert_not_called()
+
+
+def test_repair_notion_database_maps_value_error(monkeypatch):
+    from cja_auto_sdr.output.writers.notion import NotionConfigurationError, repair_notion_database
+
+    monkeypatch.setenv("NOTION_TOKEN", "tok")
+
+    fake_cls = MagicMock()
+    fake_cls.return_value.databases.retrieve.return_value = {"id": "db1", "data_sources": []}
+    with patch("cja_auto_sdr.output.writers.notion._require_notion_client", return_value=fake_cls):
+        with pytest.raises(NotionConfigurationError, match="no data source"):
+            repair_notion_database("db1", MagicMock())

--- a/tests/test_output_content_validation.py
+++ b/tests/test_output_content_validation.py
@@ -38,7 +38,7 @@ def rich_data_dict():
         "Metadata": pd.DataFrame(
             {
                 "Property": ["Generated At", "Data View ID", "Tool Version", "Total Metrics"],
-                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.9.0", 3],
+                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.10.0", 3],
             },
         ),
         "Data Quality": pd.DataFrame(
@@ -104,7 +104,7 @@ def rich_metadata_dict():
         "Generated At": "2025-01-15 10:30:00 PST",
         "Data View ID": "dv_content_test",
         "Data View Name": "Test DataView",
-        "Tool Version": "3.9.0",
+        "Tool Version": "3.10.0",
         "Metrics Count": "3",
         "Dimensions Count": "4",
     }
@@ -224,7 +224,7 @@ class TestJSONContentValidation:
             data = json.load(f)
 
         assert data["metadata"]["Data View ID"] == "dv_content_test"
-        assert data["metadata"]["Tool Version"] == "3.9.0"
+        assert data["metadata"]["Tool Version"] == "3.10.0"
 
     def test_json_metadata_preserves_partial_markers(self, tmp_path, rich_data_dict, rich_metadata_dict):
         logger = logging.getLogger("json_test")

--- a/tests/test_ux_features.py
+++ b/tests/test_ux_features.py
@@ -344,11 +344,11 @@ class TestCombinedFeatures:
 class TestVersionUpdated:
     """Test that version is correct"""
 
-    def test_version_is_3_9_0(self):
-        """Test that version is 3.9.0"""
+    def test_version_is_3_10_0(self):
+        """Test that version is 3.10.0"""
         from cja_auto_sdr.generator import __version__
 
-        assert __version__ == "3.9.0"
+        assert __version__ == "3.10.0"
 
 
 class TestFormatAutoDetection:


### PR DESCRIPTION
## Summary

Adds two Notion registry-database maintenance commands, bringing cja_auto_sdr to parity with aa_auto_sdr's repair/schema tooling (tailored for the CJA registry):

- **`--notion-repair-database`** — reconcile an existing CJA SDR Registry database with the canonical schema. It adds any missing properties with a single `data_sources.update` and reports properties whose type differs, **without changing or removing** anything that exists (and never touches rows). Needs only `NOTION_TOKEN` and a database id (`--notion-database-id` or `NOTION_DATABASE_ID`); combine with `--dry-run` to preview.
- **`--notion-print-database-schema`** — print the canonical registry schema (property names and types) and exit. Needs no credentials.

This closes a real gap: `ensure_database` previously hard-failed on a schema-incomplete database with no way to fix it short of recreating it (which loses rows and page links). That error now names `--notion-repair-database` as the remedy.

Built subagent-driven from the spec + plan in `docs/superpowers/` (implementer + reviewer per task, final whole-branch review).

## Design decisions

- **Add-only** — repair adds missing properties; type conflicts are reported, never changed; properties are never removed; rows are never modified.
- **Title-safe** — the title is never added (a database always has exactly one); a property named `Name` that is not a title is reported as a conflict.
- **Precedence** — `--notion-print-database-schema` outranks all real modes so it is never silently dropped; `--notion-repair-database` sits before `DRY_RUN` so `--dry-run` is a sub-flag, and it fails closed when combined with any other command.
- The standalone policies deliberately do not clear the mode flags (the bug Codex caught on prune), and the repair dispatch configures a console logger so its output is visible.

## Tests

- Schema introspection, `repair_database_schema` (add-only, conflicts, title-safe, dry-run no-write, no-data-source raise), orchestration (token-only, error mapping incl. API-error → NotionAPIError), and CLI wiring (both flags, precedence, conflict guard, no-db-id exit, print-schema needs no creds).
- Full suite **8233 passed, 16 skipped** (8249 collected); coverage gate, version-sync (3.10.0), and lint all clean.

## Reviews

Per-task reviews (spec + quality) plus a final whole-branch review (Opus): **READY**, no Critical or Important code issues. The final review's doc-sync finding (AGENT_AUTOMATION) and the tracked API-error test gap were fixed in this branch.

## Live smoke — DONE ✅ (run 2026-06-21 against the cja_auto_sdr TEST page)

Ran end to end with real Notion credentials. Bootstrapped a test registry database under the TEST page (`384e94feda1680e6becffa87a1a26153`), exercised every path, and verified each result directly via the Notion API. All checks passed.

- [x] **Print schema** — `--notion-print-database-schema` listed all 14 properties with types (and the Data Quality select options), exit 0. Confirmed it works with `NOTION_TOKEN` unset (no credentials read).
- [x] **Remove a property** — deleted the `Timezone` column from the test database via the API (count 14 → 13).
- [x] **Dry-run repair** — `--notion-repair-database --dry-run` printed "[dry-run] would add property: Timezone", exit 0, and made no change (verified `Timezone` still absent).
- [x] **Repair** — `--notion-repair-database` added `Timezone` back as `rich_text` (count → 14), exit 0. Re-run printed "Registry database schema is up to date."
- [x] **Token-only** — removed `Timezone` again and repaired with `NOTION_PARENT_PAGE_ID` explicitly unset; it added the property and exited 0 (no parent page required).
- [x] **No database id** — `--notion-repair-database` with no id configured exited 1: "requires a database id. Pass --notion-database-id <id> or set NOTION_DATABASE_ID (or use --notion-create-database to bootstrap a new registry)."
- [x] **Conflict reporting** — changed `Metrics Count` to `rich_text` in Notion; repair reported "Property 'Metrics Count' has type rich_text, expected number — left unchanged.", exit 0, and the property was **not** changed (verified still `rich_text`). Confirms the add-only guarantee.
- [x] **Cross-flag rejections** — `--org-report` and `--list-dataviews` (higher-precedence) exited 1 with "standalone maintenance command"; `--batch` and a positional data view exited 1 with "positional data view arguments".

All test artifacts (the bootstrapped database and its detail page) were archived to the Notion trash afterward, so the TEST page is left clean.

Ready to come out of draft for merge + the v3.10.0 tag/release.
