### PR TITLE
fix: resolve repo sweep findings (diff error marks, markdown escaping, flaky lock tests, dead code)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ All notable changes to the CJA SDR Generator project will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.11.4] - 2026-07-11
+
+### Fixed
+
+- **Diff:** the snapshot missing-inventory error listing now reflects actual metric/dimension presence instead of printing unconditional checkmarks (the `✗` branch was unreachable).
+- **SDR markdown:** `escape_markdown` guards `pd.isna` against list-like input (which returns an array and raised `ValueError` on truth-testing), matching its sibling formatters.
+- **Tests:** multi-process lock contention tests raise their child ready-wait deadlines from 3s to 15s, eliminating an observed spawn-start flake under parallel (xdist) load; happy-path duration is unchanged.
+
+### Removed
+
+- Dead code with zero callers, verified by repo-wide reference search and coverage: the unreferenced inventory-mode delegator shims in `generator.py`, the orphaned `_write_info_fd` lock helper (production uses `_write_info_path`), and the write-only `reported_total_declares_zero` trending-assessment field.
+
+### Documentation
+
+- CLAUDE.md source layout now lists the Notion output modules and the watch mode.
+
 ## [3.11.3] - 2026-07-02
 
 ### Performance

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Package manager: **uv**
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
-- Current version: v3.11.3
+- Current version: v3.11.4
 - Tests: **8,378** across 163 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
 - Current version: v3.11.3
-- Tests: **8,377** across 163 files at **95% coverage gate**
+- Tests: **8,378** across 163 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)
 
@@ -123,7 +123,10 @@ src/cja_auto_sdr/
 │   ├── registry.py          # Format registry
 │   ├── run_summary.py       # Run summary output helpers
 │   ├── excel.py             # Shared Excel formatting utilities
-│   ├── writers/             # Format writers (csv, excel, json, html, markdown)
+│   ├── notion_registry.py   # Notion page registry (tracks published pages)
+│   ├── notion_database.py   # Notion database integration helpers
+│   ├── notion_org_publisher.py # Org-report Notion publisher
+│   ├── writers/             # Format writers (csv, excel, json, html, markdown, notion)
 │   ├── sdr/                 # SDR document generators
 │   ├── diff/                # Diff renderers (console, grouped, csv, json, html, excel, markdown, pr_comment)
 │   └── inventory/           # Inventory summary display
@@ -157,6 +160,7 @@ src/cja_auto_sdr/
 | Org-wide | `--org-report` | Analyze all data views in organization |
 | Diff | `--diff <source> <target>` | Compare snapshots |
 | Trending | `--trending-window N` | Drift detection over time window |
+| Watch | `--watch <dv_ids...> --interval N` | Continuous monitoring loop |
 | Discovery | `--list-dataviews` etc. | List available resources |
 | Config | `--config`, `--show-config` | Profile/config management |
 | Stats | `--stats` | Diagnostics and statistics |

--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (8,377+ tests)
+├── tests/                     # Test suite (8,378+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -943,7 +943,7 @@ cja_auto_sdr --list-dataviews --log-level DEBUG
 At launch, the tool logs diagnostic lines containing the tool version, Python version, platform, active log level, inferred run mode (batch, single, or discovery), and dependency versions. These appear automatically at `INFO` level and are useful for troubleshooting environment issues in CI/CD logs or support requests:
 
 ```text
-CJA SDR Generator v3.11.3 | Python 3.14.2 | darwin | log_level=INFO | mode=single
+CJA SDR Generator v3.11.4 | Python 3.14.2 | darwin | log_level=INFO | mode=single
 Dependencies: cjapy=0.3.0, pandas=2.3.3, numpy=2.2.1, xlsxwriter=3.2.9, tqdm=4.67.0
 ```
 

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -190,7 +190,7 @@ This command:
 
 ```bash
 $ uv run cja_auto_sdr -V
-cja_auto_sdr 3.11.3
+cja_auto_sdr 3.11.4
 ```
 
 > **Important:** All commands in this guide assume you're in the `cja_auto_sdr` directory. If you see "command not found", make sure you're in the right directory and have run `uv sync`.

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Quick Reference Card
 
-Single-page command cheat sheet for CJA SDR Generator v3.11.3.
+Single-page command cheat sheet for CJA SDR Generator v3.11.4.
 
 ## Four Main Modes
 

--- a/src/cja_auto_sdr/core/locks/backends.py
+++ b/src/cja_auto_sdr/core/locks/backends.py
@@ -137,14 +137,6 @@ def _is_missing_metadata_stale(lock_path: Path, stale_threshold_seconds: int) ->
     return age_seconds >= reclaim_after_seconds
 
 
-def _write_info_fd(fd: int, info: LockInfo) -> None:
-    payload = (json.dumps(info.to_dict(), sort_keys=True) + "\n").encode("utf-8")
-    os.lseek(fd, 0, os.SEEK_SET)
-    os.ftruncate(fd, 0)
-    _write_all(fd, payload)
-    os.fsync(fd)
-
-
 class AcquireStatus(StrEnum):
     """Explicit lock acquisition outcomes used by backend internals."""
 

--- a/src/cja_auto_sdr/core/version.py
+++ b/src/cja_auto_sdr/core/version.py
@@ -1,3 +1,3 @@
 """Version information for CJA Auto SDR."""
 
-__version__ = "3.11.3"
+__version__ = "3.11.4"

--- a/src/cja_auto_sdr/diff/commands.py
+++ b/src/cja_auto_sdr/diff/commands.py
@@ -538,8 +538,14 @@ def handle_diff_snapshot_command(
             )
             print(file=sys.stderr)
             print(f"Snapshot '{snapshot_file}' contains:", file=sys.stderr)
-            print(f"  {'✓' if True else '✗'} Metrics ({len(source_snapshot.metrics)} items)", file=sys.stderr)
-            print(f"  {'✓' if True else '✗'} Dimensions ({len(source_snapshot.dimensions)} items)", file=sys.stderr)
+            print(
+                f"  {'✓' if source_snapshot.metrics else '✗'} Metrics ({len(source_snapshot.metrics)} items)",
+                file=sys.stderr,
+            )
+            print(
+                f"  {'✓' if source_snapshot.dimensions else '✗'} Dimensions ({len(source_snapshot.dimensions)} items)",
+                file=sys.stderr,
+            )
             print(
                 f"  {'✓' if inv_summary['calculated_metrics']['present'] else '✗'} Calculated Metrics Inventory ({inv_summary['calculated_metrics']['count']} items)",
                 file=sys.stderr,

--- a/src/cja_auto_sdr/generator.py
+++ b/src/cja_auto_sdr/generator.py
@@ -6478,31 +6478,6 @@ def _execute_sdr_processing_modes(
     )
 
 
-def _resolve_inventory_mode_configuration(args: argparse.Namespace, *, argv: list[str]) -> list[str]:
-    from cja_auto_sdr.cli.execution import resolve_inventory_mode_configuration as _impl
-
-    return _impl(args, argv=argv)
-
-
-def _dispatch_inventory_summary_mode(
-    args: argparse.Namespace,
-    *,
-    data_views: list[str],
-    effective_log_level: str,
-    inventory_order: list[str],
-    run_state: dict[str, Any] | None = None,
-) -> None:
-    from cja_auto_sdr.cli.execution import dispatch_inventory_summary_mode as _impl
-
-    _impl(
-        args,
-        data_views=data_views,
-        effective_log_level=effective_log_level,
-        inventory_order=inventory_order,
-        run_state=run_state,
-    )
-
-
 def _prepare_sdr_execution_context(
     args: argparse.Namespace,
     *,

--- a/src/cja_auto_sdr/org/models.py
+++ b/src/cja_auto_sdr/org/models.py
@@ -723,7 +723,6 @@ class _TrendingSnapshotDataViewAssessment:
     has_data_view_ids: bool
     ambiguous_identifiers: bool
     reported_total: int
-    reported_total_declares_zero: bool
     effective_total: int
     complete_data_view_ids: bool
 
@@ -942,7 +941,6 @@ def _snapshot_data_view_assessment(snapshot: TrendingSnapshot) -> _TrendingSnaps
         has_data_view_ids=bool(normalized_ids) or snapshot.has_data_view_ids,
         ambiguous_identifiers=ambiguous_identifiers,
         reported_total=_snapshot_reported_data_view_total(snapshot),
-        reported_total_declares_zero=_snapshot_declares_zero_data_views(snapshot),
         effective_total=effective_total,
         complete_data_view_ids=bool(complete_data_view_ids),
     )

--- a/src/cja_auto_sdr/output/sdr/__init__.py
+++ b/src/cja_auto_sdr/output/sdr/__init__.py
@@ -866,8 +866,14 @@ def write_html_output(
 
 def escape_markdown(text: Any) -> str:
     """Escape special markdown characters in table cells"""
-    if pd.isna(text) or text is None:
+    if text is None:
         return ""
+    try:
+        if pd.isna(text):
+            return ""
+    except TypeError, ValueError:
+        # pd.isna returns an array for list-like input; truth-testing it raises.
+        pass
     text = str(text)
     # Escape pipe characters that would break tables
     text = text.replace("|", "\\|")

--- a/tests/README.md
+++ b/tests/README.md
@@ -175,7 +175,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 8,377 comprehensive tests**
+**Total: 8,378 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -184,16 +184,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 8,271 | 157 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 8,272 | 157 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 0 | 0 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **8,377** | **163** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **8,378** | **163** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 8,271 | 157 | `-m "unit and not slow"` |
+| `test-unit` | 8,272 | 157 | `-m "unit and not slow"` |
 | `test-integration` | 96 | 5 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -265,7 +265,7 @@ tests/
 | `test_config_dataclasses.py` | 89 | Config dataclasses and constants functions |
 | `test_lock_manager.py` | 68 | Lock manager acquire/release/heartbeat lifecycle |
 | `test_lazy_forwarding.py` | 73 | Lazy-forwarding infrastructure and make_getattr() |
-| `test_lock_backend_edge_cases.py` | 165 | Lock backend metadata I/O, stale detection, legacy parsing |
+| `test_lock_backend_edge_cases.py` | 164 | Lock backend metadata I/O, stale detection, legacy parsing |
 | `test_derived_fields_coverage.py` | 161 | Derived field complexity scoring, logic summary, predicates |
 | `test_org_analyzer_coverage.py` | 166 | Org analyzer governance, naming audit, sampling, memory, drift, clustering |
 | `test_org_analyzer_metadata_enrichment.py` | 3 | Org analyzer metadata enrichment payload handling |
@@ -277,7 +277,7 @@ tests/
 | `test_diff_inventory_output.py` | 96 | Inventory diff output across all formats (console, JSON, HTML, Excel, MD, CSV) |
 | `test_cli_command_handlers.py` | 160 | CLI dispatch for --stats, --org-report, --list-snapshots, discovery inspection, diff config unpacking |
 | `test_profile_management.py` | 54 | Interactive profile creation, import, test, show |
-| `test_snapshot_commands.py` | 71 | Snapshot creation, comparison, name resolution |
+| `test_snapshot_commands.py` | 72 | Snapshot creation, comparison, name resolution |
 | `test_config_and_resolution.py` | 115 | Config status, validation, stats, name resolution |
 | `test_derived_fields_edge_cases.py` | 34 | Derived fields edge cases and coverage |
 | `test_diff_command_coverage.py` | 46 | Diff command edge cases and coverage |
@@ -360,13 +360,13 @@ tests/
 | `test_cli_notion_repair.py` | 14 | CLI flag wiring for --notion-repair-database and --notion-print-database-schema |
 | `test_org_analyzer_similarity.py` | 1 | Org similarity-engine union-hoisting characterization test |
 | `test_org_writers_csv.py` | 1 | Org components-CSV bucket-lookup characterization test |
-| `test_sdr_markdown_escaping.py` | 3 | SDR markdown vectorized cell-escaping characterization test |
+| `test_sdr_markdown_escaping.py` | 4 | SDR markdown vectorized cell-escaping characterization test |
 | `test_diff_excel.py` | 3 | Diff Excel row-coloring characterization tests |
 | `test_org_snapshot_parse_cache.py` | 1 | Org snapshot JSON parse-cache characterization test |
 | `test_diff_snapshot_retention.py` | 1 | Diff snapshot-retention parse-cache characterization test |
 | `test_diff_comparator_normalize.py` | 1 | Diff field-normalization type-fast-path characterization test |
 | `test_logging_diagnostics.py` | 2 | emit_diagnostic isEnabledFor guard characterization tests |
-| **Total** | **8,377** | **Collected via pytest --collect-only** |
+| **Total** | **8,378** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -824,7 +824,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (8,377 tests total)
+- [x] Comprehensive test coverage (8,378 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 80 tests

--- a/tests/test_lock_backend_edge_cases.py
+++ b/tests/test_lock_backend_edge_cases.py
@@ -730,30 +730,7 @@ class TestIsLockInfoStale:
 
 
 # ---------------------------------------------------------------------------
-# 15. _write_info_fd() (standalone helper)
-# ---------------------------------------------------------------------------
-
-
-class TestWriteInfoFd:
-    def test_write_info_fd_writes_json(self, tmp_path: Path) -> None:
-        from cja_auto_sdr.core.locks.backends import _write_info_fd
-
-        f = tmp_path / "fd_test"
-        fd = os.open(str(f), os.O_CREAT | os.O_RDWR, 0o600)
-        try:
-            info = _build_lock_info("fd-write-test")
-            _write_info_fd(fd, info)
-            # Read it back
-            os.lseek(fd, 0, os.SEEK_SET)
-            content = os.read(fd, 4096)
-            data = json.loads(content.decode("utf-8"))
-            assert data["lock_id"] == "fd-write-test"
-        finally:
-            os.close(fd)
-
-
-# ---------------------------------------------------------------------------
-# 16. Backend write_info() / write_failure_tombstone() with closed handle
+# 15. Backend write_info() / write_failure_tombstone() with closed handle
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_org_report.py
+++ b/tests/test_org_report.py
@@ -236,7 +236,9 @@ class TestOrgReportLock:
             )
             proc.start()
 
-            deadline = time.time() + 3
+            # Generous ready-wait: spawn-start under xdist CPU saturation can take
+            # several seconds; polling exits as soon as the child signals.
+            deadline = time.time() + 15
             while _read_signal(ready_file) is None and time.time() < deadline:
                 time.sleep(0.02)
 
@@ -264,7 +266,9 @@ class TestOrgReportLock:
             )
             proc.start()
 
-            deadline = time.time() + 5
+            # Generous ready-wait: spawn-start under xdist CPU saturation can take
+            # several seconds; polling exits as soon as the child signals.
+            deadline = time.time() + 15
             while _read_signal(ready_file) is None and time.time() < deadline:
                 time.sleep(0.02)
 
@@ -286,7 +290,9 @@ class TestOrgReportLock:
             )
             proc.start()
 
-            deadline = time.time() + 3
+            # Generous ready-wait: spawn-start under xdist CPU saturation can take
+            # several seconds; polling exits as soon as the child signals.
+            deadline = time.time() + 15
             while _read_signal(ready_file) is None and time.time() < deadline:
                 time.sleep(0.02)
 
@@ -313,7 +319,9 @@ class TestOrgReportLock:
             )
             proc.start()
 
-            deadline = time.time() + 3
+            # Generous ready-wait: spawn-start under xdist CPU saturation can take
+            # several seconds; polling exits as soon as the child signals.
+            deadline = time.time() + 15
             while _read_signal(ready_file) is None and time.time() < deadline:
                 time.sleep(0.02)
 

--- a/tests/test_output_content_validation.py
+++ b/tests/test_output_content_validation.py
@@ -38,7 +38,7 @@ def rich_data_dict():
         "Metadata": pd.DataFrame(
             {
                 "Property": ["Generated At", "Data View ID", "Tool Version", "Total Metrics"],
-                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.11.3", 3],
+                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.11.4", 3],
             },
         ),
         "Data Quality": pd.DataFrame(
@@ -104,7 +104,7 @@ def rich_metadata_dict():
         "Generated At": "2025-01-15 10:30:00 PST",
         "Data View ID": "dv_content_test",
         "Data View Name": "Test DataView",
-        "Tool Version": "3.11.3",
+        "Tool Version": "3.11.4",
         "Metrics Count": "3",
         "Dimensions Count": "4",
     }
@@ -224,7 +224,7 @@ class TestJSONContentValidation:
             data = json.load(f)
 
         assert data["metadata"]["Data View ID"] == "dv_content_test"
-        assert data["metadata"]["Tool Version"] == "3.11.3"
+        assert data["metadata"]["Tool Version"] == "3.11.4"
 
     def test_json_metadata_preserves_partial_markers(self, tmp_path, rich_data_dict, rich_metadata_dict):
         logger = logging.getLogger("json_test")

--- a/tests/test_sdr_markdown_escaping.py
+++ b/tests/test_sdr_markdown_escaping.py
@@ -12,7 +12,7 @@ write the string "" into a typed extension array).
 import numpy as np
 import pandas as pd
 
-from cja_auto_sdr.output.sdr import df_to_markdown_table
+from cja_auto_sdr.output.sdr import df_to_markdown_table, escape_markdown
 
 
 def _escape_markdown_ref(text):
@@ -115,3 +115,13 @@ def test_df_to_markdown_table_handles_nullable_extension_dtypes():
 
     result = df_to_markdown_table(df, "Nullable Types")
     assert result == expected
+
+
+def test_escape_markdown_handles_list_values():
+    """List-like cells must render as their escaped str() form, not raise.
+
+    `pd.isna` returns an ndarray for list input, and truth-testing that array
+    raises ValueError. Every sibling formatter guards this; escape_markdown
+    must too.
+    """
+    assert escape_markdown(["a|b", "c"]) == "['a\\|b', 'c']"

--- a/tests/test_snapshot_commands.py
+++ b/tests/test_snapshot_commands.py
@@ -798,6 +798,24 @@ class TestHandleDiffSnapshotCommand:
         captured = capsys.readouterr()
         assert "Invalid snapshot file" in captured.err
 
+    def test_missing_inventory_error_marks_empty_core_sections(self, tmp_path, capsys):
+        """The 'snapshot contains' listing must reflect actual metric/dimension presence."""
+        snap_file = str(tmp_path / "baseline.json")
+        _write_snapshot_file(snap_file, _make_snapshot(metrics=[], dimensions=[]))
+
+        success, _has_changes, _exit_code = handle_diff_snapshot_command(
+            data_view_id="dv_test",
+            snapshot_file=snap_file,
+            quiet=True,
+            include_calc_metrics=True,
+        )
+
+        assert success is False
+        captured = capsys.readouterr()
+        assert "Cannot perform inventory diff" in captured.err
+        assert "✗ Metrics (0 items)" in captured.err
+        assert "✗ Dimensions (0 items)" in captured.err
+
     @patch("cja_auto_sdr.generator.cjapy")
     @patch("cja_auto_sdr.generator.configure_cjapy")
     def test_diff_snapshot_with_banner(self, mock_configure, mock_cjapy, tmp_path, capsys):

--- a/tests/test_ux_features.py
+++ b/tests/test_ux_features.py
@@ -344,11 +344,11 @@ class TestCombinedFeatures:
 class TestVersionUpdated:
     """Test that version is correct"""
 
-    def test_version_is_3_11_3(self):
-        """Test that version is 3.11.3"""
+    def test_version_is_3_11_4(self):
+        """Test that version is 3.11.4"""
         from cja_auto_sdr.generator import __version__
 
-        assert __version__ == "3.11.3"
+        assert __version__ == "3.11.4"
 
 
 class TestFormatAutoDetection:


### PR DESCRIPTION
Fix PR from a full-repo defect/bug/dead-code sweep (ruff, vulture, coverage analysis, and hand verification of every candidate). Opened as a draft to collect review on the judgment calls listed at the bottom.

## Bug fixes

- **diff/commands.py** — the snapshot missing-inventory error printed `{'✓' if True else '✗'}` for Metrics and Dimensions, so the ✗ branch was unreachable and the checkmarks were unconditional. They now reflect actual presence. New regression test: `test_missing_inventory_error_marks_empty_core_sections`.
- **output/sdr/`__init__`.py** — `escape_markdown` called `pd.isna(text)` unguarded. For list-like input `pd.isna` returns an array and truth-testing it raises `ValueError`. Every sibling formatter (`coerce_scalar_text`, `_format_diff_value`, `_normalize_value`) guards this; now this one does too. New test: `test_escape_markdown_handles_list_values`.

## Flaky test fix

- **tests/test_org_report.py** — the multi-process lock tests polled only 3s for the spawned child's ready signal; macOS spawn-start under xdist CPU saturation exceeded that (observed: `test_lock_contention_multi_process_lease_backend` failed with `_read_signal(...) == None`). All four ready-wait deadlines raised to 15s; polling exits as soon as the child signals, so happy-path time is unchanged.

## Dead code removed (verified: zero callers anywhere in src/tests/scripts/examples/tools/docs)

- `generator.py` — `_resolve_inventory_mode_configuration` / `_dispatch_inventory_summary_mode` delegator shims. Coverage proves their bodies never execute; the contract tests import the `cli.execution` implementations directly.
- `core/locks/backends.py` — `_write_info_fd`, an orphaned fd-level variant; all production paths use `_write_info_path`. Its single pinning test removed.
- `org/models.py` — `reported_total_declares_zero`, a write-only field on the private `_TrendingSnapshotDataViewAssessment` dataclass (set at construction, never read).

## Docs / counts

- CLAUDE.md source layout now lists the Notion output modules and the watch mode row it was missing.
- Test counts refreshed: 8,378 (net +1: two tests added, one removed).

## Judgment calls deliberately NOT touched — reviewer input wanted

These are production-dead but test-pinned. Several turned out to be deliberate test seams over live logic (thin wrappers the tests use to exercise real code paths), so I left all of them alone rather than guess:

- `__main__.py`: `_is_fast_path_flag`, `_has_run_summary_flag`, `_completion_fast_path_shell` — wrappers over the live `_resolve_fast_path_request` / `_scan_option_tokens`; ~35 behavioral tests use them as the executable spec for fast-path semantics. Recommend keep.
- `generator.py`: `RECOVERABLE_VALIDATION_EXCEPTIONS` (commented as a backwards-compat alias for external importers), `_coerce_http_status_code` / `_iter_error_chain_nodes` / `_extract_http_status_codes` compat wrappers, `_format_as_json`, `set_ttl`, `FAILURE_CODE_REGISTRY` (its test validates codes against documentation — a real contract).
- `api/quality.py`: the six granular `check_*` methods — production uses `check_all_quality_issues_optimized` only; these serve as the reference implementation for the optimized-vs-original comparison tests. Recommend keep, possibly with a comment saying so.
- Test-pinned public helpers with no production callers: `org/snapshot_utils.py` (`org_report_snapshot_history_exclusion_reason`, `org_report_snapshot_comparison_eligible`, `successful_org_report_data_view_rows`), `core/discovery_payloads.py` (`coerce_component_rows_or_none`, `is_component_error_payload`), `org/cache.py` (`get_cached_modified`, `_iter_org_report_snapshot_dirs`), `api/cache.py` (`log_statistics`), `inventory/utils.py` (`record_error`), `cli/mode_scoped_options.py` (`org_report_mode_scoped_option_names`), `org/models.py` (`_snapshot_data_view_ids_cover_snapshot` — a seam over `_snapshot_inferred_complete_data_view_ids`).

## Verification

- Full suite: 8,361 passed / 16 skipped, coverage 99% (gate 95%)
- Contract tests (`test_generator_mock_contract`, `test_backwards_compat`, `test_lazy_forwarding`): 109 passed
- `ruff check` and `ruff format --check`: clean
- `scripts/update_test_counts.py --check` and `scripts/check_version_sync.py`: clean
- Only full-suite failure was `test_optimized_scales_better`, the known slow-marked wall-clock perf test that is xdist-unstable by design and runs serially in CI (passes serially)
