### PR TITLE
chore: refresh README coverage badge to 98%

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Lint](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/lint.yml/badge.svg)](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/lint.yml)
 [![Version Sync](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/version-sync.yml/badge.svg)](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/version-sync.yml)
 [![Python 3.14+](https://img.shields.io/badge/python-3.14%2B-blue.svg)](https://www.python.org/downloads/)
-[![Coverage](https://img.shields.io/badge/coverage-99%25-brightgreen.svg)](tests/)
+[![Coverage](https://img.shields.io/badge/coverage-98%25-brightgreen.svg)](tests/)
 [![Tests](https://img.shields.io/badge/tests-8254-brightgreen.svg)](tests/)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)


### PR DESCRIPTION
The static coverage badge read **99%**, but the actual unit-slice coverage (the gate methodology — `pytest -m "unit and not slow" --cov=cja_auto_sdr --cov-fail-under=95`) is **98%** (21,124 statements, 331 missed). Confirmed locally; matches what the `update-badges` bot computed.

Applying it via a normal PR so the required checks run — bot-authored PRs (opened with `GITHUB_TOKEN`) don't trigger them, which is why the bot's PR #86 couldn't merge. Once this lands, main's coverage badge is accurate, the bot finds no drift, and #86 + the `bot/update-badges` branch can be cleared out.

https://claude.ai/code/session_011to9ekGpfJUaGGWKmUxhTA