### PR TITLE
docs: add release runbook (RELEASING.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,8 +274,13 @@ Prefer exact data view IDs (`dv_...`) over names for unattended automation. Name
 
 ---
 
+## Releasing
+
+Releasing `cja-auto-sdr` to PyPI is **human-initiated**: it happens only when a maintainer publishes a GitHub Release, which fires `.github/workflows/release.yml` to build and upload over Trusted Publishing (OIDC). Agent and unattended runs — `--agent-mode`, scheduled jobs, CI — never publish; they have no path to trigger a release. See [`RELEASING.md`](RELEASING.md) for the runbook.
+
 ## See Also
 
+- [`RELEASING.md`](RELEASING.md) — release runbook and PyPI publishing
 - [`docs/AGENT_AUTOMATION.md`](docs/AGENT_AUTOMATION.md) — scheduling patterns, agent framework integration, notifications, security
 - [`scripts/orchestrator.py`](scripts/orchestrator.py) — multi-org orchestration script
 - [`docs/CLI_REFERENCE.md`](docs/CLI_REFERENCE.md) — full human-facing CLI documentation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,11 +238,23 @@ All of these files must be updated (validated by `scripts/check_version_sync.py`
 
 ### Release Process
 
+> **Full runbook (source of truth):** [`RELEASING.md`](RELEASING.md).
+
 ```bash
 # After updating all version files:
 git tag v<version>
-gh release create v<version> --latest
+gh release create v<version> --latest   # release.yml then builds + publishes to PyPI over OIDC
 ```
+
+---
+
+## Releasing
+
+Releasing publishes `cja-auto-sdr` to PyPI. The full runbook is [`RELEASING.md`](RELEASING.md).
+
+- **Trigger:** publishing a GitHub Release fires `.github/workflows/release.yml`, which builds and uploads to PyPI via **Trusted Publishing (OIDC)** — no API tokens.
+- **Human-initiated:** only a maintainer publishing a Release triggers a publish; agent and unattended runs never publish (see [AGENTS.md](AGENTS.md#releasing)).
+- **Docs/CI-only changes need no release** — merge to `main` with no version bump, tag, or publish.
 
 ---
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,55 @@
+# Releasing
+
+How to cut a release of `cja-auto-sdr` and publish it to [PyPI](https://pypi.org/project/cja-auto-sdr/).
+
+> Releasing is **human-initiated**. A publish happens only when a maintainer publishes a GitHub Release; agent and unattended runs never publish. See [AGENTS.md](AGENTS.md#releasing).
+
+## How publishing works
+
+`.github/workflows/release.yml` runs on the `release: published` event. It builds the sdist and wheel with `uv build`, validates metadata with `twine check`, verifies the release tag matches the built version, then uploads to PyPI using **Trusted Publishing (OIDC)**. There are no stored API tokens: GitHub Actions mints a short-lived OIDC token that PyPI verifies against the registered publisher (owner `brian-a-au`, repo `cja_auto_sdr`, workflow `release.yml`, environment `pypi`).
+
+## Runbook
+
+### 1. Bump the version
+
+Update `src/cja_auto_sdr/core/version.py` and add a `CHANGELOG.md` entry, then sync the remaining version references. The complete list is the [Version Bump Checklist](CLAUDE.md#version-bump-checklist) — 8 files, validated by `scripts/check_version_sync.py`. Verify locally before opening the PR:
+
+```bash
+uv run python scripts/check_version_sync.py
+uv run python scripts/update_test_counts.py --check
+```
+
+### 2. Merge to `main`
+
+Open a PR with the version bump and merge it once CI is green. The release tag must point at the merged commit on `main`.
+
+### 3. Tag the release
+
+```bash
+git tag v<version>            # e.g. git tag v3.11.6
+git push origin v<version>
+```
+
+Pushing the tag triggers `patch-release-gate.yml`, which re-runs `check_version_sync.py --require-tag` and confirms the tag ref matches the canonical version.
+
+### 4. Publish the GitHub Release
+
+```bash
+gh release create v<version> --latest --title "v<version> — <summary>" --notes "..."
+```
+
+Publishing the Release fires `release.yml`, which builds and uploads to PyPI. Watch it complete:
+
+```bash
+gh run watch --workflow release.yml
+```
+
+`gh release create` creates the tag if it does not already exist, so step 3 is optional when you release straight from `main`.
+
+## Notes
+
+- **No tokens.** Publishing uses OIDC Trusted Publishing; there are no PyPI API tokens in the repo or in Actions secrets.
+- **Tag/version guard.** `release.yml` fails the build if the release tag does not match the version built from `version.py`, so a mistagged release cannot publish.
+- **PyPI is immutable.** A version can never be re-uploaded or overwritten, and a deleted version number cannot be reused. Bump the version for every publish; never retag an existing one.
+- **Docs and CI-only changes need no release.** Changes that do not affect the published package (documentation, workflows, tests) ship by merging to `main` — no version bump, tag, or PyPI publish.
+- **First publish.** The inaugural release (v3.11.5) created the project on PyPI and converted the pending Trusted Publisher to active; every release since is fully automatic.


### PR DESCRIPTION
## Summary

Adds a release runbook and links it from the two contract docs. There was no documented release process in the repo before this (only the gitignored `docs/superpowers/` plans).

## Changes
- **`RELEASING.md`** (new): the 4-step runbook — bump `version.py` + `CHANGELOG.md`, merge, tag `vX.Y.Z`, publish a GitHub Release; `release.yml` then builds and uploads to PyPI over OIDC. Notes cover the no-token OIDC model, the tag/version guard, PyPI version immutability, and that docs/CI-only changes need no release.
- **`CLAUDE.md`**: adds a `## Releasing` section and points the Release Process at `RELEASING.md` as the source of truth.
- **`AGENTS.md`**: adds a `## Releasing` note (releasing is human-initiated; agent/unattended runs never publish) and a See Also pointer.

## Scope
Docs-only. **No version bump, no tag, no PyPI publish.** `version.py` and `CHANGELOG.md` are untouched (verified), and `check_version_sync.py` / `update_test_counts.py --check` still pass.