### PR TITLE
ci: bump setup-uv to v8.3.2, stop pruning wheel cache, add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Keeps GitHub Actions pins current. setup-uv v8+ no longer publishes
+# floating major tags (supply-chain hardening), so workflows pin exact
+# versions and rely on this config to surface updates.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,11 +19,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: "3.14"
           enable-cache: true
           cache-dependency-glob: uv.lock
+          prune-cache: false
       - name: Sync dependencies
         run: uv sync --dev
       - name: Ruff check
@@ -55,10 +56,11 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: "3.14"
           enable-cache: true
           cache-dependency-glob: uv.lock
+          prune-cache: false
       - name: Verify lockfile is in sync
         run: uv lock --check

--- a/.github/workflows/patch-release-gate.yml
+++ b/.github/workflows/patch-release-gate.yml
@@ -27,11 +27,12 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: "3.14"
           enable-cache: true
           cache-dependency-glob: uv.lock
+          prune-cache: false
       - name: Sync dependencies
         run: uv sync --dev
       - name: Verify version, changelog, docs, release tag, and CI tag ref

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,11 +25,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: "3.14"
           enable-cache: true
           cache-dependency-glob: uv.lock
+          prune-cache: false
       - name: Build sdist and wheel
         run: |
           rm -f dist/*.whl dist/*.tar.gz

--- a/.github/workflows/test-counts.yml
+++ b/.github/workflows/test-counts.yml
@@ -23,11 +23,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: "3.14"
           enable-cache: true
           cache-dependency-glob: uv.lock
+          prune-cache: false
       - name: Sync dependencies
         run: uv sync --dev
       - name: Verify test counts are up to date

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,11 +41,12 @@ jobs:
         python-version: ["3.14"]
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
           cache-dependency-glob: uv.lock
+          prune-cache: false
       - name: Sync dependencies
         run: uv sync --dev
       - name: Run focused release-gate contract tests
@@ -59,11 +60,12 @@ jobs:
         python-version: ["3.14"]
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
           cache-dependency-glob: uv.lock
+          prune-cache: false
       - name: Sync dependencies
         run: uv sync --dev --extra clustering
       - name: Run unit tests with coverage (95% gate applies to this slice)
@@ -126,11 +128,12 @@ jobs:
         python-version: ["3.14"]
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
           cache-dependency-glob: uv.lock
+          prune-cache: false
       - name: Sync dependencies
         run: uv sync --dev --extra clustering
       - name: Run integration, end-to-end, and slow test slices
@@ -153,11 +156,12 @@ jobs:
         python-version: ["3.14"]
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
           cache-dependency-glob: uv.lock
+          prune-cache: false
       - name: Sync dependencies
         run: uv sync --dev
       - name: Run run-summary JSON contract tests
@@ -174,11 +178,12 @@ jobs:
         python-version: ["3.14"]
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
           cache-dependency-glob: uv.lock
+          prune-cache: false
       - name: Sync dependencies
         run: uv sync --dev
       - name: Smoke test - version, help, exit-codes
@@ -198,11 +203,12 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: "3.14"
           enable-cache: true
           cache-dependency-glob: uv.lock
+          prune-cache: false
       - name: Build wheel
         run: |
           rm -f dist/*.whl dist/*.tar.gz
@@ -232,11 +238,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: "3.14"
           enable-cache: true
           cache-dependency-glob: uv.lock
+          prune-cache: false
       - name: Clean build artifacts
         run: rm -f dist/*.whl dist/*.tar.gz
       - name: Build package

--- a/.github/workflows/update-badges.yml
+++ b/.github/workflows/update-badges.yml
@@ -32,11 +32,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: "3.14"
           enable-cache: true
           cache-dependency-glob: uv.lock
+          prune-cache: false
 
       - name: Sync dependencies
         run: uv sync --dev --extra clustering

--- a/.github/workflows/version-sync.yml
+++ b/.github/workflows/version-sync.yml
@@ -19,10 +19,11 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: "3.14"
           enable-cache: true
           cache-dependency-glob: uv.lock
+          prune-cache: false
       - name: Verify version strings are in sync
         run: uv run python scripts/check_version_sync.py


### PR DESCRIPTION
## Why

setup-uv ships with `prune-cache: true` by default, which runs `uv cache prune --ci` before saving the cache. That strips pre-built wheels (numpy, pandas, scipy, etc.) from the saved cache, so every CI run re-downloads them from PyPI despite reporting a cache hit. This repo's dependency tree installs almost entirely from pre-built wheels, so the cache was carrying little of value across ~10 jobs per push.

Separately, the `@v7` floating tag is a dead-end: the v7 line last moved at v7.6.0 (2026-03-16), and starting with v8.0.0 setup-uv publishes only immutable exact-version tags (no more `@v8`), as supply-chain hardening.

## Changes

- **Pin `astral-sh/setup-uv@v8.3.2`** at all 14 call sites across 7 workflows. The v8.0.0 breaking changes don't affect this repo (removed `manifest-file` format is unused; the other change is the tag policy itself). Picks up: no more GitHub token sent to the astral.sh mirror (v8.2.0), better cache-save failure reporting.
- **`prune-cache: false`** at all 14 sites, so cached wheels survive and cache hits stop re-downloading from PyPI.
- **Add `.github/dependabot.yml`** (github-actions ecosystem, weekly, grouped into one PR) — with exact pins, nothing else keeps the version current.

## Verification

- 14/14 sites pinned to `v8.3.2`, zero `@v7` references remain
- 14/14 sites have `prune-cache: false`; input confirmed present in v8.3.2's `action.yml`
- All 7 workflow files + `dependabot.yml` parse as valid YAML
- actionlint runs in this PR's lint workflow

CI-only change: no version bump, tag, or release.