### PR TITLE
perf: v3.11.3 safe optimizations (byte-identical)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ All notable changes to the CJA SDR Generator project will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.11.3] - 2026-07-02
+
+### Performance
+
+- Removed remaining redundant CPU work in per-component paths with **no behavior change** (identical output, exit codes, API-call semantics, and CLI surface):
+  - **Derived-field inventory:** `build()` iterates `to_dict("records")` instead of `iterrows()`, dropping the per-row pandas Series construction; scales with metrics + dimensions count per data view.
+  - **SDR generation:** the JSON-formatting pass skips non-object dtype columns — `format_json_cell` can only rewrite dict/list cells, which only exist in object columns, so numeric/bool columns no longer pay a per-cell Python call.
+  - **Data quality:** the vectorized null-value check reuses a single `isna()` mask for both counts and item-name lookups instead of re-scanning each flagged column.
+  - **SDR Excel:** column-width computation bounds the first-line split (`str.split("\n", n=1)`), avoiding full split-list materialization for multi-line cells.
+- No new CLI flags, no public API changes. New characterization tests pin issue payloads, inventory extraction over mixed-dtype/NA frames, JSON container formatting with numeric passthrough, and first-line width equivalence.
+
 ## [3.11.2] - 2026-07-02
 
 ### Performance

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,8 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Package manager: **uv**
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
-- Current version: v3.11.2
-- Tests: **8,371** across 163 files at **95% coverage gate**
+- Current version: v3.11.3
+- Tests: **8,377** across 163 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)
 

--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (8,371+ tests)
+├── tests/                     # Test suite (8,377+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -943,7 +943,7 @@ cja_auto_sdr --list-dataviews --log-level DEBUG
 At launch, the tool logs diagnostic lines containing the tool version, Python version, platform, active log level, inferred run mode (batch, single, or discovery), and dependency versions. These appear automatically at `INFO` level and are useful for troubleshooting environment issues in CI/CD logs or support requests:
 
 ```text
-CJA SDR Generator v3.11.2 | Python 3.14.2 | darwin | log_level=INFO | mode=single
+CJA SDR Generator v3.11.3 | Python 3.14.2 | darwin | log_level=INFO | mode=single
 Dependencies: cjapy=0.3.0, pandas=2.3.3, numpy=2.2.1, xlsxwriter=3.2.9, tqdm=4.67.0
 ```
 

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -190,7 +190,7 @@ This command:
 
 ```bash
 $ uv run cja_auto_sdr -V
-cja_auto_sdr 3.11.2
+cja_auto_sdr 3.11.3
 ```
 
 > **Important:** All commands in this guide assume you're in the `cja_auto_sdr` directory. If you see "command not found", make sure you're in the right directory and have run `uv sync`.

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Quick Reference Card
 
-Single-page command cheat sheet for CJA SDR Generator v3.11.2.
+Single-page command cheat sheet for CJA SDR Generator v3.11.3.
 
 ## Four Main Modes
 

--- a/src/cja_auto_sdr/api/quality.py
+++ b/src/cja_auto_sdr/api/quality.py
@@ -296,9 +296,13 @@ class DataQualityChecker:
             # Check 4: Vectorized null value checks
             available_critical_fields = [f for f in critical_fields if f in df.columns]
             if available_critical_fields:
-                null_counts = df[available_critical_fields].isna().sum()
+                # Reuse one isna() mask for counts and item-name lookups instead
+                # of re-scanning each flagged column.
+                null_mask = df[available_critical_fields].isna()
+                null_counts = null_mask.sum()
+                has_name_column = "name" in df.columns
                 for field, null_count in null_counts[null_counts > 0].items():
-                    null_items = df[df[field].isna()]["name"].tolist() if "name" in df.columns else []
+                    null_items = df.loc[null_mask[field], "name"].tolist() if has_name_column else []
                     _record_issue(
                         severity="MEDIUM",
                         category="Null Values",

--- a/src/cja_auto_sdr/core/version.py
+++ b/src/cja_auto_sdr/core/version.py
@@ -1,3 +1,3 @@
 """Version information for CJA Auto SDR."""
 
-__version__ = "3.11.2"
+__version__ = "3.11.3"

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -3856,16 +3856,21 @@ def process_single_dataview(
             # Apply JSON formatting to all dataframes
             logger.info("Applying JSON formatting to dataframes...")
 
+            # Only object-dtype columns can hold dict/list cells; skipping the
+            # rest avoids a per-cell Python call over purely numeric columns.
             for col in lookup_df.columns:
-                lookup_df[col] = lookup_df[col].map(format_json_cell)
+                if lookup_df[col].dtype == object:
+                    lookup_df[col] = lookup_df[col].map(format_json_cell)
 
             if not metrics.empty:
                 for col in metrics.columns:
-                    metrics[col] = metrics[col].map(format_json_cell)
+                    if metrics[col].dtype == object:
+                        metrics[col] = metrics[col].map(format_json_cell)
 
             if not dimensions.empty:
                 for col in dimensions.columns:
-                    dimensions[col] = dimensions[col].map(format_json_cell)
+                    if dimensions[col].dtype == object:
+                        dimensions[col] = dimensions[col].map(format_json_cell)
 
             logger.info("JSON formatting applied successfully")
         except (KeyError, TypeError, ValueError) as e:

--- a/src/cja_auto_sdr/inventory/derived_fields.py
+++ b/src/cja_auto_sdr/inventory/derived_fields.py
@@ -324,17 +324,17 @@ class DerivedFieldInventoryBuilder:
         # Track processing statistics
         stats = BatchProcessingStats(logger=self.logger)
 
-        # Process metrics
+        # Process metrics (records iteration avoids per-row Series construction)
         if metrics_df is not None and not metrics_df.empty:
-            for _, row in metrics_df.iterrows():
+            for row in metrics_df.to_dict("records"):
                 summary = self._process_row(row, "Metric", stats)
                 if summary:
                     inventory.fields.append(summary)
                     stats.record_success()
 
-        # Process dimensions
+        # Process dimensions (records iteration avoids per-row Series construction)
         if dimensions_df is not None and not dimensions_df.empty:
-            for _, row in dimensions_df.iterrows():
+            for row in dimensions_df.to_dict("records"):
                 summary = self._process_row(row, "Dimension", stats)
                 if summary:
                     inventory.fields.append(summary)
@@ -352,11 +352,11 @@ class DerivedFieldInventoryBuilder:
 
     def _process_row(
         self,
-        row: pd.Series,
+        row: dict[str, Any] | pd.Series,
         component_type: str,
         stats: BatchProcessingStats | None = None,
     ) -> DerivedFieldSummary | None:
-        """Process a single row and return a DerivedFieldSummary if it's a derived field."""
+        """Process a single row (records dict or Series) and return a DerivedFieldSummary if it's a derived field."""
         # Check if this is a derived field
         source_type = self._normalize_source_type(row.get("sourceFieldType", ""))
 

--- a/src/cja_auto_sdr/output/sdr/__init__.py
+++ b/src/cja_auto_sdr/output/sdr/__init__.py
@@ -339,7 +339,9 @@ def apply_excel_formatting(
             col_lower = col.lower()
             max_cap = column_width_caps.get(col_lower, default_cap)
             if len(df) > 0:
-                content_max = int(df_str[col].str.split("\n").str[0].str.len().max())
+                # Only the first line matters for width; n=1 avoids splitting
+                # the remainder of multi-line cells.
+                content_max = int(df_str[col].str.split("\n", n=1).str[0].str.len().max())
             else:
                 content_max = 0
             max_len = min(max(content_max, len(str(col))) + 2, max_cap)

--- a/tests/README.md
+++ b/tests/README.md
@@ -175,7 +175,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 8,371 comprehensive tests**
+**Total: 8,377 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -184,16 +184,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 8,265 | 157 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 8,271 | 157 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 0 | 0 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **8,371** | **163** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **8,377** | **163** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 8,265 | 157 | `-m "unit and not slow"` |
+| `test-unit` | 8,271 | 157 | `-m "unit and not slow"` |
 | `test-integration` | 96 | 5 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -209,7 +209,7 @@ tests/
 | `test_org_report_integration.py` | 17 | Org-wide analysis integration tests: end-to-end flows, caching, filtering, governance |
 | `test_cli.py` | 412 | Command-line interface and argument parsing |
 | `test_profiles.py` | 80 | Multi-organization profile support |
-| `test_derived_inventory.py` | 62 | Derived fields inventory feature |
+| `test_derived_inventory.py` | 64 | Derived fields inventory feature |
 | `test_diff_snapshot_cjapy_payloads.py` | 5 | Diff snapshot cjapy payload classification |
 | `test_inventory_pragma_coverage.py` | 18 | Inventory pragma coverage hardening |
 | `test_inventory_summary_cjapy_payloads.py` | 4 | Inventory summary cjapy payload classification |
@@ -223,7 +223,7 @@ tests/
 | `test_cjapy_retry_interaction.py` | 58 | cjapy retry/status-payload normalization contract |
 | `test_classify_component_payload.py` | 10 | Shared component payload classification helper |
 | `test_utils.py` | 50 | Utility functions and helpers |
-| `test_excel_formatting.py` | 29 | Excel sheet formatting and styling |
+| `test_excel_formatting.py` | 30 | Excel sheet formatting and styling |
 | `test_parallel_api_fetcher.py` | 41 | Parallel API data fetching |
 | `test_api_tuning.py` | 25 | API worker auto-tuning |
 | `test_error_messages.py` | 23 | Enhanced error messages and guidance |
@@ -250,7 +250,7 @@ tests/
 | `test_diagnostic_events.py` | 23 | Structured diagnostic event vocabulary, logger adapters, and redaction |
 | `test_output_content_validation.py` | 29 | Output format content validation (CSV, JSON, HTML, Excel, Markdown roundtrip) |
 | `test_output_extraction_contracts.py` | 347 | Extraction contracts for output.diff and output.inventory |
-| `test_malformed_api_responses.py` | 20 | Negative tests for malformed/unexpected API responses |
+| `test_malformed_api_responses.py` | 21 | Negative tests for malformed/unexpected API responses |
 | `test_main_entry_points.py` | 43 | main() and _main_impl() entry points, dispatch, run_state, run summary |
 | `test_quality_policy_and_run_summary.py` | 171 | Quality policy functions and run summary/status inference |
 | `test_e2e_integration.py` | 16 | End-to-end integration tests with real pipeline, mocked API boundary |
@@ -326,7 +326,7 @@ tests/
 | `test_lock_info_normalization.py` | 54 | Lock-info normalization classmethod direct unit tests |
 | `test_resilience_edge_cases.py` | 74 | Resilience edge-case tests |
 | `test_cache_edge_cases.py` | 20 | Cache edge-case tests |
-| `test_quality_edge_cases.py` | 21 | Quality edge-case tests |
+| `test_quality_edge_cases.py` | 23 | Quality edge-case tests |
 | `test_tuning_edge_cases.py` | 15 | Tuning edge-case tests |
 | `test_fetch_edge_cases.py` | 9 | Fetch edge-case tests |
 | `test_advisories.py` | 53 | Advisory model, builder, and rollup tests |
@@ -366,7 +366,7 @@ tests/
 | `test_diff_snapshot_retention.py` | 1 | Diff snapshot-retention parse-cache characterization test |
 | `test_diff_comparator_normalize.py` | 1 | Diff field-normalization type-fast-path characterization test |
 | `test_logging_diagnostics.py` | 2 | emit_diagnostic isEnabledFor guard characterization tests |
-| **Total** | **8,371** | **Collected via pytest --collect-only** |
+| **Total** | **8,377** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -824,7 +824,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (8,371 tests total)
+- [x] Comprehensive test coverage (8,377 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 80 tests
@@ -833,7 +833,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Shared validation cache tests (test_shared_cache.py) - 30 tests
 - [x] Calculated metrics inventory tests (test_calculated_metrics_inventory.py) - 366 tests
 - [x] Segments inventory tests (test_segments_inventory.py) - 48 tests
-- [x] Derived fields inventory tests (test_derived_inventory.py) - 62 tests
+- [x] Derived fields inventory tests (test_derived_inventory.py) - 64 tests
 - [x] Inventory utilities tests (test_inventory_utils.py) - 56 tests
 - [x] Git integration tests (test_git_integration.py) - 41 tests
 - [x] Inventory diff support in snapshot comparisons (test_diff_comparison.py) - 169 tests

--- a/tests/test_derived_inventory.py
+++ b/tests/test_derived_inventory.py
@@ -1573,3 +1573,58 @@ class TestNewLogicSummaryHandlers:
 
         field = inventory.fields[0]
         assert "profile" in field.logic_summary.lower() or "loyaltyTier" in field.logic_summary
+
+
+# ==================== ROW ITERATION EQUIVALENCE ====================
+
+
+class TestBuildRowIterationEquivalence:
+    """Characterization tests pinning build() outputs for mixed-dtype frames.
+
+    Guards row-iteration refactors (iterrows vs records): NA definitions are
+    skipped silently, non-derived rows are ignored, NA descriptions coerce to
+    empty string, and pure-numeric columns must not affect extraction.
+    """
+
+    def test_build_pins_field_values_with_mixed_dtypes_and_na(self, sample_derived_field_definition):
+        metrics_df = pd.DataFrame(
+            {
+                "id": ["metrics/one", "metrics/two", "metrics/three"],
+                "name": ["One", "Two", "Three"],
+                "description": ["First metric", None, "Third metric"],
+                "sourceFieldType": ["derived", "derived", "standard"],
+                "type": ["int", "decimal", "int"],
+                "fieldDefinition": [sample_derived_field_definition, pd.NA, pd.NA],
+                "sortOrder": [1, 2, 3],
+            },
+        )
+
+        builder = DerivedFieldInventoryBuilder()
+        inventory = builder.build(metrics_df, pd.DataFrame(), "dv_pin", "Pin View")
+
+        # Only the first row survives: NA definition and non-derived rows skip.
+        assert inventory.metrics_count == 1
+        assert inventory.dimensions_count == 0
+        field = inventory.fields[0]
+        assert field.component_id == "metrics/one"
+        assert field.component_name == "One"
+        assert field.component_type == "Metric"
+        assert field.description == "First metric"
+        assert field.definition_json == sample_derived_field_definition
+
+    def test_build_coerces_na_description_to_empty_string(self, sample_math_only_field):
+        metrics_df = pd.DataFrame(
+            {
+                "id": ["metrics/profit"],
+                "name": ["Profit"],
+                "description": [pd.NA],
+                "sourceFieldType": ["derived"],
+                "fieldDefinition": [sample_math_only_field],
+            },
+        )
+
+        builder = DerivedFieldInventoryBuilder()
+        inventory = builder.build(metrics_df, pd.DataFrame(), "dv_pin", "Pin View")
+
+        assert inventory.metrics_count == 1
+        assert inventory.fields[0].description == ""

--- a/tests/test_excel_formatting.py
+++ b/tests/test_excel_formatting.py
@@ -428,6 +428,25 @@ class TestRowHeightVectorization:
         assert new == ref
 
 
+class TestColumnWidthFirstLineVectorization:
+    """Characterization test: bounded first-line split (``n=1``) matches the
+    unbounded ``str.split("\\n")`` reference for column-width computation.
+    """
+
+    def test_first_line_widths_match_reference(self):
+        df = pd.DataFrame(
+            {
+                "name": ["short", "first line\na second line that is much longer than the first", ""],
+                "value": [1, None, "x\ny\nz"],
+            },
+        )
+        df_str = df.astype(str)
+        for col in df_str.columns:
+            ref = int(df_str[col].str.split("\n").str[0].str.len().max())
+            new = int(df_str[col].str.split("\n", n=1).str[0].str.len().max())
+            assert new == ref
+
+
 class TestApplyExcelFormattingRowHeight:
     """Tests for row height calculations"""
 

--- a/tests/test_malformed_api_responses.py
+++ b/tests/test_malformed_api_responses.py
@@ -7,7 +7,9 @@ Validates that the pipeline handles gracefully:
 - Empty or corrupted responses during processing
 """
 
+import json
 import logging
+from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pandas as pd
@@ -357,6 +359,53 @@ class TestMalformedDataFrameSchemas:
         )
         # Should not crash — JSON formatting handles dicts/lists via format_json_cell
         assert result.success is True
+
+    @_apply
+    def test_json_output_pins_container_formatting_and_numeric_passthrough(
+        self,
+        mock_fetcher_class,
+        mock_init_cja,
+        mock_setup_logging,
+        malformed_config,
+        output_dir,
+    ):
+        """Pin format_json_cell behavior: dict/list cells become indented JSON
+        strings while pure-numeric columns pass through byte-identical.
+        Guards refactors of the per-column JSON-formatting pass."""
+        _setup_mocks(
+            mock_setup_logging,
+            mock_init_cja,
+            mock_fetcher_class,
+            pd.DataFrame(
+                {
+                    "id": ["m1", "m2"],
+                    "name": ["M1", "M2"],
+                    "type": ["int", "int"],
+                    "title": ["M1", "M2"],
+                    "description": [{"nested": "dict"}, ["a", "list"]],
+                    "sortOrder": [7, 9],
+                },
+            ),
+            pd.DataFrame([{"id": "d1", "name": "D1", "type": "string", "title": "D1", "description": "d"}]),
+            {"id": "dv_test", "name": "Test DV", "owner": {"name": "Owner"}},
+        )
+
+        result = process_single_dataview(
+            data_view_id="dv_test",
+            config_file=malformed_config,
+            output_dir=output_dir,
+            output_format="json",
+            quiet=True,
+        )
+        assert result.success is True
+
+        json_files = list(Path(output_dir).glob("CJA_DataView_*.json"))
+        assert len(json_files) == 1
+        payload = json.loads(json_files[0].read_text(encoding="utf-8"))
+        metrics = payload["metrics"]
+        assert metrics[0]["description"] == json.dumps({"nested": "dict"}, indent=2)
+        assert metrics[1]["description"] == json.dumps(["a", "list"], indent=2)
+        assert [m["sortOrder"] for m in metrics] == [7, 9]
 
 
 # ===================================================================

--- a/tests/test_output_content_validation.py
+++ b/tests/test_output_content_validation.py
@@ -38,7 +38,7 @@ def rich_data_dict():
         "Metadata": pd.DataFrame(
             {
                 "Property": ["Generated At", "Data View ID", "Tool Version", "Total Metrics"],
-                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.11.2", 3],
+                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.11.3", 3],
             },
         ),
         "Data Quality": pd.DataFrame(
@@ -104,7 +104,7 @@ def rich_metadata_dict():
         "Generated At": "2025-01-15 10:30:00 PST",
         "Data View ID": "dv_content_test",
         "Data View Name": "Test DataView",
-        "Tool Version": "3.11.2",
+        "Tool Version": "3.11.3",
         "Metrics Count": "3",
         "Dimensions Count": "4",
     }
@@ -224,7 +224,7 @@ class TestJSONContentValidation:
             data = json.load(f)
 
         assert data["metadata"]["Data View ID"] == "dv_content_test"
-        assert data["metadata"]["Tool Version"] == "3.11.2"
+        assert data["metadata"]["Tool Version"] == "3.11.3"
 
     def test_json_metadata_preserves_partial_markers(self, tmp_path, rich_data_dict, rich_metadata_dict):
         logger = logging.getLogger("json_test")

--- a/tests/test_quality_edge_cases.py
+++ b/tests/test_quality_edge_cases.py
@@ -283,3 +283,44 @@ class TestParallelExecution:
         assert len(df) == 2
         truncation_logged = any("Limiting data quality issues" in str(call) for call in mock_logger.info.call_args_list)
         assert not truncation_logged
+
+
+# ==================== Null Value Payload Pinning ====================
+
+
+class TestNullValuePayloadPinning:
+    """Characterization tests pinning exact null-value issue payloads.
+
+    Guards refactors of the vectorized null check (check 4): item names,
+    field ordering, and details strings must stay byte-identical when
+    multiple critical fields carry nulls in different rows.
+    """
+
+    def test_multiple_critical_fields_pin_item_names_and_details(self):
+        checker = DataQualityChecker(logger=logging.getLogger("test"), quiet=True)
+        df = pd.DataFrame(
+            {
+                "id": ["m1", None, "m3"],
+                "name": ["Alpha", "Beta", "Gamma"],
+                "type": [None, "metric", None],
+            },
+        )
+
+        checker.check_all_quality_issues_optimized(df, "Metrics", ["id", "name"], ["id", "type"])
+
+        null_issues = [i for i in checker.issues if i["Category"] == "Null Values"]
+        assert [(i["Item Name"], i["Issue"], i["Details"]) for i in null_issues] == [
+            ("Beta", 'Null values in "id" field', "1 item(s) missing id. Items: Beta"),
+            ("Alpha, Gamma", 'Null values in "type" field', "2 item(s) missing type. Items: Alpha, Gamma"),
+        ]
+
+    def test_null_items_without_name_column_pin_empty_item_list(self):
+        checker = DataQualityChecker(logger=logging.getLogger("test"), quiet=True)
+        df = pd.DataFrame({"id": ["m1", None], "type": ["metric", "metric"]})
+
+        checker.check_all_quality_issues_optimized(df, "Metrics", ["id"], ["id"])
+
+        null_issues = [i for i in checker.issues if i["Category"] == "Null Values"]
+        assert [(i["Item Name"], i["Details"]) for i in null_issues] == [
+            ("", "1 item(s) missing id. Items: "),
+        ]

--- a/tests/test_ux_features.py
+++ b/tests/test_ux_features.py
@@ -344,11 +344,11 @@ class TestCombinedFeatures:
 class TestVersionUpdated:
     """Test that version is correct"""
 
-    def test_version_is_3_11_2(self):
-        """Test that version is 3.11.2"""
+    def test_version_is_3_11_3(self):
+        """Test that version is 3.11.3"""
         from cja_auto_sdr.generator import __version__
 
-        assert __version__ == "3.11.2"
+        assert __version__ == "3.11.3"
 
 
 class TestFormatAutoDetection:


### PR DESCRIPTION
## Summary

Follow-up to #97 — four more conservative, behavior-preserving performance optimizations. Same discipline as v3.11.2: byte-identical output, no CLI or API surface changes, each refactor guarded by characterization tests committed first (green against the pre-change code).

### Optimizations

| Area | Change | Scales with |
|------|--------|-------------|
| Derived-field inventory | `build()` iterates `to_dict("records")` instead of `iterrows()`, dropping per-row Series construction (matches the existing pattern in `inventory/utils.py`) | metrics + dimensions count per data view |
| SDR generation | JSON-formatting pass skips non-object dtype columns — `format_json_cell` can only rewrite dict/list cells, which only exist in object columns | cells in numeric/bool columns |
| Data quality | Null-value check reuses one `isna()` mask for counts and item-name lookups instead of re-scanning each flagged column | rows × null-bearing critical fields |
| SDR Excel | Column-width pass bounds the first-line split (`str.split("\n", n=1)`), avoiding full split-list materialization for multi-line cells | multi-line cells (description columns) |

### Test coverage

Pinning tests land in the first commit and lock the baseline:
- `TestBuildRowIterationEquivalence` — inventory extraction over mixed-dtype/NA frames (NA definitions skip silently, NA descriptions coerce to `""`, numeric columns inert)
- `TestNullValuePayloadPinning` — exact issue payloads (item names, ordering, details strings) across multiple critical fields
- `TestColumnWidthFirstLineVectorization` — bounded vs unbounded split equivalence
- `test_json_output_pins_container_formatting_and_numeric_passthrough` — end-to-end JSON output: dict/list cells serialize as indented JSON strings, numeric columns pass through untouched

### Verification

- Full suite: 8,361 passed, 16 skipped (8,377 collected)
- Contract tests (`test_generator_mock_contract`, `test_backwards_compat`, `test_lazy_forwarding`): 109 passed
- `ruff check src/ tests/ scripts/ examples/` and `ruff format --check`: clean
- `scripts/check_version_sync.py`: all references match 3.11.3
- `scripts/update_test_counts.py --check`: up to date

Leaving this open for review — do not merge yet.
