### PR TITLE
feat: enable PyPI publishing via Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+name: release
+
+# Publishes cja-auto-sdr to PyPI via Trusted Publishing (OIDC) when a
+# GitHub release is published. No API tokens: the `pypi` environment is
+# registered as a trusted publisher on PyPI against this workflow file.
+#
+# Release flow (see CLAUDE.md):
+#   git tag v<version>
+#   gh release create v<version> --latest   # <- fires this workflow
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.14"
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+      - name: Build sdist and wheel
+        run: |
+          rm -f dist/*.whl dist/*.tar.gz
+          uv build
+      - name: Validate distribution metadata
+        run: uvx twine check dist/*
+      - name: Verify tag matches built version
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          if [ ! -f "dist/cja_auto_sdr-${tag}-py3-none-any.whl" ]; then
+            echo "No wheel matching release tag ${GITHUB_REF_NAME} (expected version ${tag}) in dist/:" >&2
+            ls -1 dist/ >&2
+            exit 1
+          fi
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: pypi
+    permissions:
+      id-token: write # required for OIDC trusted publishing
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,6 +190,7 @@ uv run pytest tests/ --collect-only -q  # Get accurate test count
 | `version-sync.yml` | `scripts/check_version_sync.py` — single source of truth for version consistency |
 | `patch-release-gate.yml` | Release validation (version, changelog, docs, tag ref, test counts) |
 | `test-counts.yml` | Validates README test count inventory is current |
+| `release.yml` | Publishes to PyPI via Trusted Publishing (OIDC) on GitHub release; `pypi` environment, no API tokens |
 
 ### Test Organization
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 <img width="1024" height="572" alt="image" src="https://github.com/user-attachments/assets/54a43474-3fc6-4379-909c-452c19cdeac2" />
 
+[![PyPI](https://img.shields.io/pypi/v/cja-auto-sdr.svg)](https://pypi.org/project/cja-auto-sdr/)
 [![Tests](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/tests.yml/badge.svg)](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/tests.yml)
 [![Lint](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/lint.yml/badge.svg)](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/lint.yml)
 [![Version Sync](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/version-sync.yml/badge.svg)](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/version-sync.yml)
@@ -97,6 +98,27 @@ A **Solution Design Reference** is the essential documentation that bridges your
 - **DevOps Engineers** automating CJA audits in CI/CD pipelines
 
 ## Quick Start
+
+### Install from PyPI (recommended)
+
+The tool is published on [PyPI](https://pypi.org/project/cja-auto-sdr/), so most users can install it with a single command — no clone required:
+
+```bash
+pip install cja-auto-sdr
+
+# or install it as an isolated CLI tool with uv:
+uv tool install cja-auto-sdr
+```
+
+Optional features ship as extras:
+
+```bash
+pip install "cja-auto-sdr[full]"   # clustering + env + shell completion + notion
+```
+
+This puts the `cja-auto-sdr` (and `cja_auto_sdr`) command on your PATH. Verify with `cja-auto-sdr --version`, then skip ahead to [Configure Credentials](#3-configure-credentials).
+
+To set up a development checkout from source instead, follow the numbered steps below.
 
 ### 1. Clone the Repository
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -40,7 +40,37 @@ uv --version
 
 ## Project Setup
 
-### Option 1: Clone from Git (Recommended)
+### Install from PyPI (Recommended for most users)
+
+The package is published on [PyPI](https://pypi.org/project/cja-auto-sdr/). If you just want to run the tool (not modify it), install it directly — no git clone or `uv sync` needed:
+
+```bash
+# Standard install
+pip install cja-auto-sdr
+
+# Or install as an isolated CLI tool (keeps its own venv)
+uv tool install cja-auto-sdr
+```
+
+To include optional features, install the matching extras:
+
+```bash
+pip install "cja-auto-sdr[clustering]"   # scipy-based clustering
+pip install "cja-auto-sdr[env]"          # .env credential loading
+pip install "cja-auto-sdr[completion]"   # shell completion
+pip install "cja-auto-sdr[notion]"       # Notion publishing
+pip install "cja-auto-sdr[full]"         # everything above
+```
+
+Verify the install:
+
+```bash
+cja-auto-sdr --version
+```
+
+Then continue to [Configuration](#next-steps) to set up your Adobe credentials. The Git-based options below are for contributors who want an editable source checkout.
+
+### Option 1: Clone from Git (for development)
 
 **Step 1: Choose an installation location**
 


### PR DESCRIPTION
## Summary

Enables `cja-auto-sdr` on PyPI with token-less **Trusted Publishing** (OIDC), matching the pending publisher already registered on PyPI (`brian-a-au/cja_auto_sdr`, workflow `release.yml`, environment `pypi`).

## Changes
- **`.github/workflows/release.yml`** — on GitHub release publish: build sdist+wheel with uv, `twine check`, verify the tag matches the built version, then publish to PyPI via `pypa/gh-action-pypi-publish` (OIDC, `id-token: write`, `pypi` environment). No API tokens.
- **README** — add PyPI version badge; document `pip install cja-auto-sdr` / `uv tool install` as the recommended install path.
- **docs/INSTALLATION.md** — add PyPI install as the recommended option (with extras).
- **CLAUDE.md** — list `release.yml` in the CI workflow table.

## Release flow (unchanged)
```
git tag v<version>
gh release create v<version> --latest   # -> builds + publishes to PyPI
```
The first successful run creates the project on PyPI and converts the pending publisher to active.

## Notes
- The PyPI badge shows "no releases" until the first publish, then populates automatically.
- Optionally create the `pypi` GitHub environment in repo settings to gate publishing behind approval (the workflow auto-creates it otherwise).