### PR TITLE
v3.11.0: --notion-database-title (custom registry database title)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to the CJA SDR Generator project will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.11.0] - 2026-06-22
+
+### Added
+- **`--notion-database-title`** — set a custom title for the database created by `--notion-create-database` (default: "CJA SDR Registry"). Falls back to the `NOTION_DATABASE_TITLE` environment variable. Applies only when a new database is created; ignored when attaching an existing one with `--notion-database-id`.
+
 ## [3.10.0] - 2026-06-21
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,8 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Package manager: **uv**
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
-- Current version: v3.10.0
-- Tests: **8,254** across 155 files at **95% coverage gate**
+- Current version: v3.11.0
+- Tests: **8,258** across 155 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Version Sync](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/version-sync.yml/badge.svg)](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/version-sync.yml)
 [![Python 3.14+](https://img.shields.io/badge/python-3.14%2B-blue.svg)](https://www.python.org/downloads/)
 [![Coverage](https://img.shields.io/badge/coverage-98%25-brightgreen.svg)](tests/)
-[![Tests](https://img.shields.io/badge/tests-8254-brightgreen.svg)](tests/)
+[![Tests](https://img.shields.io/badge/tests-8258-brightgreen.svg)](tests/)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
@@ -481,7 +481,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (8,254+ tests)
+├── tests/                     # Test suite (8,258+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -510,6 +510,7 @@ uv pip install 'cja-auto-sdr[notion]'
 | `--notion-force-new` | Force a new Notion page instead of updating the existing one for this data view | False |
 | `--notion-database-id ID` | ID of the "CJA SDR Registry" database to upsert a row into after publishing. Falls back to the `NOTION_DATABASE_ID` env var. When neither is set, no row is written | - |
 | `--notion-create-database` | Bootstrap a new "CJA SDR Registry" database under `NOTION_PARENT_PAGE_ID`, print its ID to stdout, and exit. Use this ID as `NOTION_DATABASE_ID` for subsequent runs | - |
+| `--notion-database-title NAME` | Title for the database created by `--notion-create-database`. Falls back to the `NOTION_DATABASE_TITLE` env var. Only applies when a new database is created; ignored when attaching an existing one with `--notion-database-id` | `CJA SDR Registry` |
 | `--notion-prune-orphans` | Archive Notion pages that were left behind by `--notion-force-new`. The registry records the superseded page ID each time a new page is forced; this command archives those pages in Notion (moved to Notion trash — recoverable, not permanently deleted) and clears them from the registry. Requires only `NOTION_TOKEN`. Rejected when combined with `--org-report`, `--diff`, `--batch`, `--watch`, or `--push-to-notion`. Combine with `--dry-run` to preview without making changes. **Limitation:** only pages orphaned by `--notion-force-new` from v3.9.0 onward are tracked; pre-existing orphans from earlier runs are not catalogued | - |
 | `--notion-repair-database` | Reconcile an existing "CJA SDR Registry" database with the canonical schema. **Add-only:** adds missing properties and reports any type conflicts — never changes or removes existing properties or data rows. Requires only `NOTION_TOKEN` and a database ID (`--notion-database-id` or `NOTION_DATABASE_ID`). Use when the schema grows across versions instead of recreating the database. Combine with `--dry-run` to preview what would be added without making changes | - |
 | `--notion-print-database-schema` | Print the canonical "CJA SDR Registry" schema (property names and types) and exit. Requires no credentials. Use this to inspect the expected schema before bootstrapping or repairing a database | - |
@@ -749,6 +750,7 @@ Preset flag for running CJA SDR Generator from AI agents, scripts, and automatio
 | `NOTION_TOKEN` | Notion integration token (required for `--format notion` and related flags) |
 | `NOTION_PARENT_PAGE_ID` | Notion page ID under which SDR pages and databases are created |
 | `NOTION_DATABASE_ID` | ID of the "CJA SDR Registry" database; when set, every `--format notion` run upserts a registry row. Falls back to `--notion-database-id`. Unset = no row written |
+| `NOTION_DATABASE_TITLE` | Title for a database created by `--notion-create-database` (default: `CJA SDR Registry`). Overridden by `--notion-database-title`. No effect when attaching an existing database |
 
 **Console & CI Integration:**
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -229,12 +229,13 @@ These variables are used when publishing SDRs to Notion (`--format notion`, `--p
 | `NOTION_TOKEN` | Notion integration token (starts with `secret_`) | **Yes** (for any Notion output) |
 | `NOTION_PARENT_PAGE_ID` | ID of the Notion page under which SDR detail pages are created. Also used as the parent when bootstrapping a new registry database with `--notion-create-database` | **Yes** (for any Notion output) |
 | `NOTION_DATABASE_ID` | ID of an existing "CJA SDR Registry" database. When set, every `--format notion` run upserts the data view's row in the registry with all counts and Data Quality. Unset = no database row written (v3.7.0 behavior preserved). Can also be supplied via `--notion-database-id` | No |
+| `NOTION_DATABASE_TITLE` | Title for a database created by `--notion-create-database` (default: "CJA SDR Registry"). Overridden by `--notion-database-title`. Applies only when a new database is created; ignored when attaching an existing one | No |
 
 > **Bootstrapping `NOTION_DATABASE_ID`:** Run `cja_auto_sdr --notion-create-database` once. It creates a new "CJA SDR Registry" database under `NOTION_PARENT_PAGE_ID` and prints the new database ID to stdout. Copy that value into your environment or `.env` file as `NOTION_DATABASE_ID`, then use it on subsequent runs.
 >
 > **Unset behavior:** If `NOTION_DATABASE_ID` is not set (and `--notion-database-id` is not passed), `--format notion` runs exactly as in v3.7.0 — the SDR detail page is created or updated, but no registry row is written.
 >
-> **Schema drift (v3.10.0):** If the tool adds new registry properties in a later version and your database is missing those columns, run `cja_auto_sdr --notion-repair-database` to add them (add-only — never removes existing properties or rows). Use `--dry-run` to preview first. Run `cja_auto_sdr --notion-print-database-schema` to see the full canonical schema without credentials.
+> **Schema drift (v3.11.0):** If the tool adds new registry properties in a later version and your database is missing those columns, run `cja_auto_sdr --notion-repair-database` to add them (add-only — never removes existing properties or rows). Use `--dry-run` to preview first. Run `cja_auto_sdr --notion-print-database-schema` to see the full canonical schema without credentials.
 
 ### Setting Environment Variables
 
@@ -942,7 +943,7 @@ cja_auto_sdr --list-dataviews --log-level DEBUG
 At launch, the tool logs diagnostic lines containing the tool version, Python version, platform, active log level, inferred run mode (batch, single, or discovery), and dependency versions. These appear automatically at `INFO` level and are useful for troubleshooting environment issues in CI/CD logs or support requests:
 
 ```text
-CJA SDR Generator v3.10.0 | Python 3.14.2 | darwin | log_level=INFO | mode=single
+CJA SDR Generator v3.11.0 | Python 3.14.2 | darwin | log_level=INFO | mode=single
 Dependencies: cjapy=0.3.0, pandas=2.3.3, numpy=2.2.1, xlsxwriter=3.2.9, tqdm=4.67.0
 ```
 

--- a/docs/NOTION_SETUP.md
+++ b/docs/NOTION_SETUP.md
@@ -114,7 +114,7 @@ Run this once:
 cja_auto_sdr --notion-create-database
 ```
 
-This creates a new "CJA SDR Registry" database under `NOTION_PARENT_PAGE_ID`, with the full schema, and prints the new database ID to stdout. Copy that value and set it:
+This creates a new "CJA SDR Registry" database under `NOTION_PARENT_PAGE_ID`, with the full schema, and prints the new database ID to stdout. To give the database a different title, add `--notion-database-title "My Title"` (or set `NOTION_DATABASE_TITLE`); the title only applies when the database is created. Copy the printed database ID and set it:
 
 ```bash
 export NOTION_DATABASE_ID=abc123def456abc123def456abc123de

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -190,7 +190,7 @@ This command:
 
 ```bash
 $ uv run cja_auto_sdr -V
-cja_auto_sdr 3.10.0
+cja_auto_sdr 3.11.0
 ```
 
 > **Important:** All commands in this guide assume you're in the `cja_auto_sdr` directory. If you see "command not found", make sure you're in the right directory and have run `uv sync`.

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Quick Reference Card
 
-Single-page command cheat sheet for CJA SDR Generator v3.10.0.
+Single-page command cheat sheet for CJA SDR Generator v3.11.0.
 
 ## Four Main Modes
 
@@ -580,7 +580,7 @@ cja_auto_sdr --notion-prune-orphans --dry-run --output-dir ./out
 # Archive orphaned pages (moved to Notion trash — recoverable)
 cja_auto_sdr --notion-prune-orphans --output-dir ./out
 
-# --- Registry Schema & Repair (v3.10.0) ---
+# --- Registry Schema & Repair (v3.11.0) ---
 
 # See the canonical registry schema (no credentials required)
 cja_auto_sdr --notion-print-database-schema

--- a/src/cja_auto_sdr/cli/parser.py
+++ b/src/cja_auto_sdr/cli/parser.py
@@ -1482,6 +1482,19 @@ Requirements:
         ),
     )
     notion_group.add_argument(
+        "--notion-database-title",
+        type=str,
+        default=None,
+        metavar="NAME",
+        dest="notion_database_title",
+        help=(
+            "Title for the database created by --notion-create-database "
+            "(default: 'CJA SDR Registry'). Falls back to env var NOTION_DATABASE_TITLE. "
+            "Only applies when a new database is created; ignored when attaching an "
+            "existing one with --notion-database-id."
+        ),
+    )
+    notion_group.add_argument(
         "--notion-print-database-schema",
         action="store_true",
         default=False,

--- a/src/cja_auto_sdr/core/version.py
+++ b/src/cja_auto_sdr/core/version.py
@@ -1,3 +1,3 @@
 """Version information for CJA Auto SDR."""
 
-__version__ = "3.10.0"
+__version__ = "3.11.0"

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -6997,6 +6997,13 @@ def _main_impl(run_state: dict[str, Any] | None = None):
 
     # Parse arguments (will show error and help if no data views provided)
     args = parse_arguments()
+    # --notion-database-title is a convenience for NOTION_DATABASE_TITLE: surface it
+    # in the environment so every create path (single SDR, org-report, push-to-notion)
+    # resolves the new database's title uniformly without threading it through the
+    # pipeline config. The flag wins over a .env value (load_dotenv won't override it).
+    _notion_database_title = getattr(args, "notion_database_title", None)
+    if isinstance(_notion_database_title, str) and _notion_database_title:
+        os.environ["NOTION_DATABASE_TITLE"] = _notion_database_title
     inferred_mode = _infer_run_mode_enum(args)
     active_modes = _active_run_modes(args)
     prevalidation_effective_args = _resolve_semantic_validation_args(args, inferred_mode=inferred_mode)

--- a/src/cja_auto_sdr/output/notion_database.py
+++ b/src/cja_auto_sdr/output/notion_database.py
@@ -17,6 +17,7 @@ metadata.
 from __future__ import annotations
 
 import datetime as _dt
+import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -26,6 +27,7 @@ if TYPE_CHECKING:
     import pandas as pd
 
 __all__ = [
+    "DATABASE_DEFAULT_TITLE",
     "DATABASE_SCHEMA",
     "DATA_QUALITY_OPTIONS",
     "SchemaRepairResult",
@@ -41,6 +43,10 @@ __all__ = [
 
 DATA_QUALITY_OPTIONS = ["healthy", "degraded", "partial", "unknown"]
 _DATA_QUALITY_OPTION_COLORS = {"healthy": "green", "degraded": "red", "partial": "yellow", "unknown": "default"}
+
+# Default title for a freshly-created registry database. Overridable via the
+# --notion-database-title flag or the NOTION_DATABASE_TITLE env var.
+DATABASE_DEFAULT_TITLE = "CJA SDR Registry"
 
 # Notion database property definitions (used at create time).
 DATABASE_SCHEMA: dict[str, dict[str, Any]] = {
@@ -305,10 +311,14 @@ def ensure_database(
             "SDR Registry database under NOTION_PARENT_PAGE_ID.",
         )
 
+    # Title resolves from NOTION_DATABASE_TITLE (which the --notion-database-title
+    # flag populates) and falls back to the default. This runs after .env is
+    # loaded by the calling writer, so a .env-configured title is honored too.
+    title_text = os.environ.get("NOTION_DATABASE_TITLE") or DATABASE_DEFAULT_TITLE
     created = _call_with_rate_limit_retry(
         client.databases.create,
         parent={"type": "page_id", "page_id": parent_page_id},
-        title=[{"type": "text", "text": {"content": "CJA SDR Registry"}}],
+        title=[{"type": "text", "text": {"content": title_text}}],
         initial_data_source={"properties": DATABASE_SCHEMA},
     )
     data_sources = created.get("data_sources") or []

--- a/tests/README.md
+++ b/tests/README.md
@@ -167,7 +167,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 8,254 comprehensive tests**
+**Total: 8,258 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -176,16 +176,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 8,148 | 149 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 8,152 | 149 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 0 | 0 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **8,254** | **155** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **8,258** | **155** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 8,148 | 149 | `-m "unit and not slow"` |
+| `test-unit` | 8,152 | 149 | `-m "unit and not slow"` |
 | `test-integration` | 96 | 5 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -344,13 +344,13 @@ tests/
 | `test_notion_writer.py` | 73 | Notion block builder + API layer tests |
 | `test_cli_notion.py` | 28 | CLI flag wiring for --format notion and --push-to-notion |
 | `test_push_to_notion.py` | 5 | --push-to-notion JSON ingest and error paths |
-| `test_cli_notion_database.py` | 32 | CLI flag wiring for --notion-create-database and --notion-database-id |
-| `test_notion_database.py` | 33 | Notion database creation and upsert tests |
+| `test_cli_notion_database.py` | 34 | CLI flag wiring for --notion-create-database and --notion-database-id |
+| `test_notion_database.py` | 35 | Notion database creation and upsert tests |
 | `test_notion_org_publisher.py` | 10 | --org-report --format notion catalog publisher tests |
 | `test_notion_registry_v2.py` | 11 | Notion registry v2 schema and legacy v1 migration tests |
 | `test_cli_notion_prune.py` | 20 | CLI flag wiring for --notion-prune-orphans |
 | `test_cli_notion_repair.py` | 14 | CLI flag wiring for --notion-repair-database and --notion-print-database-schema |
-| **Total** | **8,254** | **Collected via pytest --collect-only** |
+| **Total** | **8,258** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -808,7 +808,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (8,254 tests total)
+- [x] Comprehensive test coverage (8,258 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 78 tests

--- a/tests/test_cli_notion_database.py
+++ b/tests/test_cli_notion_database.py
@@ -739,3 +739,24 @@ def test_watch_with_notion_rejected_in_watch_mode(capsys) -> None:
     captured = capsys.readouterr()
     assert "--watch is not supported with --format notion" in captured.err
     assert "only supported in SDR generation" not in captured.err
+
+
+def test_notion_database_title_flag_parses() -> None:
+    assert parse_arguments(["--notion-database-title", "X", "dv1"]).notion_database_title == "X"
+    assert parse_arguments(["dv1"]).notion_database_title is None
+
+
+def test_notion_database_title_flag_populates_env(monkeypatch) -> None:
+    """The flag is a convenience that surfaces NOTION_DATABASE_TITLE for the create path."""
+    import os
+    import sys as _sys
+
+    from cja_auto_sdr.generator import _main_impl
+
+    monkeypatch.delenv("NOTION_DATABASE_TITLE", raising=False)
+    monkeypatch.setattr(
+        _sys, "argv", ["cja_auto_sdr", "--notion-print-database-schema", "--notion-database-title", "Custom Reg"]
+    )
+    with pytest.raises(SystemExit):
+        _main_impl()
+    assert os.environ.get("NOTION_DATABASE_TITLE") == "Custom Reg"

--- a/tests/test_notion_database.py
+++ b/tests/test_notion_database.py
@@ -480,3 +480,33 @@ def test_repair_flags_absent_canonical_title_as_conflict() -> None:
     assert ("Name", "title", "missing") in result.conflicts
     assert "Name" not in result.to_add
     assert result.applied is False
+
+
+def test_ensure_database_uses_custom_title_from_env(monkeypatch) -> None:
+    """A new registry database is created with the NOTION_DATABASE_TITLE title."""
+    monkeypatch.setenv("NOTION_DATABASE_TITLE", "My Registry")
+    from cja_auto_sdr.output.notion_database import ensure_database
+
+    cap: dict = {}
+    client = MagicMock()
+    client.databases.create.side_effect = lambda **kw: (cap.update(kw), {"id": "db1", "data_sources": [{"id": "ds1"}]})[
+        1
+    ]
+    db_id, ds_id = ensure_database(client, parent_page_id="p", database_id=None, create_if_missing=True)
+
+    assert (db_id, ds_id) == ("db1", "ds1")
+    assert cap["title"][0]["text"]["content"] == "My Registry"
+
+
+def test_ensure_database_default_title_when_env_unset(monkeypatch) -> None:
+    monkeypatch.delenv("NOTION_DATABASE_TITLE", raising=False)
+    from cja_auto_sdr.output.notion_database import DATABASE_DEFAULT_TITLE, ensure_database
+
+    cap: dict = {}
+    client = MagicMock()
+    client.databases.create.side_effect = lambda **kw: (cap.update(kw), {"id": "db1", "data_sources": [{"id": "ds1"}]})[
+        1
+    ]
+    ensure_database(client, parent_page_id="p", database_id=None, create_if_missing=True)
+
+    assert cap["title"][0]["text"]["content"] == DATABASE_DEFAULT_TITLE

--- a/tests/test_output_content_validation.py
+++ b/tests/test_output_content_validation.py
@@ -38,7 +38,7 @@ def rich_data_dict():
         "Metadata": pd.DataFrame(
             {
                 "Property": ["Generated At", "Data View ID", "Tool Version", "Total Metrics"],
-                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.10.0", 3],
+                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.11.0", 3],
             },
         ),
         "Data Quality": pd.DataFrame(
@@ -104,7 +104,7 @@ def rich_metadata_dict():
         "Generated At": "2025-01-15 10:30:00 PST",
         "Data View ID": "dv_content_test",
         "Data View Name": "Test DataView",
-        "Tool Version": "3.10.0",
+        "Tool Version": "3.11.0",
         "Metrics Count": "3",
         "Dimensions Count": "4",
     }
@@ -224,7 +224,7 @@ class TestJSONContentValidation:
             data = json.load(f)
 
         assert data["metadata"]["Data View ID"] == "dv_content_test"
-        assert data["metadata"]["Tool Version"] == "3.10.0"
+        assert data["metadata"]["Tool Version"] == "3.11.0"
 
     def test_json_metadata_preserves_partial_markers(self, tmp_path, rich_data_dict, rich_metadata_dict):
         logger = logging.getLogger("json_test")

--- a/tests/test_ux_features.py
+++ b/tests/test_ux_features.py
@@ -344,11 +344,11 @@ class TestCombinedFeatures:
 class TestVersionUpdated:
     """Test that version is correct"""
 
-    def test_version_is_3_10_0(self):
-        """Test that version is 3.10.0"""
+    def test_version_is_3_11_0(self):
+        """Test that version is 3.11.0"""
         from cja_auto_sdr.generator import __version__
 
-        assert __version__ == "3.10.0"
+        assert __version__ == "3.11.0"
 
 
 class TestFormatAutoDetection:

--- a/tools/cja_sdr_generate.json
+++ b/tools/cja_sdr_generate.json
@@ -77,6 +77,10 @@
         "type": "boolean",
         "description": "Bootstrap a new CJA SDR Registry database under NOTION_PARENT_PAGE_ID, print the new database ID to stdout, and exit. Use the printed ID as notion_database_id or NOTION_DATABASE_ID for subsequent runs."
       },
+      "notion_database_title": {
+        "type": "string",
+        "description": "Title for the database created by notion_create_database (default: 'CJA SDR Registry'). Falls back to the NOTION_DATABASE_TITLE env var. Only applies when a new database is created; ignored when attaching an existing one via notion_database_id."
+      },
       "notion_force_new": {
         "type": "boolean",
         "description": "Force creation of a new Notion page even if one already exists for this data view. The superseded page ID is recorded as an orphan in .notion_pages.json. Clean it up later with the standalone CLI command `cja_auto_sdr --notion-prune-orphans` (a maintenance command that takes no data view ID, so it is not exposed in this generate manifest)."


### PR DESCRIPTION
## Summary

Adds **`--notion-database-title`**, bringing cja_auto_sdr to parity with `aa_auto_sdr`'s flag of the same name. It sets the title of the database created by `--notion-create-database` (default: "CJA SDR Registry").

## Design (lean, env-resolved)

All three create paths (single SDR, org-report, push-to-notion) call `ensure_database` after `.env` is loaded, so the title resolves there with no threading through `ProcessingConfig` / the pipeline config:

- `ensure_database` resolves the title from `NOTION_DATABASE_TITLE` (or the default) at create time.
- `--notion-database-title` is a convenience that populates `NOTION_DATABASE_TITLE` in `_main_impl`, so every create path picks it up uniformly. The flag wins over a `.env` value (load_dotenv won't override it). The bridge guards on `isinstance(str)` so it's inert for MagicMock-args unit tests.
- **Superset of aa** (which is flag-only): cja also accepts a `NOTION_DATABASE_TITLE` env var, consistent with how `NOTION_DATABASE_ID` works.

Only applies when a new database is created; ignored when attaching an existing one with `--notion-database-id`.

## Scope

Minor release (v3.11.0) — a new backward-compatible flag, consistent with how every prior Notion flag landed (v3.8.0–v3.10.0). Not a patch.

## Tests

`ensure_database` uses the custom title from the env and the default when unset; the flag parses; the flag populates the env. Flag added to the `cja_sdr_generate` tool manifest and documented in CLI_REFERENCE, CONFIGURATION, and NOTION_SETUP. Full suite **8242 passed, 16 skipped** (8258 collected); version-sync 3.11.0; lint clean.

## Optional live smoke (before merge)

- [ ] `cja_auto_sdr <dv> --format notion --notion-create-database --notion-database-title "My Reg"` creates the database titled "My Reg" (verify in Notion).
- [ ] Same via the env var `NOTION_DATABASE_TITLE`.
- [ ] Without either, the database is titled "CJA SDR Registry".

https://claude.ai/code/session_011to9ekGpfJUaGGWKmUxhTA