### PR TITLE
chore: release v3.11.5 (first PyPI publish)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to the CJA SDR Generator project will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.11.5] - 2026-07-13
+
+### Added
+
+- **PyPI distribution:** the tool is now published to [PyPI](https://pypi.org/project/cja-auto-sdr/) — install with `pip install cja-auto-sdr` (or `uv tool install cja-auto-sdr`), with optional extras (`clustering`, `env`, `completion`, `notion`, `full`). Releases publish automatically via a new `release.yml` GitHub Actions workflow using PyPI Trusted Publishing (OIDC) — no stored API tokens. The workflow builds the sdist and wheel, validates metadata with `twine check`, verifies the tag matches the built version, and uploads on GitHub release publish.
+
+### Documentation
+
+- README and `docs/INSTALLATION.md` now document PyPI install as the recommended path, and the README carries a PyPI version badge. `release.yml` is listed in the CLAUDE.md CI workflow table.
+
 ## [3.11.4] - 2026-07-11
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Package manager: **uv**
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
-- Current version: v3.11.4
+- Current version: v3.11.5
 - Tests: **8,378** across 163 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -943,7 +943,7 @@ cja_auto_sdr --list-dataviews --log-level DEBUG
 At launch, the tool logs diagnostic lines containing the tool version, Python version, platform, active log level, inferred run mode (batch, single, or discovery), and dependency versions. These appear automatically at `INFO` level and are useful for troubleshooting environment issues in CI/CD logs or support requests:
 
 ```text
-CJA SDR Generator v3.11.4 | Python 3.14.2 | darwin | log_level=INFO | mode=single
+CJA SDR Generator v3.11.5 | Python 3.14.2 | darwin | log_level=INFO | mode=single
 Dependencies: cjapy=0.3.0, pandas=2.3.3, numpy=2.2.1, xlsxwriter=3.2.9, tqdm=4.67.0
 ```
 

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -190,7 +190,7 @@ This command:
 
 ```bash
 $ uv run cja_auto_sdr -V
-cja_auto_sdr 3.11.4
+cja_auto_sdr 3.11.5
 ```
 
 > **Important:** All commands in this guide assume you're in the `cja_auto_sdr` directory. If you see "command not found", make sure you're in the right directory and have run `uv sync`.

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Quick Reference Card
 
-Single-page command cheat sheet for CJA SDR Generator v3.11.4.
+Single-page command cheat sheet for CJA SDR Generator v3.11.5.
 
 ## Four Main Modes
 

--- a/src/cja_auto_sdr/core/version.py
+++ b/src/cja_auto_sdr/core/version.py
@@ -1,3 +1,3 @@
 """Version information for CJA Auto SDR."""
 
-__version__ = "3.11.4"
+__version__ = "3.11.5"

--- a/tests/test_output_content_validation.py
+++ b/tests/test_output_content_validation.py
@@ -38,7 +38,7 @@ def rich_data_dict():
         "Metadata": pd.DataFrame(
             {
                 "Property": ["Generated At", "Data View ID", "Tool Version", "Total Metrics"],
-                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.11.4", 3],
+                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.11.5", 3],
             },
         ),
         "Data Quality": pd.DataFrame(
@@ -104,7 +104,7 @@ def rich_metadata_dict():
         "Generated At": "2025-01-15 10:30:00 PST",
         "Data View ID": "dv_content_test",
         "Data View Name": "Test DataView",
-        "Tool Version": "3.11.4",
+        "Tool Version": "3.11.5",
         "Metrics Count": "3",
         "Dimensions Count": "4",
     }
@@ -224,7 +224,7 @@ class TestJSONContentValidation:
             data = json.load(f)
 
         assert data["metadata"]["Data View ID"] == "dv_content_test"
-        assert data["metadata"]["Tool Version"] == "3.11.4"
+        assert data["metadata"]["Tool Version"] == "3.11.5"
 
     def test_json_metadata_preserves_partial_markers(self, tmp_path, rich_data_dict, rich_metadata_dict):
         logger = logging.getLogger("json_test")

--- a/tests/test_ux_features.py
+++ b/tests/test_ux_features.py
@@ -344,11 +344,11 @@ class TestCombinedFeatures:
 class TestVersionUpdated:
     """Test that version is correct"""
 
-    def test_version_is_3_11_4(self):
-        """Test that version is 3.11.4"""
+    def test_version_is_3_11_5(self):
+        """Test that version is 3.11.5"""
         from cja_auto_sdr.generator import __version__
 
-        assert __version__ == "3.11.4"
+        assert __version__ == "3.11.5"
 
 
 class TestFormatAutoDetection:


### PR DESCRIPTION
## Summary

Version bump **3.11.4 → 3.11.5**, the inaugural PyPI release.

This is the first release cut after the Trusted Publishing pipeline (`release.yml`) landed on main, so publishing the GitHub release for `v3.11.5` will publish `cja-auto-sdr` to PyPI for the first time and convert the pending trusted publisher to active.

## Changes
- Bump `__version__` to 3.11.5 and sync all version references (docs, tests, CLAUDE.md).
- Add CHANGELOG `## [3.11.5]` entry documenting PyPI availability + the release workflow.

## Verified locally
- `check_version_sync.py` → OK (all references match 3.11.5)
- `update_test_counts.py --check` → up to date
- Version tests + output-content-validation tests → 30 passed
- `ruff check` → clean

## After merge
Tag + release on main triggers the publish:
```
git tag v3.11.5 <merge-sha>
gh release create v3.11.5 --latest
```