### PR TITLE
ci(security): complete GitHub security parity

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,36 @@
+# Copilot instructions for `cja_auto_sdr`
+
+- Read and follow the repository-root `AGENTS.md` before editing. It is the
+  authoritative project and tool contract.
+- This is a Python 3.14+ CLI managed with `uv`. Install the development
+  environment with `uv sync`.
+- Preserve the core safety invariant: Adobe Customer Journey Analytics API
+  access is read-only. Never add an SDK or HTTP call that creates, updates, or
+  deletes Adobe CJA state.
+- Output-side integrations are separate from Adobe CJA access. They may write
+  only when an existing, explicit user-selected workflow authorizes it, such as
+  publishing an SDR to Notion.
+- Never expose `ORG_ID`, `CLIENT_ID`, `SECRET`, `SCOPES`, access tokens, profile
+  contents, sandbox names, or live customer resource data in code, tests, logs,
+  fixtures, or pull requests. Use mocks and synthetic fixtures.
+- Keep the Adobe SDK boundary inside `src/cja_auto_sdr/api/`; downstream code
+  should consume the project's own models rather than leaking `cjapy` objects.
+- Preserve documented CLI exit codes, stdout and stderr JSON contracts, output
+  conventions, snapshot compatibility, agent-mode behavior, and cross-platform
+  behavior.
+- Match existing typing, logging, and test patterns. Add or update focused tests
+  for behavior changes; do not weaken a security check merely to make CI pass.
+- For GitHub Actions changes, grant only the minimum `GITHUB_TOKEN` permissions
+  and pin new third-party actions to a full commit SHA with a version comment.
+
+Run the narrowest relevant tests while iterating, then validate a completed
+change with:
+
+```bash
+uv run pytest -q
+uv run ruff check src/ tests/ scripts/ examples/
+uv run ruff format --check src/ tests/ scripts/ examples/
+uv lock --check
+uv run python scripts/check_version_sync.py
+uv run python scripts/update_test_counts.py --check
+```

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,11 @@
 # versions and rely on this config to surface updates.
 version: 2
 updates:
+  - package-ecosystem: uv
+    directory: /
+    schedule:
+      interval: weekly
+
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,22 @@
+name: dependency-review
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Reject newly introduced vulnerable dependencies
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: moderate
+          fail-on-scopes: runtime, development, unknown

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,7 @@ uv run pytest tests/ --collect-only -q  # Get accurate test count
 |----------|---------|
 | `tests.yml` | Unit tests (95% coverage gate, `-n auto` xdist), integration/e2e/slow tests, run-summary contracts, cross-platform smoke tests, package build |
 | `lint.yml` | Ruff check + format, actionlint, shellcheck |
+| `dependency-review.yml` | Blocks pull requests that introduce moderate-or-higher vulnerable dependencies |
 | `version-sync.yml` | `scripts/check_version_sync.py` — single source of truth for version consistency |
 | `patch-release-gate.yml` | Release validation (version, changelog, docs, tag ref, test counts) |
 | `test-counts.yml` | Validates README test count inventory is current |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are applied to the latest released version of `cja-auto-sdr`.
+Upgrade to the newest release before reporting an issue that may already have
+been fixed.
+
+## Reporting a vulnerability
+
+Please use GitHub's private vulnerability reporting for this repository:
+
+<https://github.com/brian-a-au/cja_auto_sdr/security/advisories/new>
+
+Do not open a public issue for a suspected vulnerability. Include the affected
+version, impact, reproduction steps or a proof of concept, and any suggested
+mitigation. Please remove credentials, access tokens, organization and client
+IDs, profile contents, sandbox names, live customer resource data, and other
+sensitive information from the report.
+
+You should receive an acknowledgement through the private advisory within
+seven days. Confirmed issues will be coordinated there until a fix and
+disclosure are ready.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# Temporary negative control for dependency-review on PR #113.
+jinja2==2.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-# Temporary negative control for dependency-review on PR #113.
-jinja2==2.10


### PR DESCRIPTION
## Summary

Pull requests now reject newly introduced dependencies with moderate-or-higher known vulnerabilities, while weekly maintenance also covers the root `uv` dependency graph. The repository gains a private disclosure policy and coding-agent guardrails tailored to CJA credentials, customer data, stable CLI contracts, and the read-only Adobe API boundary.

The rollout preserves CodeQL default setup, secret scanning, push protection, Dependabot security updates, every existing required check, package versions, and release behavior. Four pre-existing high-severity CodeQL alerts remain outside this configuration PR and are not represented as resolved.

Session-settled decision carried from planning: full tracked-config and repository-settings parity was user-approved over settings-only enablement.

## Validation

- `uv run pytest -q` - 8,362 passed, 16 skipped
- `uv run ruff check src/ tests/ scripts/ examples/`
- `uv run ruff format --check src/ tests/ scripts/ examples/`
- `uv lock --check`
- version-sync and test-count inventory checks
- Dependabot and workflow YAML structural assertions
- independent correctness, standards, agent-surface, security, and adversarial review

Live rollout evidence completed on this PR:

- Baseline and restored-head checks passed: [initial run](https://github.com/brian-a-au/cja_auto_sdr/actions/runs/30406403752), [latest-head run](https://github.com/brian-a-au/cja_auto_sdr/actions/runs/30406476308)
- [Negative-control run](https://github.com/brian-a-au/cja_auto_sdr/actions/runs/30406437212) rejected a temporary Jinja2 2.10 manifest with high and moderate advisories; the manifest is absent from the latest tree
- Private vulnerability reporting is enabled and the advisory route is available
- Strict `main` protection preserves all seven prior app-bound checks and adds only `dependency-review`, bound to GitHub Actions app ID `15368`

After merge, the next root `uv` Dependabot update log will provide the final scheduled-operation proof.

## New concepts

Dependency maintenance and dependency review solve different halves of supply-chain safety. Dependabot proposes updates after packages are already declared; dependency review compares a pull request's base and head dependency graphs and blocks newly introduced vulnerable versions before merge.

This repository uses both because update automation alone cannot stop a contributor from adding a known-vulnerable package. Dependency review remains intentionally narrow: it evaluates dependency changes on pull requests and does not replace CodeQL or remediate existing alerts.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
