### PR TITLE
docs: Notion integration documentation sweep (no version bump)

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ cja_auto_sdr "Production Analytics"
 | Export as Markdown | `cja_auto_sdr dv_12345 --format markdown` |
 | Generate all formats | `cja_auto_sdr dv_12345 --format all` |
 | **Notion SDR Registry (v3.8.0)** | |
-| Bootstrap registry database (one-time) | `cja_auto_sdr --notion-create-database` |
+| Create registry database (first publish) | `cja_auto_sdr dv_12345 --format notion --notion-create-database` (optionally `--notion-database-title "Name"`) |
 | Publish detail page + registry row | `cja_auto_sdr dv_12345 --format notion` (with `NOTION_DATABASE_ID` set) |
 | Batch publish with complete rows | `cja_auto_sdr --batch dv_1 dv_2 dv_3 --format notion` |
 | Org-report lightweight catalog | `cja_auto_sdr --org-report --format notion` (counts only; no detail pages) |

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ cja_auto_sdr "Production Analytics"
 | Create registry database (first publish) | `cja_auto_sdr dv_12345 --format notion --notion-create-database` (optionally `--notion-database-title "Name"`) |
 | Publish detail page + registry row | `cja_auto_sdr dv_12345 --format notion` (with `NOTION_DATABASE_ID` set) |
 | Batch publish with complete rows | `cja_auto_sdr --batch dv_1 dv_2 dv_3 --format notion` |
-| Org-report lightweight catalog | `cja_auto_sdr --org-report --format notion` (counts only; no detail pages) |
+| Org-report lightweight catalog | `cja_auto_sdr --org-report --format notion --notion-database-id <id>` (counts only; no detail pages; needs a registry database) |
 | **Notion Maintenance (v3.9.0)** | |
 | Preview orphan pages (dry run) | `cja_auto_sdr --notion-prune-orphans --dry-run --output-dir ./out` |
 | Archive orphan pages (Notion trash) | `cja_auto_sdr --notion-prune-orphans --output-dir ./out` |

--- a/docs/AGENT_AUTOMATION.md
+++ b/docs/AGENT_AUTOMATION.md
@@ -452,9 +452,11 @@ Page IDs are tracked in `.notion_pages.json` so re-runs update the existing page
 The registry database maintains one row per data view in a "CJA SDR Registry" Notion database, keyed by Data View ID. It has 14 properties covering counts, data quality, timezone, currency, and a link to the detail page.
 
 ```bash
-# One-time: bootstrap the registry database
-uv run cja_auto_sdr --notion-create-database
-# Prints: notion://databases/<id>  ← save this
+# One-time: create the registry database on your first publish
+# (--notion-create-database needs a data view + --format notion; it is not standalone)
+uv run cja_auto_sdr dv_12345 --format notion --notion-create-database
+# Prints the new database ID  ← save this
+# Optional custom title: add --notion-database-title "My Registry" (or set NOTION_DATABASE_TITLE)
 
 export NOTION_DATABASE_ID=<id-from-above>
 

--- a/docs/AGENT_AUTOMATION.md
+++ b/docs/AGENT_AUTOMATION.md
@@ -472,8 +472,9 @@ uv run cja_auto_sdr --batch dv_12345 dv_67890 dv_abcde --format notion
 `--org-report --format notion` writes a lightweight catalog row per data view from the org report summary. This is fast (serial, no extra API calls) but only fills Name, Data View ID, Metrics Count, Dimensions Count, owner/dates, and an SDR Page link where a detail page already exists. Segments, Calculated Metrics, Derived Fields counts, and Data Quality are not populated.
 
 ```bash
-# Lightweight catalog from org report (fast, counts only)
-uv run cja_auto_sdr --org-report --format notion
+# Lightweight catalog from org report (fast, counts only).
+# Requires a registry database (it writes only rows, no detail pages):
+uv run cja_auto_sdr --org-report --format notion --notion-database-id <id>  # or set NOTION_DATABASE_ID
 
 # Follow up with batch for complete rows on key data views
 uv run cja_auto_sdr --batch dv_12345 dv_67890 --format notion

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -570,7 +570,9 @@ cja_auto_sdr --batch dv_12345 dv_67890 --format notion
 # Fills Name, Data View ID, Metrics/Dimensions Count, and SDR Page link
 # where a detail page already exists. Segments/CM/DF counts, and Data Quality
 # are NOT populated (those columns are empty). Runs serially.
-cja_auto_sdr --org-report --format notion
+# Requires a registry database (it only writes rows, no pages):
+cja_auto_sdr --org-report --format notion --notion-database-id <id>
+# (or set NOTION_DATABASE_ID; bootstrap one first via a single --format notion --notion-create-database run)
 ```
 
 > **Idempotency:** Page IDs are tracked in `.notion_pages.json` in the output directory so re-runs update the existing page rather than creating duplicates. Use `--notion-force-new` to override.

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -509,7 +509,7 @@ uv pip install 'cja-auto-sdr[notion]'
 | `--push-to-notion JSON_FILE` | Push an existing SDR JSON artifact to Notion (standalone mode; no CJA API call) | - |
 | `--notion-force-new` | Force a new Notion page instead of updating the existing one for this data view | False |
 | `--notion-database-id ID` | ID of the "CJA SDR Registry" database to upsert a row into after publishing. Falls back to the `NOTION_DATABASE_ID` env var. When neither is set, no row is written | - |
-| `--notion-create-database` | Bootstrap a new "CJA SDR Registry" database under `NOTION_PARENT_PAGE_ID`, print its ID to stdout, and exit. Use this ID as `NOTION_DATABASE_ID` for subsequent runs | - |
+| `--notion-create-database` | Create a new "CJA SDR Registry" database under `NOTION_PARENT_PAGE_ID` during the publish run when no database ID is configured. Pass it alongside a data view and `--format notion`; the new database ID is printed on success — capture it as `NOTION_DATABASE_ID` for subsequent runs. Ignored if `--notion-database-id` (or `NOTION_DATABASE_ID`) is already set | - |
 | `--notion-database-title NAME` | Title for the database created by `--notion-create-database`. Falls back to the `NOTION_DATABASE_TITLE` env var. Only applies when a new database is created; ignored when attaching an existing one with `--notion-database-id` | `CJA SDR Registry` |
 | `--notion-prune-orphans` | Archive Notion pages that were left behind by `--notion-force-new`. The registry records the superseded page ID each time a new page is forced; this command archives those pages in Notion (moved to Notion trash — recoverable, not permanently deleted) and clears them from the registry. Requires only `NOTION_TOKEN`. Rejected when combined with `--org-report`, `--diff`, `--batch`, `--watch`, or `--push-to-notion`. Combine with `--dry-run` to preview without making changes. **Limitation:** only pages orphaned by `--notion-force-new` from v3.9.0 onward are tracked; pre-existing orphans from earlier runs are not catalogued | - |
 | `--notion-repair-database` | Reconcile an existing "CJA SDR Registry" database with the canonical schema. **Add-only:** adds missing properties and reports any type conflicts — never changes or removes existing properties or data rows. Requires only `NOTION_TOKEN` and a database ID (`--notion-database-id` or `NOTION_DATABASE_ID`). Use when the schema grows across versions instead of recreating the database. Combine with `--dry-run` to preview what would be added without making changes | - |
@@ -550,9 +550,9 @@ cja_auto_sdr --notion-prune-orphans --output-dir ./out
 
 # --- SDR Registry Database (v3.8.0) ---
 
-# Step 1: Bootstrap the registry database once (prints the database ID)
-cja_auto_sdr --notion-create-database
-# Output: notion://databases/<id>  ← capture this
+# Step 1: Create the registry database on your first publish (prints the database ID)
+cja_auto_sdr dv_12345 --format notion --notion-create-database
+# Output includes the new database ID  ← capture it as NOTION_DATABASE_ID
 
 # Step 2: Set the database ID in your environment
 export NOTION_DATABASE_ID=<id-from-step-1>

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -226,12 +226,12 @@ These variables are used when publishing SDRs to Notion (`--format notion`, `--p
 
 | Variable | Description | Required |
 |----------|-------------|----------|
-| `NOTION_TOKEN` | Notion integration token (starts with `secret_`) | **Yes** (for any Notion output) |
+| `NOTION_TOKEN` | Notion integration token (starts with `ntn_` for newer integrations, or `secret_` for older ones) | **Yes** (for any Notion output) |
 | `NOTION_PARENT_PAGE_ID` | ID of the Notion page under which SDR detail pages are created. Also used as the parent when bootstrapping a new registry database with `--notion-create-database` | **Yes** (for any Notion output) |
 | `NOTION_DATABASE_ID` | ID of an existing "CJA SDR Registry" database. When set, every `--format notion` run upserts the data view's row in the registry with all counts and Data Quality. Unset = no database row written (v3.7.0 behavior preserved). Can also be supplied via `--notion-database-id` | No |
 | `NOTION_DATABASE_TITLE` | Title for a database created by `--notion-create-database` (default: "CJA SDR Registry"). Overridden by `--notion-database-title`. Applies only when a new database is created; ignored when attaching an existing one | No |
 
-> **Bootstrapping `NOTION_DATABASE_ID`:** Run `cja_auto_sdr --notion-create-database` once. It creates a new "CJA SDR Registry" database under `NOTION_PARENT_PAGE_ID` and prints the new database ID to stdout. Copy that value into your environment or `.env` file as `NOTION_DATABASE_ID`, then use it on subsequent runs.
+> **Bootstrapping `NOTION_DATABASE_ID`:** Add `--notion-create-database` to your first publish run — `cja_auto_sdr <data_view_id> --format notion --notion-create-database` (it needs a data view and `--format notion`; it is not a standalone command). It creates a new "CJA SDR Registry" database under `NOTION_PARENT_PAGE_ID`, publishes that data view, and prints the new database ID. Copy that value into your environment or `.env` file as `NOTION_DATABASE_ID`, then use it on subsequent runs.
 >
 > **Unset behavior:** If `NOTION_DATABASE_ID` is not set (and `--notion-database-id` is not passed), `--format notion` runs exactly as in v3.7.0 — the SDR detail page is created or updated, but no registry row is written.
 >

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -235,7 +235,7 @@ These variables are used when publishing SDRs to Notion (`--format notion`, `--p
 >
 > **Unset behavior:** If `NOTION_DATABASE_ID` is not set (and `--notion-database-id` is not passed), `--format notion` runs exactly as in v3.7.0 — the SDR detail page is created or updated, but no registry row is written.
 >
-> **Schema drift (v3.11.0):** If the tool adds new registry properties in a later version and your database is missing those columns, run `cja_auto_sdr --notion-repair-database` to add them (add-only — never removes existing properties or rows). Use `--dry-run` to preview first. Run `cja_auto_sdr --notion-print-database-schema` to see the full canonical schema without credentials.
+> **Schema drift (v3.10.0):** If the tool adds new registry properties in a later version and your database is missing those columns, run `cja_auto_sdr --notion-repair-database` to add them (add-only — never removes existing properties or rows). Use `--dry-run` to preview first. Run `cja_auto_sdr --notion-print-database-schema` to see the full canonical schema without credentials.
 
 ### Setting Environment Variables
 

--- a/docs/NOTION_SETUP.md
+++ b/docs/NOTION_SETUP.md
@@ -108,13 +108,13 @@ Unlike a manual setup, you do not create the database properties yourself. The t
 
 ### Bootstrap a new database
 
-Run this once:
+Add `--notion-create-database` to your first publish run (it needs a data view and `--format notion`; it is not a standalone command):
 
 ```bash
-cja_auto_sdr --notion-create-database
+cja_auto_sdr <data_view_id> --format notion --notion-create-database
 ```
 
-This creates a new "CJA SDR Registry" database under `NOTION_PARENT_PAGE_ID`, with the full schema, and prints the new database ID to stdout. To give the database a different title, add `--notion-database-title "My Title"` (or set `NOTION_DATABASE_TITLE`); the title only applies when the database is created. Copy the printed database ID and set it:
+This creates a new "CJA SDR Registry" database under `NOTION_PARENT_PAGE_ID` with the full schema, publishes that data view's detail page and row, and prints the new database ID. To give the database a different title, add `--notion-database-title "My Title"` (or set `NOTION_DATABASE_TITLE`); the title only applies when the database is created. Copy the printed database ID and set it:
 
 ```bash
 export NOTION_DATABASE_ID=abc123def456abc123def456abc123de

--- a/docs/ORG_WIDE_ANALYSIS.md
+++ b/docs/ORG_WIDE_ANALYSIS.md
@@ -353,8 +353,9 @@ cja_auto_sdr --org-report --format reports
 # Generate CSV + JSON for data pipelines
 cja_auto_sdr --org-report --format data
 
-# Publish a lightweight Notion catalog (counts only; no detail pages)
-cja_auto_sdr --org-report --format notion
+# Publish a lightweight Notion catalog (counts only; no detail pages).
+# Requires a registry database (it writes only rows):
+cja_auto_sdr --org-report --format notion --notion-database-id <id>  # or set NOTION_DATABASE_ID
 ```
 
 ## Output Formats
@@ -452,7 +453,7 @@ Multiple CSV files in a directory:
 
 ### Notion (v3.8.0 — lightweight catalog)
 
-`--org-report --format notion` writes one row to the "CJA SDR Registry" database per data view in the org report summary. Requires `NOTION_TOKEN`, `NOTION_PARENT_PAGE_ID`, and `NOTION_DATABASE_ID` (or `--notion-database-id`).
+`--org-report --format notion` writes one row to the "CJA SDR Registry" database per data view in the org report summary. It creates no detail pages, so a registry database is required: set `NOTION_DATABASE_ID` (or pass `--notion-database-id`). Requires `NOTION_TOKEN`. `NOTION_PARENT_PAGE_ID` is needed only if you bootstrap a new database with `--notion-create-database`.
 
 **What is populated:**
 - Name, Data View ID, Metrics Count, Dimensions Count, owner, dates
@@ -467,8 +468,8 @@ Multiple CSV files in a directory:
 > **Full org-report detail-page generation** (writing a complete Notion page per data view directly from org-report mode) is planned for a future release. For now, the recommended pattern is: run `--org-report --format notion` to populate a quick catalog, then run `--batch <ids> --format notion` for any data views that need complete rows and detail pages.
 
 ```bash
-# Lightweight catalog from org report
-cja_auto_sdr --org-report --format notion
+# Lightweight catalog from org report (requires a registry database)
+cja_auto_sdr --org-report --format notion --notion-database-id <id>  # or set NOTION_DATABASE_ID
 
 # Follow up with batch for complete rows on specific data views
 cja_auto_sdr --batch dv_12345 dv_67890 --format notion

--- a/docs/OUTPUT_FORMATS.md
+++ b/docs/OUTPUT_FORMATS.md
@@ -414,8 +414,8 @@ cja_auto_sdr --push-to-notion ./reports/dv_12345_sdr.json
 export NOTION_DATABASE_ID=<database-id>
 cja_auto_sdr dv_12345 --format notion
 
-# Bootstrap a new registry database and capture its ID
-cja_auto_sdr --notion-create-database
+# Create a new registry database during a publish run and capture its ID
+cja_auto_sdr dv_12345 --format notion --notion-create-database
 ```
 
 **Block layout:**
@@ -454,7 +454,7 @@ When `NOTION_DATABASE_ID` is set (or `--notion-database-id` is passed), every `-
 | Segments Count | Number | Total segments scoped to the data view |
 | Calculated Metrics Count | Number | Total calculated metrics for the data view |
 | Derived Fields Count | Number | Total derived fields in the data view |
-| Data Quality | Select | Summary of data quality status (`passed`, `issues_found`, `skipped`, `unknown`) |
+| Data Quality | Select | Worst data-quality severity as a status (`healthy`, `degraded`, `partial`, `unknown`) |
 
 > **`SDR Page` is a URL string, not a Notion relation.** The property holds `notion://pages/<id>` as plain text. This avoids permission constraints that would prevent cross-database relations in most Notion workspace configurations.
 >
@@ -463,9 +463,9 @@ When `NOTION_DATABASE_ID` is set (or `--notion-database-id` is passed), every `-
 **Bootstrap workflow:**
 
 ```bash
-# 1. Create the registry database (one-time setup)
-cja_auto_sdr --notion-create-database
-# Prints: notion://databases/<id>
+# 1. Create the registry database on your first publish (needs a data view + --format notion)
+cja_auto_sdr dv_12345 --format notion --notion-create-database
+# Prints the new database ID  ← capture it
 
 # 2. Add the database ID to your environment
 export NOTION_DATABASE_ID=<id>  # or add to .env

--- a/docs/OUTPUT_FORMATS.md
+++ b/docs/OUTPUT_FORMATS.md
@@ -30,7 +30,7 @@ The tool supports multiple output formats beyond Excel, providing flexible integ
 
 > The Discovery column covers both discovery commands (`--list-dataviews`, `--list-connections`, `--list-datasets`) and discovery inspection commands (`--describe-dataview`, `--list-metrics`, `--list-dimensions`, `--list-segments`, `--list-calculated-metrics`). All output console (table), JSON, or CSV. They do not generate file-based formats like Excel, HTML, or Markdown.
 >
-> **Notion + Org-Wide Analysis:** `--org-report --format notion` writes a lightweight catalog row per data view (Name, Data View ID, Metrics/Dimensions Count, SDR Page link). Segments, Calculated Metrics, Derived Fields counts, and Data Quality are not populated. No detail pages are created. For complete rows, use `--batch <ids> --format notion`.
+> **Notion + Org-Wide Analysis:** `--org-report --format notion` writes a lightweight catalog row per data view (Name, Data View ID, Metrics/Dimensions Count, SDR Page link) and **requires a registry database** (`NOTION_DATABASE_ID` or `--notion-database-id`), since it writes only rows. Segments, Calculated Metrics, Derived Fields counts, and Data Quality are not populated. No detail pages are created. For complete rows, use `--batch <ids> --format notion`.
 
 ### Format Aliases (introduced in v3.2.0)
 
@@ -495,7 +495,7 @@ cja_auto_sdr --notion-repair-database --notion-database-id <id>
 
 **Org-report catalog (lightweight):**
 
-`--org-report --format notion` writes one registry row per data view from the org report summary. It fills Name, Data View ID, Metrics Count, Dimensions Count, owner/dates, and an SDR Page link where a detail page already exists. The following columns are **not** populated because the org report does not fetch that data:
+`--org-report --format notion` writes one registry row per data view from the org report summary. Because it writes only rows (no detail pages), it **requires a registry database** — set `NOTION_DATABASE_ID` or pass `--notion-database-id <id>` (running it without one exits with an error). It fills Name, Data View ID, Metrics Count, Dimensions Count, owner/dates, and an SDR Page link where a detail page already exists. The following columns are **not** populated because the org report does not fetch that data:
 
 - Segments Count
 - Calculated Metrics Count

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -403,7 +403,8 @@ cja_auto_sdr --list-dataviews  # Uses client-a
 | `--push-to-notion JSON_FILE` | Push existing JSON artifact to Notion (no CJA API call) |
 | `--notion-force-new` | Force a new Notion page instead of updating existing; records the superseded page as an orphan |
 | `--notion-database-id ID` | ID of the "CJA SDR Registry" database; upserts a row after publishing. Falls back to `NOTION_DATABASE_ID` env var |
-| `--notion-create-database` | Bootstrap a new "CJA SDR Registry" database under `NOTION_PARENT_PAGE_ID`, print its ID, and exit |
+| `--notion-create-database` | Create a new "CJA SDR Registry" database during the publish run when none is configured. Pass with a data view and `--format notion`; prints the new ID to capture as `NOTION_DATABASE_ID`. Ignored if a database id is already set |
+| `--notion-database-title NAME` | Title for the database created by `--notion-create-database` (default: `CJA SDR Registry`). Falls back to `NOTION_DATABASE_TITLE`. Applies only when a new database is created |
 | `--notion-prune-orphans` | Archive Notion pages left behind by `--notion-force-new` (moved to Notion trash, recoverable). Combine with `--dry-run` to preview. Only tracks orphans created from v3.9.0 onward |
 | `--notion-repair-database` | Reconcile an existing registry database with the canonical schema. Add-only: adds missing properties, reports type conflicts, never removes existing properties or rows. Requires `NOTION_TOKEN` and a database id (`--notion-database-id` or `NOTION_DATABASE_ID`). Combine with `--dry-run` to preview |
 | `--notion-print-database-schema` | Print the canonical registry schema (property names + types) and exit. No credentials required |
@@ -552,10 +553,11 @@ cja_auto_sdr dv_12345 --snapshot ./baseline.json --include-all-inventory
 # Compare against snapshot with inventory (same behavior)
 cja_auto_sdr dv_12345 --diff-snapshot ./baseline.json --include-all-inventory
 
-# --- Notion SDR Registry (v3.9.0) ---
+# --- Notion SDR Registry (v3.8.0) ---
 
-# Bootstrap the registry database (one-time; prints the database ID)
-cja_auto_sdr --notion-create-database
+# Create the registry database on your first publish (needs a data view + --format notion)
+cja_auto_sdr dv_12345 --format notion --notion-create-database
+# Optional: name it — cja_auto_sdr dv_12345 --format notion --notion-create-database --notion-database-title "My Registry"
 
 # Publish a detail page AND upsert a complete registry row (all 14 properties)
 export NOTION_DATABASE_ID=<id-from-bootstrap>
@@ -580,7 +582,7 @@ cja_auto_sdr --notion-prune-orphans --dry-run --output-dir ./out
 # Archive orphaned pages (moved to Notion trash — recoverable)
 cja_auto_sdr --notion-prune-orphans --output-dir ./out
 
-# --- Registry Schema & Repair (v3.11.0) ---
+# --- Registry Schema & Repair (v3.10.0) ---
 
 # See the canonical registry schema (no credentials required)
 cja_auto_sdr --notion-print-database-schema

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -572,7 +572,8 @@ cja_auto_sdr --batch dv_12345 dv_67890 --format notion
 # Org-report catalog (lightweight rows — counts only, no detail pages)
 # Populates Name, Data View ID, Metrics/Dimensions Count, SDR Page link
 # Segments/CM/DF counts and Data Quality are NOT filled in
-cja_auto_sdr --org-report --format notion
+# Requires a registry database (writes only rows, no detail pages):
+cja_auto_sdr --org-report --format notion --notion-database-id <id>  # or set NOTION_DATABASE_ID
 
 # --- Notion Orphan Pruning (v3.9.0) ---
 
@@ -604,6 +605,12 @@ export SCOPES="your_scopes_from_developer_console"
 # Optional settings
 export OUTPUT_DIR=./reports
 export LOG_LEVEL=INFO
+
+# Notion integration (for --format notion / --push-to-notion / registry)
+export NOTION_TOKEN=ntn_...               # or secret_... (older integrations)
+export NOTION_PARENT_PAGE_ID=<page-id>    # parent for detail pages + new databases
+export NOTION_DATABASE_ID=<database-id>   # existing SDR Registry database (enables rows)
+export NOTION_DATABASE_TITLE="CJA SDR Registry"  # title for a newly created database
 
 # Console color policy
 export NO_COLOR=1            # disable ANSI colors globally

--- a/tools/cja_sdr_generate.json
+++ b/tools/cja_sdr_generate.json
@@ -75,7 +75,7 @@
       },
       "notion_create_database": {
         "type": "boolean",
-        "description": "Bootstrap a new CJA SDR Registry database under NOTION_PARENT_PAGE_ID, print the new database ID to stdout, and exit. Use the printed ID as notion_database_id or NOTION_DATABASE_ID for subsequent runs."
+        "description": "Create a new CJA SDR Registry database under NOTION_PARENT_PAGE_ID during this publish run when no database is configured (requires data_view_id and format 'notion'; it is not a standalone command). The new database ID is printed on success — capture it as notion_database_id or NOTION_DATABASE_ID for subsequent runs. Ignored if notion_database_id or NOTION_DATABASE_ID is already set."
       },
       "notion_database_title": {
         "type": "string",

--- a/tools/cja_sdr_governance.json
+++ b/tools/cja_sdr_governance.json
@@ -27,7 +27,7 @@
       "format": {
         "type": "string",
         "enum": ["console", "json", "csv", "html", "markdown", "excel", "notion"],
-        "description": "Output format for the org report. Use 'json' for agent/machine-readable output. Use 'notion' to publish a lightweight catalog row per data view to the CJA SDR Registry database (requires NOTION_TOKEN, NOTION_PARENT_PAGE_ID, and NOTION_DATABASE_ID or notion_database_id). The org-report Notion catalog fills Name, Data View ID, Metrics/Dimensions Count, owner/dates, and SDR Page link — it does NOT populate Segments, Calculated Metrics, Derived Fields counts or Data Quality, and does NOT create detail pages. Runs serially."
+        "description": "Output format for the org report. Use 'json' for agent/machine-readable output. Use 'notion' to publish a lightweight catalog row per data view to the CJA SDR Registry database. It writes only rows (no detail pages), so it requires NOTION_TOKEN and a database (NOTION_DATABASE_ID or notion_database_id); NOTION_PARENT_PAGE_ID is not needed (this manifest does not create databases). The org-report Notion catalog fills Name, Data View ID, Metrics/Dimensions Count, owner/dates, and SDR Page link — it does NOT populate Segments, Calculated Metrics, Derived Fields counts or Data Quality, and does NOT create detail pages. Runs serially."
       },
       "output": {
         "type": "string",


### PR DESCRIPTION
## Summary

Documentation-only sweep of the entire Notion integration against the actual v3.11.0 behavior. **No code changes, no version bump** (stays 3.11.0). Found via two review passes (a broad sweep + an in-depth verification sweep) cross-checked against the code and the running CLI.

## Fixes

**Critical accuracy (commands that would fail as documented):**
- **`--notion-create-database` was shown as a standalone command in ~10 places** — it actually requires a data view + `--format notion` (standalone errors "At least one data view ID or name is required"). Corrected every example to `cja_auto_sdr <dv> --format notion --notion-create-database` and dropped the misleading "and exit" framing.
- **`--org-report --format notion` was shown bare in ~6 examples** — it writes only registry rows (no detail pages), so it requires a configured database. Bare form exits 1. Added `--notion-database-id <id>` / a "needs a database" note to every example and the prose.

**Other corrections:**
- Wrong Data Quality select values in OUTPUT_FORMATS (`passed`/`issues_found`/`skipped` → the real `healthy`/`degraded`/`partial`/`unknown`).
- Overstated `NOTION_PARENT_PAGE_ID` requirement for the org catalog (only needed when bootstrapping a new DB) — fixed in ORG_WIDE_ANALYSIS + the governance manifest.
- Added the v3.11.0 `--notion-database-title` flag to QUICK_REFERENCE + AGENT_AUTOMATION (was only in CLI_REFERENCE/CONFIGURATION/NOTION_SETUP).
- Fixed stale version tags (registry/bootstrap = v3.8.0, repair/schema = v3.10.0; CONFIGURATION + QUICK_REFERENCE).
- `NOTION_TOKEN` prefix note now includes `ntn_` (newer) and `secret_` (older); added NOTION_* vars to the QUICK_REFERENCE env block.

## Verification

The in-depth second sweep confirmed all fixes, and verified (against code + live CLI) that the schema (14 properties), DQ severity mapping, standalone-vs-not guards, dry-run/add-only/archive-not-delete semantics, force-new orphan recording, the workers/watch/batch rejections, push-to-notion exclusivity, and the NOTION_SETUP end-to-end walkthrough are all accurate. version-sync OK at 3.11.0; test counts unchanged.

Files: README, CLI_REFERENCE, QUICK_REFERENCE, CONFIGURATION, NOTION_SETUP, OUTPUT_FORMATS, ORG_WIDE_ANALYSIS, AGENT_AUTOMATION, tools/cja_sdr_generate.json, tools/cja_sdr_governance.json.

https://claude.ai/code/session_011to9ekGpfJUaGGWKmUxhTA