### PR TITLE
fix(deps): patch idna/urllib3 CVEs (v3.11.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to the CJA SDR Generator project will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.11.7] - 2026-07-13
+
+### Security
+
+- **Dependency audit:** raised the version floors on two transitive dependencies flagged by `uv audit`. `idna` now requires `>=3.15` (fixes CVE-2026-45409 / GHSA-65pc-fj4g-8rjx — specially crafted input to `idna.encode()` could bypass the earlier CVE-2024-3651 fix) and `urllib3` now requires `>=2.7.0` (fixes CVE-2026-44431 / GHSA-qccp-gfcp-xxvc — sensitive headers forwarded across origins in proxied low-level redirects — and CVE-2026-44432 / GHSA-mf9v-mfxr-j63j — decompression-bomb safeguards bypassed in parts of the streaming API). Both arrive transitively (via `cjapy` → `requests` and `notion-client` → `httpx`); promoting them to direct dependencies with a secure minimum enforces the fix in the lockfile and for anyone installing from PyPI. The lockfile now resolves `idna 3.18` and `urllib3 2.7.0`, and `uv audit` reports no known vulnerabilities. (The remaining `pathlib is archived` adverse status is a hard dependency declared by `cjapy` upstream and is not a vulnerability.)
+
 ## [3.11.6] - 2026-07-13
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Package manager: **uv**
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
-- Current version: v3.11.6
+- Current version: v3.11.7
 - Tests: **8,378** across 163 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -943,7 +943,7 @@ cja_auto_sdr --list-dataviews --log-level DEBUG
 At launch, the tool logs diagnostic lines containing the tool version, Python version, platform, active log level, inferred run mode (batch, single, or discovery), and dependency versions. These appear automatically at `INFO` level and are useful for troubleshooting environment issues in CI/CD logs or support requests:
 
 ```text
-CJA SDR Generator v3.11.6 | Python 3.14.2 | darwin | log_level=INFO | mode=single
+CJA SDR Generator v3.11.7 | Python 3.14.2 | darwin | log_level=INFO | mode=single
 Dependencies: cjapy=0.3.0, pandas=2.3.3, numpy=2.2.1, xlsxwriter=3.2.9, tqdm=4.67.0
 ```
 

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -190,7 +190,7 @@ This command:
 
 ```bash
 $ uv run cja_auto_sdr -V
-cja_auto_sdr 3.11.6
+cja_auto_sdr 3.11.7
 ```
 
 > **Important:** All commands in this guide assume you're in the `cja_auto_sdr` directory. If you see "command not found", make sure you're in the right directory and have run `uv sync`.

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Quick Reference Card
 
-Single-page command cheat sheet for CJA SDR Generator v3.11.6.
+Single-page command cheat sheet for CJA SDR Generator v3.11.7.
 
 ## Four Main Modes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,11 @@ dependencies = [
     "pandas>=2.3.3,<3",
     "xlsxwriter>=3.2.9",
     "tqdm>=4.66.0",
+    # Security floors for transitive dependencies (pulled via cjapy->requests and
+    # notion-client->httpx). Promoted to direct deps so the secure minimum is enforced
+    # in our lockfile and propagated to PyPI installers. Remove once upstream raises floors.
+    "idna>=3.15",       # CVE-2026-45409 — idna.encode() bypass (GHSA-65pc-fj4g-8rjx)
+    "urllib3>=2.7.0",   # CVE-2026-44431/44432 — cross-origin header leak + decompression bomb
 ]
 
 [project.urls]

--- a/src/cja_auto_sdr/core/version.py
+++ b/src/cja_auto_sdr/core/version.py
@@ -1,3 +1,3 @@
 """Version information for CJA Auto SDR."""
 
-__version__ = "3.11.6"
+__version__ = "3.11.7"

--- a/tests/test_output_content_validation.py
+++ b/tests/test_output_content_validation.py
@@ -38,7 +38,7 @@ def rich_data_dict():
         "Metadata": pd.DataFrame(
             {
                 "Property": ["Generated At", "Data View ID", "Tool Version", "Total Metrics"],
-                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.11.6", 3],
+                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.11.7", 3],
             },
         ),
         "Data Quality": pd.DataFrame(
@@ -104,7 +104,7 @@ def rich_metadata_dict():
         "Generated At": "2025-01-15 10:30:00 PST",
         "Data View ID": "dv_content_test",
         "Data View Name": "Test DataView",
-        "Tool Version": "3.11.6",
+        "Tool Version": "3.11.7",
         "Metrics Count": "3",
         "Dimensions Count": "4",
     }
@@ -224,7 +224,7 @@ class TestJSONContentValidation:
             data = json.load(f)
 
         assert data["metadata"]["Data View ID"] == "dv_content_test"
-        assert data["metadata"]["Tool Version"] == "3.11.6"
+        assert data["metadata"]["Tool Version"] == "3.11.7"
 
     def test_json_metadata_preserves_partial_markers(self, tmp_path, rich_data_dict, rich_metadata_dict):
         logger = logging.getLogger("json_test")

--- a/tests/test_ux_features.py
+++ b/tests/test_ux_features.py
@@ -345,10 +345,10 @@ class TestVersionUpdated:
     """Test that version is correct"""
 
     def test_version_is_3_11_6(self):
-        """Test that version is 3.11.6"""
+        """Test that version is 3.11.7"""
         from cja_auto_sdr.generator import __version__
 
-        assert __version__ == "3.11.6"
+        assert __version__ == "3.11.7"
 
 
 class TestFormatAutoDetection:

--- a/uv.lock
+++ b/uv.lock
@@ -78,9 +78,11 @@ name = "cja-auto-sdr"
 source = { editable = "." }
 dependencies = [
     { name = "cjapy" },
+    { name = "idna" },
     { name = "numpy" },
     { name = "pandas" },
     { name = "tqdm" },
+    { name = "urllib3" },
     { name = "xlsxwriter" },
 ]
 
@@ -119,6 +121,7 @@ requires-dist = [
     { name = "argcomplete", marker = "extra == 'completion'", specifier = ">=3.0.0" },
     { name = "argcomplete", marker = "extra == 'full'", specifier = ">=3.0.0" },
     { name = "cjapy", specifier = ">=0.3.1" },
+    { name = "idna", specifier = ">=3.15" },
     { name = "notion-client", marker = "extra == 'full'", specifier = ">=3.0.0" },
     { name = "notion-client", marker = "extra == 'notion'", specifier = ">=3.0.0" },
     { name = "numpy", specifier = ">=2.2.0,!=2.4.0" },
@@ -128,6 +131,7 @@ requires-dist = [
     { name = "scipy", marker = "extra == 'clustering'", specifier = ">=1.14.0" },
     { name = "scipy", marker = "extra == 'full'", specifier = ">=1.14.0" },
     { name = "tqdm", specifier = ">=4.66.0" },
+    { name = "urllib3", specifier = ">=2.7.0" },
     { name = "xlsxwriter", specifier = ">=3.2.9" },
 ]
 provides-extras = ["clustering", "completion", "env", "full", "notion"]
@@ -276,11 +280,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -596,11 +600,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Patch release **v3.11.6 → v3.11.7** resolving the 6 known vulnerabilities reported by `uv audit`.

Both offending packages are transitive; raising their floors as **direct dependencies** fixes our locked `uv.lock` **and** propagates the secure minimum to anyone installing from PyPI.

| Package | Was | Now (floor) | Resolves |
|---|---|---|---|
| `idna` | 3.11 | `>=3.15` (locks 3.18) | CVE-2026-45409 / GHSA-65pc-fj4g-8rjx — `idna.encode()` bypass of the CVE-2024-3651 fix |
| `urllib3` | 2.6.3 | `>=2.7.0` (locks 2.7.0) | CVE-2026-44431 / GHSA-qccp-gfcp-xxvc (cross-origin header leak in proxied redirects) · CVE-2026-44432 / GHSA-mf9v-mfxr-j63j (decompression-bomb bypass in the streaming API) |

Provenance: `idna` arrives via `cjapy → requests` and `notion-client → httpx`; `urllib3` via `cjapy → requests`.

## Verification

- `uv audit --preview-features audit` → **no known vulnerabilities** (was 6).
- `uv.lock` diff touches only `idna` (3.11→3.18) and `urllib3` (2.6.3→2.7.0).
- `scripts/check_version_sync.py` → all references match `3.11.7`.
- Ruff clean; unit suite **8,252 passed / 15 skipped, 99.12% coverage** (95% gate).

## Out of scope

`uv audit` also reports one **adverse status**: `pathlib is archived`. That is the archived PyPI backport (`pathlib 1.0.1`) declared as a **hard dependency by `cjapy 0.3.1` itself** — we cannot remove a parent's declared dependency, and it is an archived-status notice, not a vulnerability. It clears only when `cjapy` drops it upstream.

## Notes

The PyPI version badge is intentionally left as the dynamic `img.shields.io/pypi/v/cja-auto-sdr`. It already tracks PyPI live; any staleness on the GitHub-rendered README is GitHub's camo image-proxy cache (3h TTL) and self-heals.