### PR TITLE
feat(discovery): expose dataset connection metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Dataset discovery metadata:** `--list-datasets --format json` now retains allowlisted, normalized CJA Connection dataset metadata under the additive `connectionMetadata` object. It covers the CJA dataset role, schema, identity, lookup relationships, streaming/backfill/last-ingested state, and data-source type while preserving explicit `null`, `false`, and empty values. Metadata remains scoped to each dataset-to-Connection relationship; CSV/table columns and the permission-degraded ID-only fallback are unchanged.
+- **Dataset discovery metadata:** `--list-datasets --format json` now retains allowlisted, normalized CJA Connection dataset metadata under the additive `connectionMetadata` object. It covers the CJA dataset role, schema, identity, lookup relationships, streaming/backfill/last-ingested state, and data-source type while preserving explicit `null`, `false`, and empty values. Metadata remains scoped to each dataset-to-Connection relationship; CSV/table columns and the permission-degraded ID-only fallback are unchanged. GET-all uses Adobe's supported ingestion/backfill expansions, while schema metadata is retrieved best-effort from the Connection-by-ID endpoint only for Connections referenced by discovered Data Views.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to the CJA SDR Generator project will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.12.0] - 2026-08-30
+
+### Added
+
+- **Dataset discovery metadata:** `--list-datasets --format json` now retains allowlisted, normalized CJA Connection dataset metadata under the additive `connectionMetadata` object. It covers the CJA dataset role, schema, identity, lookup relationships, streaming/backfill/last-ingested state, and data-source type while preserving explicit `null`, `false`, and empty values. Metadata remains scoped to each dataset-to-Connection relationship; CSV/table columns and the permission-degraded ID-only fallback are unchanged.
+
+### Documentation
+
+- Documented the complete dataset discovery JSON field mapping and clarified that CJA role, XDM schema behavior, AEP Profile enablement, and reporting readiness are separate concepts.
+
 ## [3.11.8] - 2026-08-03
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Package manager: **uv**
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
-- Current version: v3.11.8
+- Current version: v3.12.0
 - Tests: **8,388** across 164 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
 - Current version: v3.12.0
-- Tests: **8,388** across 164 files at **95% coverage gate**
+- Tests: **8,407** across 165 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
 - Current version: v3.12.0
-- Tests: **8,407** across 165 files at **95% coverage gate**
+- Tests: **8,416** across 165 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 [![Version Sync](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/version-sync.yml/badge.svg)](https://github.com/brian-a-au/cja_auto_sdr/actions/workflows/version-sync.yml)
 [![Python 3.14+](https://img.shields.io/badge/python-3.14%2B-blue.svg)](https://www.python.org/downloads/)
 [![Coverage](https://img.shields.io/badge/coverage-99%25-brightgreen.svg)](https://github.com/brian-a-au/cja_auto_sdr/tree/main/tests)
-[![Tests](https://img.shields.io/badge/tests-8388-brightgreen.svg)](https://github.com/brian-a-au/cja_auto_sdr/tree/main/tests)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/brian-a-au/cja_auto_sdr/blob/main/LICENSE)
@@ -505,7 +504,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (8,388+ tests)
+├── tests/                     # Test suite (8,407+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/README.md
+++ b/README.md
@@ -504,7 +504,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (8,407+ tests)
+├── tests/                     # Test suite (8,416+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -968,6 +968,8 @@ The normalized field mapping is:
 
 Only fields reported by Adobe are included. A missing field is omitted; an explicit JSON `null`, `false`, empty string, empty list, or empty object remains distinct. Values with an unexpected type are omitted rather than copied through. Consumers must ignore unknown future keys in discovery JSON. CSV and table output retain their existing columns and do not render `connectionMetadata`.
 
+The JSON discovery path retrieves Connection and ingestion metadata with the GET-all expansions `name,ownerFullName,dataSets,dataSetLastIngested,backfillsSummaryDataSets`. Adobe exposes `schemaInfo` only on GET-by-ID, so the tool makes one best-effort `dataSets,schemaInfo` detail request for each Connection referenced by the discovered Data Views. If an individual detail request fails or returns a partial response, the Connection and its GET-all metadata remain in the output while unavailable schema fields are omitted. This does not trigger the product-admin fallback.
+
 Dataset role is configuration on the dataset-to-Connection relationship. The same AEP dataset can therefore have different `connectionMetadata` in different Connections; consumers must not merge it globally by dataset ID. `role` is not inferred, and it does not describe XDM record/time-series behavior or AEP Real-Time Customer Profile enablement. Ingestion timestamps, streaming flags, and backfill summaries are status observations, not proof of end-to-end CJA reporting readiness.
 
 If Connection administration details are unavailable, the existing product-admin warning and ID-only fallback remain in effect; datasets and `connectionMetadata` are unavailable in that response.

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -886,6 +886,92 @@ cja_auto_sdr dv_12345 --dry-run
 >
 > **Discovery Filters:** `--list-dataviews`, `--list-connections`, and `--list-datasets` support `--filter`, `--exclude`, `--limit`, and `--sort` for filtering, limiting, and ordering results.
 
+#### Dataset discovery JSON metadata
+
+`--list-datasets --format json` adds connection-scoped metadata to a dataset when the CJA Connections API reports it. The existing `id` and `name` fields are unchanged. Optional metadata is grouped under `connectionMetadata`:
+
+```json
+{
+  "dataViews": [
+    {
+      "id": "dv_example",
+      "name": "Example Data View",
+      "connection": {
+        "id": "dg_example",
+        "name": "Example Connection"
+      },
+      "datasets": [
+        {
+          "id": "dataset_example",
+          "name": "Web Events",
+          "connectionMetadata": {
+            "role": "event",
+            "schema": {
+              "id": "schema_example",
+              "name": "Web Event Schema",
+              "ref": {
+                "id": "https://ns.adobe.com/example/schemas/example",
+                "contentType": "application/vnd.adobe.xed-full+json;version=1"
+              }
+            },
+            "identity": {
+              "timestampId": "timestamp",
+              "visitorId": "identityMap",
+              "namespace": "ECID",
+              "usePrimaryIdNamespace": false,
+              "identityMap": true,
+              "namespaceColumn": "identityMap"
+            },
+            "lookup": {
+              "keyField": "accountId",
+              "parentFields": ["accountId"],
+              "parentDatasetId": "parent_dataset_example",
+              "parentDatasetType": "event"
+            },
+            "ingestion": {
+              "streaming": true,
+              "backfillSummary": {
+                "total": 2,
+                "failed": 0,
+                "inProgress": 0,
+                "completed": 2,
+                "invalid": false
+              },
+              "lastIngestedTime": "2026-08-29T12:34:56Z",
+              "streamingEnabledAt": "2026-01-02T03:04:05Z"
+            },
+            "dataSource": {
+              "id": "webData",
+              "type": "Web Data",
+              "description": "Browser event data"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "count": 1
+}
+```
+
+The normalized field mapping is:
+
+| JSON field | CJA Connections field |
+|---|---|
+| `connectionMetadata.role` | `type` |
+| `connectionMetadata.schema.id`, `.name`, `.ref` | `schemaInfo.schemaId`, `.schemaName`, `.schemaRef` |
+| `connectionMetadata.identity.timestampId`, `.visitorId` | `timestampId`, `visitorId` |
+| `connectionMetadata.identity.namespace`, `.usePrimaryIdNamespace`, `.identityMap`, `.namespaceColumn` | `identityNamespace`, `usePrimaryIdNamespace`, `identityMap`, `identityNamespaceCol` |
+| `connectionMetadata.lookup.keyField`, `.parentFields`, `.parentDatasetId`, `.parentDatasetType` | `lookupKeyField`, `lookupParentFields`, `lookupParentDataSetId`, `lookupParentDataSetType` |
+| `connectionMetadata.ingestion.streaming`, `.backfillSummary`, `.lastIngestedTime`, `.streamingEnabledAt` | `streaming`, `backfillSummary`, `lastIngestedTime`, `streamingEnabledAt` |
+| `connectionMetadata.dataSource` | `dataSourceType` (`id`, `type`, and `description`) |
+
+Only fields reported by Adobe are included. A missing field is omitted; an explicit JSON `null`, `false`, empty string, empty list, or empty object remains distinct. Values with an unexpected type are omitted rather than copied through. Consumers must ignore unknown future keys in discovery JSON. CSV and table output retain their existing columns and do not render `connectionMetadata`.
+
+Dataset role is configuration on the dataset-to-Connection relationship. The same AEP dataset can therefore have different `connectionMetadata` in different Connections; consumers must not merge it globally by dataset ID. `role` is not inferred, and it does not describe XDM record/time-series behavior or AEP Real-Time Customer Profile enablement. Ingestion timestamps, streaming flags, and backfill summaries are status observations, not proof of end-to-end CJA reporting readiness.
+
+If Connection administration details are unavailable, the existing product-admin warning and ID-only fallback remain in effect; datasets and `connectionMetadata` are unavailable in that response.
+
 ### Discovery Inspection Commands
 
 ```bash

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -943,7 +943,7 @@ cja_auto_sdr --list-dataviews --log-level DEBUG
 At launch, the tool logs diagnostic lines containing the tool version, Python version, platform, active log level, inferred run mode (batch, single, or discovery), and dependency versions. These appear automatically at `INFO` level and are useful for troubleshooting environment issues in CI/CD logs or support requests:
 
 ```text
-CJA SDR Generator v3.11.8 | Python 3.14.2 | darwin | log_level=INFO | mode=single
+CJA SDR Generator v3.12.0 | Python 3.14.2 | darwin | log_level=INFO | mode=single
 Dependencies: cjapy=0.3.0, pandas=2.3.3, numpy=2.2.1, xlsxwriter=3.2.9, tqdm=4.67.0
 ```
 

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -190,7 +190,7 @@ This command:
 
 ```bash
 $ uv run cja_auto_sdr -V
-cja_auto_sdr 3.11.8
+cja_auto_sdr 3.12.0
 ```
 
 > **Important:** All commands in this guide assume you're in the `cja_auto_sdr` directory. If you see "command not found", make sure you're in the right directory and have run `uv sync`.

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Quick Reference Card
 
-Single-page command cheat sheet for CJA SDR Generator v3.11.8.
+Single-page command cheat sheet for CJA SDR Generator v3.12.0.
 
 ## Four Main Modes
 

--- a/src/cja_auto_sdr/cli/commands/discovery.py
+++ b/src/cja_auto_sdr/cli/commands/discovery.py
@@ -60,6 +60,7 @@ from cja_auto_sdr.core.discovery_payloads import (
 from cja_auto_sdr.core.discovery_payloads import (
     count_component_items_or_na as _count_component_items_or_na_from_assessment,
 )
+from cja_auto_sdr.core.error_policies import RECOVERABLE_OPTIONAL_ENRICHMENT_EXCEPTIONS
 
 # ---------------------------------------------------------------------------
 # Exception classes
@@ -837,8 +838,9 @@ def _build_calculated_metric_display_row(item: dict[str, Any]) -> dict[str, Any]
 _DATASET_METADATA_MISSING = object()
 _DATASET_DISCOVERY_BASE_EXPANSION = "name,ownerFullName,dataSets"
 _DATASET_DISCOVERY_CONNECTION_EXPANSION = (
-    f"{_DATASET_DISCOVERY_BASE_EXPANSION},schemaInfo,dataSetLastIngested,backfillsSummaryDataSets"
+    f"{_DATASET_DISCOVERY_BASE_EXPANSION},dataSetLastIngested,backfillsSummaryDataSets"
 )
+_DATASET_DISCOVERY_SCHEMA_EXPANSION = "dataSets,schemaInfo"
 
 
 def _normalize_dataset_metadata_text(value: Any) -> str | object | None:
@@ -1082,6 +1084,63 @@ def _extract_dataset_info(dataset: Any, *, include_connection_metadata: bool = F
         if connection_metadata:
             result["connectionMetadata"] = connection_metadata
     return result
+
+
+def _dataset_needs_schema_hydration(dataset: Any) -> bool:
+    """Return whether a dataset can gain valid schemaInfo from a detail response."""
+    if not isinstance(dataset, dict) or _extract_dataset_info(dataset)["id"] == "N/A":
+        return False
+    if "schemaInfo" not in dataset:
+        return True
+    return _normalize_schema_info(dataset["schemaInfo"]) is _DATASET_METADATA_MISSING
+
+
+def _merge_dataset_schema_info(
+    raw_datasets: list[Any],
+    connection_detail: Any,
+    *,
+    expected_connection_id: str,
+) -> list[Any]:
+    """Merge schemaInfo from a by-ID Connection response without replacing base fields."""
+    if not isinstance(connection_detail, dict):
+        return raw_datasets
+    reported_connection_id = connection_detail.get("id", connection_detail.get("idWithoutPrefix"))
+    if (
+        isinstance(reported_connection_id, str)
+        and reported_connection_id.removeprefix("dg_") != expected_connection_id.removeprefix("dg_")
+    ):
+        return raw_datasets
+    detail_datasets = connection_detail.get("dataSets", connection_detail.get("datasets", []))
+    if not isinstance(detail_datasets, list):
+        return raw_datasets
+
+    schema_by_dataset_id: dict[str, Any] = {}
+    for detail_dataset in detail_datasets:
+        if not isinstance(detail_dataset, dict) or "schemaInfo" not in detail_dataset:
+            continue
+        schema_info = detail_dataset["schemaInfo"]
+        if _normalize_schema_info(schema_info) is _DATASET_METADATA_MISSING:
+            continue
+        dataset_id = _extract_dataset_info(detail_dataset)["id"]
+        if dataset_id != "N/A" and dataset_id not in schema_by_dataset_id:
+            schema_by_dataset_id[dataset_id] = schema_info
+
+    if not schema_by_dataset_id:
+        return raw_datasets
+
+    merged_datasets: list[Any] = []
+    changed = False
+    for raw_dataset in raw_datasets:
+        if not _dataset_needs_schema_hydration(raw_dataset):
+            merged_datasets.append(raw_dataset)
+            continue
+        dataset_id = _extract_dataset_info(raw_dataset)["id"]
+        if dataset_id not in schema_by_dataset_id:
+            merged_datasets.append(raw_dataset)
+            continue
+        merged_datasets.append({**raw_dataset, "schemaInfo": schema_by_dataset_id[dataset_id]})
+        changed = True
+    return merged_datasets if changed else raw_datasets
 
 
 def _extract_connections_list(raw_connections: Any) -> list:
@@ -1663,6 +1722,7 @@ def _fetch_datasets(
         )
         raw_connections = cja.getConnections(output="raw", expansion=connection_expansion)
         conn_map: dict = {}  # connection_id -> {name, datasets}
+        raw_datasets_by_connection: dict[str, list[Any]] = {}
         for conn in _extract_connections_list(raw_connections):
             if not isinstance(conn, dict):
                 continue
@@ -1681,6 +1741,7 @@ def _fetch_datasets(
             }
             if include_connection_metadata:
                 conn_info["json_datasets"] = datasets
+                raw_datasets_by_connection[conn_id] = raw_datasets
             conn_map[conn_id] = conn_info
 
         # Step 2: Fetch all data views
@@ -1753,6 +1814,45 @@ def _fetch_datasets(
             searchable_fields=["id", "name", "connection", "datasets"],
             default_sort_field="name",
         )
+
+        # schemaInfo is supported by Adobe only on GET /connections/{id}, not
+        # GET /connections. Hydrate only Connections retained in the final JSON
+        # rows, treating this optional detail as best effort.
+        if include_connection_metadata and conn_map:
+            connection_ids_to_hydrate: list[str] = []
+            for entry in display_data:
+                connection = entry.get("connection")
+                if not isinstance(connection, dict):
+                    continue
+                connection_id = connection.get("id")
+                raw_datasets = raw_datasets_by_connection.get(connection_id, [])
+                if (
+                    isinstance(connection_id, str)
+                    and connection_id in conn_map
+                    and any(_dataset_needs_schema_hydration(dataset) for dataset in raw_datasets)
+                ):
+                    connection_ids_to_hydrate.append(connection_id)
+
+            for connection_id in dict.fromkeys(connection_ids_to_hydrate):
+                try:
+                    connection_detail = cja.getConnection(
+                        connectionId=connection_id.removeprefix("dg_"),
+                        expansion=_DATASET_DISCOVERY_SCHEMA_EXPANSION,
+                    )
+                except RECOVERABLE_OPTIONAL_ENRICHMENT_EXCEPTIONS:  # Intentional best-effort boundary
+                    continue
+                raw_datasets = raw_datasets_by_connection[connection_id]
+                merged_datasets = _merge_dataset_schema_info(
+                    raw_datasets,
+                    connection_detail,
+                    expected_connection_id=connection_id,
+                )
+                if merged_datasets is raw_datasets:
+                    continue
+                conn_map[connection_id]["json_datasets"] = [
+                    _extract_dataset_info(dataset, include_connection_metadata=True)
+                    for dataset in merged_datasets
+                ]
 
         if not is_machine_readable and sys.stdout.isatty():
             # Clear progress line with ANSI erase-line escape

--- a/src/cja_auto_sdr/cli/commands/discovery.py
+++ b/src/cja_auto_sdr/cli/commands/discovery.py
@@ -16,6 +16,7 @@ import sys
 import textwrap
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from numbers import Integral
 from typing import Any
 
 import pandas as pd
@@ -833,7 +834,201 @@ def _build_calculated_metric_display_row(item: dict[str, Any]) -> dict[str, Any]
 # ---------------------------------------------------------------------------
 
 
-def _extract_dataset_info(dataset: Any) -> dict:
+_DATASET_METADATA_MISSING = object()
+_DATASET_DISCOVERY_BASE_EXPANSION = "name,ownerFullName,dataSets"
+_DATASET_DISCOVERY_CONNECTION_EXPANSION = (
+    f"{_DATASET_DISCOVERY_BASE_EXPANSION},schemaInfo,dataSetLastIngested,backfillsSummaryDataSets"
+)
+
+
+def _normalize_dataset_metadata_text(value: Any) -> str | object | None:
+    """Normalize an optional API text field without collapsing null or empty."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    return _DATASET_METADATA_MISSING
+
+
+def _normalize_dataset_metadata_bool(value: Any) -> bool | object | None:
+    """Normalize an optional API boolean without coercing truthy values."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    return _DATASET_METADATA_MISSING
+
+
+def _normalize_dataset_metadata_int(value: Any) -> int | object | None:
+    """Normalize an optional API integer without accepting booleans or floats."""
+    if value is None:
+        return None
+    if isinstance(value, Integral) and not isinstance(value, bool):
+        return int(value)
+    return _DATASET_METADATA_MISSING
+
+
+def _normalize_lookup_parent_fields(value: Any) -> str | list[str | None] | object | None:
+    """Accept the documented string form and observed list-shaped parent fields."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        if all(item is None or isinstance(item, str) for item in value):
+            return list(value)
+        return _DATASET_METADATA_MISSING
+    return _DATASET_METADATA_MISSING
+
+
+def _normalized_dataset_metadata_field(
+    record: dict[str, Any],
+    source_key: str,
+    normalizer: Callable[[Any], Any],
+) -> Any:
+    """Return a normalized allowlisted field or the internal missing sentinel."""
+    if source_key not in record:
+        return _DATASET_METADATA_MISSING
+    return normalizer(record[source_key])
+
+
+def _normalize_allowlisted_object(
+    value: Any,
+    fields: tuple[tuple[str, str, Callable[[Any], Any]], ...],
+) -> dict[str, Any] | object | None:
+    """Normalize a nested Adobe object through an explicit field allowlist."""
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        return _DATASET_METADATA_MISSING
+
+    normalized: dict[str, Any] = {}
+    for source_key, output_key, normalizer in fields:
+        field_value = _normalized_dataset_metadata_field(value, source_key, normalizer)
+        if field_value is not _DATASET_METADATA_MISSING:
+            normalized[output_key] = field_value
+    if normalized or not value:
+        return normalized
+    return _DATASET_METADATA_MISSING
+
+
+_SCHEMA_REF_FIELDS = (
+    ("id", "id", _normalize_dataset_metadata_text),
+    ("contentType", "contentType", _normalize_dataset_metadata_text),
+)
+_SCHEMA_FIELDS = (
+    ("schemaId", "id", _normalize_dataset_metadata_text),
+    ("schemaName", "name", _normalize_dataset_metadata_text),
+    (
+        "schemaRef",
+        "ref",
+        lambda value: _normalize_allowlisted_object(value, _SCHEMA_REF_FIELDS),
+    ),
+)
+_BACKFILL_SUMMARY_FIELDS = (
+    ("total", "total", _normalize_dataset_metadata_int),
+    ("failed", "failed", _normalize_dataset_metadata_int),
+    ("inProgress", "inProgress", _normalize_dataset_metadata_int),
+    ("completed", "completed", _normalize_dataset_metadata_int),
+    ("invalid", "invalid", _normalize_dataset_metadata_bool),
+)
+_DATA_SOURCE_FIELDS = (
+    ("id", "id", _normalize_dataset_metadata_text),
+    ("type", "type", _normalize_dataset_metadata_text),
+    ("description", "description", _normalize_dataset_metadata_text),
+)
+
+
+def _normalize_schema_info(value: Any) -> dict[str, Any] | object | None:
+    """Normalize the allowlisted schemaInfo object."""
+    return _normalize_allowlisted_object(value, _SCHEMA_FIELDS)
+
+
+def _normalize_backfill_summary(value: Any) -> dict[str, Any] | object | None:
+    """Normalize the allowlisted backfillSummary object."""
+    return _normalize_allowlisted_object(value, _BACKFILL_SUMMARY_FIELDS)
+
+
+def _normalize_data_source_type(value: Any) -> dict[str, Any] | object | None:
+    """Normalize the allowlisted dataSourceType object."""
+    return _normalize_allowlisted_object(value, _DATA_SOURCE_FIELDS)
+
+
+_IDENTITY_FIELDS = (
+    ("timestampId", "timestampId", _normalize_dataset_metadata_text),
+    ("visitorId", "visitorId", _normalize_dataset_metadata_text),
+    ("identityNamespace", "namespace", _normalize_dataset_metadata_text),
+    ("usePrimaryIdNamespace", "usePrimaryIdNamespace", _normalize_dataset_metadata_bool),
+    ("identityMap", "identityMap", _normalize_dataset_metadata_bool),
+    ("identityNamespaceCol", "namespaceColumn", _normalize_dataset_metadata_text),
+)
+_LOOKUP_FIELDS = (
+    ("lookupKeyField", "keyField", _normalize_dataset_metadata_text),
+    ("lookupParentFields", "parentFields", _normalize_lookup_parent_fields),
+    ("lookupParentDataSetId", "parentDatasetId", _normalize_dataset_metadata_text),
+    ("lookupParentDataSetType", "parentDatasetType", _normalize_dataset_metadata_text),
+)
+_INGESTION_FIELDS = (
+    ("streaming", "streaming", _normalize_dataset_metadata_bool),
+    ("backfillSummary", "backfillSummary", _normalize_backfill_summary),
+    ("lastIngestedTime", "lastIngestedTime", _normalize_dataset_metadata_text),
+    ("streamingEnabledAt", "streamingEnabledAt", _normalize_dataset_metadata_text),
+)
+
+
+def _build_dataset_metadata_group(
+    dataset: dict[str, Any],
+    fields: tuple[tuple[str, str, Callable[[Any], Any]], ...],
+) -> dict[str, Any]:
+    """Build one metadata group, omitting absent and malformed source fields."""
+    group: dict[str, Any] = {}
+    for source_key, output_key, normalizer in fields:
+        field_value = _normalized_dataset_metadata_field(dataset, source_key, normalizer)
+        if field_value is not _DATASET_METADATA_MISSING:
+            group[output_key] = field_value
+    return group
+
+
+def _extract_dataset_connection_metadata(dataset: dict[str, Any]) -> dict[str, Any]:
+    """Extract allowlisted connection-scoped dataset metadata for JSON discovery."""
+    metadata: dict[str, Any] = {}
+
+    role = _normalized_dataset_metadata_field(dataset, "type", _normalize_dataset_metadata_text)
+    if role is not _DATASET_METADATA_MISSING:
+        metadata["role"] = role
+
+    schema = _normalized_dataset_metadata_field(
+        dataset,
+        "schemaInfo",
+        _normalize_schema_info,
+    )
+    if schema is not _DATASET_METADATA_MISSING:
+        metadata["schema"] = schema
+
+    identity = _build_dataset_metadata_group(dataset, _IDENTITY_FIELDS)
+    if identity:
+        metadata["identity"] = identity
+
+    lookup = _build_dataset_metadata_group(dataset, _LOOKUP_FIELDS)
+    if lookup:
+        metadata["lookup"] = lookup
+
+    ingestion = _build_dataset_metadata_group(dataset, _INGESTION_FIELDS)
+    if ingestion:
+        metadata["ingestion"] = ingestion
+
+    data_source = _normalized_dataset_metadata_field(
+        dataset,
+        "dataSourceType",
+        _normalize_data_source_type,
+    )
+    if data_source is not _DATASET_METADATA_MISSING:
+        metadata["dataSource"] = data_source
+
+    return metadata
+
+
+def _extract_dataset_info(dataset: Any, *, include_connection_metadata: bool = False) -> dict:
     """
     Resilient parser for dataset objects from connection API responses.
 
@@ -844,7 +1039,8 @@ def _extract_dataset_info(dataset: Any) -> dict:
         dataset: A dataset object (dict or other) from the dataSets array
 
     Returns:
-        Dict with 'id' and 'name' keys (values may be 'N/A' if not found)
+        Dict with 'id' and 'name' keys (values may be 'N/A' if not found),
+        plus optional normalized connection metadata when requested.
     """
     if not isinstance(dataset, dict):
         # Preserve previous fallback semantics for scalar falsey values while
@@ -880,7 +1076,12 @@ def _extract_dataset_info(dataset: Any) -> dict:
         treat_null_like_strings=True,
     )
 
-    return {"id": ds_id, "name": ds_name}
+    result: dict[str, Any] = {"id": ds_id, "name": ds_name}
+    if include_connection_metadata:
+        connection_metadata = _extract_dataset_connection_metadata(dataset)
+        if connection_metadata:
+            result["connectionMetadata"] = connection_metadata
+    return result
 
 
 def _extract_connections_list(raw_connections: Any) -> list:
@@ -1454,7 +1655,13 @@ def _fetch_datasets(
         from cja_auto_sdr.generator import _format_as_csv
 
         # Step 1: Fetch all connections and build lookup map
-        raw_connections = cja.getConnections(output="raw", expansion="name,ownerFullName,dataSets")
+        include_connection_metadata = output_format == "json"
+        connection_expansion = (
+            _DATASET_DISCOVERY_CONNECTION_EXPANSION
+            if include_connection_metadata
+            else _DATASET_DISCOVERY_BASE_EXPANSION
+        )
+        raw_connections = cja.getConnections(output="raw", expansion=connection_expansion)
         conn_map: dict = {}  # connection_id -> {name, datasets}
         for conn in _extract_connections_list(raw_connections):
             if not isinstance(conn, dict):
@@ -1464,10 +1671,17 @@ def _fetch_datasets(
             raw_datasets = conn.get("dataSets", conn.get("datasets", []))
             if not isinstance(raw_datasets, list):
                 raw_datasets = []
-            conn_map[conn_id] = {
+            datasets = [
+                _extract_dataset_info(ds, include_connection_metadata=include_connection_metadata)
+                for ds in raw_datasets
+            ]
+            conn_info = {
                 "name": conn_name,
-                "datasets": [_extract_dataset_info(ds) for ds in raw_datasets],
+                "datasets": [{"id": ds["id"], "name": ds["name"]} for ds in datasets],
             }
+            if include_connection_metadata:
+                conn_info["json_datasets"] = datasets
+            conn_map[conn_id] = conn_info
 
         # Step 2: Fetch all data views
         available_dvs = cja.getDataViews()
@@ -1549,7 +1763,20 @@ def _fetch_datasets(
             "requires product-admin privileges). Showing connection IDs only."
         )
 
-        result_payload: dict = {"dataViews": display_data, "count": len(display_data)}
+        result_data = display_data
+        if output_format == "json":
+            result_data = [
+                {
+                    **entry,
+                    "datasets": conn_map.get(entry["connection"]["id"], {}).get(
+                        "json_datasets",
+                        entry["datasets"],
+                    ),
+                }
+                for entry in display_data
+            ]
+
+        result_payload: dict = {"dataViews": result_data, "count": len(result_data)}
         if _no_conn_details:
             result_payload["warning"] = _CONN_PERM_WARNING.replace("\n", " ")
 

--- a/src/cja_auto_sdr/cli/commands/discovery.py
+++ b/src/cja_auto_sdr/cli/commands/discovery.py
@@ -1105,10 +1105,9 @@ def _merge_dataset_schema_info(
     if not isinstance(connection_detail, dict):
         return raw_datasets
     reported_connection_id = connection_detail.get("id", connection_detail.get("idWithoutPrefix"))
-    if (
-        isinstance(reported_connection_id, str)
-        and reported_connection_id.removeprefix("dg_") != expected_connection_id.removeprefix("dg_")
-    ):
+    if isinstance(reported_connection_id, str) and reported_connection_id.removeprefix(
+        "dg_"
+    ) != expected_connection_id.removeprefix("dg_"):
         return raw_datasets
     detail_datasets = connection_detail.get("dataSets", connection_detail.get("datasets", []))
     if not isinstance(detail_datasets, list):
@@ -1850,8 +1849,7 @@ def _fetch_datasets(
                 if merged_datasets is raw_datasets:
                     continue
                 conn_map[connection_id]["json_datasets"] = [
-                    _extract_dataset_info(dataset, include_connection_metadata=True)
-                    for dataset in merged_datasets
+                    _extract_dataset_info(dataset, include_connection_metadata=True) for dataset in merged_datasets
                 ]
 
         if not is_machine_readable and sys.stdout.isatty():

--- a/src/cja_auto_sdr/core/version.py
+++ b/src/cja_auto_sdr/core/version.py
@@ -1,3 +1,3 @@
 """Version information for CJA Auto SDR."""
 
-__version__ = "3.11.8"
+__version__ = "3.12.0"

--- a/tests/README.md
+++ b/tests/README.md
@@ -28,6 +28,7 @@ tests/
 ├── test_discovery_payloads.py       # Discovery payload classification tests
 ├── test_discovery_component_consistency.py  # Discovery component consistency tests
 ├── test_discovery_extraction.py     # Discovery module extraction and backwards-compat tests
+├── test_discovery_dataset_metadata.py # Connection-scoped dataset discovery metadata contracts
 ├── test_dry_run.py                  # Dry-run mode tests
 ├── test_diagnostic_events.py        # Structured diagnostic event vocabulary and redaction tests
 ├── test_early_exit.py               # Early exit optimization tests
@@ -176,7 +177,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 8,388 comprehensive tests**
+**Total: 8,407 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -185,16 +186,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 8,282 | 158 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 8,301 | 159 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 0 | 0 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **8,388** | **164** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **8,407** | **165** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 8,282 | 158 | `-m "unit and not slow"` |
+| `test-unit` | 8,301 | 159 | `-m "unit and not slow"` |
 | `test-integration` | 96 | 5 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -248,6 +249,7 @@ tests/
 | `test_discovery_payloads.py` | 63 | Discovery payload classification (error detection, component extraction) |
 | `test_discovery_component_consistency.py` | 7 | Discovery component retrieval consistency |
 | `test_discovery_extraction.py` | 46 | Discovery module extraction and backwards-compat contracts |
+| `test_discovery_dataset_metadata.py` | 19 | Connection-scoped dataset discovery metadata contracts |
 | `test_diagnostic_events.py` | 23 | Structured diagnostic event vocabulary, logger adapters, and redaction |
 | `test_output_content_validation.py` | 29 | Output format content validation (CSV, JSON, HTML, Excel, Markdown roundtrip) |
 | `test_output_extraction_contracts.py` | 347 | Extraction contracts for output.diff and output.inventory |
@@ -368,7 +370,7 @@ tests/
 | `test_diff_snapshot_retention.py` | 1 | Diff snapshot-retention parse-cache characterization test |
 | `test_diff_comparator_normalize.py` | 1 | Diff field-normalization type-fast-path characterization test |
 | `test_logging_diagnostics.py` | 2 | emit_diagnostic isEnabledFor guard characterization tests |
-| **Total** | **8,388** | **Collected via pytest --collect-only** |
+| **Total** | **8,407** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -826,7 +828,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (8,388 tests total)
+- [x] Comprehensive test coverage (8,407 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 80 tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -177,7 +177,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 8,407 comprehensive tests**
+**Total: 8,416 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -186,16 +186,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 8,301 | 159 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 8,310 | 159 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 0 | 0 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **8,407** | **165** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **8,416** | **165** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 8,301 | 159 | `-m "unit and not slow"` |
+| `test-unit` | 8,310 | 159 | `-m "unit and not slow"` |
 | `test-integration` | 96 | 5 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -249,7 +249,7 @@ tests/
 | `test_discovery_payloads.py` | 63 | Discovery payload classification (error detection, component extraction) |
 | `test_discovery_component_consistency.py` | 7 | Discovery component retrieval consistency |
 | `test_discovery_extraction.py` | 46 | Discovery module extraction and backwards-compat contracts |
-| `test_discovery_dataset_metadata.py` | 19 | Connection-scoped dataset discovery metadata contracts |
+| `test_discovery_dataset_metadata.py` | 27 | Connection-scoped dataset discovery metadata contracts |
 | `test_diagnostic_events.py` | 23 | Structured diagnostic event vocabulary, logger adapters, and redaction |
 | `test_output_content_validation.py` | 29 | Output format content validation (CSV, JSON, HTML, Excel, Markdown roundtrip) |
 | `test_output_extraction_contracts.py` | 347 | Extraction contracts for output.diff and output.inventory |
@@ -340,7 +340,7 @@ tests/
 | `test_agent_output_contract.py` | 43 | Centralized agent-output contract resolver tests |
 | `test_agent_playbooks.py` | 38 | Agent playbook structural validation tests |
 | `test_agent_workflows.py` | 69 | Agent workflow shell script validation tests |
-| `test_manifest_agent_contract.py` | 16 | Manifest vs runtime capability drift tests |
+| `test_manifest_agent_contract.py` | 17 | Manifest vs runtime capability drift tests |
 | `test_tool_manifests.py` | 40 | Tool manifest schema and content tests |
 | `test_watch_duration_parser.py` | 24 | parse_duration_seconds Nh|Nd|Nw grammar tests |
 | `test_redact_text.py` | 4 | redact_text public helper contract tests |
@@ -370,7 +370,7 @@ tests/
 | `test_diff_snapshot_retention.py` | 1 | Diff snapshot-retention parse-cache characterization test |
 | `test_diff_comparator_normalize.py` | 1 | Diff field-normalization type-fast-path characterization test |
 | `test_logging_diagnostics.py` | 2 | emit_diagnostic isEnabledFor guard characterization tests |
-| **Total** | **8,407** | **Collected via pytest --collect-only** |
+| **Total** | **8,416** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -828,7 +828,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (8,407 tests total)
+- [x] Comprehensive test coverage (8,416 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 80 tests

--- a/tests/test_discovery_dataset_metadata.py
+++ b/tests/test_discovery_dataset_metadata.py
@@ -238,12 +238,335 @@ def test_repeated_dataset_ids_keep_connection_scoped_metadata_separate() -> None
     }
     cja.getConnections.assert_called_once_with(
         output="raw",
-        expansion=("name,ownerFullName,dataSets,schemaInfo,dataSetLastIngested,backfillsSummaryDataSets"),
+        expansion=("name,ownerFullName,dataSets,dataSetLastIngested,backfillsSummaryDataSets"),
     )
 
 
-def test_permission_degraded_dataset_discovery_remains_id_only() -> None:
+def test_json_hydrates_schema_by_id_only_for_referenced_connections() -> None:
+    cja = MagicMock()
+    cja.getConnections.return_value = [
+        {
+            "id": "dg_used",
+            "name": "Used Connection",
+            "dataSets": [
+                {
+                    "dataSetId": "ds_used",
+                    "name": "Used Dataset",
+                    "type": "event",
+                    "lastIngestedTime": "2026-08-29T12:34:56Z",
+                    "backfillSummary": {"total": 1, "failed": 0, "completed": 1},
+                }
+            ],
+        },
+        {
+            "id": "dg_unused",
+            "name": "Unused Connection",
+            "dataSets": [{"dataSetId": "ds_unused", "name": "Unused Dataset", "type": "lookup"}],
+        },
+    ]
+    cja.getDataViews.return_value = [
+        {"id": "dv_1", "name": "First View", "parentDataGroupId": "dg_used"},
+        {"id": "dv_2", "name": "Second View", "parentDataGroupId": "dg_used"},
+    ]
+    cja.getConnection.return_value = {
+        "id": "dg_used",
+        "dataSets": [
+            {
+                "dataSetId": "ds_used",
+                "schemaInfo": {"schemaId": "schema_1", "schemaName": "Used Schema"},
+            }
+        ],
+    }
+
+    output = _fetch_datasets("json")(cja, True)
+
+    assert isinstance(output, str)
+    payload = json.loads(output)
+    for data_view in payload["dataViews"]:
+        assert data_view["datasets"] == [
+            {
+                "id": "ds_used",
+                "name": "Used Dataset",
+                "connectionMetadata": {
+                    "role": "event",
+                    "schema": {"id": "schema_1", "name": "Used Schema"},
+                    "ingestion": {
+                        "backfillSummary": {"total": 1, "failed": 0, "completed": 1},
+                        "lastIngestedTime": "2026-08-29T12:34:56Z",
+                    },
+                },
+            }
+        ]
+    cja.getConnections.assert_called_once_with(
+        output="raw",
+        expansion="name,ownerFullName,dataSets,dataSetLastIngested,backfillsSummaryDataSets",
+    )
+    cja.getConnection.assert_called_once_with(
+        connectionId="used",
+        expansion="dataSets,schemaInfo",
+    )
+
+
+def test_schema_detail_failure_preserves_collection_metadata_without_permission_warning() -> None:
+    cja = MagicMock()
+    cja.getConnections.return_value = [
+        {
+            "id": "dg_1",
+            "name": "Connection",
+            "dataSets": [
+                {
+                    "dataSetId": "ds_1",
+                    "name": "Dataset",
+                    "type": "profile",
+                    "lastIngestedTime": "2026-08-29T12:34:56Z",
+                }
+            ],
+        }
+    ]
+    cja.getDataViews.return_value = [{"id": "dv_1", "name": "View", "parentDataGroupId": "dg_1"}]
+    cja.getConnection.side_effect = RuntimeError("detail endpoint unavailable")
+
+    output = _fetch_datasets("json")(cja, True)
+
+    assert isinstance(output, str)
+    payload = json.loads(output)
+    assert "warning" not in payload
+    assert payload["dataViews"][0]["datasets"] == [
+        {
+            "id": "ds_1",
+            "name": "Dataset",
+            "connectionMetadata": {
+                "role": "profile",
+                "ingestion": {"lastIngestedTime": "2026-08-29T12:34:56Z"},
+            },
+        }
+    ]
+    cja.getConnection.assert_called_once_with(connectionId="1", expansion="dataSets,schemaInfo")
+
+
+def test_partial_schema_detail_response_preserves_collection_metadata() -> None:
+    cja = MagicMock()
+    cja.getConnections.return_value = [
+        {
+            "id": "dg_1",
+            "name": "Connection",
+            "dataSets": [
+                {
+                    "dataSetId": "ds_1",
+                    "name": "Dataset",
+                    "type": "event",
+                    "streaming": False,
+                }
+            ],
+        }
+    ]
+    cja.getDataViews.return_value = [{"id": "dv_1", "name": "View", "parentDataGroupId": "dg_1"}]
+    cja.getConnection.return_value = {"id": "dg_1", "dataSets": "partial"}
+
+    output = _fetch_datasets("json")(cja, True)
+
+    assert isinstance(output, str)
+    payload = json.loads(output)
+    assert "warning" not in payload
+    assert payload["dataViews"][0]["datasets"] == [
+        {
+            "id": "ds_1",
+            "name": "Dataset",
+            "connectionMetadata": {
+                "role": "event",
+                "ingestion": {"streaming": False},
+            },
+        }
+    ]
+
+
+def test_schema_detail_hydrates_matching_subset_without_changing_other_datasets() -> None:
+    cja = MagicMock()
+    cja.getConnections.return_value = [
+        {
+            "id": "dg_1",
+            "name": "Connection",
+            "dataSets": [
+                {"dataSetId": "ds_1", "name": "First", "type": "event"},
+                {"dataSetId": "ds_2", "name": "Second", "type": "lookup", "lookupKeyField": "id"},
+            ],
+        }
+    ]
+    cja.getDataViews.return_value = [{"id": "dv_1", "name": "View", "parentDataGroupId": "dg_1"}]
+    cja.getConnection.return_value = {
+        "id": "dg_1",
+        "dataSets": [{"dataSetId": "ds_2", "schemaInfo": {"schemaId": "schema_2"}}],
+    }
+
+    output = _fetch_datasets("json")(cja, True)
+
+    assert isinstance(output, str)
+    datasets = json.loads(output)["dataViews"][0]["datasets"]
+    assert datasets == [
+        {
+            "id": "ds_1",
+            "name": "First",
+            "connectionMetadata": {"role": "event"},
+        },
+        {
+            "id": "ds_2",
+            "name": "Second",
+            "connectionMetadata": {
+                "role": "lookup",
+                "schema": {"id": "schema_2"},
+                "lookup": {"keyField": "id"},
+            },
+        },
+    ]
+
+
+def test_mismatched_connection_detail_cannot_cross_contaminate_shared_dataset_id() -> None:
+    cja = MagicMock()
+    cja.getConnections.return_value = [
+        {
+            "id": "dg_1",
+            "name": "First Connection",
+            "dataSets": [{"dataSetId": "ds_shared", "name": "Shared", "type": "event"}],
+        },
+        {
+            "id": "dg_2",
+            "name": "Second Connection",
+            "dataSets": [{"dataSetId": "ds_shared", "name": "Shared", "type": "lookup"}],
+        },
+    ]
+    cja.getDataViews.return_value = [
+        {"id": "dv_1", "name": "First View", "parentDataGroupId": "dg_1"},
+        {"id": "dv_2", "name": "Second View", "parentDataGroupId": "dg_2"},
+    ]
+    cja.getConnection.side_effect = [
+        {
+            "id": "dg_2",
+            "dataSets": [{"dataSetId": "ds_shared", "schemaInfo": {"schemaId": "wrong_schema"}}],
+        },
+        {
+            "id": "dg_2",
+            "dataSets": [{"dataSetId": "ds_shared", "schemaInfo": {"schemaId": "right_schema"}}],
+        },
+    ]
+
+    output = _fetch_datasets("json")(cja, True)
+
+    assert isinstance(output, str)
+    by_id = {data_view["id"]: data_view for data_view in json.loads(output)["dataViews"]}
+    assert "schema" not in by_id["dv_1"]["datasets"][0]["connectionMetadata"]
+    assert by_id["dv_2"]["datasets"][0]["connectionMetadata"]["schema"] == {
+        "id": "right_schema"
+    }
+
+
+def test_enriched_json_projects_exactly_to_the_legacy_contract() -> None:
     output, _ = _run_dataset_fetch(
+        connections=[
+            {
+                "id": "conn_1",
+                "name": "Connection",
+                "dataSets": [
+                    {
+                        "dataSetId": "ds_1",
+                        "name": "Dataset",
+                        "type": "summary",
+                        "streaming": False,
+                    }
+                ],
+            }
+        ],
+        data_views=[{"id": "dv_1", "name": "View", "parentDataGroupId": "conn_1"}],
+    )
+
+    payload = json.loads(output)
+    legacy_projection = {
+        **payload,
+        "dataViews": [
+            {
+                **data_view,
+                "datasets": [
+                    {"id": dataset["id"], "name": dataset["name"]} for dataset in data_view["datasets"]
+                ],
+            }
+            for data_view in payload["dataViews"]
+        ],
+    }
+
+    assert legacy_projection == {
+        "dataViews": [
+            {
+                "id": "dv_1",
+                "name": "View",
+                "connection": {"id": "conn_1", "name": "Connection"},
+                "datasets": [{"id": "ds_1", "name": "Dataset"}],
+            }
+        ],
+        "count": 1,
+    }
+
+
+def test_schema_hydration_is_limited_to_connections_in_final_json_rows() -> None:
+    cja = MagicMock()
+    cja.getConnections.return_value = [
+        {
+            "id": f"dg_{suffix}",
+            "name": f"{suffix.title()} Connection",
+            "dataSets": [{"dataSetId": f"ds_{suffix}", "name": f"{suffix.title()} Dataset"}],
+        }
+        for suffix in ("alpha", "beta", "gamma")
+    ]
+    cja.getDataViews.return_value = [
+        {"id": f"dv_{suffix}", "name": f"{suffix.title()} View", "parentDataGroupId": f"dg_{suffix}"}
+        for suffix in ("gamma", "beta", "alpha")
+    ]
+    cja.getConnection.return_value = {
+        "id": "dg_alpha",
+        "dataSets": [{"dataSetId": "ds_alpha", "schemaInfo": {"schemaId": "schema_alpha"}}],
+    }
+
+    output = _fetch_datasets("json", limit=1, sort_expression="name")(cja, True)
+
+    assert isinstance(output, str)
+    payload = json.loads(output)
+    assert [data_view["id"] for data_view in payload["dataViews"]] == ["dv_alpha"]
+    assert payload["dataViews"][0]["datasets"][0]["connectionMetadata"]["schema"] == {
+        "id": "schema_alpha"
+    }
+    cja.getConnection.assert_called_once_with(connectionId="alpha", expansion="dataSets,schemaInfo")
+
+
+def test_schema_hydration_skips_connections_that_cannot_gain_schema() -> None:
+    output, cja = _run_dataset_fetch(
+        connections=[
+            {"id": "dg_empty", "name": "Empty", "dataSets": []},
+            {
+                "id": "dg_complete",
+                "name": "Complete",
+                "dataSets": [
+                    {
+                        "dataSetId": "ds_complete",
+                        "name": "Complete Dataset",
+                        "schemaInfo": {"schemaId": "schema_complete"},
+                    }
+                ],
+            },
+        ],
+        data_views=[
+            {"id": "dv_empty", "name": "Empty View", "parentDataGroupId": "dg_empty"},
+            {"id": "dv_complete", "name": "Complete View", "parentDataGroupId": "dg_complete"},
+        ],
+    )
+
+    payload = json.loads(output)
+    by_id = {data_view["id"]: data_view for data_view in payload["dataViews"]}
+    assert by_id["dv_complete"]["datasets"][0]["connectionMetadata"]["schema"] == {
+        "id": "schema_complete"
+    }
+    cja.getConnection.assert_not_called()
+
+
+def test_permission_degraded_dataset_discovery_remains_id_only() -> None:
+    output, cja = _run_dataset_fetch(
         connections=[],
         data_views=[{"id": "dv_1", "name": "View", "parentDataGroupId": "conn_hidden"}],
     )
@@ -258,6 +581,7 @@ def test_permission_degraded_dataset_discovery_remains_id_only() -> None:
         }
     ]
     assert "product-admin privileges" in payload["warning"]
+    cja.getConnection.assert_not_called()
 
 
 @pytest.mark.parametrize("output_format", ["csv", "table"])
@@ -292,6 +616,7 @@ def test_tabular_output_ignores_enriched_metadata(output_format: str) -> None:
         assert "schema_1" not in output
         assert "streaming" not in output
     cja.getConnections.assert_called_once_with(output="raw", expansion="name,ownerFullName,dataSets")
+    cja.getConnection.assert_not_called()
 
 
 def test_filtering_and_sorting_still_use_enriched_dataset_rows() -> None:

--- a/tests/test_discovery_dataset_metadata.py
+++ b/tests/test_discovery_dataset_metadata.py
@@ -454,9 +454,7 @@ def test_mismatched_connection_detail_cannot_cross_contaminate_shared_dataset_id
     assert isinstance(output, str)
     by_id = {data_view["id"]: data_view for data_view in json.loads(output)["dataViews"]}
     assert "schema" not in by_id["dv_1"]["datasets"][0]["connectionMetadata"]
-    assert by_id["dv_2"]["datasets"][0]["connectionMetadata"]["schema"] == {
-        "id": "right_schema"
-    }
+    assert by_id["dv_2"]["datasets"][0]["connectionMetadata"]["schema"] == {"id": "right_schema"}
 
 
 def test_enriched_json_projects_exactly_to_the_legacy_contract() -> None:
@@ -484,9 +482,7 @@ def test_enriched_json_projects_exactly_to_the_legacy_contract() -> None:
         "dataViews": [
             {
                 **data_view,
-                "datasets": [
-                    {"id": dataset["id"], "name": dataset["name"]} for dataset in data_view["datasets"]
-                ],
+                "datasets": [{"id": dataset["id"], "name": dataset["name"]} for dataset in data_view["datasets"]],
             }
             for data_view in payload["dataViews"]
         ],
@@ -529,9 +525,7 @@ def test_schema_hydration_is_limited_to_connections_in_final_json_rows() -> None
     assert isinstance(output, str)
     payload = json.loads(output)
     assert [data_view["id"] for data_view in payload["dataViews"]] == ["dv_alpha"]
-    assert payload["dataViews"][0]["datasets"][0]["connectionMetadata"]["schema"] == {
-        "id": "schema_alpha"
-    }
+    assert payload["dataViews"][0]["datasets"][0]["connectionMetadata"]["schema"] == {"id": "schema_alpha"}
     cja.getConnection.assert_called_once_with(connectionId="alpha", expansion="dataSets,schemaInfo")
 
 
@@ -559,9 +553,7 @@ def test_schema_hydration_skips_connections_that_cannot_gain_schema() -> None:
 
     payload = json.loads(output)
     by_id = {data_view["id"]: data_view for data_view in payload["dataViews"]}
-    assert by_id["dv_complete"]["datasets"][0]["connectionMetadata"]["schema"] == {
-        "id": "schema_complete"
-    }
+    assert by_id["dv_complete"]["datasets"][0]["connectionMetadata"]["schema"] == {"id": "schema_complete"}
     cja.getConnection.assert_not_called()
 
 

--- a/tests/test_discovery_dataset_metadata.py
+++ b/tests/test_discovery_dataset_metadata.py
@@ -1,0 +1,367 @@
+"""Contracts for connection-scoped dataset metadata in dataset discovery JSON."""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from cja_auto_sdr.cli.commands.discovery import _extract_dataset_info, _fetch_datasets
+
+
+def _run_dataset_fetch(
+    *,
+    connections: list[dict] | None = None,
+    data_views: list[dict] | None = None,
+    output_format: str = "json",
+    filter_pattern: str | None = None,
+    exclude_pattern: str | None = None,
+    sort_expression: str | None = None,
+) -> tuple[str, MagicMock]:
+    cja = MagicMock()
+    cja.getConnections.return_value = connections or []
+    cja.getDataViews.return_value = data_views or []
+    result = _fetch_datasets(
+        output_format,
+        filter_pattern=filter_pattern,
+        exclude_pattern=exclude_pattern,
+        sort_expression=sort_expression,
+    )(cja, output_format in {"json", "csv"})
+    assert isinstance(result, str)
+    return result, cja
+
+
+@pytest.mark.parametrize("dataset_type", ["event", "profile", "lookup", "summary"])
+def test_dataset_role_is_retained_without_inference(dataset_type: str) -> None:
+    result = _extract_dataset_info(
+        {"id": "ds_1", "name": "Neutral Name", "type": dataset_type},
+        include_connection_metadata=True,
+    )
+
+    assert result == {
+        "id": "ds_1",
+        "name": "Neutral Name",
+        "connectionMetadata": {"role": dataset_type},
+    }
+
+
+def test_dataset_metadata_normalizes_schema_identity_lookup_and_ingestion() -> None:
+    result = _extract_dataset_info(
+        {
+            "dataSetId": "ds_lookup",
+            "dataSetName": "Account Lookup",
+            "type": "lookup",
+            "schemaInfo": {
+                "schemaId": "schema_1",
+                "schemaName": "Account Schema",
+                "schemaRef": {"id": "ref_1", "contentType": "application/vnd.adobe.xed-full+json;version=1"},
+            },
+            "timestampId": "_repo.timestamp",
+            "visitorId": "person.id",
+            "identityNamespace": "ECID",
+            "usePrimaryIdNamespace": False,
+            "identityMap": False,
+            "identityNamespaceCol": "_repo.identity.namespace",
+            "lookupKeyField": "accountId",
+            "lookupParentFields": ["accountId", "region"],
+            "lookupParentDataSetId": "ds_event",
+            "lookupParentDataSetType": "event",
+            "streaming": False,
+            "backfillSummary": {
+                "total": 4,
+                "failed": 1,
+                "inProgress": 0,
+                "completed": 3,
+                "invalid": False,
+            },
+            "lastIngestedTime": "2026-08-29T12:34:56Z",
+            "streamingEnabledAt": "2026-01-02T03:04:05Z",
+            "dataSourceType": {"id": "webData", "type": "Web Data", "description": "Browser events"},
+        },
+        include_connection_metadata=True,
+    )
+
+    assert result == {
+        "id": "ds_lookup",
+        "name": "Account Lookup",
+        "connectionMetadata": {
+            "role": "lookup",
+            "schema": {
+                "id": "schema_1",
+                "name": "Account Schema",
+                "ref": {
+                    "id": "ref_1",
+                    "contentType": "application/vnd.adobe.xed-full+json;version=1",
+                },
+            },
+            "identity": {
+                "timestampId": "_repo.timestamp",
+                "visitorId": "person.id",
+                "namespace": "ECID",
+                "usePrimaryIdNamespace": False,
+                "identityMap": False,
+                "namespaceColumn": "_repo.identity.namespace",
+            },
+            "lookup": {
+                "keyField": "accountId",
+                "parentFields": ["accountId", "region"],
+                "parentDatasetId": "ds_event",
+                "parentDatasetType": "event",
+            },
+            "ingestion": {
+                "streaming": False,
+                "backfillSummary": {
+                    "total": 4,
+                    "failed": 1,
+                    "inProgress": 0,
+                    "completed": 3,
+                    "invalid": False,
+                },
+                "lastIngestedTime": "2026-08-29T12:34:56Z",
+                "streamingEnabledAt": "2026-01-02T03:04:05Z",
+            },
+            "dataSource": {"id": "webData", "type": "Web Data", "description": "Browser events"},
+        },
+    }
+
+
+def test_missing_metadata_preserves_existing_dataset_contract_exactly() -> None:
+    assert _extract_dataset_info(
+        {"dataset_id": "ds_legacy", "dataset_name": "Legacy"},
+        include_connection_metadata=True,
+    ) == {"id": "ds_legacy", "name": "Legacy"}
+
+
+@pytest.mark.parametrize(("value", "expected"), [("accountId", "accountId"), (None, None)])
+def test_lookup_parent_fields_preserve_documented_scalar_and_null(value, expected) -> None:
+    result = _extract_dataset_info(
+        {"id": "ds_lookup", "name": "Lookup", "lookupParentFields": value},
+        include_connection_metadata=True,
+    )
+
+    assert result["connectionMetadata"]["lookup"]["parentFields"] == expected
+
+
+def test_explicit_null_false_and_empty_metadata_remain_distinct() -> None:
+    result = _extract_dataset_info(
+        {
+            "id": "ds_1",
+            "name": "Dataset \udcff",
+            "type": None,
+            "schemaInfo": {},
+            "identityNamespace": "",
+            "usePrimaryIdNamespace": False,
+            "lookupParentFields": [],
+            "streaming": False,
+            "backfillSummary": None,
+            "dataSourceType": {},
+        },
+        include_connection_metadata=True,
+    )
+
+    assert result["name"] == "Dataset \udcff"
+    assert result["connectionMetadata"] == {
+        "role": None,
+        "schema": {},
+        "identity": {"namespace": "", "usePrimaryIdNamespace": False},
+        "lookup": {"parentFields": []},
+        "ingestion": {"streaming": False, "backfillSummary": None},
+        "dataSource": {},
+    }
+    assert "timestampId" not in result["connectionMetadata"]["identity"]
+
+
+def test_malformed_optional_metadata_is_omitted_from_strict_json() -> None:
+    result = _extract_dataset_info(
+        {
+            "id": "ds_1",
+            "name": "Dataset",
+            "type": {"not": "text"},
+            "schemaInfo": ["not", "an", "object"],
+            "timestampId": pd.NA,
+            "identityMap": "false",
+            "lookupParentFields": ["valid", {"bad": "field"}],
+            "streaming": 0,
+            "backfillSummary": {"total": float("nan"), "failed": "one", "invalid": 0},
+            "lastIngestedTime": {"bad": "timestamp"},
+            "dataSourceType": "webData",
+        },
+        include_connection_metadata=True,
+    )
+
+    assert result == {"id": "ds_1", "name": "Dataset"}
+    assert json.loads(json.dumps(result, allow_nan=False)) == result
+
+
+def test_repeated_dataset_ids_keep_connection_scoped_metadata_separate() -> None:
+    output, cja = _run_dataset_fetch(
+        connections=[
+            {
+                "id": "conn_event",
+                "name": "Events",
+                "dataSets": [{"dataSetId": "ds_shared", "name": "Shared", "type": "event", "streaming": True}],
+            },
+            {
+                "id": "conn_lookup",
+                "name": "Lookups",
+                "dataSets": [
+                    {
+                        "dataSetId": "ds_shared",
+                        "name": "Shared",
+                        "type": "lookup",
+                        "lookupKeyField": "id",
+                        "streaming": False,
+                    }
+                ],
+            },
+        ],
+        data_views=[
+            {"id": "dv_event", "name": "Event View", "parentDataGroupId": "conn_event"},
+            {"id": "dv_lookup", "name": "Lookup View", "parentDataGroupId": "conn_lookup"},
+        ],
+    )
+
+    payload = json.loads(output)
+    by_id = {item["id"]: item for item in payload["dataViews"]}
+    assert by_id["dv_event"]["datasets"][0]["connectionMetadata"] == {
+        "role": "event",
+        "ingestion": {"streaming": True},
+    }
+    assert by_id["dv_lookup"]["datasets"][0]["connectionMetadata"] == {
+        "role": "lookup",
+        "lookup": {"keyField": "id"},
+        "ingestion": {"streaming": False},
+    }
+    cja.getConnections.assert_called_once_with(
+        output="raw",
+        expansion=("name,ownerFullName,dataSets,schemaInfo,dataSetLastIngested,backfillsSummaryDataSets"),
+    )
+
+
+def test_permission_degraded_dataset_discovery_remains_id_only() -> None:
+    output, _ = _run_dataset_fetch(
+        connections=[],
+        data_views=[{"id": "dv_1", "name": "View", "parentDataGroupId": "conn_hidden"}],
+    )
+
+    payload = json.loads(output)
+    assert payload["dataViews"] == [
+        {
+            "id": "dv_1",
+            "name": "View",
+            "connection": {"id": "conn_hidden", "name": None},
+            "datasets": [],
+        }
+    ]
+    assert "product-admin privileges" in payload["warning"]
+
+
+@pytest.mark.parametrize("output_format", ["csv", "table"])
+def test_tabular_output_ignores_enriched_metadata(output_format: str) -> None:
+    output, cja = _run_dataset_fetch(
+        connections=[
+            {
+                "id": "conn_1",
+                "name": "Connection",
+                "dataSets": [
+                    {
+                        "id": "ds_1",
+                        "name": "Dataset",
+                        "type": "event",
+                        "schemaInfo": {"schemaId": "schema_1"},
+                        "streaming": False,
+                    }
+                ],
+            }
+        ],
+        data_views=[{"id": "dv_1", "name": "View", "parentDataGroupId": "conn_1"}],
+        output_format=output_format,
+    )
+
+    if output_format == "csv":
+        assert list(csv.reader(io.StringIO(output))) == [
+            ["dataview_id", "dataview_name", "connection_id", "connection_name", "dataset_id", "dataset_name"],
+            ["dv_1", "View", "conn_1", "Connection", "ds_1", "Dataset"],
+        ]
+    else:
+        assert "ds_1  Dataset" in output
+        assert "schema_1" not in output
+        assert "streaming" not in output
+    cja.getConnections.assert_called_once_with(output="raw", expansion="name,ownerFullName,dataSets")
+
+
+def test_filtering_and_sorting_still_use_enriched_dataset_rows() -> None:
+    output, _ = _run_dataset_fetch(
+        connections=[
+            {"id": "conn_z", "name": "Zed", "dataSets": [{"id": "ds_z", "name": "Keep Me", "type": "event"}]},
+            {"id": "conn_a", "name": "Alpha", "dataSets": [{"id": "ds_a", "name": "Drop Me", "type": "lookup"}]},
+        ],
+        data_views=[
+            {"id": "dv_z", "name": "Zulu", "parentDataGroupId": "conn_z"},
+            {"id": "dv_a", "name": "Alpha", "parentDataGroupId": "conn_a"},
+        ],
+        filter_pattern="Keep Me|Drop Me",
+        sort_expression="name",
+    )
+
+    payload = json.loads(output)
+    assert [item["id"] for item in payload["dataViews"]] == ["dv_a", "dv_z"]
+    assert payload["dataViews"][0]["datasets"][0]["connectionMetadata"]["role"] == "lookup"
+
+
+@pytest.mark.parametrize("output_format", ["json", "csv", "table"])
+def test_metadata_only_terms_do_not_change_legacy_filter_or_exclude(output_format: str) -> None:
+    kwargs = {
+        "connections": [
+            {
+                "id": "conn_1",
+                "name": "Connection",
+                "dataSets": [{"id": "ds_1", "name": "Neutral Dataset", "type": "lookup"}],
+            }
+        ],
+        "data_views": [{"id": "dv_1", "name": "Neutral View", "parentDataGroupId": "conn_1"}],
+        "output_format": output_format,
+    }
+
+    filtered, _ = _run_dataset_fetch(filter_pattern="lookup", **kwargs)
+    excluded, _ = _run_dataset_fetch(exclude_pattern="lookup", **kwargs)
+
+    if output_format == "json":
+        assert json.loads(filtered) == {"dataViews": [], "count": 0}
+        assert json.loads(excluded)["dataViews"][0]["datasets"][0]["connectionMetadata"]["role"] == "lookup"
+    elif output_format == "csv":
+        assert len(list(csv.reader(io.StringIO(filtered)))) == 1
+        assert len(list(csv.reader(io.StringIO(excluded)))) == 2
+    else:
+        assert "Found 0 data view(s)" in filtered
+        assert "Neutral Dataset" in excluded
+
+
+def test_dataset_sort_uses_legacy_id_and_name_projection() -> None:
+    output, _ = _run_dataset_fetch(
+        connections=[
+            {
+                "id": "conn_alpha",
+                "name": "Connection Alpha",
+                "dataSets": [{"id": "ds_same", "name": "Alpha", "type": "zzz"}],
+            },
+            {
+                "id": "conn_zulu",
+                "name": "Connection Zulu",
+                "dataSets": [{"id": "ds_same", "name": "Zulu", "type": "aaa"}],
+            },
+        ],
+        data_views=[
+            {"id": "dv_zulu", "name": "Zulu View", "parentDataGroupId": "conn_zulu"},
+            {"id": "dv_alpha", "name": "Alpha View", "parentDataGroupId": "conn_alpha"},
+        ],
+        sort_expression="datasets",
+    )
+
+    payload = json.loads(output)
+    assert [item["id"] for item in payload["dataViews"]] == ["dv_alpha", "dv_zulu"]
+    assert payload["dataViews"][0]["datasets"][0]["connectionMetadata"]["role"] == "zzz"

--- a/tests/test_manifest_agent_contract.py
+++ b/tests/test_manifest_agent_contract.py
@@ -126,6 +126,13 @@ class TestDiscoveryManifestContract:
         desc = self.manifest["parameters"]["properties"]["agent_mode"]["description"]
         assert "json" in desc.lower(), "discovery agent_mode description must mention JSON"
 
+    def test_dataset_metadata_contract_is_agent_discoverable(self):
+        """Agents must be told that dataset metadata is additive and Connection-scoped."""
+        desc = self.manifest["description"]
+        assert "connectionMetadata" in desc
+        assert "dataset-to-Connection relationship" in desc
+        assert "ignore unknown future keys" in desc
+
 
 # ---------------------------------------------------------------------------
 # Cross-manifest consistency

--- a/tests/test_output_content_validation.py
+++ b/tests/test_output_content_validation.py
@@ -38,7 +38,7 @@ def rich_data_dict():
         "Metadata": pd.DataFrame(
             {
                 "Property": ["Generated At", "Data View ID", "Tool Version", "Total Metrics"],
-                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.11.8", 3],
+                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.12.0", 3],
             },
         ),
         "Data Quality": pd.DataFrame(
@@ -104,7 +104,7 @@ def rich_metadata_dict():
         "Generated At": "2025-01-15 10:30:00 PST",
         "Data View ID": "dv_content_test",
         "Data View Name": "Test DataView",
-        "Tool Version": "3.11.8",
+        "Tool Version": "3.12.0",
         "Metrics Count": "3",
         "Dimensions Count": "4",
     }
@@ -224,7 +224,7 @@ class TestJSONContentValidation:
             data = json.load(f)
 
         assert data["metadata"]["Data View ID"] == "dv_content_test"
-        assert data["metadata"]["Tool Version"] == "3.11.8"
+        assert data["metadata"]["Tool Version"] == "3.12.0"
 
     def test_json_metadata_preserves_partial_markers(self, tmp_path, rich_data_dict, rich_metadata_dict):
         logger = logging.getLogger("json_test")

--- a/tests/test_ux_features.py
+++ b/tests/test_ux_features.py
@@ -344,11 +344,11 @@ class TestCombinedFeatures:
 class TestVersionUpdated:
     """Test that version is correct"""
 
-    def test_version_is_3_11_8(self):
-        """Test that version is 3.11.8"""
+    def test_version_is_3_12_0(self):
+        """Test that version is 3.12.0"""
         from cja_auto_sdr.generator import __version__
 
-        assert __version__ == "3.11.8"
+        assert __version__ == "3.12.0"
 
 
 class TestFormatAutoDetection:

--- a/tools/cja_sdr_discover.json
+++ b/tools/cja_sdr_discover.json
@@ -1,6 +1,6 @@
 {
   "name": "cja_sdr_discover",
-  "description": "Discover and inspect Adobe CJA resources: list data views, connections, datasets, or inspect a specific data view's metrics, dimensions, segments, and calculated metrics. Use this tool before cja_sdr_generate to find valid data_view_id values.",
+  "description": "Discover and inspect Adobe CJA resources: list data views, connections, datasets, or inspect a specific data view's metrics, dimensions, segments, and calculated metrics. JSON list_datasets results can add datasets[].connectionMetadata with CJA role, schema, identity, lookup, ingestion, and data-source details scoped to that dataset-to-Connection relationship; do not merge it globally by dataset ID, and ignore unknown future keys. Use this tool before cja_sdr_generate to find valid data_view_id values.",
   "parameters": {
     "type": "object",
     "properties": {


### PR DESCRIPTION
## Summary

`--list-datasets --format json` now exposes allowlisted, Connection-scoped dataset metadata so downstream tools can build an AEP dataset -> CJA Connection -> CJA Data View topology. This is a strictly additive JSON contract for the `v3.12.0` minor release: the outer envelope and every existing dataset `id`/`name` value remain unchanged, while CSV/table output and permission-degraded discovery retain their prior behavior.

The release also removes the README test-count badge while retaining the coverage badge and detailed test inventory.

## Contract decisions

- Optional `datasets[].connectionMetadata` groups role, schema, identity, lookup, ingestion/backfill, and data-source values through a strict allowlist.
- Missing and malformed optional values are omitted. Reported `null`, `false`, empty strings, empty arrays, and empty objects remain distinct.
- Metadata stays on each dataset-to-Connection relationship. Repeated dataset IDs are never globally merged.
- Dataset role is not inferred and is separate from XDM record/time-series behavior, AEP Profile enablement, and reporting readiness.
- Consumers that project each dataset to `{id, name}` receive the exact legacy JSON contract and must ignore unknown future additive keys.
- CSV and table output retain the exact six existing columns and do not request or render schema detail.

## Adobe endpoint compatibility

- GET-all Connections uses `name,ownerFullName,dataSets,dataSetLastIngested,backfillsSummaryDataSets`.
- Adobe exposes `schemaInfo` on Connection GET-by-ID, not GET-all. JSON discovery therefore makes one best-effort `dataSets,schemaInfo` detail request for each final-output Connection that can gain schema metadata.
- A failed or partial detail response omits only unavailable schema metadata. It does not discard GET-all metadata or trigger the Product Admin fallback.
- Explicitly mismatched Connection detail responses are rejected so a repeated dataset ID cannot acquire another Connection's schema.

## Validation

- Full suite: 8,413 passed, 3 skipped.
- Focused metadata, manifest, and tool-contract suite: 84 passed.
- Ruff and `git diff --check` pass.
- Live JSON stress test: 100 Data Views, 791 dataset placements, 169 unique Connection-to-dataset relationships, 700 schema placements, zero malformed enriched values, and no Product Admin warning.
- Live CSV test: 807 rows with the unchanged six-column header.
- Live filtered/sorted/limited JSON test: 25 rows, limit honored, sorted output, 267 dataset placements, 243 schema placements, and no warning.
- Live repeated-ID analysis found 24 dataset IDs used across Connections; 22 had different Connection-scoped metadata, confirming that consumers must not globally merge it.
- Live credentials were used only for read-only discovery. No credential values or tenant payloads were retained in the repository or PR.

## Unapplied review findings

- [ ] P2 - `src/cja_auto_sdr/cli/commands/discovery.py:1837` - Bound optional schema hydration requests. cjapy 0.3.1 does not expose a per-request timeout, so this cannot be implemented wholly in `cja_auto_sdr` without replacing or patching cjapy's transport. Returned errors and recoverable exceptions already degrade safely.

Publishing remains human-initiated after merge through the documented GitHub Release workflow.
