### PR TITLE
test: coverage hardening for v3.11.1 (98% → 99% unit slice)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to the CJA SDR Generator project will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.11.1] - 2026-06-25
+
+### Coverage
+
+- **Unit-slice coverage lifted from 98% → 99%** (98.43% → 99.14%): 149 previously-uncovered statements are now exercised, leaving the 7K-line `generator.py` monolith as the only module below 100%. No production behavior changed — this is test-only hardening plus two defensive-branch annotations.
+- The largest single gain was **`cli/commands/watch.py` (78% → 100%)**. Its real signal-handler closure, `_sleep_with_stop`, `_NullCja`, and `_resolve_cja_client` paths were only exercised by the `@slow` subprocess tests in `test_watch_signals.py`, which the unit slice excludes; in-process tests now cover them.
+- Other modules brought to **100%**: `output/writers/notion.py`, `output/notion_database.py`, `output/notion_org_publisher.py`, `output/notion_registry.py`, `pipeline/watch.py`, `api/client.py`, `api/cache.py`, `api/quality.py`, `cli/agent_output.py`, `cli/commands/discovery.py`, `cli/commands/stats.py`, `cli/interactive.py`, `core/discovery_payloads.py`, `core/exceptions.py`, `core/json_io.py`, `core/profiles.py`, `diff/cli.py`, `diff/commands.py`, `diff/git.py`, `org/analyzer.py`, `org/models.py`, `org/snapshot_utils.py`, `org/writers/compat.py`, and `org/writers/trending.py`.
+- Test count: **8,258 → 8,355** (+97), all added to existing test files (no new files).
+- Two genuinely-unreachable defensive branches were marked `# pragma: no cover` with justifications instead of contorting tests to reach them: the orphan-heading guard in `output/writers/notion.py` `_section_blocks` (the upstream column guard ensures every chunk renders a table) and the blank-id `continue` in `org/trending.py` (history-ineligible snapshots are rejected before that loop runs).
+
 ## [3.11.0] - 2026-06-22
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,8 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Package manager: **uv**
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
-- Current version: v3.11.0
-- Tests: **8,258** across 155 files at **95% coverage gate**
+- Current version: v3.11.1
+- Tests: **8,355** across 155 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)
 

--- a/README.md
+++ b/README.md
@@ -481,7 +481,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (8,258+ tests)
+├── tests/                     # Test suite (8,355+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -943,7 +943,7 @@ cja_auto_sdr --list-dataviews --log-level DEBUG
 At launch, the tool logs diagnostic lines containing the tool version, Python version, platform, active log level, inferred run mode (batch, single, or discovery), and dependency versions. These appear automatically at `INFO` level and are useful for troubleshooting environment issues in CI/CD logs or support requests:
 
 ```text
-CJA SDR Generator v3.11.0 | Python 3.14.2 | darwin | log_level=INFO | mode=single
+CJA SDR Generator v3.11.1 | Python 3.14.2 | darwin | log_level=INFO | mode=single
 Dependencies: cjapy=0.3.0, pandas=2.3.3, numpy=2.2.1, xlsxwriter=3.2.9, tqdm=4.67.0
 ```
 

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -190,7 +190,7 @@ This command:
 
 ```bash
 $ uv run cja_auto_sdr -V
-cja_auto_sdr 3.11.0
+cja_auto_sdr 3.11.1
 ```
 
 > **Important:** All commands in this guide assume you're in the `cja_auto_sdr` directory. If you see "command not found", make sure you're in the right directory and have run `uv sync`.

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Quick Reference Card
 
-Single-page command cheat sheet for CJA SDR Generator v3.11.0.
+Single-page command cheat sheet for CJA SDR Generator v3.11.1.
 
 ## Four Main Modes
 

--- a/src/cja_auto_sdr/core/version.py
+++ b/src/cja_auto_sdr/core/version.py
@@ -1,3 +1,3 @@
 """Version information for CJA Auto SDR."""
 
-__version__ = "3.11.0"
+__version__ = "3.11.1"

--- a/src/cja_auto_sdr/org/trending.py
+++ b/src/cja_auto_sdr/org/trending.py
@@ -226,7 +226,9 @@ def _extract_snapshot_from_json(
     for dv in successful_data_views:
         dv_id = org_report_data_view_row_id(dv)
         if not dv_id:
-            continue
+            # Defensive: a blank-id row would force missing_id_rows>0, which makes the
+            # snapshot history-ineligible upstream, so this loop never sees one here.
+            continue  # pragma: no cover
         metrics = _mapping_int(dv, "metrics_count", "metric_count") or 0
         dims = _mapping_int(dv, "dimensions_count", "dimension_count") or 0
         dv_component_counts[dv_id] = metrics + dims

--- a/src/cja_auto_sdr/output/writers/notion.py
+++ b/src/cja_auto_sdr/output/writers/notion.py
@@ -195,7 +195,7 @@ def _section_blocks(section_name: str, df: pd.DataFrame) -> list[dict]:
             blocks.append(table)
     # If every chunk degenerated (shouldn't happen given the column guard
     # above), drop the orphan heading so we don't render a bare section title.
-    if len(blocks) == 1:
+    if len(blocks) == 1:  # pragma: no cover - unreachable: the column guard above ensures every chunk renders a table
         return []
     return blocks
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -167,7 +167,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 8,258 comprehensive tests**
+**Total: 8,355 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -176,16 +176,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 8,152 | 149 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 8,249 | 149 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 0 | 0 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **8,258** | **155** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **8,355** | **155** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 8,152 | 149 | `-m "unit and not slow"` |
+| `test-unit` | 8,249 | 149 | `-m "unit and not slow"` |
 | `test-integration` | 96 | 5 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -200,7 +200,7 @@ tests/
 | `test_org_report.py` | 211 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
 | `test_org_report_integration.py` | 17 | Org-wide analysis integration tests: end-to-end flows, caching, filtering, governance |
 | `test_cli.py` | 412 | Command-line interface and argument parsing |
-| `test_profiles.py` | 78 | Multi-organization profile support |
+| `test_profiles.py` | 80 | Multi-organization profile support |
 | `test_derived_inventory.py` | 62 | Derived fields inventory feature |
 | `test_diff_snapshot_cjapy_payloads.py` | 5 | Diff snapshot cjapy payload classification |
 | `test_inventory_pragma_coverage.py` | 18 | Inventory pragma coverage hardening |
@@ -227,7 +227,7 @@ tests/
 | `test_process_single_dataview.py` | 47 | End-to-end single data view processing |
 | `test_optimized_validation.py` | 16 | Optimized data quality validation |
 | `test_name_resolution.py` | 24 | Data view name to ID resolution |
-| `test_shared_cache.py` | 28 | Shared validation cache |
+| `test_shared_cache.py` | 30 | Shared validation cache |
 | `test_logging_optimization.py` | 17 | Logging performance optimizations |
 | `test_env_credentials.py` | 15 | Environment variable credentials |
 | `test_dry_run.py` | 16 | Dry-run mode functionality |
@@ -236,7 +236,7 @@ tests/
 | `test_parallel_validation.py` | 9 | Parallel validation operations |
 | `test_discovery_formatters.py` | 32 | Shared discovery formatters, WorkerArgs dataclass, _exit_error, BANNER_WIDTH |
 | `test_discovery_normalization.py` | 17 | Discovery normalization helpers (missing values, owner extraction, tags) |
-| `test_discovery_payloads.py` | 61 | Discovery payload classification (error detection, component extraction) |
+| `test_discovery_payloads.py` | 63 | Discovery payload classification (error detection, component extraction) |
 | `test_discovery_component_consistency.py` | 7 | Discovery component retrieval consistency |
 | `test_discovery_extraction.py` | 46 | Discovery module extraction and backwards-compat contracts |
 | `test_diagnostic_events.py` | 23 | Structured diagnostic event vocabulary, logger adapters, and redaction |
@@ -246,41 +246,41 @@ tests/
 | `test_main_entry_points.py` | 43 | main() and _main_impl() entry points, dispatch, run_state, run summary |
 | `test_quality_policy_and_run_summary.py` | 171 | Quality policy functions and run summary/status inference |
 | `test_e2e_integration.py` | 16 | End-to-end integration tests with real pipeline, mocked API boundary |
-| `test_api_client.py` | 35 | API client exception paths and error handling |
+| `test_api_client.py` | 39 | API client exception paths and error handling |
 | `test_config_validation.py` | 55 | Configuration validation logic |
 | `test_credentials.py` | 73 | Credential resolution and source selection |
 | `test_performance_tracker.py` | 7 | Performance tracker (cache eviction, statistics) |
 | `test_snapshot.py` | 78 | Diff snapshot creation and comparison |
 | `test_colors.py` | 122 | Console color formatting, themes, TTY detection |
-| `test_exceptions.py` | 68 | Custom exception classes construction and formatting |
+| `test_exceptions.py` | 70 | Custom exception classes construction and formatting |
 | `test_logging_redaction.py` | 180 | Logging, sensitive data redaction, JSON formatter |
 | `test_config_dataclasses.py` | 89 | Config dataclasses and constants functions |
 | `test_lock_manager.py` | 68 | Lock manager acquire/release/heartbeat lifecycle |
 | `test_lazy_forwarding.py` | 73 | Lazy-forwarding infrastructure and make_getattr() |
 | `test_lock_backend_edge_cases.py` | 165 | Lock backend metadata I/O, stale detection, legacy parsing |
 | `test_derived_fields_coverage.py` | 161 | Derived field complexity scoring, logic summary, predicates |
-| `test_org_analyzer_coverage.py` | 162 | Org analyzer governance, naming audit, sampling, memory, drift, clustering |
+| `test_org_analyzer_coverage.py` | 166 | Org analyzer governance, naming audit, sampling, memory, drift, clustering |
 | `test_org_analyzer_metadata_enrichment.py` | 3 | Org analyzer metadata enrichment payload handling |
 | `test_api_coverage.py` | 98 | API cache, quality, fetch, resilience exception paths |
-| `test_diff_coverage.py` | 72 | Diff comparator, models, git integration edge cases |
+| `test_diff_coverage.py` | 75 | Diff comparator, models, git integration edge cases |
 | `test_generator_coverage.py` | 143 | Generator utility functions — coercion, normalization, diff formatting |
 | `test_generator_discovery_compat_coverage.py` | 42 | Generator discovery helper parity with extracted list-command implementations |
 | `test_segments_coverage.py` | 78 | Segment comparison operators, container types, sequence variants |
 | `test_diff_inventory_output.py` | 96 | Inventory diff output across all formats (console, JSON, HTML, Excel, MD, CSV) |
-| `test_cli_command_handlers.py` | 156 | CLI dispatch for --stats, --org-report, --list-snapshots, discovery inspection, diff config unpacking |
+| `test_cli_command_handlers.py` | 160 | CLI dispatch for --stats, --org-report, --list-snapshots, discovery inspection, diff config unpacking |
 | `test_profile_management.py` | 54 | Interactive profile creation, import, test, show |
-| `test_snapshot_commands.py` | 65 | Snapshot creation, comparison, name resolution |
+| `test_snapshot_commands.py` | 71 | Snapshot creation, comparison, name resolution |
 | `test_config_and_resolution.py` | 115 | Config status, validation, stats, name resolution |
 | `test_derived_fields_edge_cases.py` | 34 | Derived fields edge cases and coverage |
 | `test_diff_command_coverage.py` | 46 | Diff command edge cases and coverage |
-| `test_generator_interactive_and_console.py` | 37 | Generator interactive and console tests |
+| `test_generator_interactive_and_console.py` | 38 | Generator interactive and console tests |
 | `test_generator_remaining_coverage.py` | 82 | Generator remaining coverage edge cases |
 | `test_interactive_discovery_coverage.py` | 118 | Interactive discovery and helpers coverage |
 | `test_lock_backends.py` | 46 | Lock backends edge cases and coverage |
 | `test_main_impl_cli_coverage.py` | 91 | _main_impl CLI path coverage |
 | `test_main_impl_coverage.py` | 64 | _main_impl coverage edge cases |
 | `test_org_cache_branches.py` | 51 | Org cache branch coverage |
-| `test_org_writer_compat_contracts.py` | 107 | Org writer compatibility boundary contract tests |
+| `test_org_writer_compat_contracts.py` | 116 | Org writer compatibility boundary contract tests |
 | `test_org_writer_coverage.py` | 143 | Org writer edge cases and coverage |
 | `test_output_writer_coverage.py` | 37 | Output writer edge cases and coverage |
 | `test_backwards_compat.py` | 34 | Backwards compatibility tests |
@@ -290,17 +290,17 @@ tests/
 | `test_generator_mock_contract.py` | 2 | Generator mock symbol contract tests |
 | `test_completion.py` | 56 | Shell completion flag (--completion bash/zsh/fish) |
 | `test_exception_narrowing.py` | 55 | Exception narrowing boundary tests |
-| `test_coverage_hardening.py` | 100 | Coverage hardening tests |
+| `test_coverage_hardening.py` | 101 | Coverage hardening tests |
 | `test_trending_models.py` | 53 | Trending dataclass construction and bridge tests |
 | `test_trending_discovery.py` | 88 | Snapshot cache discovery, deltas, drift scoring |
 | `test_trending_cli.py` | 9 | --trending-window CLI flag parsing |
 | `test_trending_output.py` | 23 | Trending output across all 6 formats |
 | `test_trending_integration.py` | 15 | Trending backwards compatibility and integration |
-| `test_org_snapshot_utils.py` | 127 | Org snapshot helper utilities edge cases |
+| `test_org_snapshot_utils.py` | 128 | Org snapshot helper utilities edge cases |
 | `test_org_trending_contracts.py` | 108 | Org/trending public API contract tests |
 | `test_org_trending_adversarial.py` | 51 | Adversarial and stress tests for trending |
-| `test_cli_diff_contracts.py` | 70 | CLI/diff public API contract tests |
-| `test_list_command_edge_cases.py` | 61 | List command edge cases and coverage |
+| `test_cli_diff_contracts.py` | 73 | CLI/diff public API contract tests |
+| `test_list_command_edge_cases.py` | 68 | List command edge cases and coverage |
 | `test_cli_commands_config_coverage.py` | 46 | Config command edge cases and coverage |
 | `test_cli_execution.py` | 27 | CLI execution edge cases and coverage |
 | `test_diff_git_coverage.py` | 27 | Diff/git subprocess error path coverage |
@@ -314,18 +314,18 @@ tests/
 | `test_github_actions_audit.py` | 7 | GitHub Actions audit workflow helper and manifest staging tests |
 | `test_example_automation_scripts.py` | 4 | Automation shell script validation tests |
 | `test_exit_codes.py` | 11 | Exit code helpers and signal detection tests |
-| `test_json_io.py` | 33 | JSON I/O atomic write and read tests |
+| `test_json_io.py` | 35 | JSON I/O atomic write and read tests |
 | `test_lock_info_normalization.py` | 54 | Lock-info normalization classmethod direct unit tests |
 | `test_resilience_edge_cases.py` | 74 | Resilience edge-case tests |
 | `test_cache_edge_cases.py` | 20 | Cache edge-case tests |
-| `test_quality_edge_cases.py` | 19 | Quality edge-case tests |
+| `test_quality_edge_cases.py` | 21 | Quality edge-case tests |
 | `test_tuning_edge_cases.py` | 15 | Tuning edge-case tests |
 | `test_fetch_edge_cases.py` | 9 | Fetch edge-case tests |
 | `test_advisories.py` | 53 | Advisory model, builder, and rollup tests |
 | `test_agent_contract_docs.py` | 27 | Agent contract documentation validation tests |
 | `test_agent_contract_samples.py` | 6 | Agent contract sample fixture validation tests |
 | `test_agent_mode.py` | 58 | --agent-mode CLI preset and resolution tests |
-| `test_agent_output_contract.py` | 39 | Centralized agent-output contract resolver tests |
+| `test_agent_output_contract.py` | 43 | Centralized agent-output contract resolver tests |
 | `test_agent_playbooks.py` | 38 | Agent playbook structural validation tests |
 | `test_agent_workflows.py` | 69 | Agent workflow shell script validation tests |
 | `test_manifest_agent_contract.py` | 16 | Manifest vs runtime capability drift tests |
@@ -333,24 +333,24 @@ tests/
 | `test_watch_duration_parser.py` | 24 | parse_duration_seconds Nh|Nd|Nw grammar tests |
 | `test_redact_text.py` | 4 | redact_text public helper contract tests |
 | `test_watch_events.py` | 8 | cja-watch-event/v1 NDJSON schema conformance tests |
-| `test_watch_pipeline.py` | 6 | Watch pipeline cycle orchestrator tests |
+| `test_watch_pipeline.py` | 7 | Watch pipeline cycle orchestrator tests |
 | `test_watch_cli.py` | 11 | Watch mode argparse acceptance and rejection tests |
 | `test_watch_prevalidation.py` | 43 | Watch flag semantic prevalidation tests |
-| `test_watch_command.py` | 11 | Watch command dispatch and signal handler tests |
+| `test_watch_command.py` | 19 | Watch command dispatch and signal handler tests |
 | `test_watch_signals.py` | 2 | SIGINT/SIGTERM exit-0 contract tests |
 | `test_watch_dispatch.py` | 2 | End-to-end dispatch wiring tests |
 | `test_watch_logging.py` | 4 | Structured-log event emission tests |
-| `test_notion_registry.py` | 14 | Notion page ID registry CRUD tests |
-| `test_notion_writer.py` | 73 | Notion block builder + API layer tests |
+| `test_notion_registry.py` | 18 | Notion page ID registry CRUD tests |
+| `test_notion_writer.py` | 89 | Notion block builder + API layer tests |
 | `test_cli_notion.py` | 28 | CLI flag wiring for --format notion and --push-to-notion |
 | `test_push_to_notion.py` | 5 | --push-to-notion JSON ingest and error paths |
 | `test_cli_notion_database.py` | 34 | CLI flag wiring for --notion-create-database and --notion-database-id |
-| `test_notion_database.py` | 35 | Notion database creation and upsert tests |
-| `test_notion_org_publisher.py` | 10 | --org-report --format notion catalog publisher tests |
+| `test_notion_database.py` | 41 | Notion database creation and upsert tests |
+| `test_notion_org_publisher.py` | 13 | --org-report --format notion catalog publisher tests |
 | `test_notion_registry_v2.py` | 11 | Notion registry v2 schema and legacy v1 migration tests |
 | `test_cli_notion_prune.py` | 20 | CLI flag wiring for --notion-prune-orphans |
 | `test_cli_notion_repair.py` | 14 | CLI flag wiring for --notion-repair-database and --notion-print-database-schema |
-| **Total** | **8,258** | **Collected via pytest --collect-only** |
+| **Total** | **8,355** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -808,13 +808,13 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (8,258 tests total)
+- [x] Comprehensive test coverage (8,355 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
-- [x] Profile management tests (test_profiles.py) - 78 tests
+- [x] Profile management tests (test_profiles.py) - 80 tests
 - [x] API worker auto-tuning tests (test_api_tuning.py) - 25 tests
 - [x] Circuit breaker pattern tests (test_circuit_breaker.py) - 25 tests
-- [x] Shared validation cache tests (test_shared_cache.py) - 28 tests
+- [x] Shared validation cache tests (test_shared_cache.py) - 30 tests
 - [x] Calculated metrics inventory tests (test_calculated_metrics_inventory.py) - 366 tests
 - [x] Segments inventory tests (test_segments_inventory.py) - 48 tests
 - [x] Derived fields inventory tests (test_derived_inventory.py) - 62 tests

--- a/tests/test_agent_output_contract.py
+++ b/tests/test_agent_output_contract.py
@@ -18,6 +18,7 @@ from cja_auto_sdr.cli.agent_output import (
     DIFF_STDOUT_FORMATS,
     DISCOVERY_STDOUT_FORMATS,
     ORG_REPORT_STDOUT_FORMATS,
+    _cli_option_specified,
     is_stdout_path,
     resolve_agent_output_path,
     resolve_agent_quiet,
@@ -82,6 +83,32 @@ class TestIsStdoutPath:
 
     def test_empty_string_is_not_stdout(self):
         assert is_stdout_path("") is False
+
+
+# ---------------------------------------------------------------------------
+# _cli_option_specified tests
+# ---------------------------------------------------------------------------
+
+
+class TestCliOptionSpecified:
+    """Verify explicit long-option detection, including abbreviation resolution."""
+
+    def test_literal_long_option_match(self):
+        """Direct token equality returns True without abbreviation resolution."""
+        assert _cli_option_specified("--agent-mode", ["--agent-mode"]) is True
+
+    def test_value_assignment_form_match(self):
+        """``--option=value`` form is recognised as an explicit option."""
+        assert _cli_option_specified("--output", ["--output=report.json"]) is True
+
+    def test_unambiguous_abbreviation_resolves_to_canonical_option(self):
+        """Line 90: an unambiguous abbreviation (``--agent-mod``) resolves to
+        ``--agent-mode`` via the long-option resolver and returns True."""
+        assert _cli_option_specified("--agent-mode", ["--agent-mod"]) is True
+
+    def test_unrelated_token_returns_false(self):
+        """A token that neither matches literally nor resolves returns False."""
+        assert _cli_option_specified("--agent-mode", ["--nonexistent-flag-xyz"]) is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -26,6 +26,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import cja_auto_sdr.api.client as _client_module
 from cja_auto_sdr.api.client import (
     _bootstrap_dotenv,
+    _cleanup_stale_temp_configs,
     _config_from_env,
     _describe_unexpected_probe_payload,
     _normalize_dataview_listing_payload,
@@ -135,6 +136,10 @@ class TestDataviewListingPayloadHelpers:
             {"id": "dv_1"},
             {"id": "dv_2"},
         ]
+
+    def test_normalize_dataview_listing_payload_treats_none_as_empty(self):
+        """A None payload (no data views returned) normalizes to an empty list, not None."""
+        assert _normalize_dataview_listing_payload(None) == []
 
     def test_normalize_dataview_listing_payload_rejects_error_dict(self):
         assert _normalize_dataview_listing_payload({"statusCode": 500, "message": "backend timeout"}) is None
@@ -310,6 +315,48 @@ class TestConfigFromEnvCleanup:
 
         assert not recent_file.exists()
         assert mock_cjapy.configure.call_count == 3
+
+    @patch("cja_auto_sdr.api.client.tempfile.gettempdir")
+    def test_cleanup_returns_immediately_when_glob_raises_oserror(self, mock_gettempdir, mock_logger, tmp_path):
+        """A failed temp-directory scan logs and reschedules an immediate recheck (0.0)."""
+        mock_gettempdir.return_value = str(tmp_path)
+
+        with patch("cja_auto_sdr.api.client.Path.glob", side_effect=OSError("scan failed")):
+            next_scan_in = _cleanup_stale_temp_configs(mock_logger)
+
+        assert next_scan_in == 0.0
+        calls = [str(c) for c in mock_logger.debug.call_args_list]
+        assert any("Failed to scan temp directory for stale config files" in c for c in calls)
+
+    @patch("cja_auto_sdr.api.client.tempfile.gettempdir")
+    def test_cleanup_skips_candidate_when_stat_raises_oserror(self, mock_gettempdir, mock_logger, tmp_path):
+        """A candidate whose stat() fails is skipped without aborting the scan."""
+        mock_gettempdir.return_value = str(tmp_path)
+        candidate = tmp_path / "cja_env_config_stat_fail.json"
+        candidate.write_text("{}", encoding="utf-8")
+
+        with patch("cja_auto_sdr.api.client.Path.stat", side_effect=OSError("stat failed")):
+            next_scan_in = _cleanup_stale_temp_configs(mock_logger)
+
+        # No file removed (stat failed), and the candidate is left in place.
+        assert candidate.exists()
+        # Falls through to the default full-interval schedule.
+        assert next_scan_in == _client_module._LEGACY_TEMP_CONFIG_MAX_AGE_SECONDS
+
+    @patch("cja_auto_sdr.api.client.tempfile.gettempdir")
+    def test_cleanup_reschedules_immediate_when_unlink_raises_oserror(self, mock_gettempdir, mock_logger, tmp_path):
+        """A stale file that cannot be unlinked triggers an immediate recheck (retry path)."""
+        mock_gettempdir.return_value = str(tmp_path)
+        stale_file = tmp_path / "cja_env_config_unlink_fail.json"
+        stale_file.write_text("{}", encoding="utf-8")
+        os.utime(stale_file, (time.time() - 7200, time.time() - 7200))
+
+        with patch("cja_auto_sdr.api.client.Path.unlink", side_effect=OSError("unlink failed")):
+            next_scan_in = _cleanup_stale_temp_configs(mock_logger)
+
+        # File still present because unlink failed, and retry is scheduled immediately.
+        assert stale_file.exists()
+        assert next_scan_in == 0.0
 
 
 # ==================== configure_cjapy default logger (lines 96-97) ====================

--- a/tests/test_cli_command_handlers.py
+++ b/tests/test_cli_command_handlers.py
@@ -3234,6 +3234,64 @@ class TestShowStatsKeyboardInterrupt:
         assert "cancelled" in captured.out.lower()
 
 
+class TestCoerceNameResolutionResult:
+    """_coerce_name_resolution_result normalization (stats.py)."""
+
+    def test_two_tuple_gets_fresh_diagnostics(self) -> None:
+        """A legacy 2-tuple is extended with a fresh diagnostics object."""
+        from cja_auto_sdr.cli.commands.stats import _coerce_name_resolution_result
+        from cja_auto_sdr.generator import NameResolutionDiagnostics
+
+        result = _coerce_name_resolution_result((["dv_1"], {"name": ["dv_1"]}))
+        resolved_ids, name_map, diagnostics = result
+        assert resolved_ids == ["dv_1"]
+        assert name_map == {"name": ["dv_1"]}
+        assert isinstance(diagnostics, NameResolutionDiagnostics)
+
+    def test_three_tuple_with_valid_diagnostics_passthrough(self) -> None:
+        """A 3-tuple whose third element is a NameResolutionDiagnostics is kept."""
+        from cja_auto_sdr.cli.commands.stats import _coerce_name_resolution_result
+        from cja_auto_sdr.generator import NameResolutionDiagnostics
+
+        diag = NameResolutionDiagnostics(error_type="not_found", error_message="nope")
+        result = _coerce_name_resolution_result((["dv_1"], {}, diag))
+        resolved_ids, name_map, diagnostics = result
+        assert resolved_ids == ["dv_1"]
+        assert name_map == {}
+        assert diagnostics is diag
+
+    def test_three_tuple_with_invalid_diagnostics_gets_fresh(self) -> None:
+        """Line 55: a 3-tuple whose third element is *not* a
+        NameResolutionDiagnostics is replaced with a fresh one."""
+        from cja_auto_sdr.cli.commands.stats import _coerce_name_resolution_result
+        from cja_auto_sdr.generator import NameResolutionDiagnostics
+
+        result = _coerce_name_resolution_result((["dv_1"], {"n": ["dv_1"]}, "not-a-diagnostics"))
+        resolved_ids, name_map, diagnostics = result
+        assert resolved_ids == ["dv_1"]
+        assert name_map == {"n": ["dv_1"]}
+        assert isinstance(diagnostics, NameResolutionDiagnostics)
+
+
+class TestResolveDataViewNamesSystemError:
+    """resolve_data_view_names re-raises SystemError (stats.py line 273)."""
+
+    def test_system_error_is_reraised(self) -> None:
+        from cja_auto_sdr.cli.commands.stats import resolve_data_view_names
+
+        with patch("cja_auto_sdr.cli.commands.stats._generator_module") as mock_gen:
+            gen = mock_gen.return_value
+            # Keep the recoverable-exception handler from catching SystemError so
+            # it falls through to the generic ``except Exception`` block, where
+            # SystemError is re-raised (line 272-273).
+            gen.RECOVERABLE_CONFIG_API_EXCEPTIONS = (ValueError,)
+            gen.NameResolutionDiagnostics = MagicMock()
+            gen.configure_cjapy.side_effect = SystemError("interpreter boom")
+
+            with pytest.raises(SystemError, match="interpreter boom"):
+                resolve_data_view_names(["My DV"])
+
+
 # ---------------------------------------------------------------------------
 # Coverage gap tests (moved from test_small_gap_coverage.py)
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_diff_contracts.py
+++ b/tests/test_cli_diff_contracts.py
@@ -828,3 +828,152 @@ def test_dispatch_snapshot_cli_modes_prune_stdout_forces_json_output() -> None:
     generator_mod._emit_json_output.assert_called_once()
     generator_mod._emit_output.assert_not_called()
     assert run_state["output_format"] == "json"
+
+
+# ---------------------------------------------------------------------------
+# Diff-family run_state advisory-rollup propagation (cli.py L293/556/718)
+# ---------------------------------------------------------------------------
+
+
+def _diff_dispatch_args(**overrides: Any) -> argparse.Namespace:
+    """Namespace covering attributes read by the diff/snapshot CLI dispatchers."""
+    defaults: dict[str, Any] = {
+        "config_file": "config.json",
+        "output_dir": ".",
+        "format": "console",
+        "output": None,
+        "metrics_only": False,
+        "dimensions_only": False,
+        "inventory_only": False,
+        "include_derived_inventory": False,
+        "include_calculated_metrics": False,
+        "include_segments_inventory": False,
+        "changes_only": False,
+        "summary": False,
+        "extended_fields": False,
+        "side_by_side": False,
+        "no_color": False,
+        "quiet_diff": False,
+        "reverse_diff": False,
+        "warn_threshold": None,
+        "group_by_field": False,
+        "group_by_field_limit": 10,
+        "diff_output": None,
+        "format_pr_comment": False,
+        "auto_snapshot": False,
+        "auto_prune": False,
+        "snapshot_dir": "./snapshots",
+        "keep_last": 0,
+        "keep_since": None,
+        "profile": None,
+        "name_match": "exact",
+        "list_snapshots": False,
+        "prune_snapshots": False,
+        "snapshot": None,
+        "compare_snapshots": None,
+        "diff_snapshot": None,
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+def _handler_populating_rollup(*_args: Any, **kwargs: Any) -> tuple[bool, bool, None]:
+    """Diff handler stub that records an advisory rollup like the real handler."""
+    runtime_details = kwargs["runtime_details"]
+    runtime_details["advisory_rollup"] = {"severity": "INFO", "count": 0}
+    return True, False, None
+
+
+def test_dispatch_diff_records_advisory_rollup_in_run_state() -> None:
+    """cli.py L293: diff branch copies advisory_rollup into run_state details."""
+    args = _diff_dispatch_args()
+    run_state: dict[str, Any] = {}
+
+    with (
+        patch("cja_auto_sdr.diff.cli._generator_module") as mock_generator_module,
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        generator_mod = mock_generator_module.return_value
+        generator_mod.resolve_data_view_names.side_effect = [
+            (["dv_source"], []),
+            (["dv_target"], []),
+        ]
+        generator_mod.handle_diff_command.side_effect = _handler_populating_rollup
+
+        from cja_auto_sdr.diff.cli import dispatch_cross_data_view_diff_cli_mode
+
+        dispatch_cross_data_view_diff_cli_mode(
+            args,
+            data_view_inputs=["dv_source", "dv_target"],
+            ignore_fields=None,
+            labels=None,
+            show_only=None,
+            keep_last_specified=False,
+            keep_since_specified=False,
+            run_state=run_state,
+        )
+
+    assert exc_info.value.code == 0
+    assert run_state["details"]["advisories"] == {"severity": "INFO", "count": 0}
+
+
+def test_dispatch_compare_snapshots_records_advisory_rollup_in_run_state() -> None:
+    """cli.py L556: compare-snapshots branch copies advisory_rollup into run_state."""
+    args = _diff_dispatch_args(compare_snapshots=["source.json", "target.json"])
+    run_state: dict[str, Any] = {}
+
+    with (
+        patch("cja_auto_sdr.diff.cli._generator_module") as mock_generator_module,
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        generator_mod = mock_generator_module.return_value
+        generator_mod.handle_compare_snapshots_command.side_effect = _handler_populating_rollup
+
+        from cja_auto_sdr.diff.cli import dispatch_snapshot_cli_modes
+
+        dispatch_snapshot_cli_modes(
+            args,
+            data_view_inputs=[],
+            output_to_stdout=False,
+            ignore_fields=None,
+            labels=None,
+            show_only=None,
+            keep_last_specified=False,
+            keep_since_specified=False,
+            run_state=run_state,
+        )
+
+    assert exc_info.value.code == 0
+    assert run_state["details"]["advisories"] == {"severity": "INFO", "count": 0}
+
+
+def test_dispatch_diff_snapshot_records_advisory_rollup_in_run_state() -> None:
+    """cli.py L718: diff-snapshot branch copies advisory_rollup into run_state."""
+    args = _diff_dispatch_args(diff_snapshot="baseline.json")
+    run_state: dict[str, Any] = {}
+
+    with (
+        patch("cja_auto_sdr.diff.cli._generator_module") as mock_generator_module,
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        generator_mod = mock_generator_module.return_value
+        generator_mod.resolve_data_view_names.return_value = (["dv_target"], [])
+        generator_mod.handle_diff_snapshot_command.side_effect = _handler_populating_rollup
+
+        from cja_auto_sdr.diff.cli import dispatch_snapshot_cli_modes
+
+        dispatch_snapshot_cli_modes(
+            args,
+            data_view_inputs=["dv_target"],
+            output_to_stdout=False,
+            ignore_fields=None,
+            labels=None,
+            show_only=None,
+            keep_last_specified=False,
+            keep_since_specified=False,
+            run_state=run_state,
+        )
+
+    assert exc_info.value.code == 0
+    assert run_state["details"]["advisories"] == {"severity": "INFO", "count": 0}
+    assert run_state["resolved_data_views"] == ["dv_target"]

--- a/tests/test_coverage_hardening.py
+++ b/tests/test_coverage_hardening.py
@@ -854,3 +854,17 @@ class TestPromptForSelectionKeyboardInterrupt:
         with patch("builtins.input", side_effect=KeyboardInterrupt):
             result = prompt_for_selection(options, "Pick one:")
         assert result is None
+
+    def test_keyboard_interrupt_on_tty_returns_none(self) -> None:
+        """Lines 56-58: with a TTY, the input loop is entered and a
+        KeyboardInterrupt during ``input()`` returns None via the handler."""
+        from cja_auto_sdr.cli.interactive import prompt_for_selection
+
+        options = [("id1", "Option 1"), ("id2", "Option 2")]
+        with (
+            patch("sys.stdin") as mock_stdin,
+            patch("builtins.input", side_effect=KeyboardInterrupt),
+        ):
+            mock_stdin.isatty.return_value = True
+            result = prompt_for_selection(options, "Pick one:")
+        assert result is None

--- a/tests/test_diff_coverage.py
+++ b/tests/test_diff_coverage.py
@@ -1067,3 +1067,58 @@ class TestComparatorEmptyInventory:
         assert len(result.calc_metrics_diffs) == 0
         assert result.segments_diffs is not None
         assert len(result.segments_diffs) == 0
+
+
+# ==================== git.py remaining-line coverage ====================
+
+
+class TestGitRemainingLineCoverage:
+    """Cover the last uncovered branches in cja_auto_sdr.diff.git."""
+
+    def test_save_git_friendly_snapshot_with_quality_issues(self, tmp_path):
+        """Lines 150-154: quality_issues block tallies severity counts in metadata."""
+        snap = _make_snapshot()
+        quality_issues = [
+            {"Severity": "CRITICAL"},
+            {"Severity": "CRITICAL"},
+            {"Severity": "LOW"},
+            {},  # missing Severity -> defaults to UNKNOWN
+        ]
+
+        saved = save_git_friendly_snapshot(snap, tmp_path, quality_issues=quality_issues)
+
+        with open(saved["metadata"]) as f:
+            metadata = json.load(f)
+
+        assert metadata["quality"]["total_issues"] == 4
+        assert metadata["quality"]["by_severity"]["CRITICAL"] == 2
+        assert metadata["quality"]["by_severity"]["LOW"] == 1
+        assert metadata["quality"]["by_severity"]["UNKNOWN"] == 1
+
+    def test_commit_message_dimensions_modified(self):
+        """Line 203: dimensions_modified > 0 appears in commit message."""
+        summary = DiffSummary(metrics_added=0, dimensions_modified=5)
+        diff_result = DiffResult(
+            summary=summary,
+            metadata_diff=MagicMock(),
+            metric_diffs=[],
+            dimension_diffs=[],
+        )
+
+        msg = generate_git_commit_message(
+            data_view_id="dv_mod",
+            data_view_name="Modified DV",
+            metrics_count=4,
+            dimensions_count=9,
+            diff_result=diff_result,
+        )
+
+        assert "~ 5 dimensions modified" in msg
+
+    def test_init_snapshot_repo_already_a_git_repository(self, tmp_path):
+        """Line 330: short-circuits when the directory is already a Git repo."""
+        with patch("cja_auto_sdr.diff.git.is_git_repository", return_value=True):
+            ok, msg = git_init_snapshot_repo(tmp_path)
+
+        assert ok is True
+        assert msg == "Already a Git repository"

--- a/tests/test_discovery_payloads.py
+++ b/tests/test_discovery_payloads.py
@@ -566,3 +566,15 @@ def test_discovery_lookup_helpers_cover_remaining_edge_paths() -> None:
     assert _unknown_placeholder_diagnostic_key({"lookup_failure_reason": "timeout"}) == "lookup_failure_reason"
     assert _unknown_placeholder_diagnostic_key({"lookup_debug": "detail"}) == "lookup_debug"
     assert _unknown_lookup_placeholder_reason("dv1", {"id": "dv_other", "name": "Unknown"}) is None
+
+
+def test_assess_expected_lookup_id_treats_whitespace_only_bytes_id_as_missing() -> None:
+    # Whitespace-only bytes survive is_missing_value (only str inputs get
+    # blank-string handling) and coerce to a blank string, which strips empty.
+    assert _assess_expected_lookup_id({"id": b"   "}, expected_data_view_id="dv1") == (None, "missing_expected_id")
+
+
+def test_unknown_placeholder_diagnostic_key_skips_blank_lookup_prefixed_value() -> None:
+    # A lookup_-prefixed key whose value lacks substance is skipped by the final
+    # diagnostic scan, leaving no diagnostic key to report.
+    assert _unknown_placeholder_diagnostic_key({"lookup_extra": ""}) is None

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -393,3 +393,21 @@ class TestMemoryLimitExceeded:
 
     def test_inherits_cjasdr_error(self):
         assert issubclass(MemoryLimitExceeded, CJASDRError)
+
+
+class TestApiConnectionHintStatusFromMessage:
+    """Tests for _api_connection_hint_status_from_message keyword fallbacks."""
+
+    def test_unauthorized_keyword_without_numeric_status_returns_401(self):
+        from cja_auto_sdr.core.exceptions import _api_connection_hint_status_from_message
+
+        # Marker present ("unauthorized") but no 3-digit code, so coercion yields
+        # nothing and the "unauthorized" keyword fallback returns 401.
+        assert _api_connection_hint_status_from_message("Request unauthorized") == 401
+
+    def test_forbidden_keyword_without_numeric_status_returns_403(self):
+        from cja_auto_sdr.core.exceptions import _api_connection_hint_status_from_message
+
+        # Marker present ("forbidden") but no coercible 401/403 status, so the
+        # "forbidden" keyword fallback returns 403.
+        assert _api_connection_hint_status_from_message("Access forbidden") == 403

--- a/tests/test_generator_interactive_and_console.py
+++ b/tests/test_generator_interactive_and_console.py
@@ -114,6 +114,22 @@ def test_interactive_wizard_config_failure(_mock_config: Mock):
     assert generator.interactive_wizard(config_file="bad.json") is None
 
 
+@patch("cja_auto_sdr.generator.configure_cjapy", return_value=(True, "mock", None))
+@patch("cja_auto_sdr.generator.cjapy")
+def test_interactive_wizard_quit_at_yes_no_prompt(mock_cjapy: Mock, _mock_config: Mock):
+    """cli/interactive.py line 291: entering 'q' at a yes/no prompt returns None,
+    cancelling the wizard from the Segments-inventory question."""
+    mock_cja = Mock()
+    mock_cja.getDataViews.return_value = _mock_data_views()
+    mock_cjapy.CJA.return_value = mock_cja
+
+    # Select DV (1), accept default format (""), then quit at the first
+    # prompt_yes_no ("Include Segments inventory?") with 'q'.
+    user_inputs = ["1", "", "q"]
+    with patch("builtins.input", side_effect=user_inputs):
+        assert generator.interactive_wizard(profile="dev") is None
+
+
 def test_write_org_report_console_renders_all_major_sections(capsys, rich_org_report_result):
     result = rich_org_report_result
     generator.write_org_report_console(result, result.parameters, quiet=False)

--- a/tests/test_json_io.py
+++ b/tests/test_json_io.py
@@ -249,6 +249,29 @@ class TestWriteJsonAtomicCompatible:
         assert mode & 0o600 == 0o600  # owner rw at minimum
 
     @pytest.mark.skipif(_SKIP_PERMISSION_SEMANTICS, reason="requires POSIX non-root permission semantics")
+    def test_new_file_explicit_file_mode_via_atomic_replace(self, tmp_path):
+        # New (non-existent) target in a writable dir takes the atomic-replace
+        # path; an explicit file_mode chmods the staged temp before replace.
+        out = tmp_path / "new-secret.json"
+
+        write_json_atomic_compatible(out, {"secret": True}, file_mode=0o600)
+
+        assert json.loads(out.read_text(encoding="utf-8")) == {"secret": True}
+        assert stat.S_IMODE(out.stat().st_mode) == 0o600
+
+    def test_new_file_falls_back_to_direct_write_without_atomic_replace(self, tmp_path):
+        # When the destination directory cannot accept temp-file creation and
+        # replace, a new target is written directly instead.
+        out = tmp_path / "fallback.json"
+
+        with patch.object(json_io, "_directory_supports_atomic_replace", return_value=False):
+            result = write_json_atomic_compatible(out, {"fallback": True})
+
+        assert result == out
+        assert json.loads(out.read_text(encoding="utf-8")) == {"fallback": True}
+        assert list(tmp_path.glob(".*tmp")) == []
+
+    @pytest.mark.skipif(_SKIP_PERMISSION_SEMANTICS, reason="requires POSIX non-root permission semantics")
     def test_read_only_existing_file_matches_open_permissions(self, tmp_path):
         out = tmp_path / "readonly.json"
         out.write_text("{}", encoding="utf-8")

--- a/tests/test_list_command_edge_cases.py
+++ b/tests/test_list_command_edge_cases.py
@@ -21,6 +21,7 @@ from cja_auto_sdr.cli.commands.discovery import (
     _build_dimension_display_row,
     _build_metric_display_row,
     _fetch_component_payload,
+    _is_missing_sort_value,
     _normalize_component_records_or_raise,
     _normalize_optional_component_int,
     _resolve_dataview_name,
@@ -769,3 +770,58 @@ class TestNormalizeOptionalComponentIntDiscovery:
 
     def test_none_returns_default(self) -> None:
         assert _normalize_optional_component_int(None) == 0
+
+    def test_blank_string_after_missing_guard_returns_default(self) -> None:
+        """Line 717: defensive blank-string branch.
+
+        The leading ``_is_missing_discovery_value`` guard (treat_blank_string=True)
+        normally short-circuits any blank string, so the inner ``if not stripped``
+        check is unreachable through real input.  We patch the guard to report a
+        blank string as *present* so the string branch runs and the
+        ``stripped == ''`` fallback returns the default.
+        """
+        from cja_auto_sdr.cli.commands import discovery as _disc_mod
+
+        with patch.object(_disc_mod, "_is_missing_discovery_value", return_value=False):
+            assert _normalize_optional_component_int("   ") == 0
+            assert _normalize_optional_component_int("   ", default=-9) == -9
+
+
+# ---------------------------------------------------------------------------
+# _is_missing_sort_value: pd.isna error path (discovery.py lines 185-186)
+# ---------------------------------------------------------------------------
+
+
+class TestIsMissingSortValueDiscovery:
+    """Exercise _is_missing_sort_value through the canonical discovery module."""
+
+    def test_none_is_missing(self) -> None:
+        assert _is_missing_sort_value(None) is True
+
+    def test_blank_string_is_missing(self) -> None:
+        assert _is_missing_sort_value("") is True
+        assert _is_missing_sort_value("   ") is True
+
+    def test_nan_is_missing(self) -> None:
+        assert _is_missing_sort_value(float("nan")) is True
+
+    def test_concrete_value_is_not_missing(self) -> None:
+        assert _is_missing_sort_value("hello") is False
+        assert _is_missing_sort_value(42) is False
+
+    def test_pd_isna_typeerror_returns_false(self) -> None:
+        """Lines 185-186: a value whose pd.isna raises TypeError is treated as
+        present (not missing)."""
+
+        class Unisnable:
+            def __array__(self, *args, **kwargs):
+                raise TypeError("cannot coerce to array")
+
+        assert _is_missing_sort_value(Unisnable()) is False
+
+    def test_pd_isna_valueerror_returns_false(self) -> None:
+        """Lines 185-186: a value whose pd.isna raises ValueError (ambiguous
+        truth value of an array) is treated as present (not missing)."""
+        import numpy as np
+
+        assert _is_missing_sort_value(np.array([1, 2, 3])) is False

--- a/tests/test_notion_database.py
+++ b/tests/test_notion_database.py
@@ -468,6 +468,54 @@ def test_repair_raises_when_no_data_source() -> None:
         repair_database_schema(client, database_id="db1")
 
 
+def test_repair_records_wrong_typed_title_as_conflict() -> None:
+    """A "Name" property present but not of type title is a conflict, never re-added."""
+    from cja_auto_sdr.output.notion_database import repair_database_schema
+
+    existing = {"Name": {"type": "rich_text"}}
+    cap: dict = {}
+    client = _fake_repair_client(existing, capture=cap)
+
+    result = repair_database_schema(client, database_id="db1")
+
+    assert ("Name", "title", "rich_text") in result.conflicts
+    assert "Name" not in cap.get("properties", {})  # title is never added or changed
+
+
+def test_derive_data_quality_unknown_without_severity_column() -> None:
+    """A non-empty DQ frame lacking a Severity column is reported as unknown."""
+    df = pd.DataFrame([{"Message": "no severity column here"}])
+    assert derive_data_quality_status(df) == "unknown"
+
+
+def test_derive_data_quality_healthy_on_low_severity() -> None:
+    """Severities that are neither degraded nor partial fall through to healthy."""
+    df = pd.DataFrame([{"Severity": "LOW", "Message": "x"}])
+    assert derive_data_quality_status(df) == "healthy"
+
+
+def test_iso_date_value_falls_back_to_date_only_match() -> None:
+    """A value that is not ISO-parseable and lacks a time component matches the
+    date-only regex and yields a date-only Notion start value."""
+    assert _iso_date_value("2026-06-19 PDT") == {"start": "2026-06-19"}
+
+
+def test_ensure_database_existing_without_data_source_raises() -> None:
+    """A configured database with no data source is a hard error."""
+    client = MagicMock()
+    client.databases.retrieve.return_value = {"id": "db1", "data_sources": []}
+    with pytest.raises(ValueError, match="no data source"):
+        ensure_database(client, parent_page_id="parent", database_id="db1", create_if_missing=False)
+
+
+def test_ensure_database_created_without_data_source_raises() -> None:
+    """If Notion returns a created database with no data source, ensure_database raises."""
+    client = MagicMock()
+    client.databases.create.return_value = {"id": "db-new", "data_sources": []}
+    with pytest.raises(ValueError, match="did not return a data source"):
+        ensure_database(client, parent_page_id="parent", database_id=None, create_if_missing=True)
+
+
 def test_repair_flags_absent_canonical_title_as_conflict() -> None:
     """A renamed/absent title ('Name' not in live) is reported as a conflict, not silently skipped."""
     from cja_auto_sdr.output.notion_database import DATABASE_SCHEMA, _schema_property_type, repair_database_schema

--- a/tests/test_notion_org_publisher.py
+++ b/tests/test_notion_org_publisher.py
@@ -308,6 +308,78 @@ def test_bootstrap_requires_parent_page():
         patch.stopall()
 
 
+def test_ensure_database_unexpected_error_reraises():
+    """A non-API, non-ValueError error from ensure_database propagates unchanged."""
+    patches = _apply_base_patches()
+    try:
+        from cja_auto_sdr.output.notion_org_publisher import publish_org_report_catalog_to_notion
+
+        patches["cja_auto_sdr.output.notion_org_publisher.ensure_database"].side_effect = RuntimeError("disk full")
+
+        org_report = _make_org_report([])
+        with pytest.raises(RuntimeError, match="disk full"):
+            publish_org_report_catalog_to_notion(
+                org_report,
+                output_dir="/tmp/test_out",
+                logger=MagicMock(),
+                database_id="db-123",
+                create_database=False,
+            )
+    finally:
+        patch.stopall()
+
+
+def test_row_failure_non_api_error_reraises_when_not_continue_on_error():
+    """A non-API upsert failure with continue_on_error=False propagates unchanged."""
+    patches = _apply_base_patches()
+    try:
+        from cja_auto_sdr.output.notion_org_publisher import publish_org_report_catalog_to_notion
+
+        patches["cja_auto_sdr.output.notion_org_publisher.upsert_database_row"].side_effect = RuntimeError("boom")
+
+        org_report = _make_org_report([_make_summary("dv_001", "DV One")])
+        with pytest.raises(RuntimeError, match="boom"):
+            publish_org_report_catalog_to_notion(
+                org_report,
+                output_dir="/tmp/test_out",
+                logger=MagicMock(),
+                database_id="db-123",
+                create_database=False,
+            )
+    finally:
+        patch.stopall()
+
+
+def test_row_failure_api_error_raises_notion_api_error_when_not_continue_on_error():
+    """A Notion API upsert failure with continue_on_error=False → NotionAPIError."""
+    patches = _apply_base_patches()
+    try:
+        from cja_auto_sdr.output.notion_org_publisher import publish_org_report_catalog_to_notion
+        from cja_auto_sdr.output.writers.notion import NotionAPIError
+
+        class FakeAPIResponseError(Exception):
+            def __init__(self):
+                super().__init__("conflict_error")
+                self.code = "conflict_error"
+
+        FakeAPIResponseError.__name__ = "APIResponseError"
+        FakeAPIResponseError.__qualname__ = "APIResponseError"
+
+        patches["cja_auto_sdr.output.notion_org_publisher.upsert_database_row"].side_effect = FakeAPIResponseError()
+
+        org_report = _make_org_report([_make_summary("dv_001", "DV One")])
+        with pytest.raises(NotionAPIError):
+            publish_org_report_catalog_to_notion(
+                org_report,
+                output_dir="/tmp/test_out",
+                logger=MagicMock(),
+                database_id="db-123",
+                create_database=False,
+            )
+    finally:
+        patch.stopall()
+
+
 def test_adapter_forwards_continue_on_error():
     """write_org_report_notion must forward continue_on_error to the publisher."""
     from cja_auto_sdr.org.writers.notion import write_org_report_notion

--- a/tests/test_notion_registry.py
+++ b/tests/test_notion_registry.py
@@ -148,3 +148,66 @@ def test_store_page_id_concurrent_workers_preserve_all_entries(tmp_path):
     assert len(data) == n
     for i in range(n):
         assert data[f"dv_{i:03d}"] == {"page_id": f"page-{i:03d}", "database_row_id": None, "orphaned_page_ids": []}
+
+
+def test_coerce_entry_non_str_non_dict_returns_default():
+    """A registry value that is neither a string (v1) nor a dict (v2) coerces to default."""
+    from cja_auto_sdr.output.notion_registry import _coerce_entry, _default_entry
+
+    assert _coerce_entry(12345) == _default_entry()
+    assert _coerce_entry(None) == _default_entry()
+
+
+def test_load_registry_non_dict_top_level_returns_empty(tmp_path):
+    """A registry file whose JSON top-level is not an object loads as an empty registry."""
+    path = tmp_path / REGISTRY_FILENAME
+    path.write_text("[1, 2, 3]", encoding="utf-8")
+    assert load_registry(path) == {}
+
+
+def test_remove_orphaned_page_ids_absent_data_view_is_noop(tmp_path):
+    """Removing orphans for a data view absent from the registry returns without writing."""
+    from cja_auto_sdr.output.notion_registry import remove_orphaned_page_ids
+
+    path = tmp_path / REGISTRY_FILENAME
+    remove_orphaned_page_ids(path, "dv_absent", ["page-x"])  # entry is None -> early return
+    assert load_registry(path) == {}
+
+
+def test_exclusive_registry_lock_msvcrt_retries_on_oserror(tmp_path, monkeypatch):
+    """Windows path: msvcrt.locking raising OSError (lock contended) retries until it succeeds."""
+    import builtins
+
+    from cja_auto_sdr.output import notion_registry as nr_mod
+
+    state = {"lock_attempts": 0}
+
+    def fake_locking(fd, mode, nbytes):
+        # mode 1 == LK_LOCK (acquire). First acquire attempt is contended.
+        if mode == 1:
+            state["lock_attempts"] += 1
+            if state["lock_attempts"] == 1:
+                raise OSError("lock held by another process")
+
+    fake_msvcrt = type(
+        "FakeMsvcrt",
+        (),
+        {"LK_LOCK": 1, "LK_UNLCK": 0, "locking": staticmethod(fake_locking)},
+    )()
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "fcntl":
+            raise ImportError("simulated: no fcntl on Windows")
+        if name == "msvcrt":
+            return fake_msvcrt
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    reg_path = tmp_path / REGISTRY_FILENAME
+    nr_mod.store_page_id(reg_path, "dv_retry", "page-retry")
+
+    assert state["lock_attempts"] == 2  # one OSError, then a successful retry
+    data = json.loads(reg_path.read_text())
+    assert data["dv_retry"]["page_id"] == "page-retry"

--- a/tests/test_notion_writer.py
+++ b/tests/test_notion_writer.py
@@ -1165,3 +1165,222 @@ def test_repair_notion_database_resolves_db_id_from_env(monkeypatch):
 
     fc.databases.retrieve.assert_called_once()
     assert fc.databases.retrieve.call_args.kwargs["database_id"] == "db-from-env"
+
+
+# ---------------------------------------------------------------------------
+# Coverage hardening (v3.11.1): error-mapping helpers, pagination/delete edge
+# cases, prune/repair error branches, and the dotenv-absent fallbacks.
+# ---------------------------------------------------------------------------
+
+
+def test_build_sdr_blocks_includes_dq_section_when_present():
+    """A non-empty Data Quality frame renders the DQ heading plus per-row callouts."""
+    data_dict = {
+        "Data Quality": pd.DataFrame([{"Severity": "WARN", "Message": "check this"}]),
+        "Metrics": pd.DataFrame({"Name": ["m1"], "Type": ["metric"]}),
+    }
+    metadata = {"Data View Name": "Test", "Data View ID": "dv_001"}
+    blocks = build_sdr_blocks(data_dict, metadata)
+    headings = [b["heading_2"]["rich_text"][0]["text"]["content"] for b in blocks if b["type"] == "heading_2"]
+    assert any("Data Quality" in h for h in headings)
+    assert any(b["type"] == "callout" for b in blocks)
+
+
+def test_extract_api_error_code_stringifies_non_str_code():
+    """A non-string, non-None ``code`` (e.g. an enum/int) is coerced via str()."""
+    from cja_auto_sdr.output.writers import notion as _notion_mod
+
+    class FakeErr(Exception):
+        code = 123
+
+    assert _notion_mod._extract_api_error_code(FakeErr()) == "123"
+
+
+def test_extract_api_error_code_returns_none_when_code_absent():
+    """No ``code`` attribute (or an explicit None) yields None."""
+    from cja_auto_sdr.output.writers import notion as _notion_mod
+
+    class FakeErr(Exception):
+        code = None
+
+    assert _notion_mod._extract_api_error_code(FakeErr()) is None
+    assert _notion_mod._extract_api_error_code(Exception("plain")) is None
+
+
+def test_extract_retry_after_seconds_parses_numeric_header():
+    from cja_auto_sdr.output.writers import notion as _notion_mod
+
+    class FakeErr(Exception):
+        headers = {"Retry-After": "2.5"}
+
+    assert _notion_mod._extract_retry_after_seconds(FakeErr()) == 2.5
+
+
+def test_extract_retry_after_seconds_returns_none_for_unparseable_header():
+    from cja_auto_sdr.output.writers import notion as _notion_mod
+
+    class FakeErr(Exception):
+        headers = {"Retry-After": "soon-ish"}
+
+    assert _notion_mod._extract_retry_after_seconds(FakeErr()) is None
+
+
+def test_friendly_notion_error_message_for_validation_error():
+    from cja_auto_sdr.output.writers import notion as _notion_mod
+
+    class FakeErr(Exception):
+        code = "validation_error"
+
+    msg = _notion_mod._friendly_notion_error_message(FakeErr("bad payload"))
+    assert "rejected the payload" in msg
+
+
+def test_friendly_notion_error_message_falls_back_for_unknown_code():
+    from cja_auto_sdr.output.writers import notion as _notion_mod
+
+    class FakeErr(Exception):
+        code = "some_unknown_code"
+
+    msg = _notion_mod._friendly_notion_error_message(FakeErr("boom"))
+    assert "some_unknown_code" in msg
+
+
+def test_list_all_child_block_ids_breaks_when_next_cursor_missing():
+    """has_more=True but a missing next_cursor must break, not loop forever."""
+    from cja_auto_sdr.output.writers.notion import _list_all_child_block_ids
+
+    client = MagicMock()
+    client.blocks.children.list.return_value = {
+        "results": [{"id": "b1"}],
+        "has_more": True,
+        "next_cursor": None,
+    }
+    ids = _list_all_child_block_ids(client, "page-x")
+    assert ids == ["b1"]
+    client.blocks.children.list.assert_called_once()
+
+
+def test_clear_page_blocks_single_block_uses_direct_delete():
+    """A single child block is deleted directly without spinning up a thread pool."""
+    from cja_auto_sdr.output.writers.notion import _clear_page_blocks
+
+    client = MagicMock()
+    client.blocks.children.list.return_value = {"results": [{"id": "only-block"}], "has_more": False}
+    _clear_page_blocks(client, "page-x")
+    client.blocks.delete.assert_called_once_with(block_id="only-block")
+
+
+def test_resolve_notion_credentials_handles_missing_dotenv(monkeypatch):
+    """When python-dotenv is unavailable, resolution falls back to the raw env."""
+    monkeypatch.setitem(sys.modules, "dotenv", None)  # `from dotenv import load_dotenv` -> ImportError
+    monkeypatch.setenv("NOTION_TOKEN", "tok")
+    monkeypatch.setenv("NOTION_PARENT_PAGE_ID", "pid")
+    from cja_auto_sdr.output.writers.notion import resolve_notion_credentials
+
+    token, parent = resolve_notion_credentials()
+    assert token == "tok"
+    assert parent == "pid"
+
+
+def test_prune_orphans_api_error_other_than_not_found_raises(tmp_path, monkeypatch):
+    """A non-404 API error while archiving an orphan surfaces as NotionAPIError."""
+    from cja_auto_sdr.output.notion_registry import add_orphaned_page_id, get_registry_path
+    from cja_auto_sdr.output.writers.notion import NotionAPIError, prune_notion_orphans
+
+    monkeypatch.setenv("NOTION_TOKEN", "tok")
+    reg = get_registry_path(tmp_path)
+    add_orphaned_page_id(reg, "dv1", "orphan-1")
+
+    class _Forbidden(Exception):
+        code = "restricted_resource"
+
+    _Forbidden.__name__ = "APIResponseError"
+
+    fake_cls = MagicMock()
+    fake_cls.return_value.pages.update.side_effect = _Forbidden()
+    with patch("cja_auto_sdr.output.writers.notion._require_notion_client", return_value=fake_cls):
+        with pytest.raises(NotionAPIError):
+            prune_notion_orphans(tmp_path, MagicMock())
+
+
+def test_prune_orphans_non_api_error_reraises(tmp_path, monkeypatch):
+    """A non-API error while archiving an orphan propagates unchanged."""
+    from cja_auto_sdr.output.notion_registry import add_orphaned_page_id, get_registry_path
+    from cja_auto_sdr.output.writers.notion import prune_notion_orphans
+
+    monkeypatch.setenv("NOTION_TOKEN", "tok")
+    reg = get_registry_path(tmp_path)
+    add_orphaned_page_id(reg, "dv1", "orphan-1")
+
+    fake_cls = MagicMock()
+    fake_cls.return_value.pages.update.side_effect = RuntimeError("disk error")
+    with patch("cja_auto_sdr.output.writers.notion._require_notion_client", return_value=fake_cls):
+        with pytest.raises(RuntimeError, match="disk error"):
+            prune_notion_orphans(tmp_path, MagicMock())
+
+
+def test_repair_notion_database_handles_missing_dotenv(monkeypatch):
+    """repair_notion_database tolerates python-dotenv being absent."""
+    monkeypatch.setitem(sys.modules, "dotenv", None)  # force ImportError on the dotenv import
+    monkeypatch.setenv("NOTION_TOKEN", "tok")
+    from cja_auto_sdr.output.writers.notion import repair_notion_database
+
+    fake_cls = MagicMock()
+    fc = fake_cls.return_value
+    fc.databases.retrieve.return_value = {"id": "db1", "data_sources": [{"id": "ds1"}]}
+    fc.data_sources.retrieve.return_value = {"properties": {"Name": {"type": "title"}}}
+    fc.data_sources.update.return_value = {"id": "ds1"}
+    with patch("cja_auto_sdr.output.writers.notion._require_notion_client", return_value=fake_cls):
+        result = repair_notion_database("db1", MagicMock())
+    assert result.applied is True
+
+
+def test_repair_notion_database_reraises_non_api_error(monkeypatch):
+    """A non-API error from repair_database_schema propagates unchanged."""
+    from cja_auto_sdr.output.writers.notion import repair_notion_database
+
+    monkeypatch.setenv("NOTION_TOKEN", "tok")
+    fake_cls = MagicMock()
+    fake_cls.return_value.databases.retrieve.side_effect = RuntimeError("kaboom")
+    with patch("cja_auto_sdr.output.writers.notion._require_notion_client", return_value=fake_cls):
+        with pytest.raises(RuntimeError, match="kaboom"):
+            repair_notion_database("db1", MagicMock())
+
+
+def test_repair_notion_database_warns_on_missing_title(monkeypatch):
+    """A registry whose title column was renamed yields a 'missing' conflict warning."""
+    from cja_auto_sdr.output.notion_database import DATABASE_SCHEMA, _schema_property_type
+    from cja_auto_sdr.output.writers.notion import repair_notion_database
+
+    monkeypatch.setenv("NOTION_TOKEN", "tok")
+    # Full schema except the canonical title "Name" is absent -> ("Name", "title", "missing").
+    live = {n: {"type": _schema_property_type(e)} for n, e in DATABASE_SCHEMA.items() if n != "Name"}
+    fake_cls = MagicMock()
+    fc = fake_cls.return_value
+    fc.databases.retrieve.return_value = {"id": "db1", "data_sources": [{"id": "ds1"}]}
+    fc.data_sources.retrieve.return_value = {"properties": live}
+    logger = MagicMock()
+    with patch("cja_auto_sdr.output.writers.notion._require_notion_client", return_value=fake_cls):
+        result = repair_notion_database("db1", logger)
+    assert ("Name", "title", "missing") in result.conflicts
+    warn_msgs = " ".join(str(c.args[0]) for c in logger.warning.call_args_list)
+    assert "absent" in warn_msgs
+
+
+def test_repair_notion_database_logs_up_to_date_when_clean(monkeypatch):
+    """A schema that needs nothing logs the up-to-date confirmation."""
+    from cja_auto_sdr.output.notion_database import DATABASE_SCHEMA, _schema_property_type
+    from cja_auto_sdr.output.writers.notion import repair_notion_database
+
+    monkeypatch.setenv("NOTION_TOKEN", "tok")
+    live = {n: {"type": _schema_property_type(e)} for n, e in DATABASE_SCHEMA.items()}
+    fake_cls = MagicMock()
+    fc = fake_cls.return_value
+    fc.databases.retrieve.return_value = {"id": "db1", "data_sources": [{"id": "ds1"}]}
+    fc.data_sources.retrieve.return_value = {"properties": live}
+    logger = MagicMock()
+    with patch("cja_auto_sdr.output.writers.notion._require_notion_client", return_value=fake_cls):
+        result = repair_notion_database("db1", logger)
+    assert result.to_add == [] and result.conflicts == []
+    info_msgs = " ".join(str(c.args[0]) for c in logger.info.call_args_list)
+    assert "up to date" in info_msgs

--- a/tests/test_org_analyzer_coverage.py
+++ b/tests/test_org_analyzer_coverage.py
@@ -968,6 +968,76 @@ class TestRunAnalysisImplFeatureFlags:
 
 
 # ===================================================================
+# 10b. _run_analysis_impl - sampled logging + governance threshold branch
+# ===================================================================
+
+
+class TestRunAnalysisImplSamplingAndGovernance:
+    """Tests for sampled-population logging and governance threshold reporting."""
+
+    def _setup(self, mock_cja, logger, *, is_sampled: bool, **config_kwargs):
+        # Three DVs so the default 50% core threshold (ceil(3*0.5)=2) leaves
+        # single-DV components isolated rather than misclassifying them as core.
+        config = OrgReportConfig(skip_lock=True, cja_per_thread=False, skip_similarity=True, **config_kwargs)
+        analyzer = _make_analyzer(mock_cja, logger, config=config)
+        summaries = [
+            DataViewSummary(
+                data_view_id="dv1",
+                data_view_name="DV 1",
+                metric_ids={"m_shared", "m_isolated"},
+                dimension_ids={"d_shared"},
+                metric_count=2,
+                dimension_count=1,
+            ),
+            DataViewSummary(
+                data_view_id="dv2",
+                data_view_name="DV 2",
+                metric_ids={"m_shared"},
+                dimension_ids={"d_shared"},
+                metric_count=1,
+                dimension_count=1,
+            ),
+            DataViewSummary(
+                data_view_id="dv3",
+                data_view_name="DV 3",
+                metric_ids={"m_shared"},
+                dimension_ids={"d_shared"},
+                metric_count=1,
+                dimension_count=1,
+            ),
+        ]
+        patches = [
+            patch.object(
+                analyzer,
+                "_list_and_filter_data_views",
+                return_value=([{"id": "dv1"}, {"id": "dv2"}, {"id": "dv3"}], is_sampled, 10),
+            ),
+            patch.object(analyzer, "_fetch_all_data_views", return_value=summaries),
+            patch.object(analyzer, "_check_memory_warning"),
+        ]
+        return analyzer, patches
+
+    def test_sampled_population_logs_sampled_message(self, mock_cja, logger, caplog):
+        """L415: is_sampled=True logs the 'Sampled N from M' message."""
+        analyzer, patches = self._setup(mock_cja, logger, is_sampled=True)
+        with patches[0], patches[1], patches[2], caplog.at_level(logging.INFO):
+            result = analyzer.run_analysis()
+        assert result.is_sampled is True
+        assert "Sampled 3 from 10 available data views" in caplog.text
+
+    def test_governance_thresholds_checked_and_exceeded(self, mock_cja, logger, caplog):
+        """L490-497: a configured isolated_threshold triggers the governance check + warning."""
+        # isolated_threshold=0.0 means any isolated component exceeds the limit.
+        analyzer, patches = self._setup(mock_cja, logger, is_sampled=False, isolated_threshold=0.0)
+        with patches[0], patches[1], patches[2], caplog.at_level(logging.INFO):
+            result = analyzer.run_analysis()
+        assert result.governance_violations is not None
+        assert result.thresholds_exceeded is True
+        assert "Checking governance thresholds..." in caplog.text
+        assert "Governance thresholds exceeded" in caplog.text
+
+
+# ===================================================================
 # 11. _generate_recommendations branches
 # ===================================================================
 
@@ -2236,6 +2306,27 @@ class TestFetchAllDataViewsFutureException:
         assert result[0].error is not None
         assert "ValueError" in result[0].error
 
+    def test_returned_error_summary_updates_progress_postfix(self, mock_cja, logger):
+        """L787: a fetch that *returns* an error summary still flows through the success path."""
+        # Unlike the raising cases above, the worker returns (does not raise) a
+        # summary whose has_error is True, exercising the error-postfix branch.
+        config = OrgReportConfig(skip_lock=True, cja_per_thread=False)
+        analyzer = _make_analyzer(mock_cja, logger, config=config)
+        analyzer.cache = None
+
+        error_summary = DataViewSummary(
+            data_view_id="dv_err",
+            data_view_name="Errored DV",
+            error="boom from worker",
+        )
+
+        with patch.object(analyzer, "_fetch_data_view_components", return_value=error_summary):
+            result = analyzer._fetch_all_data_views([{"id": "dv_err", "name": "Errored DV"}])
+
+        assert len(result) == 1
+        assert result[0].has_error is True
+        assert result[0].error == "boom from worker"
+
 
 # ===================================================================
 # 24. _fetch_data_view_components - metric/dimension names with include_names (lines 637-638, 676-677)
@@ -2414,6 +2505,24 @@ class TestFetchDataViewComponentsMetadata:
         assert result.created is None
         assert result.modified is None
         assert result.has_description is False
+
+    def test_top_level_fetch_failure_returns_error_summary(self, mock_cja, logger):
+        """L992-994: an exception during component fetch returns an error summary, not a raise."""
+        # getMetrics raising is outside the metadata-only inner guard, so it
+        # propagates to the outer resilience handler at the end of the method.
+        config = OrgReportConfig(skip_lock=True, cja_per_thread=False)
+        analyzer = _make_analyzer(mock_cja, logger, config=config)
+
+        mock_cja.getMetrics.side_effect = RuntimeError("metrics endpoint exploded")
+
+        dv = {"id": "dv_boom", "name": "Boom DV"}
+        result = analyzer._fetch_data_view_components(dv)
+
+        assert result.data_view_id == "dv_boom"
+        assert result.data_view_name == "Boom DV"
+        assert result.error is not None
+        assert "metrics endpoint exploded" in result.error
+        assert result.fetch_duration is not None
 
 
 # ===================================================================

--- a/tests/test_org_snapshot_utils.py
+++ b/tests/test_org_snapshot_utils.py
@@ -938,6 +938,27 @@ def test_derived_history_assessment_similarity_analysis_mode_complete():
     )
 
 
+def test_derived_history_assessment_mode_complete_but_data_views_incomplete():
+    """L442: mode='complete' (no explicit complete flag) with incomplete DVs is ineligible."""
+    # similarity_analysis_complete is absent so the mode branch handles it; the
+    # DV coverage is incomplete (analyzed < total), forcing _incomplete_data_views().
+    payload = {
+        "summary": {
+            "data_views_total": 3,
+            "data_views_analyzed": 2,
+            "similarity_analysis_mode": "complete",
+        },
+        "data_views": [
+            {"id": "dv1", "error": None},
+            {"id": "dv2", "error": None},
+            {"id": "dv3", "error": "timeout"},
+        ],
+    }
+
+    assert org_report_snapshot_history_eligible(payload) is False
+    assert org_report_snapshot_history_exclusion_reason(payload) == "incomplete_data_views"
+
+
 # ---------------------------------------------------------------------------
 # L344: _derived — org_stats_only=True
 # ---------------------------------------------------------------------------

--- a/tests/test_org_writer_compat_contracts.py
+++ b/tests/test_org_writer_compat_contracts.py
@@ -1108,3 +1108,139 @@ def test_advisories_key_is_additive_does_not_remove_existing_keys(rich_org_repor
 
     # The new key must also be present
     assert "advisories" in data
+
+
+def test_format_trending_dv_label_falls_back_to_id_when_name_is_absent_or_matches():
+    """writers/trending L264: bare id is returned when no distinct display name exists."""
+    from cja_auto_sdr.org.writers.trending import _format_trending_dv_label
+
+    # No name available -> just the id.
+    assert _format_trending_dv_label("dv_001", None) == "dv_001"
+    # Empty name -> still just the id.
+    assert _format_trending_dv_label("dv_001", "") == "dv_001"
+    # Name identical to id -> avoid the redundant "name (id)" form.
+    assert _format_trending_dv_label("dv_001", "dv_001") == "dv_001"
+    # A genuinely distinct name keeps the compact "name (id)" label.
+    assert _format_trending_dv_label("dv_001", "Production") == "Production (dv_001)"
+
+
+# ---------------------------------------------------------------------------
+# Direct unit coverage for org writer compat internal binding/masking helpers
+# ---------------------------------------------------------------------------
+
+
+def test_masked_module_attr_proxy_getattr_delegates_to_wrapped_value():
+    """compat L70: attribute access on the proxy is forwarded to the wrapped callable."""
+    from cja_auto_sdr.org.writers import compat
+
+    def wrapped():
+        return "ok"
+
+    wrapped.custom_marker = "delegated"
+
+    proxy = compat._MaskedModuleAttrProxy("some.module", "wrapped", wrapped)
+    # __getattr__ only fires for attributes not in __slots__, e.g. arbitrary attrs.
+    assert proxy.custom_marker == "delegated"
+    assert proxy.__name__ == "wrapped"
+
+
+def test_peek_masked_module_attr_returns_non_callable_baseline_directly():
+    """compat L179: a non-callable masked baseline is returned without proxy wrapping."""
+    from cja_auto_sdr.org.writers import compat
+
+    module_name = "cja_auto_sdr.test_compat_peek_module"
+    attr_name = "value"
+    key = compat._compat_key(module_name, attr_name)
+
+    non_callable_baseline = "baseline-string"
+
+    def callable_top():
+        return "top"
+
+    compat._MODULE_ATTR_BINDING_STACKS[key] = [non_callable_baseline, callable_top]
+    token = compat._MASKED_MODULE_ATTRS.set({key: 1})
+    try:
+        # depth=1 -> effective_index=0 -> masked is the non-callable baseline.
+        result = compat._peek_masked_module_attr(module_name, attr_name)
+        assert result == non_callable_baseline
+    finally:
+        compat._MASKED_MODULE_ATTRS.reset(token)
+        compat._MODULE_ATTR_BINDING_STACKS.pop(key, None)
+
+
+def test_effective_module_attr_binding_imports_module_when_no_stack():
+    """compat L187-188: with no recorded stack, the live module attribute is read."""
+    from cja_auto_sdr.org.writers import compat
+
+    # core.version has a stable, real attribute and no compat binding stack.
+    result = compat._effective_module_attr_binding("cja_auto_sdr.core.version", "__version__")
+    import cja_auto_sdr.core.version as version_mod
+
+    assert result == version_mod.__version__
+
+
+def test_effective_module_attr_binding_missing_attr_returns_sentinel():
+    """compat L187-188: a missing attribute on an unstacked module yields the sentinel."""
+    from cja_auto_sdr.org.writers import compat
+
+    result = compat._effective_module_attr_binding(
+        "cja_auto_sdr.core.version",
+        "definitely_not_a_real_attribute",
+    )
+    assert result is compat._MISSING
+
+
+def test_record_module_attr_binding_noop_when_value_unchanged():
+    """compat L200: re-recording the current top-of-stack value leaves the stack intact."""
+    from cja_auto_sdr.org.writers import compat
+
+    module_name = "cja_auto_sdr.test_compat_record_module"
+    attr_name = "value"
+    key = compat._compat_key(module_name, attr_name)
+
+    sentinel = object()
+    compat._MODULE_ATTR_BINDING_STACKS[key] = [sentinel]
+    try:
+        compat._record_module_attr_binding(module_name, attr_name, sentinel)
+        # Stack must be untouched (no duplicate push).
+        assert compat._MODULE_ATTR_BINDING_STACKS[key] == [sentinel]
+    finally:
+        compat._MODULE_ATTR_BINDING_STACKS.pop(key, None)
+
+
+def test_suppress_override_is_noop_without_active_override():
+    """compat L282-283: suppressing an unset override key simply yields."""
+    from cja_auto_sdr.org.writers import compat
+
+    entered = False
+    with compat._suppress_override("cja_auto_sdr.test_compat_suppress", "missing_attr"):
+        entered = True
+    assert entered is True
+
+
+def test_mask_module_attrs_is_noop_with_empty_attr_names():
+    """compat L319-320: an empty attr-name iterable short-circuits to a plain yield."""
+    from cja_auto_sdr.org.writers import compat
+
+    entered = False
+    with compat._mask_module_attrs("cja_auto_sdr.test_compat_mask", []):
+        entered = True
+    assert entered is True
+
+
+def test_mask_module_attrs_skips_unregistered_keys_and_yields():
+    """compat L328 + L333-334: attrs without a registered baseline are skipped, then yield."""
+    from cja_auto_sdr.org.writers import compat
+
+    before = compat._current_masked_module_attrs().copy()
+    entered = False
+    # Neither attr name is present in _MASKED_MODULE_BASELINES for this module, so
+    # every key is skipped (L328) and applied_keys stays empty (L333-334).
+    with compat._mask_module_attrs(
+        "cja_auto_sdr.test_compat_mask_unregistered",
+        ["attr_one", "attr_two"],
+    ):
+        entered = True
+        # No masking should have been applied to the active context.
+        assert compat._current_masked_module_attrs() == before
+    assert entered is True

--- a/tests/test_output_content_validation.py
+++ b/tests/test_output_content_validation.py
@@ -38,7 +38,7 @@ def rich_data_dict():
         "Metadata": pd.DataFrame(
             {
                 "Property": ["Generated At", "Data View ID", "Tool Version", "Total Metrics"],
-                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.11.0", 3],
+                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.11.1", 3],
             },
         ),
         "Data Quality": pd.DataFrame(
@@ -104,7 +104,7 @@ def rich_metadata_dict():
         "Generated At": "2025-01-15 10:30:00 PST",
         "Data View ID": "dv_content_test",
         "Data View Name": "Test DataView",
-        "Tool Version": "3.11.0",
+        "Tool Version": "3.11.1",
         "Metrics Count": "3",
         "Dimensions Count": "4",
     }
@@ -224,7 +224,7 @@ class TestJSONContentValidation:
             data = json.load(f)
 
         assert data["metadata"]["Data View ID"] == "dv_content_test"
-        assert data["metadata"]["Tool Version"] == "3.11.0"
+        assert data["metadata"]["Tool Version"] == "3.11.1"
 
     def test_json_metadata_preserves_partial_markers(self, tmp_path, rich_data_dict, rich_metadata_dict):
         logger = logging.getLogger("json_test")

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -180,6 +180,16 @@ class TestLoadProfileConfigJson:
         assert result is not None
         assert result["scopes"] == "openid,AdobeID"
 
+    def test_returns_none_on_oserror(self, tmp_path):
+        """OSError while opening an existing config.json returns None."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text('{"org_id": "test@AdobeOrg"}')
+
+        with patch("cja_auto_sdr.core.profiles.open", side_effect=OSError("read denied")):
+            result = load_profile_config_json(tmp_path)
+
+        assert result is None
+
 
 class TestLoadProfileDotenv:
     """Test loading credentials from .env file"""
@@ -707,6 +717,17 @@ class TestReadProfileOrgId:
         """Returns None when config.json is a JSON array instead of object"""
         (tmp_path / "config.json").write_text('[{"org_id": "test@AdobeOrg"}]')
         assert _read_profile_org_id(tmp_path) is None
+
+    def test_handles_plain_valueerror_from_json_load(self, tmp_path):
+        """A bare ValueError (not JSONDecodeError) from json.load is swallowed."""
+        (tmp_path / "config.json").write_text('{"org_id": "test@AdobeOrg"}')
+
+        # json.load can raise ValueError subtypes other than JSONDecodeError;
+        # the dedicated ValueError branch must keep _read_profile_org_id quiet.
+        with patch("cja_auto_sdr.core.profiles.json.load", side_effect=ValueError("bad value")):
+            result = _read_profile_org_id(tmp_path)
+
+        assert result is None
 
 
 class TestListProfilesOrgId:

--- a/tests/test_quality_edge_cases.py
+++ b/tests/test_quality_edge_cases.py
@@ -6,7 +6,7 @@ data, duplicate detection, description validation, parallel execution.
 
 import logging
 from concurrent.futures import Future
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
 
@@ -256,3 +256,30 @@ class TestParallelExecution:
         severities = df["Severity"].tolist()
         assert severities[0] == "CRITICAL"
         assert severities[1] == "LOW"
+
+    def test_get_issues_dataframe_truncates_to_max_issues(self):
+        """A positive max_issues smaller than the issue count truncates and logs the cap."""
+        mock_logger = MagicMock(spec=logging.Logger)
+        checker = DataQualityChecker(logger=mock_logger, quiet=True)
+        for idx in range(5):
+            checker.add_issue("LOW", "Cat", "Metrics", f"item{idx}", f"issue {idx}")
+
+        df = checker.get_issues_dataframe(max_issues=2)
+
+        # Only the top 2 (post-sort) rows are returned.
+        assert len(df) == 2
+        # The truncation was announced via an info log carrying the cap and total.
+        mock_logger.info.assert_any_call("Limiting data quality issues to top %s (of %s total)", 2, 5)
+
+    def test_get_issues_dataframe_keeps_all_when_under_max_issues(self):
+        """When the issue count does not exceed max_issues, no truncation occurs."""
+        mock_logger = MagicMock(spec=logging.Logger)
+        checker = DataQualityChecker(logger=mock_logger, quiet=True)
+        checker.add_issue("LOW", "Cat", "Metrics", "item0", "issue 0")
+        checker.add_issue("HIGH", "Cat", "Metrics", "item1", "issue 1")
+
+        df = checker.get_issues_dataframe(max_issues=10)
+
+        assert len(df) == 2
+        truncation_logged = any("Limiting data quality issues" in str(call) for call in mock_logger.info.call_args_list)
+        assert not truncation_logged

--- a/tests/test_shared_cache.py
+++ b/tests/test_shared_cache.py
@@ -749,3 +749,68 @@ def test_shared_cache_evict_lru_falls_back_after_stale_access_metadata() -> None
         assert cache.get_statistics()["evictions"] == 1
     finally:
         cache.shutdown()
+
+
+class _LenIterMismatchCache:
+    """A mapping whose ``len()`` reports entries but whose iteration yields none.
+
+    Real ``Manager().dict()`` / ``dict`` keep ``__len__`` and ``__iter__`` in
+    agreement, so the defensive ``fallback_key is None`` guards can only be hit
+    by simulating metadata that disagrees with itself.
+    """
+
+    def __init__(self, reported_len: int) -> None:
+        self._reported_len = reported_len
+
+    def __len__(self) -> int:
+        return self._reported_len
+
+    def __bool__(self) -> bool:
+        return self._reported_len > 0
+
+    def __iter__(self):
+        return iter(())
+
+    def pop(self, key, default=None):
+        return default
+
+
+def test_shared_cache_capacity_fallback_breaks_when_iteration_empty() -> None:
+    """Defensive guard: the last-resort loop stops if iteration yields no key."""
+    cache = SharedValidationCache(max_size=1, ttl_seconds=3600)
+
+    try:
+        with (
+            patch.object(cache, "_prune_expired_entries"),
+            patch.object(cache, "_reconcile_access_times"),
+            patch.object(cache, "_evict_lru", return_value=False),
+        ):
+            # len() says full (>= max_size) but iteration is empty -> fallback_key is None.
+            cache._cache = _LenIterMismatchCache(reported_len=cache.max_size)
+            with cache._lock:
+                cache._ensure_capacity_for_new_entry(now=2.0)
+
+        # No eviction recorded because the loop broke immediately on an empty iterator.
+        assert cache.get_statistics()["evictions"] == 0
+    finally:
+        cache.shutdown()
+
+
+def test_shared_cache_evict_lru_returns_false_when_fallback_iteration_empty() -> None:
+    """Defensive guard: eviction reports failure when no concrete key can be found."""
+    cache = SharedValidationCache(max_size=1, ttl_seconds=3600)
+
+    try:
+        # Access metadata points at a key that is not in the (truthy but empty-on-iter) cache.
+        cache._access_times["ghost"] = 0.0
+        cache._cache = _LenIterMismatchCache(reported_len=1)
+
+        with cache._lock:
+            removed = cache._evict_lru(now=2.0, access_times_reconciled=True)
+
+        assert removed is False
+        # Stale access metadata for the missing key was cleaned up on the way out.
+        assert "ghost" not in cache._access_times
+        assert cache.get_statistics()["evictions"] == 0
+    finally:
+        cache.shutdown()

--- a/tests/test_snapshot_commands.py
+++ b/tests/test_snapshot_commands.py
@@ -1687,3 +1687,121 @@ class TestMainCompareWithPrevMode:
         assert exc_info.value.code == 1
         captured = capsys.readouterr()
         assert "No previous snapshots found" in captured.err
+
+
+# ==================== diff/commands.py remaining-line coverage ====================
+
+
+class TestDiffCommandsRemainingCoverage:
+    """Cover the last uncovered branches in cja_auto_sdr.diff.commands."""
+
+    def test_populate_advisory_rollup_swallows_builder_failure(self, caplog):
+        """Lines 51-52: builder exceptions are logged and swallowed, never raised."""
+        import logging as _logging
+
+        from cja_auto_sdr.diff.commands import _populate_diff_advisory_rollup
+
+        runtime_details: dict = {}
+        diff_result = _make_diff_result()
+
+        with (
+            patch(
+                "cja_auto_sdr.core.advisory_builders.build_diff_advisories",
+                side_effect=RuntimeError("boom"),
+            ),
+            caplog.at_level(_logging.DEBUG, logger="diff"),
+        ):
+            # Must not raise even though the builder blows up.
+            _populate_diff_advisory_rollup(runtime_details, diff_result, changes_only=False)
+
+        assert "advisory_rollup" not in runtime_details
+        assert "Advisory rollup computation failed" in caplog.text
+
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_snapshot_command_keyboard_interrupt_propagates(self, mock_configure, tmp_path):
+        """Line 131: KeyboardInterrupt is re-raised, not swallowed as a handler error."""
+        mock_configure.side_effect = KeyboardInterrupt()
+
+        with pytest.raises(KeyboardInterrupt):
+            handle_snapshot_command(
+                data_view_id="dv_123",
+                snapshot_file=str(tmp_path / "snap.json"),
+                quiet=True,
+            )
+
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_diff_command_system_exit_propagates(self, mock_configure):
+        """Line 381: SystemExit is re-raised from handle_diff_command."""
+        from cja_auto_sdr.diff.commands import handle_diff_command
+
+        mock_configure.side_effect = SystemExit(3)
+
+        with pytest.raises(SystemExit) as exc_info:
+            handle_diff_command(
+                source_id="dv_src",
+                target_id="dv_tgt",
+                quiet=True,
+                quiet_diff=True,
+            )
+
+        assert exc_info.value.code == 3
+
+    @patch("cja_auto_sdr.generator.configure_cjapy")
+    def test_diff_snapshot_command_keyboard_interrupt_propagates(self, mock_configure, tmp_path):
+        """Line 710: KeyboardInterrupt is re-raised from handle_diff_snapshot_command."""
+        snap_file = str(tmp_path / "baseline.json")
+        _write_snapshot_file(snap_file)
+        mock_configure.side_effect = KeyboardInterrupt()
+
+        with pytest.raises(KeyboardInterrupt):
+            handle_diff_snapshot_command(
+                data_view_id="dv_123",
+                snapshot_file=snap_file,
+                quiet=True,
+                quiet_diff=True,
+            )
+
+    def test_compare_snapshots_command_keyboard_interrupt_propagates(self, tmp_path):
+        """Line 887: KeyboardInterrupt is re-raised from handle_compare_snapshots_command."""
+        src_file = str(tmp_path / "source.json")
+        tgt_file = str(tmp_path / "target.json")
+        _write_snapshot_file(src_file)
+        _write_snapshot_file(tgt_file)
+
+        mock_manager = MagicMock()
+        mock_manager.load_snapshot.side_effect = KeyboardInterrupt()
+        with (
+            patch("cja_auto_sdr.generator.SnapshotManager", return_value=mock_manager),
+            pytest.raises(KeyboardInterrupt),
+        ):
+            handle_compare_snapshots_command(
+                source_file=src_file,
+                target_file=tgt_file,
+                quiet=True,
+                quiet_diff=True,
+            )
+
+    def test_compare_snapshots_command_cjasdrerror_returns_failure(self, tmp_path, capsys):
+        """Lines 889-891: CJASDRError is caught and returns a controlled failure tuple."""
+        from cja_auto_sdr.core.exceptions import CJASDRError
+
+        src_file = str(tmp_path / "source.json")
+        tgt_file = str(tmp_path / "target.json")
+        _write_snapshot_file(src_file)
+        _write_snapshot_file(tgt_file)
+
+        mock_manager = MagicMock()
+        mock_manager.load_snapshot.side_effect = CJASDRError("snapshot subsystem failed")
+        with patch("cja_auto_sdr.generator.SnapshotManager", return_value=mock_manager):
+            success, has_changes, exit_code = handle_compare_snapshots_command(
+                source_file=src_file,
+                target_file=tgt_file,
+                quiet=True,
+                quiet_diff=True,
+            )
+
+        assert success is False
+        assert has_changes is False
+        assert exit_code is None
+        captured = capsys.readouterr()
+        assert "Failed to compare snapshots" in captured.err

--- a/tests/test_trending_models.py
+++ b/tests/test_trending_models.py
@@ -758,6 +758,11 @@ def test_org_model_helpers_cover_manual_snapshot_fallbacks() -> None:
     assert _snapshot_count_declares_zero(False) is False
     assert _snapshot_count_declares_zero("0") is True
 
+    # L851: no explicit reported total and no declared headline total -> 0 fallback.
+    undeclared_total_snapshot = SimpleNamespace(data_view_count=None)
+    assert _snapshot_declares_data_view_total(undeclared_total_snapshot) is False
+    assert _snapshot_reported_data_view_total(undeclared_total_snapshot) == 0
+
     incomplete_snapshot = TrendingSnapshot(
         timestamp="2026-03-19T00:00:00Z",
         data_view_count=3,

--- a/tests/test_ux_features.py
+++ b/tests/test_ux_features.py
@@ -344,11 +344,11 @@ class TestCombinedFeatures:
 class TestVersionUpdated:
     """Test that version is correct"""
 
-    def test_version_is_3_11_0(self):
-        """Test that version is 3.11.0"""
+    def test_version_is_3_11_1(self):
+        """Test that version is 3.11.1"""
         from cja_auto_sdr.generator import __version__
 
-        assert __version__ == "3.11.0"
+        assert __version__ == "3.11.1"
 
 
 class TestFormatAutoDetection:

--- a/tests/test_watch_command.py
+++ b/tests/test_watch_command.py
@@ -316,3 +316,128 @@ def test_run_watch_suppresses_in_memory_note_in_quiet_mode(MockRunner, capsys):
 
     captured = capsys.readouterr()
     assert "snapshots in memory" not in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers — installed signal handler, _sleep_with_stop, _NullCja,
+# _resolve_cja_client. These are mocked away in the loop-level tests above, so
+# the unit slice never exercised their bodies (the real behavior was only
+# covered by the @slow subprocess tests in test_watch_signals.py).
+# ---------------------------------------------------------------------------
+
+
+def test_installed_signal_handler_records_reason_and_sets_stop_flag():
+    """The handler installed by _install_signal_handlers maps the signal to a
+    reason string and sets the module stop flag (both SIGINT and SIGTERM)."""
+    from cja_auto_sdr.cli.commands import watch as watch_mod
+
+    watch_mod._install_signal_handlers()
+
+    sigint_handler = _signal.getsignal(_signal.SIGINT)
+    sigint_handler(_signal.SIGINT, None)
+    assert watch_mod._stop_requested.is_set()
+    assert watch_mod._stop_reason_holder["reason"] == "sigint"
+
+    watch_mod._stop_requested.clear()
+    watch_mod._stop_reason_holder.clear()
+
+    sigterm_handler = _signal.getsignal(_signal.SIGTERM)
+    sigterm_handler(_signal.SIGTERM, None)
+    assert watch_mod._stop_requested.is_set()
+    assert watch_mod._stop_reason_holder["reason"] == "sigterm"
+    # reset_watch_module_state (autouse) restores the previous handlers + state.
+
+
+def test_sleep_with_stop_returns_when_deadline_already_passed():
+    """A zero-second interval takes the remaining<=0 early-return path."""
+    from cja_auto_sdr.cli.commands.watch import _sleep_with_stop
+
+    _stop_requested.clear()
+    _sleep_with_stop(0)  # returns immediately, no hang
+
+
+def test_sleep_with_stop_wakes_immediately_when_stop_event_is_set():
+    """A positive interval enters the wait branch and unblocks as soon as the
+    stop event fires, rather than sleeping the full duration."""
+    import threading
+
+    from cja_auto_sdr.cli.commands.watch import _sleep_with_stop
+
+    _stop_requested.clear()
+    timer = threading.Timer(0.02, _stop_requested.set)
+    timer.start()
+    try:
+        _sleep_with_stop(2)  # would block ~2s if the wake-on-stop path were broken
+    finally:
+        timer.cancel()
+        _stop_requested.clear()
+
+
+def test_null_cja_getdataview_raises_connection_error():
+    """The test-mode stub fails fast so snapshot fetch errors without real creds."""
+    from cja_auto_sdr.cli.commands.watch import _NullCja
+
+    with pytest.raises(ConnectionError, match="test mode"):
+        _NullCja().getDataView("dv_x")
+
+
+def test_resolve_cja_client_returns_null_cja_in_test_mode(monkeypatch):
+    """With the test-mode env var set, _resolve_cja_client short-circuits to _NullCja."""
+    from cja_auto_sdr.cli.commands import watch as watch_mod
+
+    monkeypatch.setenv("CJA_AUTO_SDR_WATCH_TEST_MODE", "1")
+    client = watch_mod._resolve_cja_client(MagicMock())
+    assert isinstance(client, watch_mod._NullCja)
+
+
+def test_resolve_cja_client_configures_and_returns_real_client(monkeypatch):
+    """Without test mode, _resolve_cja_client configures credentials then returns
+    generator.cjapy.CJA()."""
+    from cja_auto_sdr.cli.commands import watch as watch_mod
+
+    monkeypatch.delenv("CJA_AUTO_SDR_WATCH_TEST_MODE", raising=False)
+    args = MagicMock()
+    args.profile = "prod"
+    args.config_file = "cfg.json"
+
+    with (
+        patch("cja_auto_sdr.api.client.configure_cjapy", return_value=(True, "env", {})) as mock_cfg,
+        patch("cja_auto_sdr.generator.cjapy") as mock_cjapy,
+    ):
+        result = watch_mod._resolve_cja_client(args)
+
+    mock_cfg.assert_called_once()
+    assert mock_cfg.call_args.kwargs["profile"] == "prod"
+    assert mock_cfg.call_args.kwargs["config_file"] == "cfg.json"
+    assert result is mock_cjapy.CJA.return_value
+
+
+def test_resolve_cja_client_raises_when_configuration_fails(monkeypatch):
+    """A failed configure_cjapy surfaces as a RuntimeError."""
+    from cja_auto_sdr.cli.commands import watch as watch_mod
+
+    monkeypatch.delenv("CJA_AUTO_SDR_WATCH_TEST_MODE", raising=False)
+    args = MagicMock()
+    args.profile = None
+    args.config_file = "config.json"
+
+    with patch("cja_auto_sdr.api.client.configure_cjapy", return_value=(False, None, None)):
+        with pytest.raises(RuntimeError, match="Failed to configure CJA credentials"):
+            watch_mod._resolve_cja_client(args)
+
+
+@patch("cja_auto_sdr.cli.commands.watch._resolve_cja_client", side_effect=RuntimeError("cred boom"))
+def test_run_watch_returns_1_when_credential_resolution_fails(mock_resolve, capsys):
+    """When cja is None and credential resolution raises RuntimeError, run_watch
+    prints the error to stderr and returns exit code 1."""
+    args = MagicMock()
+    args.watch_data_views = ["dv_abc"]
+    args.watch_interval = "1h"
+    args.watch_threshold = 1
+
+    exit_code = run_watch(args, cja=None)
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "ERROR: cred boom" in captured.err
+    mock_resolve.assert_called_once()

--- a/tests/test_watch_pipeline.py
+++ b/tests/test_watch_pipeline.py
@@ -126,6 +126,25 @@ def test_fetch_failure_emits_error_event_and_continues():
     assert events[0].data_view_id == "dv_abc"
 
 
+def test_diff_failure_emits_error_event_and_continues(fake_snapshot):
+    """A comparator.compare() exception on a non-baseline cycle yields an
+    ErrorEvent with stage='diff' and does not abort the run."""
+    snapshot_manager = MagicMock()
+    snapshot_manager.create_snapshot.return_value = fake_snapshot
+    comparator = MagicMock()
+    comparator.compare.side_effect = ValueError("diff exploded")
+    runner = WatchCycleRunner(snapshot_manager=snapshot_manager, comparator=comparator, threshold=1)
+
+    list(runner.run_cycle(cja=MagicMock(), data_view_ids=["dv_abc"], cycle=1))  # baseline
+    events = list(runner.run_cycle(cja=MagicMock(), data_view_ids=["dv_abc"], cycle=2))
+
+    assert len(events) == 1
+    assert isinstance(events[0], ErrorEvent)
+    assert events[0].stage == "diff"
+    assert events[0].error_class == "ValueError"
+    assert events[0].data_view_id == "dv_abc"
+
+
 def test_one_failure_does_not_block_other_data_views(fake_snapshot):
     snapshot_manager = MagicMock()
     snapshot_manager.create_snapshot.side_effect = [


### PR DESCRIPTION
## Summary

Patch release **v3.11.1** — a test-only coverage-hardening pass. Lifts unit-slice coverage from **98.43% → 99.14%** by covering 149 previously-uncovered statements, so the 7K-line `generator.py` monolith is now the **only** module below 100%. No production behavior changed.

## What changed

- **`cli/commands/watch.py` 78% → 100%** (the largest single gap). Its real signal-handler closure, `_sleep_with_stop`, `_NullCja`, and `_resolve_cja_client` paths were only exercised by the `@slow` subprocess tests in `test_watch_signals.py`, which the unit slice excludes — in-process tests now cover them.
- **Notion cluster to 100%**: `output/writers/notion.py`, `output/notion_database.py`, `output/notion_org_publisher.py`, `output/notion_registry.py`, `pipeline/watch.py` (error-mapping helpers, pagination/delete edges, prune/repair error branches, dotenv-absent fallbacks, Windows lock retry).
- **Scattered single/double-line gaps to 100%** across `api/` (`client.py`, `cache.py`, `quality.py`), `cli/` (`agent_output.py`, `commands/discovery.py`, `commands/stats.py`, `interactive.py`), `core/` (`discovery_payloads.py`, `exceptions.py`, `json_io.py`, `profiles.py`), `diff/` (`cli.py`, `commands.py`, `git.py`), and `org/` (`analyzer.py`, `models.py`, `snapshot_utils.py`, `writers/compat.py`, `writers/trending.py`).
- **Two genuinely-unreachable defensive branches** marked `# pragma: no cover` with justifications rather than contorting tests: the orphan-heading guard in `output/writers/notion.py:_section_blocks` and the blank-id `continue` in `org/trending.py`.
- **Version bump to 3.11.1** with all version references synced + a `### Coverage` CHANGELOG entry.

## Numbers

| | Before | After |
|---|---|---|
| Unit-slice coverage | 98.43% | **99.14%** |
| Tests | 8,258 | **8,355** (+97) |
| Sub-100% modules | ~20 | **1** (`generator.py`) |

All +97 tests landed in existing test files (no new files). The only production-source changes are the version bump and the two pragma annotations.

## Verification

- Full suite: **8,339 passed, 16 skipped, 0 failed**
- `ruff check src/ tests/ scripts/ examples/`: clean
- `ruff format --check`: clean
- `scripts/check_version_sync.py`: OK at 3.11.1
- `scripts/update_test_counts.py --check`: up to date

> Note: the README `tests-NNNN` shields badge is owned by the `update-badges.yml` workflow (auto-rewritten on merge to main), so it's intentionally left for CI rather than hand-edited.

https://claude.ai/code/session_01JCbzNi2UWuKjmK6E1AXKBS