### PR TITLE
docs(readme): link SDR companion projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@
 
 A production-ready Python CLI that automates the creation of Solution Design Reference (SDR) documentation from your Adobe Customer Journey Analytics (CJA) implementation. Read-only against CJA.
 
-Counterpart to [`aa_auto_sdr`](https://github.com/brian-a-au/aa_auto_sdr); shares UX conventions, does not share code.
+[`cja_auto_sdr`](https://github.com/brian-a-au/cja_auto_sdr) and [`aa_auto_sdr`](https://github.com/brian-a-au/aa_auto_sdr) are counterpart SDR generators for Customer Journey Analytics and Adobe Analytics, respectively. They share UX conventions, not code.
+
+Companion projects: [`sdr-visualizer`](https://github.com/brian-a-au/sdr-visualizer) turns generated JSON snapshots into self-contained visual catalogs, while [`sdr-grader`](https://github.com/brian-a-au/sdr-grader) provides deterministic, rule-based quality grading.
 
 ## What It Is
 
@@ -534,4 +536,4 @@ cja_auto_sdr/
 - [CJA API Documentation](https://developer.adobe.com/cja-apis/docs/)
 - [cjapy Library](https://github.com/pitchmuc/cjapy)
 - [uv Package Manager](https://github.com/astral-sh/uv)
-- [Changelog](https://github.com/brian-a-au/cja_auto_sdr/blob/main/CHANGELOG.md)
+- [Counterpart project: `aa_auto_sdr`](https://github.com/brian-a-au/aa_auto_sdr) — Adobe Analytics equivalent

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 A production-ready Python CLI that automates the creation of Solution Design Reference (SDR) documentation from your Adobe Customer Journey Analytics (CJA) implementation. Read-only against CJA.
 
-[`cja_auto_sdr`](https://github.com/brian-a-au/cja_auto_sdr) and [`aa_auto_sdr`](https://github.com/brian-a-au/aa_auto_sdr) are counterpart SDR generators for Customer Journey Analytics and Adobe Analytics, respectively. They share UX conventions, not code.
+Counterpart to [`aa_auto_sdr`](https://github.com/brian-a-au/aa_auto_sdr); shares UX conventions, does not share code.
 
 Companion projects: [`sdr-visualizer`](https://github.com/brian-a-au/sdr-visualizer) turns generated JSON snapshots into self-contained visual catalogs, while [`sdr-grader`](https://github.com/brian-a-au/sdr-grader) provides deterministic, rule-based quality grading.
 


### PR DESCRIPTION
Readers can now navigate directly among the CJA and Adobe Analytics SDR generators and their visualization and grading companions. The Additional Resources list now mirrors the AA repository's reciprocal counterpart link.
