### PR TITLE
chore: release v3.11.6 — fix stretched PyPI banner image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to the CJA SDR Generator project will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.11.6] - 2026-07-13
+
+### Fixed
+
+- **PyPI project page:** the README banner image no longer stretches on PyPI. The `<img>` carried a fixed `height` attribute, which PyPI's description CSS kept while capping the width to the container, distorting the aspect ratio. Dropping the fixed height (keeping `width`) lets it scale proportionally, and the placeholder `alt` text is now descriptive. Since the PyPI long description is frozen at upload time per release, this fix ships as a new version.
+
 ## [3.11.5] - 2026-07-13
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Package manager: **uv**
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
-- Current version: v3.11.5
+- Current version: v3.11.6
 - Tests: **8,378** across 163 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Adobe Customer Journey Analytics SDR Generator
 
-<img width="1024" height="572" alt="image" src="https://github.com/user-attachments/assets/54a43474-3fc6-4379-909c-452c19cdeac2" />
+<img width="1024" alt="Adobe Customer Journey Analytics SDR Generator" src="https://github.com/user-attachments/assets/54a43474-3fc6-4379-909c-452c19cdeac2" />
 
 [![PyPI](https://img.shields.io/pypi/v/cja-auto-sdr)](https://pypi.org/project/cja-auto-sdr/)
 [![Tests](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/tests.yml/badge.svg)](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/tests.yml)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -943,7 +943,7 @@ cja_auto_sdr --list-dataviews --log-level DEBUG
 At launch, the tool logs diagnostic lines containing the tool version, Python version, platform, active log level, inferred run mode (batch, single, or discovery), and dependency versions. These appear automatically at `INFO` level and are useful for troubleshooting environment issues in CI/CD logs or support requests:
 
 ```text
-CJA SDR Generator v3.11.5 | Python 3.14.2 | darwin | log_level=INFO | mode=single
+CJA SDR Generator v3.11.6 | Python 3.14.2 | darwin | log_level=INFO | mode=single
 Dependencies: cjapy=0.3.0, pandas=2.3.3, numpy=2.2.1, xlsxwriter=3.2.9, tqdm=4.67.0
 ```
 

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -190,7 +190,7 @@ This command:
 
 ```bash
 $ uv run cja_auto_sdr -V
-cja_auto_sdr 3.11.5
+cja_auto_sdr 3.11.6
 ```
 
 > **Important:** All commands in this guide assume you're in the `cja_auto_sdr` directory. If you see "command not found", make sure you're in the right directory and have run `uv sync`.

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Quick Reference Card
 
-Single-page command cheat sheet for CJA SDR Generator v3.11.5.
+Single-page command cheat sheet for CJA SDR Generator v3.11.6.
 
 ## Four Main Modes
 

--- a/src/cja_auto_sdr/core/version.py
+++ b/src/cja_auto_sdr/core/version.py
@@ -1,3 +1,3 @@
 """Version information for CJA Auto SDR."""
 
-__version__ = "3.11.5"
+__version__ = "3.11.6"

--- a/tests/test_output_content_validation.py
+++ b/tests/test_output_content_validation.py
@@ -38,7 +38,7 @@ def rich_data_dict():
         "Metadata": pd.DataFrame(
             {
                 "Property": ["Generated At", "Data View ID", "Tool Version", "Total Metrics"],
-                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.11.5", 3],
+                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.11.6", 3],
             },
         ),
         "Data Quality": pd.DataFrame(
@@ -104,7 +104,7 @@ def rich_metadata_dict():
         "Generated At": "2025-01-15 10:30:00 PST",
         "Data View ID": "dv_content_test",
         "Data View Name": "Test DataView",
-        "Tool Version": "3.11.5",
+        "Tool Version": "3.11.6",
         "Metrics Count": "3",
         "Dimensions Count": "4",
     }
@@ -224,7 +224,7 @@ class TestJSONContentValidation:
             data = json.load(f)
 
         assert data["metadata"]["Data View ID"] == "dv_content_test"
-        assert data["metadata"]["Tool Version"] == "3.11.5"
+        assert data["metadata"]["Tool Version"] == "3.11.6"
 
     def test_json_metadata_preserves_partial_markers(self, tmp_path, rich_data_dict, rich_metadata_dict):
         logger = logging.getLogger("json_test")

--- a/tests/test_ux_features.py
+++ b/tests/test_ux_features.py
@@ -344,11 +344,11 @@ class TestCombinedFeatures:
 class TestVersionUpdated:
     """Test that version is correct"""
 
-    def test_version_is_3_11_5(self):
-        """Test that version is 3.11.5"""
+    def test_version_is_3_11_6(self):
+        """Test that version is 3.11.6"""
         from cja_auto_sdr.generator import __version__
 
-        assert __version__ == "3.11.5"
+        assert __version__ == "3.11.6"
 
 
 class TestFormatAutoDetection:


### PR DESCRIPTION
## Summary

Fixes the README banner rendering **stretched** on the PyPI project page, and ships it as a patch release because that's the only way to update PyPI.

### Root cause
The banner `<img>` had a fixed `height="572"`. PyPI's description CSS caps the image width to the container but leaves that fixed height, so the aspect ratio distorts. Removing `height` (keeping `width="1024"`) lets it scale proportionally. Also replaced the placeholder `alt="image"` with descriptive text.

### Why a release is required
PyPI freezes the README (`long_description`) at upload time — the project page shows the description from the published distribution and can't be edited in place. So the corrected README only reaches PyPI via a new upload. Bump **3.11.5 → 3.11.6**.

## Verified locally
- `check_version_sync.py` → OK (3.11.6)
- `update_test_counts.py --check` → up to date
- Version + output-content-validation tests → 30 passed

## After merge
Tag + release triggers the publish, which re-uploads the fixed description:
```
git tag v3.11.6 <merge-sha> && gh release create v3.11.6 --latest
```