### PR TITLE
fix: reduce validation and org analysis overhead (v3.12.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable changes to the CJA SDR Generator project will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.12.1] - 2026-09-04
+
+### Changed
+
+- **Data quality validation:** avoid copying full DataFrame rows when only counts or names are needed, reuse null masks, and format issue names once. Existing issue payloads and severity ordering are preserved.
+- **Org analysis:** remove the redundant preliminary data-view listing from locked runs; the normal listing path handles empty and filtered organizations. Build clustering distances directly in SciPy's condensed format instead of allocating a square matrix, preserving cluster membership and cohesion rounding.
+- **Validation cache:** simplify local LRU capacity maintenance by removing an unreachable fallback for non-shrinking eviction.
+
+### Tests
+
+- Consolidate duplicate and ineffective tests, strengthen complete quality-output comparisons, and verify that locked org analysis lists data views only once.
+- Isolate temporary Git repository tests from inherited commit-signing configuration so they do not depend on a developer's signing agent.
+
 ## [3.12.0] - 2026-08-30
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,8 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Package manager: **uv**
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
-- Current version: v3.12.0
-- Tests: **8,416** across 165 files at **95% coverage gate**
+- Current version: v3.12.1
+- Tests: **8,399** across 165 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)
 

--- a/README.md
+++ b/README.md
@@ -496,7 +496,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (8,416+ tests)
+├── tests/                     # Test suite (8,399+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -943,7 +943,7 @@ cja_auto_sdr --list-dataviews --log-level DEBUG
 At launch, the tool logs diagnostic lines containing the tool version, Python version, platform, active log level, inferred run mode (batch, single, or discovery), and dependency versions. These appear automatically at `INFO` level and are useful for troubleshooting environment issues in CI/CD logs or support requests:
 
 ```text
-CJA SDR Generator v3.12.0 | Python 3.14.2 | darwin | log_level=INFO | mode=single
+CJA SDR Generator v3.12.1 | Python 3.14.2 | darwin | log_level=INFO | mode=single
 Dependencies: cjapy=0.3.0, pandas=2.3.3, numpy=2.2.1, xlsxwriter=3.2.9, tqdm=4.67.0
 ```
 

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -190,7 +190,7 @@ This command:
 
 ```bash
 $ uv run cja_auto_sdr -V
-cja_auto_sdr 3.12.0
+cja_auto_sdr 3.12.1
 ```
 
 > **Important:** All commands in this guide assume you're in the `cja_auto_sdr` directory. If you see "command not found", make sure you're in the right directory and have run `uv sync`.

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Quick Reference Card
 
-Single-page command cheat sheet for CJA SDR Generator v3.12.0.
+Single-page command cheat sheet for CJA SDR Generator v3.12.1.
 
 ## Four Main Modes
 

--- a/src/cja_auto_sdr/api/cache.py
+++ b/src/cja_auto_sdr/api/cache.py
@@ -227,16 +227,9 @@ class ValidationCache:
         # when the cache is already at capacity.
         self._prune_expired_entries(now, debug_enabled)
 
-        # Defensive bound in case a future change causes eviction to stop shrinking.
-        max_eviction_attempts = len(self._cache) + 1
-        for _ in range(max_eviction_attempts):
-            if len(self._cache) < self.max_size:
-                return
+        # The lock protects this OrderedDict, and each eviction removes one entry.
+        while len(self._cache) >= self.max_size:
             self._evict_lru(debug_enabled)
-
-        if len(self._cache) >= self.max_size:
-            self.logger.warning("Cache capacity maintenance could not evict entries; clearing cache defensively")
-            self._cache.clear()
 
     def _prune_expired_entries(self, now: float, debug_enabled: bool = False) -> int:
         """Remove expired entries before capacity-based eviction (must be called within lock)."""

--- a/src/cja_auto_sdr/api/quality.py
+++ b/src/cja_auto_sdr/api/quality.py
@@ -123,16 +123,18 @@ class DataQualityChecker:
 
             for field in critical_fields:
                 if field in df.columns:
-                    null_count = df[field].isna().sum()
+                    null_mask = df[field].isna()
+                    null_count = null_mask.sum()
                     if null_count > 0:
-                        null_items = df[df[field].isna()]["name"].tolist() if "name" in df.columns else []
+                        null_items = df.loc[null_mask, "name"].tolist() if "name" in df.columns else []
+                        item_names = ", ".join(str(x) for x in null_items)
                         self.add_issue(
                             severity="MEDIUM",
                             category="Null Values",
                             item_type=item_type,
-                            item_name=", ".join(str(x) for x in null_items),
+                            item_name=item_names,
                             description=f'Null values in "{field}" field',
-                            details=f"{null_count} item(s) missing {field}. Items: {', '.join(str(x) for x in null_items)}",
+                            details=f"{null_count} item(s) missing {field}. Items: {item_names}",
                         )
         except (KeyError, TypeError, AttributeError, ValueError) as e:
             self.logger.error(_format_error_msg("checking null values", item_type, e))
@@ -148,11 +150,10 @@ class DataQualityChecker:
                 self.logger.info("'description' column not found in %s", item_type)
                 return
 
-            missing_desc = df[df["description"].isna() | (df["description"] == "")]
-
-            missing_desc_count = len(missing_desc)
+            missing_desc = df["description"].isna() | (df["description"] == "")
+            missing_desc_count = missing_desc.sum()
             if missing_desc_count > 0:
-                item_names = missing_desc["name"].tolist() if "name" in missing_desc.columns else []
+                item_names = df.loc[missing_desc, "name"].tolist() if "name" in df.columns else []
                 self.add_issue(
                     severity="LOW",
                     category="Missing Descriptions",
@@ -190,8 +191,7 @@ class DataQualityChecker:
                 self.logger.warning("'id' column not found in %s", item_type)
                 return
 
-            missing_ids = df[df["id"].isna() | (df["id"] == "")]
-            missing_ids_count = len(missing_ids)
+            missing_ids_count = (df["id"].isna() | (df["id"] == "")).sum()
             if missing_ids_count > 0:
                 self.add_issue(
                     severity="HIGH",
@@ -212,15 +212,10 @@ class DataQualityChecker:
         critical_fields: list[str],
     ):
         """
-        Optimized single-pass validation combining all checks
+        Combine vectorized checks, exiting early for empty data or missing required fields.
 
-        PERFORMANCE OPTIMIZATIONS:
-        - 40-55% faster than sequential individual checks
-        - Reduces DataFrame scans from 6 to 1
-        - Uses vectorized pandas operations
-        - Early exit on critical errors (5-10% additional improvement)
-        - Validation caching (50-90% improvement on cache hits)
-        - Better CPU cache utilization
+        Optional caching reuses validation results. Masks and column selection
+        avoid materializing full rows when only counts or names are needed.
         """
         try:
             # Check cache first (before any processing)
@@ -303,36 +298,38 @@ class DataQualityChecker:
                 has_name_column = "name" in df.columns
                 for field, null_count in null_counts[null_counts > 0].items():
                     null_items = df.loc[null_mask[field], "name"].tolist() if has_name_column else []
+                    item_names = ", ".join(str(x) for x in null_items)
                     _record_issue(
                         severity="MEDIUM",
                         category="Null Values",
-                        item_name=", ".join(str(x) for x in null_items),
+                        item_name=item_names,
                         description=f'Null values in "{field}" field',
-                        details=f"{null_count} item(s) missing {field}. Items: {', '.join(str(x) for x in null_items)}",
+                        details=f"{null_count} item(s) missing {field}. Items: {item_names}",
                     )
 
             # Check 5: Vectorized missing descriptions check
             if "description" in df.columns:
-                missing_desc = df[df["description"].isna() | (df["description"] == "")]
-                if len(missing_desc) > 0:
-                    item_names = missing_desc["name"].tolist() if "name" in missing_desc.columns else []
+                missing_desc = df["description"].isna() | (df["description"] == "")
+                missing_desc_count = missing_desc.sum()
+                if missing_desc_count > 0:
+                    item_names = df.loc[missing_desc, "name"].tolist() if "name" in df.columns else []
                     _record_issue(
                         severity="LOW",
                         category="Missing Descriptions",
-                        item_name=f"{len(missing_desc)} items",
-                        description=f"{len(missing_desc)} items without descriptions",
+                        item_name=f"{missing_desc_count} items",
+                        description=f"{missing_desc_count} items without descriptions",
                         details=f"Items: {', '.join(str(x) for x in item_names)}",
                     )
 
             # Check 6: Vectorized ID validity check
             if "id" in df.columns:
-                missing_ids = df[df["id"].isna() | (df["id"] == "")]
-                if len(missing_ids) > 0:
+                missing_ids_count = (df["id"].isna() | (df["id"] == "")).sum()
+                if missing_ids_count > 0:
                     _record_issue(
                         severity="HIGH",
                         category="Invalid IDs",
-                        item_name=f"{len(missing_ids)} items",
-                        description=f"{len(missing_ids)} items with missing or invalid IDs",
+                        item_name=f"{missing_ids_count} items",
+                        description=f"{missing_ids_count} items with missing or invalid IDs",
                         details="Items without valid IDs may cause issues in reporting",
                     )
 

--- a/src/cja_auto_sdr/core/version.py
+++ b/src/cja_auto_sdr/core/version.py
@@ -1,3 +1,3 @@
 """Version information for CJA Auto SDR."""
 
-__version__ = "3.12.0"
+__version__ = "3.12.1"

--- a/src/cja_auto_sdr/org/analyzer.py
+++ b/src/cja_auto_sdr/org/analyzer.py
@@ -22,11 +22,7 @@ from typing import TYPE_CHECKING, Any
 import pandas as pd
 from tqdm import tqdm
 
-from cja_auto_sdr.api.client import (
-    _describe_unexpected_probe_payload,
-    _normalize_dataview_listing_payload,
-    _normalize_dataview_listing_payload_or_raise,
-)
+from cja_auto_sdr.api.client import _normalize_dataview_listing_payload_or_raise
 from cja_auto_sdr.core.constants import (
     DEFAULT_ORG_REPORT_WORKERS,
     GOVERNANCE_MAX_OVERLAP_THRESHOLD,
@@ -311,9 +307,6 @@ class OrgComponentAnalyzer:
                 )
                 try:
                     self._assert_lock_healthy()
-                    quick_check_result = self._quick_check_empty_org()
-                    if quick_check_result is not None:
-                        return quick_check_result
                     # Run the analysis while holding the lock
                     return self._run_analysis_impl()
                 except LockOwnershipLostError:
@@ -352,37 +345,6 @@ class OrgComponentAnalyzer:
         """
         normalized = " ".join(str(error).split())
         return normalized or type(error).__name__
-
-    def _quick_check_empty_org(self) -> OrgReportResult | None:
-        """Return an empty-org result if no data views exist, otherwise None."""
-        # This provides better UX - users learn about empty results before long work begins
-        try:
-            quick_check = self.cja.getDataViews()
-            normalized_quick_check = _normalize_dataview_listing_payload(quick_check)
-            if normalized_quick_check is None:
-                self.logger.warning(
-                    "Ignoring unexpected getDataViews() payload during org-report quick check: %s",
-                    _describe_unexpected_probe_payload(quick_check),
-                )
-                return None
-            if not normalized_quick_check:
-                self.logger.warning("No data views found in organization; returning empty org report")
-                return OrgReportResult(
-                    timestamp=datetime.now(UTC).isoformat(),
-                    org_id=self.org_id,
-                    parameters=self.config,
-                    data_view_summaries=[],
-                    component_index={},
-                    distribution=ComponentDistribution(),
-                    similarity_pairs=None,
-                    recommendations=[],
-                    duration=0.0,
-                    is_sampled=False,
-                    total_available_data_views=0,
-                )
-        except Exception as e:  # Intentional: quick-check is diagnostic and must not block normal analysis flow.
-            self.logger.debug("Quick empty-org check skipped: %s", e)
-        return None
 
     def _run_analysis_impl(self) -> OrgReportResult:
         """Internal implementation of org-wide analysis (called within lock)."""
@@ -1292,7 +1254,6 @@ class OrgComponentAnalyzer:
         try:
             import numpy as np
             from scipy.cluster.hierarchy import fcluster, linkage
-            from scipy.spatial.distance import squareform
         except ImportError:
             self.logger.warning(
                 "scipy not available - skipping clustering. Install with: uv pip install 'cja-auto-sdr[clustering]'",
@@ -1310,15 +1271,13 @@ class OrgComponentAnalyzer:
 
         n = len(valid_summaries)
 
-        # Build distance matrix from precomputed pairwise Jaccard similarities
-        dist_matrix = np.zeros((n, n))
-        for (i, j), jaccard in pairwise.items():
-            distance = 1 - jaccard
-            dist_matrix[i, j] = distance
-            dist_matrix[j, i] = distance
-
-        # Convert to condensed form for scipy
-        condensed_dist = squareform(dist_matrix)
+        # SciPy consumes the upper triangle in row order. Build it directly
+        # instead of allocating and then copying an n-by-n distance matrix.
+        condensed_dist = np.fromiter(
+            (1 - pairwise[(i, j)] for i in range(n) for j in range(i + 1, n)),
+            dtype=float,
+            count=n * (n - 1) // 2,
+        )
 
         # Perform hierarchical clustering
         try:
@@ -1350,7 +1309,10 @@ class OrgComponentAnalyzer:
                 for i in range(len(member_indices)):
                     for j in range(i + 1, len(member_indices)):
                         idx_i, idx_j = member_indices[i], member_indices[j]
-                        similarities.append(1 - dist_matrix[idx_i, idx_j])
+                        # Preserve the distance round trip used by the old matrix
+                        # so four-decimal rounding stays stable at float boundaries.
+                        distance = 1 - pairwise[(idx_i, idx_j)]
+                        similarities.append(1 - distance)
                 cohesion = sum(similarities) / len(similarities) if similarities else 0.0
 
             # Infer cluster name from common prefix

--- a/tests/README.md
+++ b/tests/README.md
@@ -177,7 +177,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 8,416 comprehensive tests**
+**Total: 8,399 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -186,16 +186,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 8,310 | 159 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 8,293 | 159 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 0 | 0 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **8,416** | **165** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **8,399** | **165** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 8,310 | 159 | `-m "unit and not slow"` |
+| `test-unit` | 8,293 | 159 | `-m "unit and not slow"` |
 | `test-integration` | 96 | 5 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -207,7 +207,7 @@ tests/
 |-----------|-------|---------------|
 | `test_diff_comparison.py` | 169 | Data view diff comparison feature with inventory support |
 | `test_ux_features.py` | 124 | UX features: --open, --stats, --output, --list-dataviews formats, inventory validation, inventory summary, include-all-inventory |
-| `test_org_report.py` | 211 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
+| `test_org_report.py` | 209 | Org-wide component analysis: config, distribution, similarity, output formats, large org scaling, output path aliases |
 | `test_org_report_integration.py` | 17 | Org-wide analysis integration tests: end-to-end flows, caching, filtering, governance |
 | `test_cli.py` | 412 | Command-line interface and argument parsing |
 | `test_profiles.py` | 80 | Multi-organization profile support |
@@ -217,7 +217,7 @@ tests/
 | `test_inventory_summary_cjapy_payloads.py` | 4 | Inventory summary cjapy payload classification |
 | `test_inventory_utils.py` | 56 | Inventory utilities and helpers |
 | `test_segments_inventory.py` | 48 | Segments inventory feature |
-| `test_edge_cases.py` | 39 | Edge cases, configuration dataclasses, custom exceptions |
+| `test_edge_cases.py` | 35 | Edge cases, configuration dataclasses, custom exceptions |
 | `test_calculated_metrics_inventory.py` | 366 | Calculated metrics inventory feature |
 | `test_git_integration.py` | 41 | Git integration, snapshot management, inventory snapshots |
 | `test_output_formats.py` | 37 | CSV, JSON, HTML, Markdown output generation |
@@ -233,9 +233,9 @@ tests/
 | `test_circuit_breaker.py` | 25 | Circuit breaker pattern |
 | `test_retry.py` | 25 | Retry with exponential backoff |
 | `test_batch_processor.py` | 26 | Batch processing of multiple data views |
-| `test_validation_cache.py` | 25 | Validation result caching |
+| `test_validation_cache.py` | 24 | Validation result caching |
 | `test_process_single_dataview.py` | 47 | End-to-end single data view processing |
-| `test_optimized_validation.py` | 16 | Optimized data quality validation |
+| `test_optimized_validation.py` | 14 | Optimized data quality validation |
 | `test_name_resolution.py` | 24 | Data view name to ID resolution |
 | `test_shared_cache.py` | 30 | Shared validation cache |
 | `test_logging_optimization.py` | 17 | Logging performance optimizations |
@@ -243,7 +243,7 @@ tests/
 | `test_dry_run.py` | 16 | Dry-run mode functionality |
 | `test_early_exit.py` | 11 | Early exit optimizations |
 | `test_data_quality.py` | 10 | Data quality validation logic |
-| `test_parallel_validation.py` | 9 | Parallel validation operations |
+| `test_parallel_validation.py` | 8 | Parallel validation operations |
 | `test_discovery_formatters.py` | 32 | Shared discovery formatters, WorkerArgs dataclass, _exit_error, BANNER_WIDTH |
 | `test_discovery_normalization.py` | 17 | Discovery normalization helpers (missing values, owner extraction, tags) |
 | `test_discovery_payloads.py` | 63 | Discovery payload classification (error detection, component extraction) |
@@ -270,11 +270,11 @@ tests/
 | `test_lazy_forwarding.py` | 73 | Lazy-forwarding infrastructure and make_getattr() |
 | `test_lock_backend_edge_cases.py` | 164 | Lock backend metadata I/O, stale detection, legacy parsing |
 | `test_derived_fields_coverage.py` | 161 | Derived field complexity scoring, logic summary, predicates |
-| `test_org_analyzer_coverage.py` | 166 | Org analyzer governance, naming audit, sampling, memory, drift, clustering |
+| `test_org_analyzer_coverage.py` | 163 | Org analyzer governance, naming audit, sampling, memory, drift, clustering |
 | `test_org_analyzer_metadata_enrichment.py` | 3 | Org analyzer metadata enrichment payload handling |
 | `test_api_coverage.py` | 98 | API cache, quality, fetch, resilience exception paths |
 | `test_diff_coverage.py` | 75 | Diff comparator, models, git integration edge cases |
-| `test_generator_coverage.py` | 143 | Generator utility functions — coercion, normalization, diff formatting |
+| `test_generator_coverage.py` | 140 | Generator utility functions — coercion, normalization, diff formatting |
 | `test_generator_discovery_compat_coverage.py` | 42 | Generator discovery helper parity with extracted list-command implementations |
 | `test_segments_coverage.py` | 78 | Segment comparison operators, container types, sequence variants |
 | `test_diff_inventory_output.py` | 96 | Inventory diff output across all formats (console, JSON, HTML, Excel, MD, CSV) |
@@ -336,7 +336,7 @@ tests/
 | `test_advisories.py` | 53 | Advisory model, builder, and rollup tests |
 | `test_agent_contract_docs.py` | 27 | Agent contract documentation validation tests |
 | `test_agent_contract_samples.py` | 6 | Agent contract sample fixture validation tests |
-| `test_agent_mode.py` | 58 | --agent-mode CLI preset and resolution tests |
+| `test_agent_mode.py` | 57 | --agent-mode CLI preset and resolution tests |
 | `test_agent_output_contract.py` | 43 | Centralized agent-output contract resolver tests |
 | `test_agent_playbooks.py` | 38 | Agent playbook structural validation tests |
 | `test_agent_workflows.py` | 69 | Agent workflow shell script validation tests |
@@ -370,7 +370,7 @@ tests/
 | `test_diff_snapshot_retention.py` | 1 | Diff snapshot-retention parse-cache characterization test |
 | `test_diff_comparator_normalize.py` | 1 | Diff field-normalization type-fast-path characterization test |
 | `test_logging_diagnostics.py` | 2 | emit_diagnostic isEnabledFor guard characterization tests |
-| **Total** | **8,416** | **Collected via pytest --collect-only** |
+| **Total** | **8,399** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -828,8 +828,8 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (8,416 tests total)
-- [x] Org-wide analysis tests (test_org_report.py) - 211 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
+- [x] Comprehensive test coverage (8,399 tests total)
+- [x] Org-wide analysis tests (test_org_report.py) - 209 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 80 tests
 - [x] API worker auto-tuning tests (test_api_tuning.py) - 25 tests
@@ -857,7 +857,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] CJA initialization tests (test_cja_initialization.py)
 - [x] Name resolution tests (test_name_resolution.py)
 - [x] Data view diff comparison tests (test_diff_comparison.py) - 169 tests covering snapshots, comparison logic, output formats, CLI arguments, name resolution
-- [x] Edge case tests (test_edge_cases.py) - 39 tests covering custom exceptions, configuration dataclasses, OutputWriter Protocol, boundary conditions
+- [x] Edge case tests (test_edge_cases.py) - 35 tests covering custom exceptions, configuration dataclasses, OutputWriter Protocol, boundary conditions
 
 ## Future Enhancements
 

--- a/tests/test_agent_mode.py
+++ b/tests/test_agent_mode.py
@@ -174,12 +174,6 @@ class TestAgentModeConstraints:
 class TestAgentModeDiffStdout:
     """Verify --agent-mode diff stdout JSON behavior."""
 
-    def test_agent_mode_diff_sets_json_stdout(self):
-        """--agent-mode with --diff should set json format and stdout output."""
-        args = parse_arguments(["--diff", "dv_a", "dv_b", "--agent-mode"])
-        assert args.format == "json"
-        assert args.output == "-"
-
     def test_diff_stdout_detection_logic_honors_dash_alias(self):
         """The diff dispatch helper should treat '-' as stdout for JSON output."""
         args = parse_arguments(["--diff", "dv_a", "dv_b", "--agent-mode"])

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -142,15 +142,6 @@ class TestCustomExceptions:
 class TestConfigurationDataclasses:
     """Test configuration dataclasses"""
 
-    def test_retry_config_defaults(self):
-        """Test RetryConfig default values"""
-        config = RetryConfig()
-        assert config.max_retries == 3
-        assert config.base_delay == 1.0
-        assert config.max_delay == 30.0
-        assert config.exponential_base == 2
-        assert config.jitter is True
-
     def test_retry_config_custom_values(self):
         """Test RetryConfig with custom values"""
         config = RetryConfig(max_retries=5, base_delay=0.5, max_delay=60.0, exponential_base=3, jitter=False)
@@ -169,34 +160,12 @@ class TestConfigurationDataclasses:
         assert d["base_delay"] == 1.0
         assert d["jitter"] is True
 
-    def test_cache_config_defaults(self):
-        """Test CacheConfig default values"""
-        config = CacheConfig()
-        assert config.enabled is False
-        assert config.max_size == 1000
-        assert config.ttl_seconds == 3600
-
     def test_cache_config_custom_values(self):
         """Test CacheConfig with custom values"""
         config = CacheConfig(enabled=True, max_size=500, ttl_seconds=7200)
         assert config.enabled is True
         assert config.max_size == 500
         assert config.ttl_seconds == 7200
-
-    def test_log_config_defaults(self):
-        """Test LogConfig default values"""
-        config = LogConfig()
-        assert config.level == "INFO"
-        assert config.file_max_bytes == 10 * 1024 * 1024
-        assert config.file_backup_count == 5
-
-    def test_worker_config_defaults(self):
-        """Test WorkerConfig default values"""
-        config = WorkerConfig()
-        assert config.api_fetch_workers == 3
-        assert config.validation_workers == 2
-        assert config.batch_workers == 4
-        assert config.max_batch_workers == 256
 
     def test_sdr_config_defaults(self):
         """Test SDRConfig with nested defaults"""

--- a/tests/test_generator_coverage.py
+++ b/tests/test_generator_coverage.py
@@ -240,23 +240,9 @@ class TestInferRunStatus:
     def test_exit_zero_ignores_state(self):
         assert _infer_run_status(0, {"quality_gate_failed": True}) == "success"
 
-    def test_quality_gate_exit_two_is_policy_exit(self):
-        run_state = {"quality_gate_failed": True}
-        assert _infer_run_status(2, run_state) == "policy_exit"
-
     def test_quality_gate_exit_one_is_error(self):
         run_state = {"quality_gate_failed": True}
         assert _infer_run_status(1, run_state) == "error"
-
-    def test_org_threshold_exit_two_is_policy_exit(self):
-        run_state = {
-            "mode": RunMode.ORG_REPORT,
-            "details": {
-                "thresholds_exceeded": True,
-                "fail_on_threshold": True,
-            },
-        }
-        assert _infer_run_status(2, run_state) == "policy_exit"
 
     def test_org_threshold_missing_fail_on_is_error(self):
         run_state = {
@@ -276,13 +262,6 @@ class TestInferRunStatus:
             "details": {"operation_success": True},
         }
         assert _infer_run_status(exit_code, run_state) == "policy_exit"
-
-    def test_diff_mode_operation_failed_is_error(self):
-        run_state = {
-            "mode": RunMode.DIFF,
-            "details": {"operation_success": False},
-        }
-        assert _infer_run_status(2, run_state) == "error"
 
     def test_unknown_exit_code_is_error(self):
         assert _infer_run_status(1, {}) == "error"

--- a/tests/test_git_integration.py
+++ b/tests/test_git_integration.py
@@ -1,9 +1,12 @@
 """Tests for Git integration functionality."""
 
 import json
+import os
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from cja_auto_sdr.generator import (
     DataViewSnapshot,
@@ -14,6 +17,15 @@ from cja_auto_sdr.generator import (
     is_git_repository,
     save_git_friendly_snapshot,
 )
+
+
+@pytest.fixture(autouse=True)
+def disable_test_commit_signing(monkeypatch):
+    """Temporary test repositories must not invoke a developer's signing agent."""
+    index = int(os.environ.get("GIT_CONFIG_COUNT", "0"))
+    monkeypatch.setenv("GIT_CONFIG_COUNT", str(index + 1))
+    monkeypatch.setenv(f"GIT_CONFIG_KEY_{index}", "commit.gpgsign")
+    monkeypatch.setenv(f"GIT_CONFIG_VALUE_{index}", "false")
 
 
 class TestIsGitRepository:

--- a/tests/test_optimized_validation.py
+++ b/tests/test_optimized_validation.py
@@ -150,23 +150,6 @@ class TestOptimizedValidation:
         has_missing_desc = any("description" in str(row["Issue"]).lower() for _, row in issues_df.iterrows())
         assert has_missing_desc
 
-    def test_optimized_null_values(self, sample_metrics_df):
-        """Test optimized validation detects null values"""
-        logger = logging.getLogger("test")
-        validator = DataQualityChecker(logger)
-
-        validator.check_all_quality_issues_optimized(
-            sample_metrics_df,
-            "Metrics",
-            ["id", "name", "type"],
-            ["id", "name", "description"],
-        )
-
-        issues_df = validator.get_issues_dataframe()
-
-        # Should detect null values
-        assert len(issues_df) > 0
-
     def test_optimized_required_fields(self):
         """Test optimized validation detects missing required fields"""
         logger = logging.getLogger("test")
@@ -297,13 +280,7 @@ class TestOptimizedVsOriginalValidation:
 
         optimized_issues = validator_optimized.get_issues_dataframe()
 
-        # Both should find same number of issues
-        assert len(original_issues) == len(optimized_issues)
-
-        # Both should have same severity distribution
-        original_severities = sorted(original_issues["Severity"].tolist())
-        optimized_severities = sorted(optimized_issues["Severity"].tolist())
-        assert original_severities == optimized_severities
+        pd.testing.assert_frame_equal(original_issues, optimized_issues)
 
     def test_results_match_for_dimensions(self, sample_dimensions_df):
         """Test optimized and original produce same results for dimensions"""
@@ -331,8 +308,7 @@ class TestOptimizedVsOriginalValidation:
 
         optimized_issues = validator_optimized.get_issues_dataframe()
 
-        # Both should find same number of issues
-        assert len(original_issues) == len(optimized_issues)
+        pd.testing.assert_frame_equal(original_issues, optimized_issues)
 
     def test_results_match_for_empty_dataframe(self):
         """Test optimized and original produce same results for empty DataFrame"""
@@ -515,25 +491,6 @@ class TestOptimizedValidationPerformance:
 
 class TestEdgeCases:
     """Test edge cases for optimized validation"""
-
-    def test_dataframe_with_missing_columns(self):
-        """Test optimized validation handles missing columns gracefully"""
-        logger = logging.getLogger("test")
-        validator = DataQualityChecker(logger)
-
-        # DataFrame missing 'description' column
-        df = pd.DataFrame([{"id": "1", "name": "Test", "type": "metric"}])
-
-        # Should not crash
-        validator.check_all_quality_issues_optimized(
-            df,
-            "Metrics",
-            ["id", "name", "type"],
-            ["id", "name", "description"],
-        )
-
-        issues_df = validator.get_issues_dataframe()
-        assert len(issues_df) >= 0  # Should complete without error
 
     def test_dataframe_with_all_null_values(self):
         """Test optimized validation handles all-null DataFrames"""

--- a/tests/test_org_analyzer_coverage.py
+++ b/tests/test_org_analyzer_coverage.py
@@ -1313,41 +1313,6 @@ class TestExceptionHandlers:
         f2.cancel.assert_called_once()
         f3.cancel.assert_called_once()
 
-    def test_quick_check_empty_org_exception_path(self, mock_cja, logger, caplog):
-        """_quick_check_empty_org should return None when API raises."""
-        mock_cja.getDataViews.side_effect = ConnectionError("network down")
-        analyzer = _make_analyzer(mock_cja, logger)
-        with caplog.at_level(logging.DEBUG):
-            result = analyzer._quick_check_empty_org()
-        assert result is None
-        assert "Quick empty-org check skipped" in caplog.text
-
-    def test_quick_check_empty_org_returns_result_when_empty(self, mock_cja, logger):
-        """_quick_check_empty_org should return OrgReportResult when no DVs."""
-        mock_cja.getDataViews.return_value = []
-        analyzer = _make_analyzer(mock_cja, logger)
-        result = analyzer._quick_check_empty_org()
-        assert result is not None
-        assert result.data_view_summaries == []
-        assert result.total_available_data_views == 0
-
-    def test_quick_check_empty_org_returns_none_when_dvs_exist(self, mock_cja, logger):
-        """_quick_check_empty_org returns None when data views exist."""
-        mock_cja.getDataViews.return_value = [{"id": "dv1", "name": "DV 1"}]
-        analyzer = _make_analyzer(mock_cja, logger)
-        result = analyzer._quick_check_empty_org()
-        assert result is None
-
-    def test_quick_check_empty_org_ignores_error_payload(self, mock_cja, logger, caplog):
-        """Error-shaped getDataViews payloads must not be mistaken for an empty org."""
-        mock_cja.getDataViews.return_value = {"statusCode": 503, "message": "backend timeout"}
-        analyzer = _make_analyzer(mock_cja, logger)
-        with caplog.at_level(logging.WARNING):
-            result = analyzer._quick_check_empty_org()
-        assert result is None
-        assert "unexpected getDataViews() payload" in caplog.text
-        assert "statusCode=503" in caplog.text
-
     def test_list_and_filter_data_views_raises_on_error_payload(self, mock_cja, logger):
         """Main org-report listing path must fail on error-shaped getDataViews payloads."""
         mock_cja.getDataViews.return_value = {"statusCode": 500, "message": "backend timeout"}
@@ -2526,18 +2491,19 @@ class TestFetchDataViewComponentsMetadata:
 
 
 # ===================================================================
-# 26. run_analysis with lock: quick_check_empty_org returns early (line 123)
+# 26. run_analysis with lock: empty and filtered-out listings
 # ===================================================================
 
 
-class TestRunAnalysisLockedQuickCheckExit:
-    """Line 123: quick_check_empty_org returns non-None inside lock path."""
+class TestRunAnalysisLockedEmptyOrg:
+    """Empty or filtered-out listings return before fetching components."""
 
-    def test_quick_check_exits_early_with_lock(self, mock_cja, logger):
-        """skip_lock=False + empty org -> returns quick_check_result."""
+    @pytest.mark.parametrize("listing", [[], [{"id": "dv1", "name": "Production"}]])
+    def test_empty_org_exits_early_with_lock(self, mock_cja, logger, listing):
+        """The normal listing path handles empty organizations without a probe."""
         from unittest.mock import MagicMock, patch
 
-        config = OrgReportConfig(skip_lock=False, cja_per_thread=False)
+        config = OrgReportConfig(skip_lock=False, cja_per_thread=False, filter_pattern="^Sandbox$")
         analyzer = _make_analyzer(mock_cja, logger, config=config)
 
         mock_lock = MagicMock()
@@ -2545,14 +2511,15 @@ class TestRunAnalysisLockedQuickCheckExit:
         mock_lock.__enter__ = MagicMock(return_value=mock_lock)
         mock_lock.__exit__ = MagicMock(return_value=False)
 
-        empty_result = MagicMock()
-        with (
-            patch("cja_auto_sdr.org.analyzer.OrgReportLock", return_value=mock_lock),
-            patch.object(analyzer, "_assert_lock_healthy"),
-            patch.object(analyzer, "_quick_check_empty_org", return_value=empty_result),
-        ):
+        mock_cja.getDataViews.return_value = listing
+        with patch("cja_auto_sdr.org.analyzer.OrgReportLock", return_value=mock_lock):
             result = analyzer.run_analysis()
-        assert result is empty_result
+        assert result.data_view_summaries == []
+        assert result.total_available_data_views == 0
+        mock_cja.getDataViews.assert_called_once_with()
+        mock_cja.getMetrics.assert_not_called()
+        mock_cja.getDimensions.assert_not_called()
+        mock_lock.__exit__.assert_called_once()
 
 
 # ===================================================================
@@ -3066,10 +3033,6 @@ def _install_fake_scipy(
 ) -> dict[str, object]:
     captured: dict[str, object] = {}
 
-    def squareform(matrix):
-        captured["matrix"] = matrix.copy()
-        return "condensed"
-
     def linkage(condensed_dist, method):
         captured["condensed_dist"] = condensed_dist
         captured["method"] = method
@@ -3086,23 +3049,16 @@ def _install_fake_scipy(
     scipy_module = types.ModuleType("scipy")
     cluster_module = types.ModuleType("scipy.cluster")
     hierarchy_module = types.ModuleType("scipy.cluster.hierarchy")
-    spatial_module = types.ModuleType("scipy.spatial")
-    distance_module = types.ModuleType("scipy.spatial.distance")
 
     hierarchy_module.linkage = linkage
     hierarchy_module.fcluster = fcluster
-    distance_module.squareform = squareform
 
     cluster_module.hierarchy = hierarchy_module
-    spatial_module.distance = distance_module
     scipy_module.cluster = cluster_module
-    scipy_module.spatial = spatial_module
 
     monkeypatch.setitem(sys.modules, "scipy", scipy_module)
     monkeypatch.setitem(sys.modules, "scipy.cluster", cluster_module)
     monkeypatch.setitem(sys.modules, "scipy.cluster.hierarchy", hierarchy_module)
-    monkeypatch.setitem(sys.modules, "scipy.spatial", spatial_module)
-    monkeypatch.setitem(sys.modules, "scipy.spatial.distance", distance_module)
 
     return captured
 
@@ -3135,9 +3091,7 @@ def test_compute_clusters_with_fake_scipy_covers_cluster_building(
     assert clusters[0].cluster_name == "Prod"
     assert clusters[0].cohesion_score == 0.9
     assert captured["method"] == "average"
-    matrix = captured["matrix"]
-    assert float(matrix[0, 1]) == pytest.approx(0.1)
-    assert float(matrix[1, 2]) == pytest.approx(0.8)
+    assert captured["condensed_dist"] == pytest.approx([0.1, 0.9, 0.8])
     assert captured["criterion"] == "distance"
 
 

--- a/tests/test_org_report.py
+++ b/tests/test_org_report.py
@@ -739,34 +739,6 @@ class TestAnalyzerLockIntegration:
         assert analyzer.lock_runtime_state.contention is False
         assert analyzer.lock_runtime_state.backend is None
 
-    def test_quick_check_empty_org_returns_empty_result(self):
-        """Test that quick check returns empty OrgReportResult when no data views exist"""
-        import logging
-
-        mock_cja = Mock()
-        mock_cja.getDataViews.return_value = []
-        logger = logging.getLogger("test_quick_check_empty")
-
-        analyzer = OrgComponentAnalyzer(mock_cja, OrgReportConfig(skip_lock=True), logger)
-
-        result = analyzer._quick_check_empty_org()
-        assert result is not None
-        assert result.total_available_data_views == 0
-        assert result.data_view_summaries == []
-
-    def test_quick_check_non_empty_org_returns_none(self):
-        """Test that quick check returns None when data views exist"""
-        import logging
-
-        mock_cja = Mock()
-        mock_cja.getDataViews.return_value = [{"id": "dv_1", "name": "DV 1"}]
-        logger = logging.getLogger("test_quick_check_non_empty")
-
-        analyzer = OrgComponentAnalyzer(mock_cja, OrgReportConfig(skip_lock=True), logger)
-
-        result = analyzer._quick_check_empty_org()
-        assert result is None
-
     def test_analyzer_aborts_when_lock_ownership_is_lost_mid_run(self):
         """Analyzer must fail closed if lock ownership is lost during execution."""
         import logging
@@ -788,12 +760,10 @@ class TestAnalyzerLockIntegration:
             MockLock.return_value = mock_lock_instance
 
             analyzer = OrgComponentAnalyzer(mock_cja, config, logger, org_id="test_org@AdobeOrg")
-            analyzer._quick_check_empty_org = Mock(return_value=None)
 
             with pytest.raises(LockOwnershipLostError):
                 analyzer.run_analysis()
 
-            analyzer._quick_check_empty_org.assert_called_once()
             mock_cja.getDataViews.assert_not_called()
             assert analyzer.lock_runtime_state.observed is True
             assert analyzer.lock_runtime_state.acquired is True

--- a/tests/test_output_content_validation.py
+++ b/tests/test_output_content_validation.py
@@ -38,7 +38,7 @@ def rich_data_dict():
         "Metadata": pd.DataFrame(
             {
                 "Property": ["Generated At", "Data View ID", "Tool Version", "Total Metrics"],
-                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.12.0", 3],
+                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.12.1", 3],
             },
         ),
         "Data Quality": pd.DataFrame(
@@ -104,7 +104,7 @@ def rich_metadata_dict():
         "Generated At": "2025-01-15 10:30:00 PST",
         "Data View ID": "dv_content_test",
         "Data View Name": "Test DataView",
-        "Tool Version": "3.12.0",
+        "Tool Version": "3.12.1",
         "Metrics Count": "3",
         "Dimensions Count": "4",
     }
@@ -224,7 +224,7 @@ class TestJSONContentValidation:
             data = json.load(f)
 
         assert data["metadata"]["Data View ID"] == "dv_content_test"
-        assert data["metadata"]["Tool Version"] == "3.12.0"
+        assert data["metadata"]["Tool Version"] == "3.12.1"
 
     def test_json_metadata_preserves_partial_markers(self, tmp_path, rich_data_dict, rich_metadata_dict):
         logger = logging.getLogger("json_test")

--- a/tests/test_parallel_validation.py
+++ b/tests/test_parallel_validation.py
@@ -216,27 +216,6 @@ class TestParallelValidation:
         assert all(issue["Severity"] == "CRITICAL" for issue in checker.issues)
         assert all(issue["Category"] == "Empty Data" for issue in checker.issues)
 
-    def test_parallel_error_handling(self):
-        """Verify graceful error handling in parallel mode"""
-        logger = logging.getLogger("test")
-        checker = DataQualityChecker(logger)
-
-        # Create valid metrics but malformed dimensions
-        valid_metrics = pd.DataFrame([{"id": "m1", "name": "Metric 1", "type": "calculated"}])
-        valid_dimensions = pd.DataFrame([{"id": "d1", "name": "Dimension 1", "type": "string"}])
-
-        # Should complete without crashing
-        checker.check_all_parallel(
-            metrics_df=valid_metrics,
-            dimensions_df=valid_dimensions,
-            metrics_required_fields=["id", "name", "type"],
-            dimensions_required_fields=["id", "name", "type"],
-            critical_fields=["id", "name", "description"],
-        )
-
-        # Should have collected issues from both validations
-        assert len(checker.issues) >= 0  # May have issues for missing descriptions
-
     def test_parallel_result_consistency(self, sample_metrics_df, sample_dimensions_df):
         """Verify parallel validation results are consistent across multiple runs"""
         logger = logging.getLogger("test")

--- a/tests/test_ux_features.py
+++ b/tests/test_ux_features.py
@@ -344,11 +344,11 @@ class TestCombinedFeatures:
 class TestVersionUpdated:
     """Test that version is correct"""
 
-    def test_version_is_3_12_0(self):
-        """Test that version is 3.12.0"""
+    def test_version_is_3_12_1(self):
+        """Test that version is 3.12.1"""
         from cja_auto_sdr.generator import __version__
 
-        assert __version__ == "3.12.0"
+        assert __version__ == "3.12.1"
 
 
 class TestFormatAutoDetection:

--- a/tests/test_validation_cache.py
+++ b/tests/test_validation_cache.py
@@ -15,7 +15,7 @@ import os
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pandas as pd
 import pytest
@@ -663,21 +663,3 @@ class TestValidationCache:
 
         with pytest.raises(ValueError, match="ttl_seconds must be > 0"):
             ValidationCache(max_size=10, ttl_seconds=0)
-
-
-# ---------------------------------------------------------------------------
-# Coverage gap tests (moved from test_small_gap_coverage.py)
-# ---------------------------------------------------------------------------
-
-
-def test_validation_cache_capacity_clear_fallback_warns_and_clears_cache() -> None:
-    logger = MagicMock()
-    cache = ValidationCache(max_size=1, ttl_seconds=3600, logger=logger)
-    cache._cache["existing"] = ([{"issue": "old"}], 1.0)
-
-    with patch.object(cache, "_evict_lru", side_effect=lambda debug_enabled=False: None):
-        with cache._lock:
-            cache._ensure_capacity_for_new_entry(now=2.0)
-
-    logger.warning.assert_called_once()
-    assert not cache._cache


### PR DESCRIPTION
Prepare v3.12.1 by removing redundant work in validation and org analysis. Locked org runs now list data views once, quality checks select only the columns they need, and clustering builds SciPy's condensed distances directly. Supported CLI options, imports, output fields, issue payloads, and clustering rounding are preserved.

This is a patch release: no new features or supported interface changes. Includes the version bump, changelog, synchronized version/test-count documentation, simplified local cache eviction, consolidated tests, and isolation of temporary Git tests from developer commit signing. Empty locked org results now use the normal listing path's measured duration and no-matches diagnostic.

Validation:
- Full suite: 8,396 passed, 3 platform/environment skips.
- Audit unit coverage gate: 99.08% (95% required).
- Ruff lint/format, lockfile, version sync, and test-count checks passed.
- Wheel and sdist built; `twine check` and embedded PyPI README link checks passed for both artifacts. Isolated wheel installation reports 3.12.1.

Measured local synthetic workloads (baseline `dcafcf1`, Python 3.14.5; nine alternating trials; identical outputs asserted):

| Workload | Before | After | Peak traced allocations before → after |
|---|---:|---:|---:|
| Validation, 1,000 rows / 5 extra columns | 1.241 ms | 1.069 ms | 93,938 → 70,011 B |
| Validation, 10,000 rows / 40 extra columns | 6.026 ms | 4.004 ms | 2,024,991 → 583,011 B |
| Clustering, 200 views | 3.374 ms | 2.118 ms | 509,538 → 188,206 B |
| Clustering, 800 views | 44.814 ms | 36.861 ms | 8,001,273 → 2,878,065 B |

Clustering timings exclude precomputed similarities; the 800-view case represents forced clustering. These are kernel measurements, not end-to-end or live-service speedup claims. The listing-call reduction is covered by an API-boundary test.

Release preparation only. After merge, a maintainer can tag the merged main commit and publish v3.12.1 according to `RELEASING.md`.
