### PR TITLE
perf: v3.11.2 safe optimizations (byte-identical)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to the CJA SDR Generator project will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.11.2] - 2026-07-02
+
+### Performance
+
+- Removed redundant CPU/I/O across hot paths with **no behavior change** (identical output, exit codes, API-call semantics, and CLI surface):
+  - **Org similarity engine:** hoisted repeated `metric_ids | dimension_ids` unions out of the O(n²) pairwise-Jaccard and similarity-matrix loops; compute union arithmetically instead of allocating a merged set per pair. Indexed data-view names once in the isolated-components recommendation.
+  - **Org writers:** O(1) bucket lookup in the components CSV (was up to six per-component list scans); single-pass counting for the "Isolated by Data View" Excel sheet (drops millions of throwaway `ComponentInfo` allocations at org scale).
+  - **SDR / diff rendering:** convert each frame to strings once for Excel column widths and row heights; vectorized SDR markdown cell escaping; diff Excel colors rows with a single `write_row` instead of per-cell `df.iloc` indexing.
+  - **Snapshot handling:** a process-local `(path, mtime, size)` parse cache so trending + prune and diff retention stop re-reading and re-parsing the same snapshot files within a run.
+  - **Micro-fixes:** type fast-path before `pd.isna` in diff field normalization; `isEnabledFor` guard in `emit_diagnostic` so suppressed diagnostics skip message/JSON formatting.
+- No new CLI flags, no public API changes. `generator.py` untouched. New characterization tests lock old-vs-new output equality.
+
 ## [3.11.1] - 2026-06-25
 
 ### Coverage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
 - Current version: v3.11.2
-- Tests: **8,369** across 163 files at **95% coverage gate**
+- Tests: **8,371** across 163 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,8 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Package manager: **uv**
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
-- Current version: v3.11.1
-- Tests: **8,355** across 155 files at **95% coverage gate**
+- Current version: v3.11.2
+- Tests: **8,369** across 163 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)
 

--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (8,355+ tests)
+├── tests/                     # Test suite (8,369+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (8,369+ tests)
+├── tests/                     # Test suite (8,371+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -943,7 +943,7 @@ cja_auto_sdr --list-dataviews --log-level DEBUG
 At launch, the tool logs diagnostic lines containing the tool version, Python version, platform, active log level, inferred run mode (batch, single, or discovery), and dependency versions. These appear automatically at `INFO` level and are useful for troubleshooting environment issues in CI/CD logs or support requests:
 
 ```text
-CJA SDR Generator v3.11.1 | Python 3.14.2 | darwin | log_level=INFO | mode=single
+CJA SDR Generator v3.11.2 | Python 3.14.2 | darwin | log_level=INFO | mode=single
 Dependencies: cjapy=0.3.0, pandas=2.3.3, numpy=2.2.1, xlsxwriter=3.2.9, tqdm=4.67.0
 ```
 

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -190,7 +190,7 @@ This command:
 
 ```bash
 $ uv run cja_auto_sdr -V
-cja_auto_sdr 3.11.1
+cja_auto_sdr 3.11.2
 ```
 
 > **Important:** All commands in this guide assume you're in the `cja_auto_sdr` directory. If you see "command not found", make sure you're in the right directory and have run `uv sync`.

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Quick Reference Card
 
-Single-page command cheat sheet for CJA SDR Generator v3.11.1.
+Single-page command cheat sheet for CJA SDR Generator v3.11.2.
 
 ## Four Main Modes
 

--- a/src/cja_auto_sdr/core/json_io.py
+++ b/src/cja_auto_sdr/core/json_io.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import errno
+import functools
 import json
 import os
 import uuid
@@ -346,3 +347,33 @@ def write_text_atomic_compatible(
         direct_write=direct_write,
         stage_write=lambda tmp_path: _stage_text_write(tmp_path, content, encoding=encoding),
     )
+
+
+# ---------------------------------------------------------------------------
+# Process-local parse cache (v3.11.2)
+# ---------------------------------------------------------------------------
+# Memoizes JSON parses keyed by (path, mtime, size) so repeated reads of the
+# same on-disk snapshot within a process (e.g. org-report trending window
+# scans and cache-prune metadata loads) skip redundant I/O + json.loads work.
+# Callers MUST treat the returned object as read-only: it is shared across
+# every caller that hits the same cache key.
+# ---------------------------------------------------------------------------
+
+
+@functools.lru_cache(maxsize=256)
+def _load_json_cached_by_stat(path: str, mtime_ns: int, size: int) -> dict:  # noqa: ARG001 — cache key components
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def load_json_cached(path) -> dict:
+    """Parse a JSON file, memoized by (path, mtime, size).
+
+    The returned object is shared across callers and MUST NOT be mutated.
+    """
+    st = os.stat(path)
+    return _load_json_cached_by_stat(str(path), st.st_mtime_ns, st.st_size)
+
+
+# expose cache_clear for tests
+load_json_cached.cache_clear = _load_json_cached_by_stat.cache_clear

--- a/src/cja_auto_sdr/core/logging.py
+++ b/src/cja_auto_sdr/core/logging.py
@@ -476,6 +476,8 @@ def emit_diagnostic(
     The call respects the effective log level and ``--quiet`` behaviour for the
     requested *level*. INFO remains the default diagnostic severity.
     """
+    if not logger.isEnabledFor(level):
+        return
     extra: dict[str, object] = {"event": event, "event_category": category, **fields}
 
     # Build human-readable text representation.

--- a/src/cja_auto_sdr/core/version.py
+++ b/src/cja_auto_sdr/core/version.py
@@ -1,3 +1,3 @@
 """Version information for CJA Auto SDR."""
 
-__version__ = "3.11.1"
+__version__ = "3.11.2"

--- a/src/cja_auto_sdr/diff/comparator.py
+++ b/src/cja_auto_sdr/diff/comparator.py
@@ -392,11 +392,14 @@ class DataViewComparator:
     def _normalize_value(self, value: Any, field_name: str | None = None) -> Any:
         if value is None:
             return ""
-        try:
-            if pd.isna(value):
-                return ""
-        except TypeError, ValueError:
-            pass
+        # str/dict/list/tuple can never be pandas-NA; skip the expensive pd.isna (which
+        # raises for containers) and fall through to normal handling.
+        if not isinstance(value, (str, dict, list, tuple)):
+            try:
+                if pd.isna(value):
+                    return ""
+            except TypeError, ValueError:
+                pass
         if isinstance(value, str):
             return value.strip()
         if isinstance(value, dict):

--- a/src/cja_auto_sdr/diff/snapshot.py
+++ b/src/cja_auto_sdr/diff/snapshot.py
@@ -15,7 +15,7 @@ from cja_auto_sdr.core.discovery_payloads import (
 )
 from cja_auto_sdr.core.error_policies import RECOVERABLE_OPTIONAL_ENRICHMENT_EXCEPTIONS
 from cja_auto_sdr.core.exceptions import attach_api_connection_hint_context
-from cja_auto_sdr.core.json_io import write_json_atomic
+from cja_auto_sdr.core.json_io import load_json_cached, write_json_atomic
 from cja_auto_sdr.diff.models import DataViewSnapshot
 
 _SNAPSHOT_FAILURE_STAGE_ATTR = "_cja_snapshot_failure_stage"
@@ -302,8 +302,7 @@ class SnapshotManager:
             if filename.endswith(".json"):
                 filepath = os.path.join(directory, filename)
                 try:
-                    with open(filepath, encoding="utf-8") as f:
-                        data = json.load(f)
+                    data = load_json_cached(filepath)
                     if "snapshot_version" in data:
                         snapshots.append(
                             {

--- a/src/cja_auto_sdr/org/analyzer.py
+++ b/src/cja_auto_sdr/org/analyzer.py
@@ -1177,14 +1177,16 @@ class OrgComponentAnalyzer:
             Tuple of (valid_summaries, pairwise_similarities dict)
         """
         valid = [s for s in summaries if s.error is None and s.all_component_ids]
+        component_sets = [s.all_component_ids for s in valid]  # each property evaluated once
         pairwise: dict[tuple, float] = {}
 
         for i in range(len(valid)):
-            set_i = valid[i].all_component_ids
+            set_i = component_sets[i]
+            len_i = len(set_i)
             for j in range(i + 1, len(valid)):
-                set_j = valid[j].all_component_ids
+                set_j = component_sets[j]
                 intersection = len(set_i & set_j)
-                union = len(set_i | set_j)
+                union = len_i + len(set_j) - intersection  # no `set_i | set_j` allocation
                 pairwise[(i, j)] = intersection / union if union > 0 else 0.0
 
         return valid, pairwise
@@ -1217,16 +1219,17 @@ class OrgComponentAnalyzer:
 
         pairs = []
         min_similarity_threshold = effective_governance_overlap_threshold(self.config.overlap_threshold)
+        component_sets = [s.all_component_ids for s in valid_summaries]  # each property evaluated once
 
         for (i, j), similarity in pairwise.items():
             if similarity >= min_similarity_threshold:
                 dv1 = valid_summaries[i]
                 dv2 = valid_summaries[j]
-                set1 = dv1.all_component_ids
-                set2 = dv2.all_component_ids
+                set1 = component_sets[i]
+                set2 = component_sets[j]
 
                 intersection = len(set1 & set2)
-                union = len(set1 | set2)
+                union = len(set1) + len(set2) - intersection  # no `set1 | set2` allocation
 
                 # Compute drift details if enabled
                 only_in_dv1 = []

--- a/src/cja_auto_sdr/org/analyzer.py
+++ b/src/cja_auto_sdr/org/analyzer.py
@@ -1433,10 +1433,13 @@ class OrgComponentAnalyzer:
                     isolated_by_dv[dv_id] = []
                 isolated_by_dv[dv_id].append(comp_id)
 
+        # Build name lookup for isolated-components recommendation
+        name_by_id = {s.data_view_id: s.data_view_name for s in summaries}
+
         # Recommendation: Data views with many isolated components
         for dv_id, isolated in isolated_by_dv.items():
             if len(isolated) > self.config.isolated_review_threshold:
-                dv_name = next((s.data_view_name for s in summaries if s.data_view_id == dv_id), "Unknown")
+                dv_name = name_by_id.get(dv_id, "Unknown")
                 recommendations.append(
                     {
                         "type": "review_isolated",

--- a/src/cja_auto_sdr/org/cache.py
+++ b/src/cja_auto_sdr/org/cache.py
@@ -17,7 +17,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
-from cja_auto_sdr.core.json_io import write_json_atomic
+from cja_auto_sdr.core.json_io import load_json_cached, write_json_atomic
 from cja_auto_sdr.core.locks.manager import LockManager, normalize_lock_stale_threshold_seconds
 from cja_auto_sdr.org.models import DataViewSummary
 from cja_auto_sdr.org.snapshot_utils import (
@@ -297,8 +297,7 @@ class OrgReportCache:
         """Load one persisted org-report snapshot and return summarized metadata."""
         path = Path(snapshot_file)
         try:
-            with open(path, encoding="utf-8") as f:
-                payload = json.load(f)
+            payload = load_json_cached(path)
         except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
             self.logger.warning("Skipping org-report snapshot %s: %s", path, exc)
             return None

--- a/src/cja_auto_sdr/org/trending.py
+++ b/src/cja_auto_sdr/org/trending.py
@@ -8,6 +8,7 @@ from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
+from cja_auto_sdr.core.json_io import load_json_cached
 from cja_auto_sdr.org.models import (
     OrgReportTrending,
     TrendingDelta,
@@ -362,8 +363,7 @@ def _load_snapshot_from_file(json_file: Path) -> TrendingSnapshot | None:
     Returns None if the file is unreadable, malformed, or not an org-report.
     """
     try:
-        with open(json_file, encoding="utf-8") as f:
-            data = json.load(f)
+        data = load_json_cached(json_file)
     except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
         logger.warning("Skipping %s: %s", json_file, exc)
         return None

--- a/src/cja_auto_sdr/org/writers/csv.py
+++ b/src/cja_auto_sdr/org/writers/csv.py
@@ -156,17 +156,18 @@ def write_org_report_csv(
     dv_df.to_csv(dv_path, index=False, encoding="utf-8")
 
     # 3. Components CSV
+    dist = result.distribution
+    bucket_by_id: dict[str, str] = {}
+    for cid in (*dist.limited_metrics, *dist.limited_dimensions):
+        bucket_by_id[cid] = "Limited"
+    for cid in (*dist.common_metrics, *dist.common_dimensions):
+        bucket_by_id[cid] = "Common"
+    for cid in (*dist.core_metrics, *dist.core_dimensions):
+        bucket_by_id[cid] = "Core"
+
     comp_data = []
     for comp_id, info in result.component_index.items():
-        # Determine distribution bucket
-        if comp_id in result.distribution.core_metrics or comp_id in result.distribution.core_dimensions:
-            bucket = "Core"
-        elif comp_id in result.distribution.common_metrics or comp_id in result.distribution.common_dimensions:
-            bucket = "Common"
-        elif comp_id in result.distribution.limited_metrics or comp_id in result.distribution.limited_dimensions:
-            bucket = "Limited"
-        else:
-            bucket = "Isolated"
+        bucket = bucket_by_id.get(comp_id, "Isolated")
 
         coverage_pct = (
             (info.presence_count / result.successful_data_views * 100) if result.successful_data_views > 0 else 0

--- a/src/cja_auto_sdr/org/writers/excel.py
+++ b/src/cja_auto_sdr/org/writers/excel.py
@@ -6,6 +6,7 @@ Renders OrgReportResult as a multi-sheet .xlsx workbook.
 from __future__ import annotations
 
 import logging
+from collections import Counter
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -13,7 +14,6 @@ import pandas as pd
 
 from cja_auto_sdr.core.constants import effective_governance_overlap_threshold
 from cja_auto_sdr.org.models import (
-    ComponentInfo,
     OrgReportResult,
     OrgReportTrending,
 )
@@ -272,28 +272,33 @@ def write_org_report_excel(
             worksheet.set_column("D:E", 15)
 
         # Sheet 4: Isolated by Data View
+        isolated_metric_counts: Counter[str] = Counter()
+        isolated_dim_counts: Counter[str] = Counter()
+        for c in result.distribution.isolated_metrics:
+            info = result.component_index.get(c)
+            if info is not None:
+                for dv_id in info.data_views:
+                    isolated_metric_counts[dv_id] += 1
+        for c in result.distribution.isolated_dimensions:
+            info = result.component_index.get(c)
+            if info is not None:
+                for dv_id in info.data_views:
+                    isolated_dim_counts[dv_id] += 1
+
         isolated_data = []
         for dv in result.data_view_summaries:
             if dv.error is not None:
                 continue
-            isolated_metrics = [
-                c
-                for c in result.distribution.isolated_metrics
-                if dv.data_view_id in result.component_index.get(c, ComponentInfo("", "")).data_views
-            ]
-            isolated_dims = [
-                c
-                for c in result.distribution.isolated_dimensions
-                if dv.data_view_id in result.component_index.get(c, ComponentInfo("", "")).data_views
-            ]
-            if isolated_metrics or isolated_dims:
+            m = isolated_metric_counts.get(dv.data_view_id, 0)
+            d = isolated_dim_counts.get(dv.data_view_id, 0)
+            if m or d:
                 isolated_data.append(
                     {
                         "Data View ID": dv.data_view_id,
                         "Data View Name": dv.data_view_name,
-                        "Isolated Metrics": len(isolated_metrics),
-                        "Isolated Dimensions": len(isolated_dims),
-                        "Total Isolated": len(isolated_metrics) + len(isolated_dims),
+                        "Isolated Metrics": m,
+                        "Isolated Dimensions": d,
+                        "Total Isolated": m + d,
                     },
                 )
 

--- a/src/cja_auto_sdr/output/diff/excel.py
+++ b/src/cja_auto_sdr/output/diff/excel.py
@@ -175,8 +175,8 @@ def write_diff_excel_output(
                     else:
                         fmt = normal_format
 
-                    for col_idx in range(len(df.columns)):
-                        worksheet.write(row_idx, col_idx, df.iloc[row_idx - 1, col_idx], fmt)
+                    row_values = [rows[row_idx - 1][k] for k in ("Status", "ID", "Name", "Details")]
+                    worksheet.write_row(row_idx, 0, row_values, fmt)
 
             write_diff_sheet(diff_result.metric_diffs, "Metrics Diff")
             write_diff_sheet(diff_result.dimension_diffs, "Dimensions Diff")
@@ -219,8 +219,8 @@ def write_diff_excel_output(
                     else:
                         fmt = normal_format
 
-                    for col_idx in range(len(df.columns)):
-                        worksheet.write(row_idx, col_idx, df.iloc[row_idx - 1, col_idx], fmt)
+                    row_values = [rows[row_idx - 1][k] for k in ("Status", "ID", "Name", "Details")]
+                    worksheet.write_row(row_idx, 0, row_values, fmt)
 
             # Write inventory diff sheets if present
             if diff_result.calc_metrics_diffs is not None:

--- a/src/cja_auto_sdr/output/sdr/__init__.py
+++ b/src/cja_auto_sdr/output/sdr/__init__.py
@@ -862,6 +862,59 @@ def write_html_output(
         raise
 
 
+def escape_markdown(text: Any) -> str:
+    """Escape special markdown characters in table cells"""
+    if pd.isna(text) or text is None:
+        return ""
+    text = str(text)
+    # Escape pipe characters that would break tables
+    text = text.replace("|", "\\|")
+    # Escape backticks
+    text = text.replace("`", "\\`")
+    # Replace newlines with spaces in table cells
+    text = text.replace("\n", " ")
+    text = text.replace("\r", " ")
+    return text.strip()
+
+
+def df_to_markdown_table(df: pd.DataFrame, sheet_name: str) -> str:
+    """Convert DataFrame to markdown table format.
+
+    Escaping is column-vectorized via `str.replace()` rather than a per-cell
+    `apply(axis=1)` call, for better performance on large DataFrames.
+    """
+    if df.empty:
+        return f"\n*No {sheet_name.lower()} found.*\n"
+
+    # Header row
+    headers = [escape_markdown(col) for col in df.columns]
+    header_row = "| " + " | ".join(headers) + " |"
+
+    # Separator row with left alignment
+    separator_row = "| " + " | ".join(["---"] * len(headers)) + " |"
+
+    # Data rows - column-wise vectorized escaping instead of per-row apply()
+    # `astype(object)` first: pandas nullable extension dtypes (Int64, Float64,
+    # boolean, category) reject writing the "" fill value in-place via `.where()`
+    # and raise TypeError, so upcast to plain object dtype before filling blanks.
+    # NA sentinels (pd.NA / np.nan / NaT) survive the object cast, so `.notna()`
+    # on the object-cast frame still agrees with `.notna()` on the original.
+    df_obj = df.astype(object)
+    df_esc = df_obj.where(df_obj.notna(), "").astype(str)
+    for col in df_esc.columns:
+        df_esc[col] = (
+            df_esc[col]
+            .str.replace("|", "\\|", regex=False)
+            .str.replace("`", "\\`", regex=False)
+            .str.replace("\n", " ", regex=False)
+            .str.replace("\r", " ", regex=False)
+            .str.strip()
+        )
+    data_rows = ["| " + " | ".join(row) + " |" for row in df_esc.itertuples(index=False)]
+
+    return "\n".join([header_row, separator_row, *data_rows])
+
+
 def write_markdown_output(
     data_dict: dict[str, pd.DataFrame],
     metadata_dict: dict[str, Any],
@@ -891,51 +944,6 @@ def write_markdown_output(
     """
     try:
         logger.info("Generating Markdown output...")
-
-        def escape_markdown(text: str) -> str:
-            """Escape special markdown characters in table cells"""
-            if pd.isna(text) or text is None:
-                return ""
-            text = str(text)
-            # Escape pipe characters that would break tables
-            text = text.replace("|", "\\|")
-            # Escape backticks
-            text = text.replace("`", "\\`")
-            # Replace newlines with spaces in table cells
-            text = text.replace("\n", " ")
-            text = text.replace("\r", " ")
-            return text.strip()
-
-        def df_to_markdown_table(df: pd.DataFrame, sheet_name: str) -> str:
-            """Convert DataFrame to markdown table format.
-
-            Escaping is column-vectorized via `str.replace()` rather than a per-cell
-            `apply(axis=1)` call, for better performance on large DataFrames.
-            """
-            if df.empty:
-                return f"\n*No {sheet_name.lower()} found.*\n"
-
-            # Header row
-            headers = [escape_markdown(col) for col in df.columns]
-            header_row = "| " + " | ".join(headers) + " |"
-
-            # Separator row with left alignment
-            separator_row = "| " + " | ".join(["---"] * len(headers)) + " |"
-
-            # Data rows - column-wise vectorized escaping instead of per-row apply()
-            df_esc = df.where(df.notna(), "").astype(str)
-            for col in df_esc.columns:
-                df_esc[col] = (
-                    df_esc[col]
-                    .str.replace("|", "\\|", regex=False)
-                    .str.replace("`", "\\`", regex=False)
-                    .str.replace("\n", " ", regex=False)
-                    .str.replace("\r", " ", regex=False)
-                    .str.strip()
-                )
-            data_rows = ["| " + " | ".join(row) + " |" for row in df_esc.itertuples(index=False)]
-
-            return "\n".join([header_row, separator_row, *data_rows])
 
         md_parts = []
 

--- a/src/cja_auto_sdr/output/sdr/__init__.py
+++ b/src/cja_auto_sdr/output/sdr/__init__.py
@@ -909,8 +909,8 @@ def write_markdown_output(
         def df_to_markdown_table(df: pd.DataFrame, sheet_name: str) -> str:
             """Convert DataFrame to markdown table format.
 
-            Uses vectorized operations instead of iterrows() for better performance
-            on large DataFrames (20-40% faster for datasets with 100+ rows).
+            Escaping is column-vectorized via `str.replace()` rather than a per-cell
+            `apply(axis=1)` call, for better performance on large DataFrames.
             """
             if df.empty:
                 return f"\n*No {sheet_name.lower()} found.*\n"
@@ -922,13 +922,18 @@ def write_markdown_output(
             # Separator row with left alignment
             separator_row = "| " + " | ".join(["---"] * len(headers)) + " |"
 
-            # Data rows - vectorized approach using apply() instead of iterrows()
-            # This avoids the overhead of creating Series objects for each row
-            def format_row(row: pd.Series) -> str:
-                cells = [escape_markdown(row[col]) for col in df.columns]
-                return "| " + " | ".join(cells) + " |"
-
-            data_rows = df.apply(format_row, axis=1).tolist()
+            # Data rows - column-wise vectorized escaping instead of per-row apply()
+            df_esc = df.where(df.notna(), "").astype(str)
+            for col in df_esc.columns:
+                df_esc[col] = (
+                    df_esc[col]
+                    .str.replace("|", "\\|", regex=False)
+                    .str.replace("`", "\\`", regex=False)
+                    .str.replace("\n", " ", regex=False)
+                    .str.replace("\r", " ", regex=False)
+                    .str.strip()
+                )
+            data_rows = ["| " + " | ".join(row) + " |" for row in df_esc.itertuples(index=False)]
 
             return "\n".join([header_row, separator_row, *data_rows])
 

--- a/src/cja_auto_sdr/output/sdr/__init__.py
+++ b/src/cja_auto_sdr/output/sdr/__init__.py
@@ -330,16 +330,19 @@ def apply_excel_formatting(
             column_width_caps = {}
             default_cap = 100
 
+        # String form of the frame computed once and reused for column widths,
+        # row heights, and Severity values below (avoids re-converting per column/row).
+        df_str = df.astype(str)
+
         # Set column widths with appropriate caps (vectorized)
         for idx, col in enumerate(df.columns):
             col_lower = col.lower()
             max_cap = column_width_caps.get(col_lower, default_cap)
-            series = df[col]
-            if len(series) > 0:
-                content_max = int(series.astype(str).str.split("\n").str[0].str.len().max())
+            if len(df) > 0:
+                content_max = int(df_str[col].str.split("\n").str[0].str.len().max())
             else:
                 content_max = 0
-            max_len = min(max(content_max, len(str(series.name))) + 2, max_cap)
+            max_len = min(max(content_max, len(str(col))) + 2, max_cap)
             worksheet.set_column(idx, idx, max_len)
 
         # Apply row formatting (offset by summary rows)
@@ -351,15 +354,24 @@ def apply_excel_formatting(
         is_data_quality_sheet = sheet_name == "Data Quality" and severity_col_idx >= 0
         is_component_sheet = sheet_name in ("Metrics", "Dimensions") and name_col_idx >= 0
 
+        # Row line counts computed once (vectorized) instead of per-row string scans
+        if len(df) > 0:
+            row_line_counts = df_str.apply(lambda s: s.str.count("\n")).max(axis=1).astype(int).tolist()
+        else:
+            row_line_counts = []
+        severity_values = df_str["Severity"].tolist() if is_data_quality_sheet else None
+        # name_values comes from the original df (not df_str) since xlsxwriter writes
+        # row_data["name"] verbatim, which may be a non-str object.
+        name_values = df["name"].tolist() if is_component_sheet else None
+
         for idx in range(len(df)):
-            row_data = df.iloc[idx]
-            max_lines = max((str(val).count("\n") for val in row_data), default=0) + 1
+            max_lines = row_line_counts[idx] + 1
             row_height = min(max_lines * 15, 400)
             excel_row = data_start_row + idx
 
             # Apply severity-based formatting for Data Quality sheet
             if is_data_quality_sheet:
-                severity = str(row_data["Severity"])
+                severity = severity_values[idx]
                 row_format, bold_format = severity_formats.get(severity, (low_format, low_bold))
 
                 # Set row height and default format
@@ -375,7 +387,7 @@ def apply_excel_formatting(
                 # Apply bold Name column for Metrics/Dimensions sheets
                 if is_component_sheet:
                     name_format = name_bold_grey if idx % 2 == 0 else name_bold_white
-                    worksheet.write(excel_row, name_col_idx, row_data["name"], name_format)
+                    worksheet.write(excel_row, name_col_idx, name_values[idx], name_format)
 
         # Add autofilter to data table (offset by summary rows)
         worksheet.autofilter(summary_rows, 0, summary_rows + len(df), len(df.columns) - 1)

--- a/tests/README.md
+++ b/tests/README.md
@@ -164,10 +164,18 @@ tests/
 ├── test_notion_registry_v2.py       # Notion registry v2 schema and legacy v1 migration tests
 ├── test_cli_notion_prune.py         # CLI flag wiring for --notion-prune-orphans
 ├── test_cli_notion_repair.py        # CLI flag wiring for --notion-repair-database and --notion-print-database-schema
+├── test_org_analyzer_similarity.py  # Org similarity-engine union-hoisting characterization test
+├── test_org_writers_csv.py          # Org components-CSV bucket-lookup characterization test
+├── test_sdr_markdown_escaping.py    # SDR markdown vectorized cell-escaping characterization test
+├── test_diff_excel.py               # Diff Excel row-coloring characterization tests
+├── test_org_snapshot_parse_cache.py # Org snapshot JSON parse-cache characterization test
+├── test_diff_snapshot_retention.py  # Diff snapshot-retention parse-cache characterization test
+├── test_diff_comparator_normalize.py # Diff field-normalization type-fast-path characterization test
+├── test_logging_diagnostics.py      # emit_diagnostic isEnabledFor guard characterization tests
 └── README.md                        # This file
 ```
 
-**Total: 8,355 comprehensive tests**
+**Total: 8,369 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -176,16 +184,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 8,249 | 149 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 8,263 | 157 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 0 | 0 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **8,355** | **155** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **8,369** | **163** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 8,249 | 149 | `-m "unit and not slow"` |
+| `test-unit` | 8,263 | 157 | `-m "unit and not slow"` |
 | `test-integration` | 96 | 5 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -215,7 +223,7 @@ tests/
 | `test_cjapy_retry_interaction.py` | 58 | cjapy retry/status-payload normalization contract |
 | `test_classify_component_payload.py` | 10 | Shared component payload classification helper |
 | `test_utils.py` | 50 | Utility functions and helpers |
-| `test_excel_formatting.py` | 28 | Excel sheet formatting and styling |
+| `test_excel_formatting.py` | 29 | Excel sheet formatting and styling |
 | `test_parallel_api_fetcher.py` | 41 | Parallel API data fetching |
 | `test_api_tuning.py` | 25 | API worker auto-tuning |
 | `test_error_messages.py` | 23 | Enhanced error messages and guidance |
@@ -281,7 +289,7 @@ tests/
 | `test_main_impl_coverage.py` | 64 | _main_impl coverage edge cases |
 | `test_org_cache_branches.py` | 51 | Org cache branch coverage |
 | `test_org_writer_compat_contracts.py` | 116 | Org writer compatibility boundary contract tests |
-| `test_org_writer_coverage.py` | 143 | Org writer edge cases and coverage |
+| `test_org_writer_coverage.py` | 145 | Org writer edge cases and coverage |
 | `test_output_writer_coverage.py` | 37 | Output writer edge cases and coverage |
 | `test_backwards_compat.py` | 34 | Backwards compatibility tests |
 | `test_exception_contracts.py` | 19 | Exception boundary contract tests |
@@ -350,7 +358,15 @@ tests/
 | `test_notion_registry_v2.py` | 11 | Notion registry v2 schema and legacy v1 migration tests |
 | `test_cli_notion_prune.py` | 20 | CLI flag wiring for --notion-prune-orphans |
 | `test_cli_notion_repair.py` | 14 | CLI flag wiring for --notion-repair-database and --notion-print-database-schema |
-| **Total** | **8,355** | **Collected via pytest --collect-only** |
+| `test_org_analyzer_similarity.py` | 1 | Org similarity-engine union-hoisting characterization test |
+| `test_org_writers_csv.py` | 1 | Org components-CSV bucket-lookup characterization test |
+| `test_sdr_markdown_escaping.py` | 1 | SDR markdown vectorized cell-escaping characterization test |
+| `test_diff_excel.py` | 3 | Diff Excel row-coloring characterization tests |
+| `test_org_snapshot_parse_cache.py` | 1 | Org snapshot JSON parse-cache characterization test |
+| `test_diff_snapshot_retention.py` | 1 | Diff snapshot-retention parse-cache characterization test |
+| `test_diff_comparator_normalize.py` | 1 | Diff field-normalization type-fast-path characterization test |
+| `test_logging_diagnostics.py` | 2 | emit_diagnostic isEnabledFor guard characterization tests |
+| **Total** | **8,369** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -808,7 +824,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (8,355 tests total)
+- [x] Comprehensive test coverage (8,369 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 80 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -175,7 +175,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 8,369 comprehensive tests**
+**Total: 8,371 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -184,16 +184,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 8,263 | 157 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 8,265 | 157 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 0 | 0 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **8,369** | **163** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **8,371** | **163** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 8,263 | 157 | `-m "unit and not slow"` |
+| `test-unit` | 8,265 | 157 | `-m "unit and not slow"` |
 | `test-integration` | 96 | 5 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -360,13 +360,13 @@ tests/
 | `test_cli_notion_repair.py` | 14 | CLI flag wiring for --notion-repair-database and --notion-print-database-schema |
 | `test_org_analyzer_similarity.py` | 1 | Org similarity-engine union-hoisting characterization test |
 | `test_org_writers_csv.py` | 1 | Org components-CSV bucket-lookup characterization test |
-| `test_sdr_markdown_escaping.py` | 1 | SDR markdown vectorized cell-escaping characterization test |
+| `test_sdr_markdown_escaping.py` | 3 | SDR markdown vectorized cell-escaping characterization test |
 | `test_diff_excel.py` | 3 | Diff Excel row-coloring characterization tests |
 | `test_org_snapshot_parse_cache.py` | 1 | Org snapshot JSON parse-cache characterization test |
 | `test_diff_snapshot_retention.py` | 1 | Diff snapshot-retention parse-cache characterization test |
 | `test_diff_comparator_normalize.py` | 1 | Diff field-normalization type-fast-path characterization test |
 | `test_logging_diagnostics.py` | 2 | emit_diagnostic isEnabledFor guard characterization tests |
-| **Total** | **8,369** | **Collected via pytest --collect-only** |
+| **Total** | **8,371** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -824,7 +824,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (8,369 tests total)
+- [x] Comprehensive test coverage (8,371 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 80 tests

--- a/tests/test_diff_comparator_normalize.py
+++ b/tests/test_diff_comparator_normalize.py
@@ -1,0 +1,59 @@
+"""Tests for DataViewComparator._normalize_value method
+
+Validates that _normalize_value correctly normalizes various input types
+for consistent diff comparison.
+"""
+
+import numpy as np
+
+
+class TestNormalizeValue:
+    """Tests for _normalize_value method of DataViewComparator"""
+
+    def test_normalize_value_stable_across_types(self):
+        """Test that _normalize_value produces expected outputs for all supported types.
+
+        Validates:
+        - None → ""
+        - NaN (float) → ""
+        - NaN (numpy) → ""
+        - Strings are stripped
+        - Numbers pass through
+        - Booleans pass through
+        - Lists are normalized element-wise
+        - Dicts are normalized recursively
+        - Tuples pass through
+        """
+        from cja_auto_sdr.diff.comparator import DataViewComparator
+
+        cmp = DataViewComparator()  # confirmed: all constructor args are optional
+
+        # None and NaN values normalize to ""
+        assert cmp._normalize_value(None) == ""
+        assert cmp._normalize_value(float("nan")) == ""
+        assert cmp._normalize_value(np.nan) == ""
+
+        # Strings are stripped of leading/trailing whitespace
+        assert cmp._normalize_value("  s  ") == "s"
+        assert cmp._normalize_value("") == ""
+
+        # Numbers pass through unchanged
+        assert cmp._normalize_value(0) == 0
+        assert cmp._normalize_value(1) == 1
+        assert cmp._normalize_value(2.5) == 2.5
+
+        # Booleans pass through unchanged (identity check)
+        assert cmp._normalize_value(True) is True
+        assert cmp._normalize_value(False) is False
+
+        # Lists are normalized element-wise, order preserved by default
+        assert cmp._normalize_value([1, 2]) == [1, 2]
+        assert cmp._normalize_value(["  a  ", "  b  "]) == ["a", "b"]
+
+        # Dicts are normalized recursively (keys sorted, empty values removed)
+        assert cmp._normalize_value({"a": 1}) == {"a": 1}
+        assert cmp._normalize_value({"a": "  s  "}) == {"a": "s"}
+
+        # Tuples fall through to `return value` (pass through unchanged)
+        assert cmp._normalize_value((1,)) == (1,)
+        assert cmp._normalize_value(("a", "b")) == ("a", "b")

--- a/tests/test_diff_excel.py
+++ b/tests/test_diff_excel.py
@@ -1,0 +1,239 @@
+"""Characterization tests for the diff Excel writer's color-coded rows.
+
+Pins exact data-cell values and per-row fill colors for
+``write_diff_excel_output`` (component-diff sheets: Metrics/Dimensions Diff)
+and its inventory counterpart (Calc Metrics/Segments Diff). These values were
+captured from the pre-refactor implementation (per-cell ``df.iloc`` scalar
+writes) and must remain byte-identical after the ``write_row`` refactor.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from openpyxl import load_workbook
+
+from cja_auto_sdr.diff.models import (
+    ChangeType,
+    ComponentDiff,
+    DiffResult,
+    DiffSummary,
+    InventoryItemDiff,
+    MetadataDiff,
+)
+from cja_auto_sdr.output.diff.excel import write_diff_excel_output
+
+logger = logging.getLogger(__name__)
+
+# Fill colors from the format definitions in write_diff_excel_output:
+#   added_format    -> bg_color #d4edda
+#   removed_format  -> bg_color #f8d7da
+#   modified_format -> bg_color #fff3cd
+#   normal_format   -> no bg_color (unfilled)
+ADDED_RGB = "FFD4EDDA"
+REMOVED_RGB = "FFF8D7DA"
+MODIFIED_RGB = "FFFFF3CD"
+UNCHANGED_RGB = "00000000"  # xlsxwriter default: no fill applied
+
+
+def _build_diff_result() -> DiffResult:
+    """Build a DiffResult exercising ADDED / REMOVED / MODIFIED / UNCHANGED
+    for both component diffs (Metrics) and inventory diffs (Calc Metrics)."""
+    metric_diffs = [
+        ComponentDiff(
+            id="m_added",
+            name="Added Metric",
+            change_type=ChangeType.ADDED,
+            source_data=None,
+            target_data={"name": "Added Metric"},
+        ),
+        ComponentDiff(
+            id="m_removed",
+            name="Removed Metric",
+            change_type=ChangeType.REMOVED,
+            source_data={"name": "Removed Metric"},
+            target_data=None,
+        ),
+        ComponentDiff(
+            id="m_modified",
+            name="Modified Metric",
+            change_type=ChangeType.MODIFIED,
+            source_data={"description": "old desc"},
+            target_data={"description": "new desc"},
+            changed_fields={"description": ("old desc", "new desc")},
+        ),
+        ComponentDiff(
+            id="m_unchanged",
+            name="Unchanged Metric",
+            change_type=ChangeType.UNCHANGED,
+            source_data={"description": "same"},
+            target_data={"description": "same"},
+        ),
+    ]
+
+    dimension_diffs = [
+        ComponentDiff(id="d_unchanged", name="Unchanged Dimension", change_type=ChangeType.UNCHANGED),
+    ]
+
+    calc_metrics_diffs = [
+        InventoryItemDiff(
+            id="cm_added", name="Added CM", change_type=ChangeType.ADDED, inventory_type="calculated_metric"
+        ),
+        InventoryItemDiff(
+            id="cm_removed", name="Removed CM", change_type=ChangeType.REMOVED, inventory_type="calculated_metric"
+        ),
+        InventoryItemDiff(
+            id="cm_modified",
+            name="Modified CM",
+            change_type=ChangeType.MODIFIED,
+            inventory_type="calculated_metric",
+            changed_fields={"formula": ("old formula", "new formula")},
+        ),
+        InventoryItemDiff(
+            id="cm_unchanged", name="Unchanged CM", change_type=ChangeType.UNCHANGED, inventory_type="calculated_metric"
+        ),
+    ]
+
+    segments_diffs = [
+        InventoryItemDiff(id="s_added", name="Added Segment", change_type=ChangeType.ADDED, inventory_type="segment"),
+        InventoryItemDiff(
+            id="s_removed", name="Removed Segment", change_type=ChangeType.REMOVED, inventory_type="segment"
+        ),
+        InventoryItemDiff(
+            id="s_modified",
+            name="Modified Segment",
+            change_type=ChangeType.MODIFIED,
+            inventory_type="segment",
+            changed_fields={"definition": ("old def", "new def")},
+        ),
+        InventoryItemDiff(
+            id="s_unchanged", name="Unchanged Segment", change_type=ChangeType.UNCHANGED, inventory_type="segment"
+        ),
+    ]
+
+    summary = DiffSummary(
+        source_metrics_count=4,
+        target_metrics_count=4,
+        metrics_added=1,
+        metrics_removed=1,
+        metrics_modified=1,
+        metrics_unchanged=1,
+        source_dimensions_count=1,
+        target_dimensions_count=1,
+        dimensions_unchanged=1,
+        source_calc_metrics_count=4,
+        target_calc_metrics_count=4,
+        calc_metrics_added=1,
+        calc_metrics_removed=1,
+        calc_metrics_modified=1,
+        calc_metrics_unchanged=1,
+        source_segments_count=4,
+        target_segments_count=4,
+        segments_added=1,
+        segments_removed=1,
+        segments_modified=1,
+        segments_unchanged=1,
+    )
+
+    metadata = MetadataDiff(
+        source_name="Source DV",
+        target_name="Target DV",
+        source_id="dv_source",
+        target_id="dv_target",
+    )
+
+    return DiffResult(
+        summary=summary,
+        metadata_diff=metadata,
+        metric_diffs=metric_diffs,
+        dimension_diffs=dimension_diffs,
+        calc_metrics_diffs=calc_metrics_diffs,
+        segments_diffs=segments_diffs,
+    )
+
+
+def test_diff_excel_cells_and_fills_unchanged(temp_output_dir):
+    """Metrics Diff sheet: cell values + per-row fill colors are pinned."""
+    diff_result = _build_diff_result()
+
+    filepath = write_diff_excel_output(diff_result, "test_diff", temp_output_dir, logger)
+
+    wb = load_workbook(filepath)
+    ws = wb["Metrics Diff"]
+
+    expected_statuses = ["ADDED", "REMOVED", "MODIFIED", "UNCHANGED"]
+    statuses = [ws.cell(row=r, column=1).value for r in range(2, 2 + len(expected_statuses))]
+    assert statuses == expected_statuses
+
+    expected_rows = [
+        ("ADDED", "m_added", "Added Metric", None),
+        ("REMOVED", "m_removed", "Removed Metric", None),
+        ("MODIFIED", "m_modified", "Modified Metric", "description: 'old desc' -> 'new desc'"),
+        ("UNCHANGED", "m_unchanged", "Unchanged Metric", None),
+    ]
+    for offset, expected_row in enumerate(expected_rows):
+        row_idx = 2 + offset
+        actual_row = tuple(ws.cell(row=row_idx, column=c).value for c in range(1, 5))
+        assert actual_row == expected_row
+
+    expected_fills = [ADDED_RGB, REMOVED_RGB, MODIFIED_RGB, UNCHANGED_RGB]
+    for offset, expected_rgb in enumerate(expected_fills):
+        row_idx = 2 + offset
+        fill = ws.cell(row=row_idx, column=1).fill
+        assert fill.fgColor.rgb == expected_rgb
+
+    # Header row untouched by the color pass (still whatever to_excel wrote).
+    assert [ws.cell(row=1, column=c).value for c in range(1, 5)] == ["Status", "ID", "Name", "Details"]
+
+
+def test_diff_excel_dimensions_sheet_unchanged_row(temp_output_dir):
+    """Dimensions Diff sheet: single UNCHANGED row has no fill."""
+    diff_result = _build_diff_result()
+
+    filepath = write_diff_excel_output(diff_result, "test_diff", temp_output_dir, logger)
+
+    wb = load_workbook(filepath)
+    ws = wb["Dimensions Diff"]
+
+    assert ws.cell(row=2, column=1).value == "UNCHANGED"
+    assert tuple(ws.cell(row=2, column=c).value for c in range(1, 5)) == (
+        "UNCHANGED",
+        "d_unchanged",
+        "Unchanged Dimension",
+        None,
+    )
+    assert ws.cell(row=2, column=1).fill.fgColor.rgb == UNCHANGED_RGB
+
+
+def test_diff_excel_inventory_sheets_cells_and_fills_unchanged(temp_output_dir):
+    """write_inventory_diff_sheet gets the identical transform: pin Calc Metrics + Segments sheets."""
+    diff_result = _build_diff_result()
+
+    filepath = write_diff_excel_output(diff_result, "test_diff", temp_output_dir, logger)
+
+    wb = load_workbook(filepath)
+
+    expected_rows_by_sheet = {
+        "Calc Metrics Diff": [
+            ("ADDED", "cm_added", "Added CM", None),
+            ("REMOVED", "cm_removed", "Removed CM", None),
+            ("MODIFIED", "cm_modified", "Modified CM", "formula: 'old formula' -> 'new formula'"),
+            ("UNCHANGED", "cm_unchanged", "Unchanged CM", None),
+        ],
+        "Segments Diff": [
+            ("ADDED", "s_added", "Added Segment", None),
+            ("REMOVED", "s_removed", "Removed Segment", None),
+            ("MODIFIED", "s_modified", "Modified Segment", "definition: 'old def' -> 'new def'"),
+            ("UNCHANGED", "s_unchanged", "Unchanged Segment", None),
+        ],
+    }
+    expected_fills = [ADDED_RGB, REMOVED_RGB, MODIFIED_RGB, UNCHANGED_RGB]
+
+    for sheet_name, expected_rows in expected_rows_by_sheet.items():
+        ws = wb[sheet_name]
+        for offset, (expected_row, expected_rgb) in enumerate(zip(expected_rows, expected_fills, strict=True)):
+            row_idx = 2 + offset
+            actual_row = tuple(ws.cell(row=row_idx, column=c).value for c in range(1, 5))
+            assert actual_row == expected_row, f"{sheet_name} row {row_idx}"
+            fill = ws.cell(row=row_idx, column=1).fill
+            assert fill.fgColor.rgb == expected_rgb, f"{sheet_name} row {row_idx} fill"

--- a/tests/test_diff_snapshot_retention.py
+++ b/tests/test_diff_snapshot_retention.py
@@ -1,0 +1,56 @@
+"""Parse-cache coverage for SnapshotManager.list_snapshots (diff retention passes).
+
+Verifies list_snapshots routes per-file JSON parsing through the shared
+core.json_io.load_json_cached helper, so repeated retention passes over the
+same snapshot directory (e.g. apply_retention_policy -> list_snapshots,
+apply_date_retention_policy -> list_snapshots) do not re-parse unchanged
+files from disk.
+"""
+
+from __future__ import annotations
+
+from cja_auto_sdr.core import json_io
+from cja_auto_sdr.diff.models import DataViewSnapshot
+from cja_auto_sdr.diff.snapshot import SnapshotManager
+
+
+def test_list_snapshots_parse_is_cached(tmp_path, monkeypatch):
+    """Each snapshot file is parsed at most once across two list_snapshots calls."""
+    mgr = SnapshotManager()  # constructor takes only an optional logger
+
+    # Write 2 valid snapshot files via the real snapshot-writing helper for
+    # schema fidelity (matches what create_snapshot/save_snapshot produce).
+    snapshot_a = DataViewSnapshot(
+        data_view_id="dv_a",
+        data_view_name="View A",
+        owner="owner@test.com",
+        description="desc a",
+        metrics=[{"id": "m1", "name": "Metric 1"}],
+        dimensions=[{"id": "d1", "name": "Dim 1"}],
+    )
+    snapshot_b = DataViewSnapshot(
+        data_view_id="dv_b",
+        data_view_name="View B",
+        owner="owner@test.com",
+        description="desc b",
+        metrics=[{"id": "m2", "name": "Metric 2"}],
+        dimensions=[{"id": "d2", "name": "Dim 2"}],
+    )
+    mgr.save_snapshot(snapshot_a, str(tmp_path / "a.json"))
+    mgr.save_snapshot(snapshot_b, str(tmp_path / "b.json"))
+
+    json_io.load_json_cached.cache_clear()
+    calls = {}
+    real_open = open
+
+    def counting_open(file, *a, **k):
+        calls[str(file)] = calls.get(str(file), 0) + 1
+        return real_open(file, *a, **k)
+
+    monkeypatch.setattr("builtins.open", counting_open)
+
+    mgr.list_snapshots(str(tmp_path))
+    mgr.list_snapshots(str(tmp_path))
+
+    assert calls, "expected the counting_open shim to observe at least one open() call"
+    assert all(v == 1 for k, v in calls.items() if k.endswith(".json"))

--- a/tests/test_excel_formatting.py
+++ b/tests/test_excel_formatting.py
@@ -408,6 +408,26 @@ class TestApplyExcelFormattingColumnWidths:
         assert output_file.exists()
 
 
+class TestRowHeightVectorization:
+    """Characterization test: vectorized row-height computation matches the
+    original per-row ``str(val).count("\\n")`` scan.
+    """
+
+    def test_row_heights_match_reference(self):
+        df = pd.DataFrame(
+            {
+                "name": ["a", "b\nb2", "c"],
+                "value": [1, 2, "x\ny\nz"],
+            },
+        )
+        # Reference: current per-row logic
+        ref = [max((str(v).count("\n") for v in df.iloc[i]), default=0) + 1 for i in range(len(df))]
+        # New: vectorized
+        df_str = df.astype(str)
+        new = (df_str.apply(lambda s: s.str.count("\n")).max(axis=1) + 1).astype(int).tolist()
+        assert new == ref
+
+
 class TestApplyExcelFormattingRowHeight:
     """Tests for row height calculations"""
 

--- a/tests/test_logging_diagnostics.py
+++ b/tests/test_logging_diagnostics.py
@@ -1,0 +1,27 @@
+"""Tests for emit_diagnostic performance optimization."""
+
+import logging as _logging
+
+from cja_auto_sdr.core.logging import emit_diagnostic
+
+
+def test_emit_diagnostic_skips_formatting_when_disabled():
+    """Verify that formatting is skipped when the log level is disabled."""
+    logger = _logging.getLogger("diag-test")
+    logger.setLevel(_logging.ERROR)  # INFO diagnostics disabled
+
+    class Boom:
+        def __repr__(self):  # would blow up if formatted
+            raise AssertionError("must not format when disabled")
+
+    # field value passed as a keyword arg (collected into **fields); must return without formatting it.
+    emit_diagnostic(logger, "x", "test", level=_logging.INFO, k=Boom())
+
+
+def test_emit_diagnostic_emits_when_enabled(caplog):
+    """Verify that emit_diagnostic still works when the log level is enabled."""
+    logger = _logging.getLogger("diag-test-2")
+    logger.setLevel(_logging.INFO)
+    with caplog.at_level(_logging.INFO, logger="diag-test-2"):
+        emit_diagnostic(logger, "y", "test", level=_logging.INFO, k="v")
+    assert any("[DIAG] y" in r.message for r in caplog.records)

--- a/tests/test_logging_diagnostics.py
+++ b/tests/test_logging_diagnostics.py
@@ -10,12 +10,17 @@ def test_emit_diagnostic_skips_formatting_when_disabled():
     logger = _logging.getLogger("diag-test")
     logger.setLevel(_logging.ERROR)  # INFO diagnostics disabled
 
-    class Boom:
-        def __repr__(self):  # would blow up if formatted
-            raise AssertionError("must not format when disabled")
+    class Probe:
+        called = False
+
+        def __repr__(self):  # records whether formatting touched this value
+            type(self).called = True
+            return "probe"
 
     # field value passed as a keyword arg (collected into **fields); must return without formatting it.
-    emit_diagnostic(logger, "x", "test", level=_logging.INFO, k=Boom())
+    emit_diagnostic(logger, "x", "test", level=_logging.INFO, k=Probe())
+
+    assert not Probe.called, "formatting must be skipped entirely when the level is disabled"
 
 
 def test_emit_diagnostic_emits_when_enabled(caplog):

--- a/tests/test_org_analyzer_similarity.py
+++ b/tests/test_org_analyzer_similarity.py
@@ -1,0 +1,38 @@
+"""Characterization tests for OrgComponentAnalyzer Jaccard similarity helpers.
+
+Pins the current (pre-optimization) numeric output of ``_compute_pairwise_jaccard``
+so that hoisting component-set unions out of the O(n^2) loops (perf task A1)
+cannot change the computed values.
+"""
+
+import logging
+from unittest.mock import MagicMock
+
+from cja_auto_sdr.org.analyzer import OrgComponentAnalyzer
+from cja_auto_sdr.org.models import DataViewSummary, OrgReportConfig
+
+
+def _dv(dv_id, metrics, dims):
+    return DataViewSummary(
+        data_view_id=dv_id,
+        data_view_name=f"DV {dv_id}",
+        metric_ids=set(metrics),
+        dimension_ids=set(dims),
+    )
+
+
+def test_pairwise_jaccard_values_are_stable():
+    summaries = [
+        _dv("a", ["m1", "m2", "m3"], ["d1", "d2"]),
+        _dv("b", ["m2", "m3", "m4"], ["d2", "d3"]),
+        _dv("c", ["m9"], ["d9"]),
+    ]
+    # OrgComponentAnalyzer.__init__ requires (cja, config, logger); _compute_pairwise_jaccard
+    # never touches self.cja, so a MagicMock stands in for the API client.
+    analyzer = OrgComponentAnalyzer(cja=MagicMock(), config=OrgReportConfig(), logger=logging.getLogger("t"))
+    valid, pairwise = analyzer._compute_pairwise_jaccard(summaries)
+    # intersection(a, b) = {m2,m3,d2} = 3 ; union(a, b) = {m1,m2,m3,m4,d1,d2,d3} = 7
+    assert pairwise[(0, 1)] == 3 / 7
+    assert pairwise[(0, 2)] == 0.0
+    assert pairwise[(1, 2)] == 0.0
+    assert [s.data_view_id for s in valid] == ["a", "b", "c"]

--- a/tests/test_org_snapshot_parse_cache.py
+++ b/tests/test_org_snapshot_parse_cache.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import json
+
+
+def test_load_json_cached_parses_once_per_stat(tmp_path, monkeypatch):
+    from cja_auto_sdr.core import json_io
+
+    p = tmp_path / "snap.json"
+    p.write_text(json.dumps({"snapshot_version": 1, "hello": "world"}), encoding="utf-8")
+
+    calls = {"n": 0}
+    real_open = open
+
+    def counting_open(file, *a, **k):
+        if str(file) == str(p):
+            calls["n"] += 1
+        return real_open(file, *a, **k)
+
+    monkeypatch.setattr("builtins.open", counting_open)
+    json_io.load_json_cached.cache_clear()  # start clean
+    a = json_io.load_json_cached(p)
+    b = json_io.load_json_cached(p)
+    assert a == {"snapshot_version": 1, "hello": "world"}
+    assert a is b  # same cached object
+    assert calls["n"] == 1  # second call served from cache

--- a/tests/test_org_writer_coverage.py
+++ b/tests/test_org_writer_coverage.py
@@ -21,6 +21,7 @@ import logging
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pandas as pd
 import pytest
 
 from cja_auto_sdr.generator import (
@@ -1363,6 +1364,95 @@ class TestWriteOrgReportExcel:
 
         returned = write_org_report_excel(result, out_path, str(tmp_path), logger)
         assert Path(returned).exists()
+
+    def test_isolated_by_dv_sheet_unchanged(self, tmp_path, rich_org_report_result):
+        """Characterization test for the 'Isolated by DV' sheet (B2 single-pass refactor).
+
+        dv_001 has no isolated components (excluded by the ``if m or d`` rule), dv_002
+        errored (skipped), and dv_003 owns the sole isolated metric and dimension. This
+        baseline was captured from the unrefactored per-DV list-comprehension code.
+        """
+        logger = logging.getLogger("test_isolated_by_dv")
+        out_path = tmp_path / "isolated.xlsx"
+
+        returned = write_org_report_excel(rich_org_report_result, out_path, str(tmp_path), logger)
+        df = pd.read_excel(returned, sheet_name="Isolated by DV")
+
+        expected = pd.DataFrame(
+            [
+                {
+                    "Data View ID": "dv_003",
+                    "Data View Name": "Tertiary Data View",
+                    "Isolated Metrics": 1,
+                    "Isolated Dimensions": 1,
+                    "Total Isolated": 2,
+                },
+            ],
+        )
+        pd.testing.assert_frame_equal(df.reset_index(drop=True), expected.reset_index(drop=True))
+
+    def test_isolated_by_dv_sheet_preserves_order_and_skips_errors(self, tmp_path):
+        """Multi-row characterization: errored DV skipped, tied totals keep summary order,
+        and an isolated component spanning two data views (the defensive membership loop)
+        is counted once per data view. Baseline captured from the unrefactored code.
+        """
+        config = OrgReportConfig()
+        summaries = [
+            DataViewSummary(data_view_id="dv_a", data_view_name="DV A", metric_count=1, dimension_count=1),
+            DataViewSummary(data_view_id="dv_err", data_view_name="DV Err", error="boom", status="error"),
+            DataViewSummary(data_view_id="dv_b", data_view_name="DV B", metric_count=1, dimension_count=0),
+            DataViewSummary(data_view_id="dv_c", data_view_name="DV C", metric_count=1, dimension_count=0),
+            DataViewSummary(data_view_id="dv_d", data_view_name="DV D", metric_count=0, dimension_count=0),
+        ]
+        distribution = ComponentDistribution(isolated_metrics=["m1", "m2"], isolated_dimensions=["d1"])
+        component_index = {
+            "m1": ComponentInfo(component_id="m1", component_type="metric", data_views={"dv_a", "dv_b"}),
+            "m2": ComponentInfo(component_id="m2", component_type="metric", data_views={"dv_c"}),
+            "d1": ComponentInfo(component_id="d1", component_type="dimension", data_views={"dv_a"}),
+        }
+        result = OrgReportResult(
+            timestamp="2026-01-01T00:00:00+00:00",
+            org_id="test_org",
+            parameters=config,
+            data_view_summaries=summaries,
+            component_index=component_index,
+            distribution=distribution,
+            similarity_pairs=None,
+            recommendations=[],
+            duration=1.0,
+        )
+        logger = logging.getLogger("test_isolated_by_dv_multi")
+        out_path = tmp_path / "isolated_multi.xlsx"
+
+        returned = write_org_report_excel(result, out_path, str(tmp_path), logger)
+        df = pd.read_excel(returned, sheet_name="Isolated by DV")
+
+        expected = pd.DataFrame(
+            [
+                {
+                    "Data View ID": "dv_a",
+                    "Data View Name": "DV A",
+                    "Isolated Metrics": 1,
+                    "Isolated Dimensions": 1,
+                    "Total Isolated": 2,
+                },
+                {
+                    "Data View ID": "dv_b",
+                    "Data View Name": "DV B",
+                    "Isolated Metrics": 1,
+                    "Isolated Dimensions": 0,
+                    "Total Isolated": 1,
+                },
+                {
+                    "Data View ID": "dv_c",
+                    "Data View Name": "DV C",
+                    "Isolated Metrics": 1,
+                    "Isolated Dimensions": 0,
+                    "Total Isolated": 1,
+                },
+            ],
+        )
+        pd.testing.assert_frame_equal(df.reset_index(drop=True), expected.reset_index(drop=True))
 
 
 # ===================================================================

--- a/tests/test_org_writers_csv.py
+++ b/tests/test_org_writers_csv.py
@@ -1,0 +1,46 @@
+"""Characterization tests for `cja_auto_sdr.org.writers.csv.write_org_report_csv`.
+
+Covers the distribution-bucket assignment for the components CSV, guarding the
+refactor from an O(n) membership-list scan per component to an O(1) dict lookup
+built once ahead of the loop (see B1 in the v3.11.2 performance plan).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from cja_auto_sdr.org.writers.csv import write_org_report_csv
+
+# Exact `org_report_components.csv` body captured from a baseline run of the
+# unchanged writer against `rich_org_report_result()`. Any refactor of the
+# bucket-assignment logic must reproduce this byte-for-byte.
+EXPECTED_COMPONENTS_CSV = (
+    "Component ID,Component Type,Name,Data View Count,Coverage (%),Distribution Bucket,Data Views\n"
+    "metric/common/1,Metric,Common Metric,2,100.0,Common,dv_001;dv_002\n"
+    "dimension/common/1,Dimension,Common Dimension,2,100.0,Common,dv_001;dv_002\n"
+    "metric/core/1,Metric,Core Metric One,2,100.0,Core,dv_001;dv_003\n"
+    "metric/core/2,Metric,Core Metric Two,2,100.0,Core,dv_001;dv_003\n"
+    "dimension/core/1,Dimension,Core Dimension,2,100.0,Core,dv_001;dv_003\n"
+    "metric/isolated/1,Metric,Isolated Metric,1,50.0,Isolated,dv_003\n"
+    "dimension/isolated/1,Dimension,Isolated Dimension,1,50.0,Isolated,dv_003\n"
+    "metric/limited/1,Metric,Limited Metric,2,100.0,Limited,dv_001;dv_002\n"
+    "dimension/limited/1,Dimension,Limited Dimension,2,100.0,Limited,dv_001;dv_002\n"
+)
+
+
+def test_components_csv_bucket_assignment_unchanged(tmp_path, rich_org_report_result):
+    """Distribution-bucket assignment in the components CSV is byte-identical.
+
+    Guards against regressions when the per-component `if/elif` membership-list
+    scan is replaced with a single `bucket_by_id` dict built once before the
+    loop.
+    """
+    result = rich_org_report_result
+    logger = logging.getLogger("test_org_writers_csv")
+
+    returned = write_org_report_csv(result, None, str(tmp_path), logger)
+
+    body = (Path(returned) / "org_report_components.csv").read_text(encoding="utf-8")
+
+    assert body == EXPECTED_COMPONENTS_CSV

--- a/tests/test_output_content_validation.py
+++ b/tests/test_output_content_validation.py
@@ -38,7 +38,7 @@ def rich_data_dict():
         "Metadata": pd.DataFrame(
             {
                 "Property": ["Generated At", "Data View ID", "Tool Version", "Total Metrics"],
-                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.11.1", 3],
+                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.11.2", 3],
             },
         ),
         "Data Quality": pd.DataFrame(
@@ -104,7 +104,7 @@ def rich_metadata_dict():
         "Generated At": "2025-01-15 10:30:00 PST",
         "Data View ID": "dv_content_test",
         "Data View Name": "Test DataView",
-        "Tool Version": "3.11.1",
+        "Tool Version": "3.11.2",
         "Metrics Count": "3",
         "Dimensions Count": "4",
     }
@@ -224,7 +224,7 @@ class TestJSONContentValidation:
             data = json.load(f)
 
         assert data["metadata"]["Data View ID"] == "dv_content_test"
-        assert data["metadata"]["Tool Version"] == "3.11.1"
+        assert data["metadata"]["Tool Version"] == "3.11.2"
 
     def test_json_metadata_preserves_partial_markers(self, tmp_path, rich_data_dict, rich_metadata_dict):
         logger = logging.getLogger("json_test")

--- a/tests/test_output_writer_coverage.py
+++ b/tests/test_output_writer_coverage.py
@@ -248,7 +248,7 @@ class TestWriteMarkdownOutputErrors:
         mock_write.assert_called_once()
 
     def test_generic_exception(self, tmp_path: Path) -> None:
-        with patch.object(pd.DataFrame, "apply", side_effect=RuntimeError("boom")):
+        with patch.object(pd.DataFrame, "astype", side_effect=RuntimeError("boom")):
             with pytest.raises(RuntimeError):
                 write_markdown_output(_sample_data(), _sample_metadata(), "test", str(tmp_path), logger)
 
@@ -501,7 +501,7 @@ def test_output_writer_branches_cover_remaining_value_and_attribute_errors(
         )
 
     with (
-        patch.object(pd.DataFrame, "apply", side_effect=TypeError("bad markdown")),
+        patch.object(pd.DataFrame, "astype", side_effect=TypeError("bad markdown")),
         pytest.raises(TypeError, match="bad markdown"),
     ):
         write_markdown_output(data, {"Generated At": "2026-03-19"}, "md", str(tmp_path), logger)

--- a/tests/test_sdr_markdown_escaping.py
+++ b/tests/test_sdr_markdown_escaping.py
@@ -1,0 +1,40 @@
+"""Equivalence tests for vectorized markdown cell escaping in the SDR markdown writer.
+
+Confirms the vectorized `df.where(...).astype(str)` + chained `.str.replace(...)` escaping
+used in `df_to_markdown_table` (src/cja_auto_sdr/output/sdr/__init__.py) produces byte-identical
+output to the original per-cell `escape_markdown()` reference implementation.
+"""
+
+import numpy as np
+import pandas as pd
+
+
+def _escape_markdown_ref(text):
+    if pd.isna(text) or text is None:
+        return ""
+    text = str(text)
+    text = text.replace("|", "\\|").replace("`", "\\`").replace("\n", " ").replace("\r", " ")
+    return text.strip()
+
+
+def test_vectorized_escaping_matches_reference():
+    df = pd.DataFrame(
+        {
+            "a": ["plain", "has|pipe", "back`tick", "line\nbreak", "  spaced  "],
+            "b": [1, 2.5, np.nan, None, "carriage\rreturn"],
+        }
+    )
+    ref_rows = [[_escape_markdown_ref(df.iloc[i][c]) for c in df.columns] for i in range(len(df))]
+
+    df_esc = df.where(df.notna(), "").astype(str)
+    for col in df_esc.columns:
+        df_esc[col] = (
+            df_esc[col]
+            .str.replace("|", "\\|", regex=False)
+            .str.replace("`", "\\`", regex=False)
+            .str.replace("\n", " ", regex=False)
+            .str.replace("\r", " ", regex=False)
+            .str.strip()
+        )
+    new_rows = [list(t) for t in df_esc.itertuples(index=False)]
+    assert new_rows == ref_rows

--- a/tests/test_sdr_markdown_escaping.py
+++ b/tests/test_sdr_markdown_escaping.py
@@ -1,12 +1,18 @@
 """Equivalence tests for vectorized markdown cell escaping in the SDR markdown writer.
 
-Confirms the vectorized `df.where(...).astype(str)` + chained `.str.replace(...)` escaping
-used in `df_to_markdown_table` (src/cja_auto_sdr/output/sdr/__init__.py) produces byte-identical
-output to the original per-cell `escape_markdown()` reference implementation.
+Confirms the vectorized `df.astype(object).where(...).astype(str)` + chained
+`.str.replace(...)` escaping used in `df_to_markdown_table`
+(src/cja_auto_sdr/output/sdr/__init__.py) produces byte-identical output to the original
+per-cell `escape_markdown()` reference implementation -- including for pandas nullable
+extension dtypes (Int64, Float64, boolean, category) that the plain
+`df.where(df.notna(), "").astype(str)` form cannot handle (it raises `TypeError` trying to
+write the string "" into a typed extension array).
 """
 
 import numpy as np
 import pandas as pd
+
+from cja_auto_sdr.output.sdr import df_to_markdown_table
 
 
 def _escape_markdown_ref(text):
@@ -44,3 +50,68 @@ def test_vectorized_escaping_matches_reference():
         )
     new_rows = [list(t) for t in df_esc.itertuples(index=False)]
     assert new_rows == ref_rows
+
+
+def _nullable_dtype_frame():
+    """A frame covering the pandas nullable extension dtypes, each with a missing value."""
+    return pd.DataFrame(
+        {
+            "int_col": pd.array([1, None, 3], dtype="Int64"),
+            "float_col": pd.array([1.5, None, 3.5], dtype="Float64"),
+            "bool_col": pd.array([True, None, False], dtype="boolean"),
+            "cat_col": pd.Categorical(["x", None, "y|z"]),
+        }
+    )
+
+
+def test_vectorized_escaping_matches_reference_for_nullable_extension_dtypes():
+    """Int64 / Float64 / boolean / category columns with missing values must escape
+    identically to the per-cell reference implementation.
+
+    This is the exact equivalence check that the plain `df.where(df.notna(), "")` form
+    fails on (TypeError writing "" into a typed extension array) -- reproduced directly
+    against the production function below in
+    `test_df_to_markdown_table_handles_nullable_extension_dtypes`.
+    """
+    df = _nullable_dtype_frame()
+    assert str(df["int_col"].dtype) == "Int64"
+    assert str(df["float_col"].dtype) == "Float64"
+    assert str(df["bool_col"].dtype) == "boolean"
+    assert str(df["cat_col"].dtype) == "category"
+
+    ref_rows = [[_escape_markdown_ref(df.iloc[i][c]) for c in df.columns] for i in range(len(df))]
+
+    df_obj = df.astype(object)
+    df_esc = df_obj.where(df_obj.notna(), "").astype(str)
+    for col in df_esc.columns:
+        df_esc[col] = (
+            df_esc[col]
+            .str.replace("|", "\\|", regex=False)
+            .str.replace("`", "\\`", regex=False)
+            .str.replace("\n", " ", regex=False)
+            .str.replace("\r", " ", regex=False)
+            .str.strip()
+        )
+    new_rows = [list(t) for t in df_esc.itertuples(index=False)]
+    assert new_rows == ref_rows
+
+
+def test_df_to_markdown_table_handles_nullable_extension_dtypes():
+    """Pins the actual production seam: `df_to_markdown_table` must render nullable
+    extension dtype columns without raising, and the rendered table must match the
+    table built from the per-cell reference escaper.
+    """
+    df = _nullable_dtype_frame()
+
+    ref_rows = [[_escape_markdown_ref(df.iloc[i][c]) for c in df.columns] for i in range(len(df))]
+    headers = [_escape_markdown_ref(col) for col in df.columns]
+    expected = "\n".join(
+        [
+            "| " + " | ".join(headers) + " |",
+            "| " + " | ".join(["---"] * len(headers)) + " |",
+            *["| " + " | ".join(row) + " |" for row in ref_rows],
+        ]
+    )
+
+    result = df_to_markdown_table(df, "Nullable Types")
+    assert result == expected

--- a/tests/test_sdr_markdown_escaping.py
+++ b/tests/test_sdr_markdown_escaping.py
@@ -22,8 +22,14 @@ def test_vectorized_escaping_matches_reference():
         {
             "a": ["plain", "has|pipe", "back`tick", "line\nbreak", "  spaced  "],
             "b": [1, 2.5, np.nan, None, "carriage\rreturn"],
+            "c": [1.0, 2.5, np.nan, 100.0, 7.0],
         }
     )
+    # Column "b" mixes in a string, so pandas infers object dtype at construction time
+    # and never hits the numeric path. Column "c" must be genuinely float64 so that
+    # `df.where(df.notna(), "")` exercises the numeric -> object upcast before `.astype(str)`.
+    # Pin the dtype so construction-time inference can't silently regress this coverage.
+    assert df["c"].dtype == "float64"
     ref_rows = [[_escape_markdown_ref(df.iloc[i][c]) for c in df.columns] for i in range(len(df))]
 
     df_esc = df.where(df.notna(), "").astype(str)

--- a/tests/test_ux_features.py
+++ b/tests/test_ux_features.py
@@ -344,11 +344,11 @@ class TestCombinedFeatures:
 class TestVersionUpdated:
     """Test that version is correct"""
 
-    def test_version_is_3_11_1(self):
-        """Test that version is 3.11.1"""
+    def test_version_is_3_11_2(self):
+        """Test that version is 3.11.2"""
         from cja_auto_sdr.generator import __version__
 
-        assert __version__ == "3.11.1"
+        assert __version__ == "3.11.2"
 
 
 class TestFormatAutoDetection:


### PR DESCRIPTION
## Summary

Byte-identical performance patch release (v3.11.1 → v3.11.2). Eleven verified optimizations that remove redundant CPU and I/O from hot paths with **no behavior change** — identical output bytes, exit codes, API-call semantics, and CLI surface. No new flags, no public API changes, `generator.py` untouched.

### Org similarity engine
- **Jaccard loops (`org/analyzer.py`):** the O(n²) pairwise-similarity loops re-evaluated the `all_component_ids` property (a fresh set union of metric + dimension ids) on every pair. Component sets are now materialized once per data view, and the union size is computed arithmetically (`|A| + |B| − |A∩B|`) instead of allocating a merged set per pair. Same change applied to `_compute_similarity_matrix`.
- **Isolated-components recommendation (`org/analyzer.py`):** replaced a per-data-view linear scan of `summaries` for name resolution with a single `{id: name}` dict built once before the loop.

### Org report writers
- **Components CSV (`org/writers/csv.py`):** bucket classification did up to six list-membership scans per component (Core/Common/Limited metrics + dimensions). Now a single dict is built once in reverse precedence order, and each component is classified with one O(1) lookup.
- **"Isolated by DV" Excel sheet (`org/writers/excel.py`):** the sheet was built with per-data-view list comprehensions over all isolated components, allocating a throwaway default `ComponentInfo("", "")` per membership test. Inverted to a single pass that accumulates per-DV counts in two `Counter`s. Row order, errored-DV skipping, and the inclusion rule are preserved exactly.

### SDR / diff rendering
- **SDR Excel formatting (`output/sdr/__init__.py`):** column-width and row-height calculation converted the frame to strings repeatedly (per column and per row). The frame is now converted with one `df.astype(str)` pass and reused for widths, heights, and Severity values; `name` cells still come from the original frame so raw objects are written verbatim.
- **SDR markdown tables (`output/sdr/__init__.py`):** per-row `df.apply(format_row, axis=1)` escaping replaced with column-wise vectorized `str.replace` chains; rows are emitted via `itertuples`. An equivalence test pins old-vs-new output exactly, including the float64-with-NaN upcast path.
- **Diff Excel coloring (`output/diff/excel.py`):** the row-color pass re-wrote every cell individually via scalar `df.iloc[row, col]` lookups. Both diff sheet writers now emit each row with a single `write_row` call sourced from the already-built row dicts. Cell values and fills verified byte-identical (raw workbook XML compared).

### Snapshot handling
- **Shared parse cache (`core/json_io.py`):** new process-local `load_json_cached()` helper memoized by `(path, mtime_ns, size)` with a bounded LRU. Org trending discovery, org snapshot metadata loading, and diff retention listing all re-parsed the same JSON snapshot files multiple times within one run; all three now share one parse per file. The mutated org-report cache loader is deliberately **not** routed through it.

### Micro-fixes
- **Diff normalization (`diff/comparator.py`):** `_normalize_value` called `pd.isna()` on every value; str/dict/list/tuple can never be pandas-NA, so a type fast-path skips the call (and its exception handling) for those types.
- **Diagnostics (`core/logging.py`):** `emit_diagnostic` formatted all field values (including `json.dumps` for containers) even when the log level was disabled and the record would be discarded. An `isEnabledFor` guard now returns before any formatting work.

## Testing

- 14 new tests across 8 new test files + 2 extended files: characterization tests capture the pre-change output as literal baselines (CSV bodies, Excel cell/fill values, markdown escaping equivalence, Jaccard values) so the refactors must reproduce it exactly; the caching and logging changes have genuine red-green tests (parse-once assertions, side-effect probe for skipped formatting).
- Full suite: 8,353 passed + 16 skipped (8,369 collected across 163 files); counts propagated to README, tests/README, CLAUDE.md.
- `scripts/check_version_sync.py` and `scripts/update_test_counts.py --check` pass; `ruff check` / `ruff format --check` clean.
- Final whole-branch review: ready to merge, no Critical or Important findings.

https://claude.ai/code/session_01NMC5Qe6fKA1vPZbbtn6tre