### PR TITLE
docs: fix PyPI badge rendering + improve install guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 <img width="1024" height="572" alt="image" src="https://github.com/user-attachments/assets/54a43474-3fc6-4379-909c-452c19cdeac2" />
 
-[![PyPI](https://img.shields.io/pypi/v/cja-auto-sdr.svg)](https://pypi.org/project/cja-auto-sdr/)
+[![PyPI](https://img.shields.io/pypi/v/cja-auto-sdr)](https://pypi.org/project/cja-auto-sdr/)
 [![Tests](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/tests.yml/badge.svg)](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/tests.yml)
 [![Lint](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/lint.yml/badge.svg)](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/lint.yml)
 [![Version Sync](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/version-sync.yml/badge.svg)](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/version-sync.yml)
 [![Python 3.14+](https://img.shields.io/badge/python-3.14%2B-blue.svg)](https://www.python.org/downloads/)
 [![Coverage](https://img.shields.io/badge/coverage-99%25-brightgreen.svg)](tests/)
-[![Tests](https://img.shields.io/badge/tests-8377-brightgreen.svg)](tests/)
+[![Tests](https://img.shields.io/badge/tests-8378-brightgreen.svg)](tests/)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
@@ -101,22 +101,23 @@ A **Solution Design Reference** is the essential documentation that bridges your
 
 ### Install from PyPI (recommended)
 
-The tool is published on [PyPI](https://pypi.org/project/cja-auto-sdr/), so most users can install it with a single command — no clone required:
+The tool is published on [PyPI](https://pypi.org/project/cja-auto-sdr/), so most users can install it without cloning. `uv` is recommended:
 
 ```bash
+uv tool install cja-auto-sdr          # isolated install; puts `cja-auto-sdr` on your PATH
+# or run once without installing:
+uvx cja-auto-sdr --list-dataviews
+# or with plain pip:
 pip install cja-auto-sdr
-
-# or install it as an isolated CLI tool with uv:
-uv tool install cja-auto-sdr
 ```
 
 Optional features ship as extras:
 
 ```bash
-pip install "cja-auto-sdr[full]"   # clustering + env + shell completion + notion
+uv tool install "cja-auto-sdr[full]"   # clustering + env + shell completion + notion
 ```
 
-This puts the `cja-auto-sdr` (and `cja_auto_sdr`) command on your PATH. Verify with `cja-auto-sdr --version`, then skip ahead to [Configure Credentials](#3-configure-credentials).
+Verify with `cja-auto-sdr --version`, then skip ahead to [Configure Credentials](#3-configure-credentials).
 
 To set up a development checkout from source instead, follow the numbered steps below.
 


### PR DESCRIPTION
## Summary

Addresses the PyPI badge showing "package or version not found", improves the install guidance, and retires the pending `bot/update-badges` PR.

### PyPI badge
shields.io correctly serves `v3.11.5` — the "not found" was GitHub's image proxy (camo) serving a copy cached when the badge was first added (PR #102, **before** the first publish). Dropping the `.svg` suffix changes the URL, so GitHub re-fetches a fresh badge.

### Install guidance
Reordered to lead with `uv` (matching `aa_auto_sdr`):
```bash
uv tool install cja-auto-sdr          # isolated install; puts `cja-auto-sdr` on your PATH
# or run once without installing:
uvx cja-auto-sdr --list-dataviews
# or with plain pip:
pip install cja-auto-sdr
```

### Retiring bot/update-badges
The open bot PR #103 only bumped the tests badge `8377 → 8378`. That value is folded in here, so once this merges the badge is current and the bot branch/PR can be closed with nothing to regenerate.

## Scope
Docs-only. No version bump; `update_test_counts.py --check` still passes.