### PR TITLE
fix(release): prevent broken PyPI README links

### DIFF
--- a/.github/workflows/patch-release-gate.yml
+++ b/.github/workflows/patch-release-gate.yml
@@ -48,3 +48,5 @@ jobs:
           fi
       - name: Verify test counts are up to date
         run: uv run python scripts/update_test_counts.py --check
+      - name: Verify PyPI README links
+        run: uv run python scripts/check_pypi_readme_links.py README.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,8 @@ jobs:
           uv build
       - name: Validate distribution metadata
         run: uvx twine check dist/*
+      - name: Validate PyPI README links
+        run: uv run python scripts/check_pypi_readme_links.py dist/*
       - name: Verify tag matches built version
         run: |
           tag="${GITHUB_REF_NAME#v}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,8 +27,13 @@ jobs:
         with:
           filters: |
             release_gate_related:
+              - "README.md"
+              - "pyproject.toml"
+              - "scripts/check_pypi_readme_links.py"
               - "scripts/check_version_sync.py"
+              - "tests/test_check_pypi_readme_links.py"
               - ".github/workflows/patch-release-gate.yml"
+              - ".github/workflows/release.yml"
               - ".github/workflows/tests.yml"
 
   release-gate-focused-tests:
@@ -50,7 +55,11 @@ jobs:
       - name: Sync dependencies
         run: uv sync --dev
       - name: Run focused release-gate contract tests
-        run: uv run pytest -q tests/test_check_version_sync.py tests/test_cli_color_policy_e2e.py
+        run: >
+          uv run pytest -q
+          tests/test_check_version_sync.py
+          tests/test_check_pypi_readme_links.py
+          tests/test_cli_color_policy_e2e.py
 
   test-unit:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ All notable changes to the CJA SDR Generator project will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.11.8] - 2026-08-03
+
+### Fixed
+
+- **PyPI README links:** replaced repository-relative documentation, test, license, and changelog targets with absolute GitHub URLs so all links work from the PyPI project page as well as GitHub.
+- **Source distribution documentation:** root-anchored the intended top-level README, license, and project metadata include patterns so Hatch no longer collects unrelated nested README files without their linked content.
+
+### CI
+
+- **Release validation:** added a standard-library-only check that inspects the long description embedded in built wheels and source distributions and rejects unsupported relative links before publication. The patch-release and focused PR gates cover the same contract.
+
 ## [3.11.7] - 2026-07-13
 
 ### Security

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,8 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Package manager: **uv**
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
-- Current version: v3.11.7
-- Tests: **8,378** across 163 files at **95% coverage gate**
+- Current version: v3.11.8
+- Tests: **8,388** across 164 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 [![Lint](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/lint.yml/badge.svg)](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/lint.yml)
 [![Version Sync](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/version-sync.yml/badge.svg)](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/version-sync.yml)
 [![Python 3.14+](https://img.shields.io/badge/python-3.14%2B-blue.svg)](https://www.python.org/downloads/)
-[![Coverage](https://img.shields.io/badge/coverage-99%25-brightgreen.svg)](tests/)
-[![Tests](https://img.shields.io/badge/tests-8378-brightgreen.svg)](tests/)
+[![Coverage](https://img.shields.io/badge/coverage-99%25-brightgreen.svg)](https://github.com/brian-a-au/cja_auto_sdr/tree/main/tests)
+[![Tests](https://img.shields.io/badge/tests-8388-brightgreen.svg)](https://github.com/brian-a-au/cja_auto_sdr/tree/main/tests)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/brian-a-au/cja_auto_sdr/blob/main/LICENSE)
 
 A production-ready Python CLI that automates the creation of Solution Design Reference (SDR) documentation from your Adobe Customer Journey Analytics (CJA) implementation. Read-only against CJA.
 
@@ -159,7 +159,7 @@ python -m venv .venv
 pip install -e .
 ```
 
-> **Windows Users:** If you encounter issues with `uv run` or NumPy import errors on Windows, we recommend using Python directly. See the [Windows-Specific Issues](docs/TROUBLESHOOTING.md#windows-specific-issues) section in the troubleshooting guide for detailed solutions.
+> **Windows Users:** If you encounter issues with `uv run` or NumPy import errors on Windows, we recommend using Python directly. See the [Windows-Specific Issues](https://github.com/brian-a-au/cja_auto_sdr/blob/main/docs/TROUBLESHOOTING.md#windows-specific-issues) section in the troubleshooting guide for detailed solutions.
 
 <!-- separator between blockquotes -->
 
@@ -172,9 +172,9 @@ pip install -e .
 
 ### 3. Configure Credentials
 
-Get your credentials from [Adobe Developer Console](https://developer.adobe.com/console/) (see [QUICKSTART_GUIDE](docs/QUICKSTART_GUIDE.md) for detailed steps).
+Get your credentials from [Adobe Developer Console](https://developer.adobe.com/console/) (see [QUICKSTART_GUIDE](https://github.com/brian-a-au/cja_auto_sdr/blob/main/docs/QUICKSTART_GUIDE.md) for detailed steps).
 
-> ⚠ **Important:** Your Adobe Developer Console project must have **both** the CJA API **and** the AEP (Experience Platform) API added. The AEP API associates your service account with an Experience Platform product profile, which is required for CJA API authentication. See the [Quickstart Guide](docs/QUICKSTART_GUIDE.md#15-add-the-adobe-experience-platform-aep-api) for setup instructions.
+> ⚠ **Important:** Your Adobe Developer Console project must have **both** the CJA API **and** the AEP (Experience Platform) API added. The AEP API associates your service account with an Experience Platform product profile, which is required for CJA API authentication. See the [Quickstart Guide](https://github.com/brian-a-au/cja_auto_sdr/blob/main/docs/QUICKSTART_GUIDE.md#15-add-the-adobe-experience-platform-aep-api) for setup instructions.
 
 #### Option A: Configuration File (Quickest)
 
@@ -376,29 +376,29 @@ cja_auto_sdr "Production Analytics"
 
 | Guide | Description |
 | ----- | ----------- |
-| [Quick Reference](docs/QUICK_REFERENCE.md) | Single-page command cheat sheet |
-| [Extended Quick Start](docs/QUICKSTART_GUIDE.md) | Complete walkthrough from zero to first SDR |
-| [Installation Guide](docs/INSTALLATION.md) | Detailed setup instructions, authentication options |
-| [Configuration Guide](docs/CONFIGURATION.md) | config.json, environment variables, Profile management |
-| [Notion Setup](docs/NOTION_SETUP.md) | Step-by-step Notion integration setup and overview |
-| [CLI Reference](docs/CLI_REFERENCE.md) | Complete command-line options and examples |
-| [Shell Completion](docs/SHELL_COMPLETION.md) | Enable tab-completion for bash/zsh |
-| [Data Quality](docs/DATA_QUALITY.md) | Validation checks, severity levels, understanding issues |
-| [Inventory Overview](docs/INVENTORY_OVERVIEW.md) | Unified guide to all component inventories |
-| [Derived Field Inventory](docs/DERIVED_FIELDS_INVENTORY.md) | Derived field analysis, complexity scores, logic summaries |
-| [Segments Inventory](docs/SEGMENTS_INVENTORY.md) | Segment filters, container types, definition summaries |
-| [Calculated Metrics Inventory](docs/CALCULATED_METRICS_INVENTORY.md) | Calculated metric formulas, complexity, references |
-| [Performance](docs/PERFORMANCE.md) | Optimization options, caching, batch processing |
-| [Troubleshooting](docs/TROUBLESHOOTING.md) | Common errors and solutions |
-| [Use Cases & Best Practices](docs/USE_CASES.md) | Automation, scheduling, workflows |
-| [Output Formats](docs/OUTPUT_FORMATS.md) | Format specifications and examples |
-| [Batch Processing](docs/BATCH_PROCESSING_GUIDE.md) | Multi-Data View processing guide |
-| [Data View Names](docs/DATA_VIEW_NAMES.md) | Using Data View names instead of IDs |
-| [Data View Comparison](docs/DIFF_COMPARISON.md) | Compare Data Views, snapshots, CI/CD integration |
-| [Git Integration](docs/GIT_INTEGRATION.md) | Version-controlled snapshots, audit trails, team collaboration |
-| [Org-Wide Analysis](docs/ORG_WIDE_ANALYSIS.md) | Cross-data view component analysis, similarity detection, governance |
-| [Agent Automation](docs/AGENT_AUTOMATION.md) | CI/CD pipelines, AI agent integration, scheduling patterns |
-| [Testing](tests/README.md) | Running and writing tests |
+| [Quick Reference](https://github.com/brian-a-au/cja_auto_sdr/blob/main/docs/QUICK_REFERENCE.md) | Single-page command cheat sheet |
+| [Extended Quick Start](https://github.com/brian-a-au/cja_auto_sdr/blob/main/docs/QUICKSTART_GUIDE.md) | Complete walkthrough from zero to first SDR |
+| [Installation Guide](https://github.com/brian-a-au/cja_auto_sdr/blob/main/docs/INSTALLATION.md) | Detailed setup instructions, authentication options |
+| [Configuration Guide](https://github.com/brian-a-au/cja_auto_sdr/blob/main/docs/CONFIGURATION.md) | config.json, environment variables, Profile management |
+| [Notion Setup](https://github.com/brian-a-au/cja_auto_sdr/blob/main/docs/NOTION_SETUP.md) | Step-by-step Notion integration setup and overview |
+| [CLI Reference](https://github.com/brian-a-au/cja_auto_sdr/blob/main/docs/CLI_REFERENCE.md) | Complete command-line options and examples |
+| [Shell Completion](https://github.com/brian-a-au/cja_auto_sdr/blob/main/docs/SHELL_COMPLETION.md) | Enable tab-completion for bash/zsh |
+| [Data Quality](https://github.com/brian-a-au/cja_auto_sdr/blob/main/docs/DATA_QUALITY.md) | Validation checks, severity levels, understanding issues |
+| [Inventory Overview](https://github.com/brian-a-au/cja_auto_sdr/blob/main/docs/INVENTORY_OVERVIEW.md) | Unified guide to all component inventories |
+| [Derived Field Inventory](https://github.com/brian-a-au/cja_auto_sdr/blob/main/docs/DERIVED_FIELDS_INVENTORY.md) | Derived field analysis, complexity scores, logic summaries |
+| [Segments Inventory](https://github.com/brian-a-au/cja_auto_sdr/blob/main/docs/SEGMENTS_INVENTORY.md) | Segment filters, container types, definition summaries |
+| [Calculated Metrics Inventory](https://github.com/brian-a-au/cja_auto_sdr/blob/main/docs/CALCULATED_METRICS_INVENTORY.md) | Calculated metric formulas, complexity, references |
+| [Performance](https://github.com/brian-a-au/cja_auto_sdr/blob/main/docs/PERFORMANCE.md) | Optimization options, caching, batch processing |
+| [Troubleshooting](https://github.com/brian-a-au/cja_auto_sdr/blob/main/docs/TROUBLESHOOTING.md) | Common errors and solutions |
+| [Use Cases & Best Practices](https://github.com/brian-a-au/cja_auto_sdr/blob/main/docs/USE_CASES.md) | Automation, scheduling, workflows |
+| [Output Formats](https://github.com/brian-a-au/cja_auto_sdr/blob/main/docs/OUTPUT_FORMATS.md) | Format specifications and examples |
+| [Batch Processing](https://github.com/brian-a-au/cja_auto_sdr/blob/main/docs/BATCH_PROCESSING_GUIDE.md) | Multi-Data View processing guide |
+| [Data View Names](https://github.com/brian-a-au/cja_auto_sdr/blob/main/docs/DATA_VIEW_NAMES.md) | Using Data View names instead of IDs |
+| [Data View Comparison](https://github.com/brian-a-au/cja_auto_sdr/blob/main/docs/DIFF_COMPARISON.md) | Compare Data Views, snapshots, CI/CD integration |
+| [Git Integration](https://github.com/brian-a-au/cja_auto_sdr/blob/main/docs/GIT_INTEGRATION.md) | Version-controlled snapshots, audit trails, team collaboration |
+| [Org-Wide Analysis](https://github.com/brian-a-au/cja_auto_sdr/blob/main/docs/ORG_WIDE_ANALYSIS.md) | Cross-data view component analysis, similarity detection, governance |
+| [Agent Automation](https://github.com/brian-a-au/cja_auto_sdr/blob/main/docs/AGENT_AUTOMATION.md) | CI/CD pipelines, AI agent integration, scheduling patterns |
+| [Testing](https://github.com/brian-a-au/cja_auto_sdr/blob/main/tests/README.md) | Running and writing tests |
 
 ## Requirements
 
@@ -503,7 +503,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (8,378+ tests)
+├── tests/                     # Test suite (8,388+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide
@@ -534,4 +534,4 @@ cja_auto_sdr/
 - [CJA API Documentation](https://developer.adobe.com/cja-apis/docs/)
 - [cjapy Library](https://github.com/pitchmuc/cjapy)
 - [uv Package Manager](https://github.com/astral-sh/uv)
-- [Changelog](CHANGELOG.md)
+- [Changelog](https://github.com/brian-a-au/cja_auto_sdr/blob/main/CHANGELOG.md)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,7 +6,7 @@ How to cut a release of `cja-auto-sdr` and publish it to [PyPI](https://pypi.org
 
 ## How publishing works
 
-`.github/workflows/release.yml` runs on the `release: published` event. It builds the sdist and wheel with `uv build`, validates metadata with `twine check`, verifies the release tag matches the built version, then uploads to PyPI using **Trusted Publishing (OIDC)**. There are no stored API tokens: GitHub Actions mints a short-lived OIDC token that PyPI verifies against the registered publisher (owner `brian-a-au`, repo `cja_auto_sdr`, workflow `release.yml`, environment `pypi`).
+`.github/workflows/release.yml` runs on the `release: published` event. It builds the sdist and wheel with `uv build`, validates metadata with `twine check`, rejects repository-relative links in the built PyPI README, verifies the release tag matches the built version, then uploads to PyPI using **Trusted Publishing (OIDC)**. There are no stored API tokens: GitHub Actions mints a short-lived OIDC token that PyPI verifies against the registered publisher (owner `brian-a-au`, repo `cja_auto_sdr`, workflow `release.yml`, environment `pypi`).
 
 ## Runbook
 
@@ -17,6 +17,9 @@ Update `src/cja_auto_sdr/core/version.py` and add a `CHANGELOG.md` entry, then s
 ```bash
 uv run python scripts/check_version_sync.py
 uv run python scripts/update_test_counts.py --check
+uv build
+uvx twine check dist/*
+uv run python scripts/check_pypi_readme_links.py dist/*
 ```
 
 ### 2. Merge to `main`

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -943,7 +943,7 @@ cja_auto_sdr --list-dataviews --log-level DEBUG
 At launch, the tool logs diagnostic lines containing the tool version, Python version, platform, active log level, inferred run mode (batch, single, or discovery), and dependency versions. These appear automatically at `INFO` level and are useful for troubleshooting environment issues in CI/CD logs or support requests:
 
 ```text
-CJA SDR Generator v3.11.7 | Python 3.14.2 | darwin | log_level=INFO | mode=single
+CJA SDR Generator v3.11.8 | Python 3.14.2 | darwin | log_level=INFO | mode=single
 Dependencies: cjapy=0.3.0, pandas=2.3.3, numpy=2.2.1, xlsxwriter=3.2.9, tqdm=4.67.0
 ```
 

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -190,7 +190,7 @@ This command:
 
 ```bash
 $ uv run cja_auto_sdr -V
-cja_auto_sdr 3.11.7
+cja_auto_sdr 3.11.8
 ```
 
 > **Important:** All commands in this guide assume you're in the `cja_auto_sdr` directory. If you see "command not found", make sure you're in the right directory and have run `uv sync`.

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Quick Reference Card
 
-Single-page command cheat sheet for CJA SDR Generator v3.11.7.
+Single-page command cheat sheet for CJA SDR Generator v3.11.8.
 
 ## Four Main Modes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,9 +70,9 @@ packages = ["src/cja_auto_sdr"]
 [tool.hatch.build.targets.sdist]
 include = [
     "/src",
-    "pyproject.toml",
-    "README.md",
-    "LICENSE",
+    "/pyproject.toml",
+    "/README.md",
+    "/LICENSE",
 ]
 
 [dependency-groups]

--- a/scripts/check_pypi_readme_links.py
+++ b/scripts/check_pypi_readme_links.py
@@ -1,0 +1,176 @@
+"""Reject repository-relative links in PyPI long descriptions.
+
+PyPI renders the distribution metadata without a repository base URL, so links
+such as ``docs/INSTALLATION.md`` point back into pypi.org instead of GitHub.
+
+Usage:
+  uv run python scripts/check_pypi_readme_links.py dist/*
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import tarfile
+import zipfile
+from dataclasses import dataclass
+from email import policy
+from email.parser import BytesParser
+from html.parser import HTMLParser
+from pathlib import Path
+from urllib.parse import urlsplit
+
+FENCE = re.compile(r" {0,3}(`{3,}|~{3,})")
+INLINE_CODE = re.compile(r"(`+).*?\1")
+MARKDOWN_DESTINATION = re.compile(r"]\(\s*(?:<([^>\n]+)>|([^\s)]+))")
+REFERENCE_DESTINATION = re.compile(r" {0,3}\[[^]]+]:\s*(?:<([^>\n]+)>|([^\s]+))")
+
+
+@dataclass(frozen=True)
+class LinkIssue:
+    """One unsupported link in a rendered long description."""
+
+    line: int
+    target: str
+
+
+class _HTMLDestinationParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.issues: list[LinkIssue] = []
+
+    def _record_attributes(self, attrs: list[tuple[str, str | None]]) -> None:
+        line, _ = self.getpos()
+        for name, value in attrs:
+            if name.lower() in {"href", "src"} and value and _is_unsupported_relative_target(value):
+                self.issues.append(LinkIssue(line=line, target=value))
+
+    def handle_starttag(self, _tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        self._record_attributes(attrs)
+
+    def handle_startendtag(self, _tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        self._record_attributes(attrs)
+
+
+def _is_unsupported_relative_target(target: str) -> bool:
+    return not (target.startswith(("#", "//")) or urlsplit(target).scheme)
+
+
+def _prose_lines(markdown: str) -> list[tuple[int, str]]:
+    """Return lines outside fenced code blocks with inline code removed."""
+    prose: list[tuple[int, str]] = []
+    fence_char = ""
+    fence_length = 0
+
+    for line_number, line in enumerate(markdown.splitlines(), start=1):
+        match = FENCE.match(line)
+        if fence_char:
+            if match and match.group(1)[0] == fence_char and len(match.group(1)) >= fence_length:
+                fence_char = ""
+                fence_length = 0
+            prose.append((line_number, ""))
+            continue
+
+        if match:
+            marker = match.group(1)
+            fence_char = marker[0]
+            fence_length = len(marker)
+            prose.append((line_number, ""))
+            continue
+
+        prose.append((line_number, INLINE_CODE.sub("", line)))
+
+    return prose
+
+
+def find_unsupported_relative_links(markdown: str) -> list[LinkIssue]:
+    """Return repository-relative Markdown and HTML destinations."""
+    issues: list[LinkIssue] = []
+    prose = _prose_lines(markdown)
+    for line_number, line in prose:
+        for pattern in (MARKDOWN_DESTINATION, REFERENCE_DESTINATION):
+            for match in pattern.finditer(line):
+                target = match.group(1) or match.group(2)
+                if _is_unsupported_relative_target(target):
+                    issues.append(LinkIssue(line=line_number, target=target))
+
+    html_parser = _HTMLDestinationParser()
+    html_parser.feed("\n".join(line for _, line in prose))
+    issues.extend(html_parser.issues)
+    return issues
+
+
+def _metadata_payload(data: bytes, *, source: Path) -> str:
+    message = BytesParser(policy=policy.default).parsebytes(data)
+    payload = message.get_payload()
+    if not isinstance(payload, str):
+        raise ValueError(f"{source}: metadata long description is not text")
+    return payload
+
+
+def read_long_description(path: Path) -> str:
+    """Read a README or the long description embedded in a wheel/sdist."""
+    if path.suffix.lower() in {".md", ".markdown"}:
+        return path.read_text(encoding="utf-8")
+
+    if path.suffix == ".whl":
+        with zipfile.ZipFile(path) as archive:
+            candidates = [name for name in archive.namelist() if name.endswith(".dist-info/METADATA")]
+            if len(candidates) != 1:
+                raise ValueError(f"{path}: expected one wheel METADATA file, found {len(candidates)}")
+            return _metadata_payload(archive.read(candidates[0]), source=path)
+
+    if path.name.endswith(".tar.gz"):
+        with tarfile.open(path, mode="r:gz") as archive:
+            candidates = [
+                member
+                for member in archive.getmembers()
+                if member.name.count("/") == 1 and member.name.endswith("/PKG-INFO")
+            ]
+            if len(candidates) != 1:
+                raise ValueError(f"{path}: expected one sdist PKG-INFO file, found {len(candidates)}")
+            extracted = archive.extractfile(candidates[0])
+            if extracted is None:
+                raise ValueError(f"{path}: could not read sdist PKG-INFO")
+            return _metadata_payload(extracted.read(), source=path)
+
+    raise ValueError(f"{path}: expected a Markdown file, wheel, or .tar.gz sdist")
+
+
+def check_paths(paths: list[Path]) -> list[str]:
+    """Return validation errors for all supplied artifacts."""
+    errors: list[str] = []
+    for path in paths:
+        try:
+            description = read_long_description(path)
+        except (OSError, UnicodeDecodeError, ValueError, tarfile.TarError, zipfile.BadZipFile) as exc:
+            errors.append(str(exc))
+            continue
+
+        errors.extend(
+            f"{path}:{issue.line}: unsupported relative PyPI README link: {issue.target}"
+            for issue in find_unsupported_relative_links(description)
+        )
+    return errors
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate PyPI README links in built distributions.")
+    parser.add_argument("paths", nargs="+", type=Path, help="Markdown, wheel, or sdist paths to validate")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    errors = check_paths(args.paths)
+    if errors:
+        sys.stdout.write("PyPI README link check FAILED\n\n")
+        sys.stdout.write("\n".join(f"  {error}" for error in errors) + "\n")
+        raise SystemExit(1)
+
+    sys.stdout.write(f"PyPI README link check OK: {len(args.paths)} artifact(s) validated\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cja_auto_sdr/core/version.py
+++ b/src/cja_auto_sdr/core/version.py
@@ -1,3 +1,3 @@
 """Version information for CJA Auto SDR."""
 
-__version__ = "3.11.7"
+__version__ = "3.11.8"

--- a/tests/README.md
+++ b/tests/README.md
@@ -120,6 +120,7 @@ tests/
 ├── test_cli_execution.py          # CLI execution edge cases and coverage
 ├── test_diff_git_coverage.py      # Diff/git subprocess error path coverage
 ├── test_generator_trending_coverage.py # Generator trending integration coverage
+├── test_check_pypi_readme_links.py  # PyPI README link validation tests
 ├── test_check_version_sync.py       # Version string sync validation across files
 ├── test_cli_color_policy_e2e.py     # End-to-end CLI color policy behavior tests
 ├── test_completion.py               # Shell completion flag (--completion bash/zsh/fish)
@@ -175,7 +176,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 8,378 comprehensive tests**
+**Total: 8,388 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -184,16 +185,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 8,272 | 157 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 8,282 | 158 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 0 | 0 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **8,378** | **163** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **8,388** | **164** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 8,272 | 157 | `-m "unit and not slow"` |
+| `test-unit` | 8,282 | 158 | `-m "unit and not slow"` |
 | `test-integration` | 96 | 5 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -313,6 +314,7 @@ tests/
 | `test_cli_execution.py` | 27 | CLI execution edge cases and coverage |
 | `test_diff_git_coverage.py` | 27 | Diff/git subprocess error path coverage |
 | `test_generator_trending_coverage.py` | 19 | Generator trending integration coverage |
+| `test_check_pypi_readme_links.py` | 10 | PyPI README link validation |
 | `test_check_version_sync.py` | 18 | Version string sync validation across files |
 | `test_cli_color_policy_e2e.py` | 7 | End-to-end CLI color policy behavior tests |
 | `test_discovery_exceptions.py` | 6 | Discovery exception classification contracts |
@@ -366,7 +368,7 @@ tests/
 | `test_diff_snapshot_retention.py` | 1 | Diff snapshot-retention parse-cache characterization test |
 | `test_diff_comparator_normalize.py` | 1 | Diff field-normalization type-fast-path characterization test |
 | `test_logging_diagnostics.py` | 2 | emit_diagnostic isEnabledFor guard characterization tests |
-| **Total** | **8,378** | **Collected via pytest --collect-only** |
+| **Total** | **8,388** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -824,7 +826,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (8,378 tests total)
+- [x] Comprehensive test coverage (8,388 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 80 tests

--- a/tests/test_check_pypi_readme_links.py
+++ b/tests/test_check_pypi_readme_links.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import io
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+from scripts import check_pypi_readme_links
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _metadata(description: str) -> bytes:
+    return (
+        "Metadata-Version: 2.4\n"
+        "Name: example\n"
+        "Version: 1.0.0\n"
+        "Description-Content-Type: text/markdown\n"
+        "\n"
+        f"{description}"
+    ).encode()
+
+
+def test_readme_has_no_pypi_unsafe_relative_links() -> None:
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+
+    issues = check_pypi_readme_links.find_unsupported_relative_links(readme)
+
+    assert issues == []
+
+
+def test_find_unsupported_relative_links_allows_urls_and_fragments() -> None:
+    markdown = "[Docs](https://example.com/docs) [Email](mailto:help@example.com) [Local](#install)"
+
+    issues = check_pypi_readme_links.find_unsupported_relative_links(markdown)
+
+    assert issues == []
+
+
+def test_find_unsupported_relative_links_reports_nested_image_and_outer_targets() -> None:
+    markdown = "[![Build](https://img.example/badge.svg)](tests/)\n[Guide](docs/GUIDE.md)"
+
+    issues = check_pypi_readme_links.find_unsupported_relative_links(markdown)
+
+    assert issues == [
+        check_pypi_readme_links.LinkIssue(line=1, target="tests/"),
+        check_pypi_readme_links.LinkIssue(line=2, target="docs/GUIDE.md"),
+    ]
+
+
+def test_find_unsupported_relative_links_reports_reference_and_html_targets() -> None:
+    markdown = (
+        "[Guide][guide]\n"
+        "[guide]: <docs/GUIDE WITH SPACES.md>\n"
+        '<a href="docs/API.md">API</a>\n'
+        '<img src="images/example.png" />\n'
+    )
+
+    issues = check_pypi_readme_links.find_unsupported_relative_links(markdown)
+
+    assert issues == [
+        check_pypi_readme_links.LinkIssue(line=2, target="docs/GUIDE WITH SPACES.md"),
+        check_pypi_readme_links.LinkIssue(line=3, target="docs/API.md"),
+        check_pypi_readme_links.LinkIssue(line=4, target="images/example.png"),
+    ]
+
+
+def test_find_unsupported_relative_links_ignores_code_contexts() -> None:
+    markdown = "`[Inline](docs/INLINE.md)`\n```markdown\n[Block](docs/BLOCK.md)\n```\n"
+
+    issues = check_pypi_readme_links.find_unsupported_relative_links(markdown)
+
+    assert issues == []
+
+
+def test_read_long_description_reads_wheel_metadata(tmp_path: Path) -> None:
+    wheel = tmp_path / "example-1.0.0-py3-none-any.whl"
+    with zipfile.ZipFile(wheel, mode="w") as archive:
+        archive.writestr("example-1.0.0.dist-info/METADATA", _metadata("[Docs](https://example.com)\n"))
+
+    description = check_pypi_readme_links.read_long_description(wheel)
+
+    assert description == "[Docs](https://example.com)\n"
+
+
+def test_read_long_description_reads_sdist_metadata(tmp_path: Path) -> None:
+    sdist = tmp_path / "example-1.0.0.tar.gz"
+    metadata = _metadata("[Docs](https://example.com)\n")
+    info = tarfile.TarInfo("example-1.0.0/PKG-INFO")
+    info.size = len(metadata)
+    with tarfile.open(sdist, mode="w:gz") as archive:
+        archive.addfile(info, io.BytesIO(metadata))
+
+    description = check_pypi_readme_links.read_long_description(sdist)
+
+    assert description == "[Docs](https://example.com)\n"
+
+
+def test_check_paths_reports_artifact_and_line(tmp_path: Path) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text("# Example\n\n[Guide](docs/GUIDE.md)\n", encoding="utf-8")
+
+    errors = check_pypi_readme_links.check_paths([readme])
+
+    assert errors == [f"{readme}:3: unsupported relative PyPI README link: docs/GUIDE.md"]
+
+
+def test_check_paths_rejects_non_inline_links_in_built_metadata(tmp_path: Path) -> None:
+    wheel = tmp_path / "example-1.0.0-py3-none-any.whl"
+    with zipfile.ZipFile(wheel, mode="w") as archive:
+        archive.writestr(
+            "example-1.0.0.dist-info/METADATA",
+            _metadata("[Guide][guide]\n\n[guide]: docs/GUIDE.md\n"),
+        )
+
+    sdist = tmp_path / "example-1.0.0.tar.gz"
+    metadata = _metadata('<a href="docs/API.md">API</a>\n')
+    info = tarfile.TarInfo("example-1.0.0/PKG-INFO")
+    info.size = len(metadata)
+    with tarfile.open(sdist, mode="w:gz") as archive:
+        archive.addfile(info, io.BytesIO(metadata))
+
+    errors = check_pypi_readme_links.check_paths([wheel, sdist])
+
+    assert errors == [
+        f"{wheel}:3: unsupported relative PyPI README link: docs/GUIDE.md",
+        f"{sdist}:1: unsupported relative PyPI README link: docs/API.md",
+    ]
+
+
+def test_main_exits_nonzero_for_unsupported_link(tmp_path: Path, monkeypatch, capsys) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text("[Guide](docs/GUIDE.md)\n", encoding="utf-8")
+    monkeypatch.setattr(check_pypi_readme_links.sys, "argv", ["check_pypi_readme_links.py", str(readme)])
+
+    with pytest.raises(SystemExit) as excinfo:
+        check_pypi_readme_links.main()
+
+    assert excinfo.value.code == 1
+    assert "PyPI README link check FAILED" in capsys.readouterr().out

--- a/tests/test_output_content_validation.py
+++ b/tests/test_output_content_validation.py
@@ -38,7 +38,7 @@ def rich_data_dict():
         "Metadata": pd.DataFrame(
             {
                 "Property": ["Generated At", "Data View ID", "Tool Version", "Total Metrics"],
-                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.11.7", 3],
+                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.11.8", 3],
             },
         ),
         "Data Quality": pd.DataFrame(
@@ -104,7 +104,7 @@ def rich_metadata_dict():
         "Generated At": "2025-01-15 10:30:00 PST",
         "Data View ID": "dv_content_test",
         "Data View Name": "Test DataView",
-        "Tool Version": "3.11.7",
+        "Tool Version": "3.11.8",
         "Metrics Count": "3",
         "Dimensions Count": "4",
     }
@@ -224,7 +224,7 @@ class TestJSONContentValidation:
             data = json.load(f)
 
         assert data["metadata"]["Data View ID"] == "dv_content_test"
-        assert data["metadata"]["Tool Version"] == "3.11.7"
+        assert data["metadata"]["Tool Version"] == "3.11.8"
 
     def test_json_metadata_preserves_partial_markers(self, tmp_path, rich_data_dict, rich_metadata_dict):
         logger = logging.getLogger("json_test")

--- a/tests/test_ux_features.py
+++ b/tests/test_ux_features.py
@@ -344,11 +344,11 @@ class TestCombinedFeatures:
 class TestVersionUpdated:
     """Test that version is correct"""
 
-    def test_version_is_3_11_6(self):
-        """Test that version is 3.11.7"""
+    def test_version_is_3_11_8(self):
+        """Test that version is 3.11.8"""
         from cja_auto_sdr.generator import __version__
 
-        assert __version__ == "3.11.7"
+        assert __version__ == "3.11.8"
 
 
 class TestFormatAutoDetection:


### PR DESCRIPTION
## Summary

PyPI users currently land on broken documentation, test, license, and changelog links because repository-relative README destinations resolve under `pypi.org`. This patch points those destinations at canonical GitHub locations and adds a publishing gate that validates the long description embedded in both the wheel and source distribution.

The release is prepared as `3.11.8`. The source distribution now includes only the intended top-level project metadata instead of collecting nested README files whose linked content is excluded.

## Validation

- Full suite: 8,372 passed and 16 skipped (8,388 collected)
- Ruff lint and formatting: passed
- Version sync, test-count sync, and lockfile checks: passed
- Wheel and sdist: passed `twine check` and the PyPI README link validator
- Built metadata: version `3.11.8`, no unsupported relative destinations

## Post-Deploy Monitoring & Validation

- Owner: release maintainer
- Window: during the release workflow and the first 15 minutes after publication
- Logs: confirm the GitHub Actions release run contains `PyPI README link check OK` and completes the PyPI publish step
- Healthy signals: the release workflow is green, PyPI lists both `3.11.8` artifacts, and representative documentation/license links open their GitHub targets
- Failure trigger: stop release follow-up if the workflow fails or any PyPI README link is broken; correct the issue in a new patch version because PyPI artifacts are immutable
