### PR TITLE
perf: reuse org similarity component unions (v3.12.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to the CJA SDR Generator project will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.12.2] - 2026-09-04
+
+### Performance
+
+- **Org similarity analysis:** reuse each successful data view's combined metric/dimension set within the pairwise Jaccard calculation instead of constructing it twice. Synthetic benchmarks measured 6.5–25.5% less time in this helper, with no end-to-end latency claim. Filtering, ordering, similarity values, and error behavior are preserved.
+
+### Tests
+
+- Add regression coverage for component-set reuse, empty and failed views, overlapping IDs, ordering, mutation between calls, and invalid component data. Retain a reproducible before/after benchmark and measurement documentation.
+
 ## [3.12.1] - 2026-09-04
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ CJA SDR Generator — a CLI tool for generating Solution Design Reference (SDR) 
 - Package manager: **uv**
 - Build system: **hatchling** (dynamic version from `src/cja_auto_sdr/core/version.py`)
 - Entry points: `cja_auto_sdr` and `cja-auto-sdr` (both via `__main__:main`)
-- Current version: v3.12.1
+- Current version: v3.12.2
 - Tests: **8,399** across 165 files at **95% coverage gate**
 - Dependencies: cjapy, numpy, pandas, xlsxwriter, tqdm
 - Optional deps: scipy (clustering), python-dotenv (env), argcomplete (completion)

--- a/README.md
+++ b/README.md
@@ -496,7 +496,7 @@ cja_auto_sdr/
 │   └── ...                    # Additional guides
 ├── examples/                  # Automation and GitHub Actions examples
 ├── scripts/                   # Utility scripts
-├── tests/                     # Test suite (8,399+ tests)
+├── tests/                     # Test suite (8,408+ tests)
 │   ├── category_rules.py      # File-based test-category rules
 │   ├── conftest.py            # Pytest fixtures and auto-marking
 │   ├── README.md              # Test inventory and execution guide

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -943,7 +943,7 @@ cja_auto_sdr --list-dataviews --log-level DEBUG
 At launch, the tool logs diagnostic lines containing the tool version, Python version, platform, active log level, inferred run mode (batch, single, or discovery), and dependency versions. These appear automatically at `INFO` level and are useful for troubleshooting environment issues in CI/CD logs or support requests:
 
 ```text
-CJA SDR Generator v3.12.1 | Python 3.14.2 | darwin | log_level=INFO | mode=single
+CJA SDR Generator v3.12.2 | Python 3.14.2 | darwin | log_level=INFO | mode=single
 Dependencies: cjapy=0.3.0, pandas=2.3.3, numpy=2.2.1, xlsxwriter=3.2.9, tqdm=4.67.0
 ```
 

--- a/docs/QUICKSTART_GUIDE.md
+++ b/docs/QUICKSTART_GUIDE.md
@@ -226,7 +226,7 @@ This command:
 
 ```bash
 $ uv run cja_auto_sdr -V
-cja_auto_sdr 3.12.1
+cja_auto_sdr 3.12.2
 ```
 
 > **Source installations:** Run `uv run` commands from the `cja_auto_sdr` repository directory after running `uv sync`. PyPI installations use `cja_auto_sdr` directly from your chosen working directory.

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Quick Reference Card
 
-Single-page command cheat sheet for CJA SDR Generator v3.12.1.
+Single-page command cheat sheet for CJA SDR Generator v3.12.2.
 
 ## Four Main Modes
 

--- a/docs/performance/pairwise-jaccard.md
+++ b/docs/performance/pairwise-jaccard.md
@@ -1,0 +1,107 @@
+# Pairwise Jaccard component-set reuse
+
+## Scope and safety
+
+`OrgComponentAnalyzer._compute_pairwise_jaccard` evaluated `all_component_ids`
+twice for every nonempty, successful data view: once to filter summaries and
+again to prepare the pairwise loop. Each property access allocates the union of
+metric and dimension IDs. The patch retains the first union in a local list.
+For N valid views, this reduces union construction from 2N to N. Empty successful
+views still require one union; failed views require none.
+
+Other candidates inspected were repeated change-type scans in diff summaries
+and repeated word splitting in cluster naming. Component-set reuse was selected
+because it eliminates allocations proportional to component count with a small
+change and no changes to the pairwise arithmetic or downstream rendering.
+
+The valid-summary and pair-index insertion orders are unchanged. Overlapping
+metric/dimension IDs remain deduplicated. Empty views are excluded, and every
+non-None error (including an empty string) skips component access. Invalid
+component operands still raise TypeError. No API, CLI, validation, exception
+handler, dependency, or persistent cache changes. Inputs are not mutated;
+subsequent calls recompute unions and observe updated inputs. Component fetching
+finishes before this analysis runs. Concurrent external mutation during this
+method is not a supported consistency guarantee; no shared cache is introduced.
+
+## Reproduction
+
+From the repository root, with the baseline commit available in local git history:
+
+```bash
+UV_CACHE_DIR=/tmp/cja-perf-uv-cache uv sync --dev --extra clustering
+PYTHONHASHSEED=0 .venv/bin/python scripts/benchmark_pairwise_jaccard.py --baseline-ref 1e5b198082a4e37127b5d974b8727f560c36cae4 --baseline-only > /tmp/cja-jaccard-before.json
+PYTHONHASHSEED=0 .venv/bin/python scripts/benchmark_pairwise_jaccard.py --baseline-ref 1e5b198082a4e37127b5d974b8727f560c36cae4 > /tmp/cja-jaccard-paired.json
+```
+
+The baseline-only run was completed before editing production code. The paired
+run loads the original method from that trusted git revision and benchmarks it
+alongside the checked-out method in the same process, using identical fixtures,
+imports, interpreter, GC settings, and hash seed. It asserts exact result equality
+before timing. Only pass trusted revisions: the harness executes the extracted
+method. Imports, fixture generation, git I/O, and correctness assertions are
+outside the timed region. GC remains enabled.
+
+Each implementation gets five warmup batches and 31 measured batches per case.
+Execution order alternates between implementations. Each batch repeats the
+helper 2,000 / 1,000 / 20 / 2 / 2 times respectively for the cases below. JSON
+includes every sample, median, quartiles, minimum, maximum, and environment.
+Run without other CPU-intensive work.
+
+Synthetic views contain equal numbers of metrics and dimensions, with half the
+IDs shared and half view-specific. This models the in-memory computation used
+by org-report similarity and clustering after component fetching, including
+small views, component-heavy views, and a larger view count. These are synthetic
+workloads, not measurements of a particular Adobe organization.
+
+## Measurements
+
+Measured on macOS 26.6.2 arm64, CPython 3.14.5 (Clang 22.1.3), fixed hash seed 0.
+All times below are microseconds per helper call. Brackets show Q1–Q3 across
+31 batch averages, not confidence intervals.
+
+| Views × components/view | Pre-edit median | Paired original median [Q1–Q3] | Modified median [Q1–Q3] | Absolute reduction | Time reduction |
+|---|---:|---:|---:|---:|---:|
+| 0 × 0 | 0.160 | 0.160 [0.155–0.166] | 0.148 [0.145–0.153] | 0.012 | immaterial |
+| 3 × 20 | 2.867 | 2.864 [2.820–2.884] | 2.141 [2.112–2.175] | 0.723 | 25.24% |
+| 5 × 2,000 | 877.710 | 880.731 [871.221–886.525] | 656.423 [649.790–669.733] | 224.308 | 25.47% |
+| 25 × 2,000 | 16,764.188 | 16,619.354 [16,490.000–16,759.916] | 15,544.604 [15,467.334–15,667.021] | 1,074.750 | 6.47% |
+| 5 × 10,000 | 5,987.459 | 5,972.208 [5,912.125–6,087.542] | 4,554.458 [4,528.520–4,684.917] | 1,417.750 | 23.74% |
+
+Nonempty cases have separated interquartile ranges. No measured small-input
+regression; the empty-input difference is too small to claim a useful speedup.
+A second independent paired run with the same settings measured 25.57%, 24.86%,
+7.89%, and 22.94% reductions for the four nonempty cases, respectively.
+The percentage benefit declines as pairwise intersections dominate at higher
+view counts. No end-to-end latency or peak-memory improvement is claimed.
+Results may differ with hardware, Python version, overlap, and component counts.
+
+## Correctness and checks
+
+Regression tests cover exact values and pair order, original summary identity,
+empty/single/40-view inputs, failed and empty-error summaries, overlapping IDs,
+input immutability, mutation between calls, invalid-operand failure behavior,
+and one property evaluation per successful summary. Existing org tests cover
+similarity, drift, clustering, governance, and serialization.
+
+```bash
+.venv/bin/pytest tests/test_org_analyzer_similarity.py tests/test_org_analyzer_coverage.py tests/test_exception_contracts.py -q
+UV_CACHE_DIR=/tmp/cja-perf-uv-cache .venv/bin/pytest tests/ -q --tb=short -m 'unit and not slow' -n auto --cov=cja_auto_sdr --cov-report=term --cov-fail-under=95 --durations=10
+UV_CACHE_DIR=/tmp/cja-perf-uv-cache .venv/bin/pytest tests/ -q --tb=short -m 'integration or e2e or slow' --durations=10
+UV_CACHE_DIR=/tmp/cja-perf-uv-cache .venv/bin/pytest tests/test_quality_policy_and_run_summary.py -q -m run_summary_contract
+UV_CACHE_DIR=/tmp/cja-perf-uv-cache .venv/bin/pytest tests/ -q --tb=short -m smoke
+.venv/bin/ruff check src/ tests/ scripts/ examples/
+.venv/bin/ruff format --check src/ tests/ scripts/ examples/
+UV_CACHE_DIR=/tmp/cja-perf-uv-cache uv lock --check --offline
+git diff --check
+```
+
+Results: 192 focused tests passed; 8,294 unit tests passed, 3 skipped, 99.07%
+coverage (95% gate); 101 integration/e2e/slow tests passed. Lint, format, lockfile,
+and whitespace checks passed. The separate run-summary and smoke gates passed
+(52 and 10 tests). Loading the original method into the same focused test suite
+also passed all 191 behavioral tests; only the new single-evaluation assertion
+was excluded because it intentionally distinguishes the optimization.
+Initial sandbox runs failed on uv cache access,
+local multiprocessing sockets, and terminal subprocess checks; the full slices
+passed with a writable uv cache and normal local process permissions. Linux and
+Windows execution remains for CI; no live Adobe API calls were needed.

--- a/scripts/benchmark_pairwise_jaccard.py
+++ b/scripts/benchmark_pairwise_jaccard.py
@@ -1,0 +1,123 @@
+"""Compare the checked-out Jaccard helper with its version at a trusted local git ref.
+
+Run with PYTHONHASHSEED=0; see docs/performance/pairwise-jaccard.md for commands.
+Only the selected method is loaded from git; imports and fixtures are shared.
+"""
+
+import argparse
+import ast
+import gc
+import json
+import logging
+import os
+import platform
+import statistics
+import subprocess
+import sys
+from pathlib import Path
+from time import perf_counter_ns
+
+from cja_auto_sdr.org.analyzer import OrgComponentAnalyzer
+from cja_auto_sdr.org.models import DataViewSummary, OrgReportConfig
+
+
+def load_baseline(ref):
+    source = subprocess.run(
+        ["git", "show", f"{ref}:src/cja_auto_sdr/org/analyzer.py"],
+        cwd=Path(__file__).resolve().parents[1],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    cls = next(
+        node
+        for node in ast.parse(source).body
+        if isinstance(node, ast.ClassDef) and node.name == "OrgComponentAnalyzer"
+    )
+    method = next(node for node in cls.body if getattr(node, "name", None) == "_compute_pairwise_jaccard")
+    namespace = {"DataViewSummary": DataViewSummary}
+    exec(compile(ast.Module(body=[method], type_ignores=[]), "<git baseline>", "exec"), namespace)  # noqa: S102
+    return namespace[method.name]
+
+
+def make_summaries(views, components):
+    # Half shared and half view-specific IDs, split evenly into metrics/dimensions.
+    return [
+        DataViewSummary(
+            data_view_id=f"dv_{view}",
+            data_view_name=f"View {view}",
+            metric_ids={f"m_{'shared' if i % 2 else view}_{i}" for i in range(components // 2)},
+            dimension_ids={f"d_{'shared' if i % 2 else view}_{i}" for i in range(components // 2)},
+        )
+        for view in range(views)
+    ]
+
+
+def measure(function, analyzer, summaries, loops):
+    start = perf_counter_ns()
+    for _ in range(loops):
+        function(analyzer, summaries)
+    return (perf_counter_ns() - start) / loops / 1_000  # microseconds per call
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--baseline-ref", required=True, help="Trusted local revision containing the original method")
+    parser.add_argument("--baseline-only", action="store_true")
+    parser.add_argument("--samples", type=int, default=31)
+    parser.add_argument("--warmups", type=int, default=5)
+    args = parser.parse_args()
+    if args.samples < 2 or args.warmups < 1:
+        parser.error("Use at least two samples and one warmup")
+    if os.environ.get("PYTHONHASHSEED") != "0":
+        parser.error("Run with PYTHONHASHSEED=0 for reproducible set layouts")
+    analyzer = OrgComponentAnalyzer(None, OrgReportConfig(), logging.getLogger("benchmark"))
+    functions = {"original": load_baseline(args.baseline_ref)}
+    if not args.baseline_only:
+        functions["modified"] = OrgComponentAnalyzer._compute_pairwise_jaccard
+    report = {
+        "python": sys.version,
+        "platform": platform.platform(),
+        "baseline_ref": args.baseline_ref,
+        "hash_seed": 0,
+        "gc_enabled": gc.isenabled(),
+        "samples": args.samples,
+        "warmups": args.warmups,
+        "cases": [],
+    }
+    for views, components, loops in [(0, 0, 2000), (3, 20, 1000), (5, 2000, 20), (25, 2000, 2), (5, 10000, 2)]:
+        summaries = make_summaries(views, components)
+        expected = functions["original"](analyzer, summaries)
+        for function in functions.values():
+            assert function(analyzer, summaries) == expected
+            for _ in range(args.warmups):
+                measure(function, analyzer, summaries, loops)
+        timings = {name: [] for name in functions}
+        for sample in range(args.samples):
+            # Alternate execution order to reduce systematic drift bias.
+            order = list(functions) if sample % 2 else list(reversed(functions))
+            for name in order:
+                timings[name].append(measure(functions[name], analyzer, summaries, loops))
+        case = {"views": views, "components_per_view": components, "loops_per_sample": loops, "timings_us": {}}
+        for name, values in timings.items():
+            quartiles = statistics.quantiles(values, n=4)
+            case["timings_us"][name] = {
+                "median": statistics.median(values),
+                "q1": quartiles[0],
+                "q3": quartiles[2],
+                "min": min(values),
+                "max": max(values),
+                "samples": values,
+            }
+        if "modified" in timings:
+            original = statistics.median(timings["original"])
+            modified = statistics.median(timings["modified"])
+            case["saved_us"] = original - modified
+            case["reduction_percent"] = 100 * (original - modified) / original
+        report["cases"].append(case)
+    json.dump(report, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cja_auto_sdr/core/version.py
+++ b/src/cja_auto_sdr/core/version.py
@@ -1,3 +1,3 @@
 """Version information for CJA Auto SDR."""
 
-__version__ = "3.12.1"
+__version__ = "3.12.2"

--- a/src/cja_auto_sdr/org/analyzer.py
+++ b/src/cja_auto_sdr/org/analyzer.py
@@ -1138,8 +1138,15 @@ class OrgComponentAnalyzer:
         Returns:
             Tuple of (valid_summaries, pairwise_similarities dict)
         """
-        valid = [s for s in summaries if s.error is None and s.all_component_ids]
-        component_sets = [s.all_component_ids for s in valid]  # each property evaluated once
+        valid = []
+        component_sets = []
+        for summary in summaries:
+            if summary.error is not None:
+                continue
+            component_ids = summary.all_component_ids
+            if component_ids:
+                valid.append(summary)
+                component_sets.append(component_ids)
         pairwise: dict[tuple, float] = {}
 
         for i in range(len(valid)):

--- a/tests/README.md
+++ b/tests/README.md
@@ -177,7 +177,7 @@ tests/
 └── README.md                        # This file
 ```
 
-**Total: 8,399 comprehensive tests**
+**Total: 8,408 comprehensive tests**
 
 ### Test Count Breakdown
 
@@ -186,16 +186,16 @@ tests/
 
 | Category | Tests | Files | Notes |
 |----------|-------|-------|-------|
-| `unit` | 8,293 | 159 | Default primary category for files without explicit integration/e2e/smoke scope |
+| `unit` | 8,302 | 159 | Default primary category for files without explicit integration/e2e/smoke scope |
 | `integration` | 73 | 3 | Cross-module integration suites |
 | `e2e` | 23 | 2 | End-to-end suites with a mocked external boundary |
 | `smoke` | 10 | 1 | Lightweight command-mode coverage |
 | `slow` | 0 | 0 | Overlay marker; these tests are also counted in a primary category |
-| **Primary Total** | **8,399** | **165** | **unit + integration + e2e + smoke** |
+| **Primary Total** | **8,408** | **165** | **unit + integration + e2e + smoke** |
 
 | CI Slice | Tests | Files | Selector |
 |----------|-------|-------|----------|
-| `test-unit` | 8,293 | 159 | `-m "unit and not slow"` |
+| `test-unit` | 8,302 | 159 | `-m "unit and not slow"` |
 | `test-integration` | 96 | 5 | `-m "integration or e2e or slow"` |
 | `smoke-test` | 10 | 1 | `-m smoke` |
 
@@ -362,7 +362,7 @@ tests/
 | `test_notion_registry_v2.py` | 11 | Notion registry v2 schema and legacy v1 migration tests |
 | `test_cli_notion_prune.py` | 20 | CLI flag wiring for --notion-prune-orphans |
 | `test_cli_notion_repair.py` | 14 | CLI flag wiring for --notion-repair-database and --notion-print-database-schema |
-| `test_org_analyzer_similarity.py` | 1 | Org similarity-engine union-hoisting characterization test |
+| `test_org_analyzer_similarity.py` | 10 | Org similarity-engine union-hoisting characterization test |
 | `test_org_writers_csv.py` | 1 | Org components-CSV bucket-lookup characterization test |
 | `test_sdr_markdown_escaping.py` | 4 | SDR markdown vectorized cell-escaping characterization test |
 | `test_diff_excel.py` | 3 | Diff Excel row-coloring characterization tests |
@@ -370,7 +370,7 @@ tests/
 | `test_diff_snapshot_retention.py` | 1 | Diff snapshot-retention parse-cache characterization test |
 | `test_diff_comparator_normalize.py` | 1 | Diff field-normalization type-fast-path characterization test |
 | `test_logging_diagnostics.py` | 2 | emit_diagnostic isEnabledFor guard characterization tests |
-| **Total** | **8,399** | **Collected via pytest --collect-only** |
+| **Total** | **8,408** | **Collected via pytest --collect-only** |
 
 ## Running Tests
 
@@ -828,7 +828,7 @@ the `tests/README.md` inventory tree or count table.
 - [x] Performance benchmarking tests (implemented in test_optimized_validation.py)
 - [x] Tests for output formats including Excel (test_output_formats.py)
 - [x] Tests for batch processing functionality (test_batch_processor.py)
-- [x] Comprehensive test coverage (8,399 tests total)
+- [x] Comprehensive test coverage (8,408 tests total)
 - [x] Org-wide analysis tests (test_org_report.py) - 209 tests (including large org scaling, output path aliases, memory warnings, smart cache invalidation)
 - [x] Org-wide analysis integration tests (test_org_report_integration.py) - 17 tests (end-to-end flows, caching, filtering, governance thresholds)
 - [x] Profile management tests (test_profiles.py) - 80 tests

--- a/tests/test_org_analyzer_similarity.py
+++ b/tests/test_org_analyzer_similarity.py
@@ -1,12 +1,10 @@
-"""Characterization tests for OrgComponentAnalyzer Jaccard similarity helpers.
-
-Pins the current (pre-optimization) numeric output of ``_compute_pairwise_jaccard``
-so that hoisting component-set unions out of the O(n^2) loops (perf task A1)
-cannot change the computed values.
-"""
+"""Characterization and regression tests for org pairwise Jaccard similarity."""
 
 import logging
+from copy import deepcopy
 from unittest.mock import MagicMock
+
+import pytest
 
 from cja_auto_sdr.org.analyzer import OrgComponentAnalyzer
 from cja_auto_sdr.org.models import DataViewSummary, OrgReportConfig
@@ -36,3 +34,75 @@ def test_pairwise_jaccard_values_are_stable():
     assert pairwise[(0, 2)] == 0.0
     assert pairwise[(1, 2)] == 0.0
     assert [s.data_view_id for s in valid] == ["a", "b", "c"]
+
+
+def test_pairwise_filters_preserve_order_and_evaluate_components_once(monkeypatch):
+    summaries = [
+        _dv("z", ["shared", "m1"], ["shared", "d1"]),
+        _dv("empty", [], []),
+        _dv("failed", [], []),
+        _dv("a", ["shared", "m1"], ["shared", "d1"]),
+        _dv("blank_error", [], []),
+        _dv("disjoint", [], ["d2"]),
+    ]
+    summaries[2].error = "API failure"
+    summaries[4].error = ""  # Even an empty error string excludes the summary.
+    original = deepcopy(summaries)
+    calls = []
+    getter = DataViewSummary.all_component_ids.fget
+
+    def tracked_getter(summary):
+        calls.append(summary.data_view_id)
+        return getter(summary)
+
+    monkeypatch.setattr(DataViewSummary, "all_component_ids", property(tracked_getter))
+    analyzer = OrgComponentAnalyzer(MagicMock(), OrgReportConfig(), logging.getLogger("t"))
+    valid, pairwise = analyzer._compute_pairwise_jaccard(summaries)
+
+    assert calls == ["z", "empty", "a", "disjoint"]
+    assert len(valid) == 3
+    assert all(actual is expected for actual, expected in zip(valid, [summaries[0], summaries[3], summaries[5]]))
+    assert list(pairwise.items()) == [((0, 1), 1.0), ((0, 2), 0.0), ((1, 2), 0.0)]
+    assert summaries == original
+    assert analyzer.cja.mock_calls == []
+
+
+@pytest.mark.parametrize("size", [0, 1, 3, 40])
+def test_pairwise_matches_direct_set_definition(size):
+    summaries = [
+        _dv(str(i), [f"m{j}" for j in range(i, i + 100)], [f"d{j}" for j in range(i, i + 50)]) for i in range(size)
+    ]
+    analyzer = OrgComponentAnalyzer(MagicMock(), OrgReportConfig(), logging.getLogger("t"))
+    valid, pairwise = analyzer._compute_pairwise_jaccard(summaries)
+    expected = {}
+    for i, left in enumerate(summaries):
+        for j in range(i + 1, size):
+            right = summaries[j]
+            left_ids = left.metric_ids | left.dimension_ids
+            right_ids = right.metric_ids | right.dimension_ids
+            expected[(i, j)] = len(left_ids & right_ids) / len(left_ids | right_ids)
+    assert valid == summaries
+    assert list(pairwise.items()) == list(expected.items())
+
+
+def test_pairwise_observes_mutation_between_calls():
+    summaries = [_dv("a", ["m1"], []), _dv("b", [], [])]
+    analyzer = OrgComponentAnalyzer(MagicMock(), OrgReportConfig(), logging.getLogger("t"))
+    assert analyzer._compute_pairwise_jaccard(summaries) == ([summaries[0]], {})
+    summaries[1].dimension_ids.add("m1")
+    assert analyzer._compute_pairwise_jaccard(summaries) == (summaries, {(0, 1): 1.0})
+    summaries[0].metric_ids.add("m2")
+    assert analyzer._compute_pairwise_jaccard(summaries) == (summaries, {(0, 1): 0.5})
+
+
+@pytest.mark.parametrize("error", [None, "", "API failure"])
+def test_pairwise_invalid_components_keep_failure_behavior(error):
+    summary = _dv("invalid", [], [])
+    summary.metric_ids = None
+    summary.error = error
+    analyzer = OrgComponentAnalyzer(MagicMock(), OrgReportConfig(), logging.getLogger("t"))
+    if error is None:
+        with pytest.raises(TypeError, match="unsupported operand type"):
+            analyzer._compute_pairwise_jaccard([summary])
+    else:
+        assert analyzer._compute_pairwise_jaccard([summary]) == ([], {})

--- a/tests/test_output_content_validation.py
+++ b/tests/test_output_content_validation.py
@@ -38,7 +38,7 @@ def rich_data_dict():
         "Metadata": pd.DataFrame(
             {
                 "Property": ["Generated At", "Data View ID", "Tool Version", "Total Metrics"],
-                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.12.1", 3],
+                "Value": ["2025-01-15 10:30:00 PST", "dv_content_test", "3.12.2", 3],
             },
         ),
         "Data Quality": pd.DataFrame(
@@ -104,7 +104,7 @@ def rich_metadata_dict():
         "Generated At": "2025-01-15 10:30:00 PST",
         "Data View ID": "dv_content_test",
         "Data View Name": "Test DataView",
-        "Tool Version": "3.12.1",
+        "Tool Version": "3.12.2",
         "Metrics Count": "3",
         "Dimensions Count": "4",
     }
@@ -224,7 +224,7 @@ class TestJSONContentValidation:
             data = json.load(f)
 
         assert data["metadata"]["Data View ID"] == "dv_content_test"
-        assert data["metadata"]["Tool Version"] == "3.12.1"
+        assert data["metadata"]["Tool Version"] == "3.12.2"
 
     def test_json_metadata_preserves_partial_markers(self, tmp_path, rich_data_dict, rich_metadata_dict):
         logger = logging.getLogger("json_test")

--- a/tests/test_ux_features.py
+++ b/tests/test_ux_features.py
@@ -344,11 +344,11 @@ class TestCombinedFeatures:
 class TestVersionUpdated:
     """Test that version is correct"""
 
-    def test_version_is_3_12_1(self):
-        """Test that version is 3.12.1"""
+    def test_version_is_3_12_2(self):
+        """Test that version is 3.12.2"""
         from cja_auto_sdr.generator import __version__
 
-        assert __version__ == "3.12.1"
+        assert __version__ == "3.12.2"
 
 
 class TestFormatAutoDetection:


### PR DESCRIPTION
## Patch release 3.12.2

Reduce repeated component-set construction in org-report similarity analysis while preserving filtering, ordering, similarity values, and error handling. Synchronize the patch version from 3.12.1 to 3.12.2 across the eight required files, add release notes, and refresh generated test counts.

All PR CI checks passed. Local release validation passed: 187 focused version/output/release-gate tests (one skipped), version and test-count synchronization, lint/format, lockfile consistency, wheel/sdist builds, `twine check`, and packaged PyPI README-link checks. The release tag will point to this PR's merged commit on `main`; publication uses the existing GitHub Release → PyPI Trusted Publishing workflow.

## Problem and change

Org-report pairwise similarity constructed each valid view's metric/dimension union twice: once for filtering and once for comparison. Reuse the first union within the call, reducing these allocations from 2N to N. The production patch adds seven net lines; pairwise arithmetic and downstream rendering are unchanged.

Also inspected repeated diff-summary scans and cluster-name splitting; union reuse offered a small, measurable allocation reduction without API or cache changes. Summary identity/order, pair insertion order, empty/error filtering (including empty-string errors), input immutability, and invalid-operand exceptions are preserved. There is no persistent cache; later calls see mutations. Fetching completes before analysis. Concurrent external mutation during analysis remains unsupported.

## Reproducible performance evidence

Baseline commit: `1e5b198082a4e37127b5d974b8727f560c36cae4`. A baseline-only run completed before production edits. The retained harness loads that original method and compares it with the checked-out method in the same process, asserting exact output equality before timing. Synthetic views have equal metric/dimension counts and 50% shared IDs, modeling the in-memory org-report similarity/clustering step.

CPython 3.14.5, macOS 26.6.2 arm64, `PYTHONHASHSEED=0`, GC enabled. Five warmup batches and 31 measured batches per implementation/case; alternating execution order. Values are microseconds/call; brackets are Q1–Q3 of batch averages. Fixture construction/imports/git I/O are excluded.

| Views × components | Original median [Q1–Q3] | Modified median [Q1–Q3] | Saved µs | Reduction |
|---|---:|---:|---:|---:|
| 0 × 0 | 0.160 [0.155–0.166] | 0.148 [0.145–0.153] | 0.012 | immaterial |
| 3 × 20 | 2.864 [2.820–2.884] | 2.141 [2.112–2.175] | 0.723 | 25.24% |
| 5 × 2,000 | 880.731 [871.221–886.525] | 656.423 [649.790–669.733] | 224.308 | 25.47% |
| 25 × 2,000 | 16,619.354 [16,490–16,759.916] | 15,544.604 [15,467.334–15,667.021] | 1,074.750 | 6.47% |
| 5 × 10,000 | 5,972.208 [5,912.125–6,087.542] | 4,554.458 [4,528.520–4,684.917] | 1,417.750 | 23.74% |

Batch loop counts: 2,000 / 1,000 / 20 / 2 / 2 respectively. A second independent run confirmed 25.57%, 24.86%, 7.89%, and 22.94% reductions on the nonempty cases. No observed small-input regression. Empty-input timing differences are immaterial. No end-to-end latency or peak-memory gain is claimed; hardware, overlap, and view counts affect results.

```bash
UV_CACHE_DIR=/tmp/cja-perf-uv-cache uv sync --dev --extra clustering
PYTHONHASHSEED=0 .venv/bin/python scripts/benchmark_pairwise_jaccard.py --baseline-ref 1e5b198082a4e37127b5d974b8727f560c36cae4 --baseline-only > /tmp/cja-jaccard-before.json
PYTHONHASHSEED=0 .venv/bin/python scripts/benchmark_pairwise_jaccard.py --baseline-ref 1e5b198082a4e37127b5d974b8727f560c36cae4 > /tmp/cja-jaccard-paired.json
```

JSON retains every sample and environment metadata. See [benchmark documentation](https://github.com/brian-a-au/cja_auto_sdr/blob/main/docs/performance/pairwise-jaccard.md) for pre-edit results, methodology, safety assessment, and exact validation commands.

## Correctness validation

- 192 focused tests passed; all 191 behavioral tests also passed with the original method loaded (excluding the new assertion that intentionally requires one property evaluation).
- Unit CI slice: 8,294 passed, 3 skipped; 99.07% coverage against the 95% gate.
- Integration/e2e/slow slice: 101 passed.
- Separate run-summary contract gate: 52 passed; smoke gate: 10 passed.
- Repository-wide Ruff lint/format, lockfile consistency, and whitespace checks passed.
- Regression coverage includes filtering, summary identity and ordering, pair ordering, overlapping IDs, empty/single/40-view inputs, unchanged inputs, mutation between calls, invalid-operand failures, and single union evaluation. Existing tests cover downstream similarity, clustering, governance, drift, and serialization.

Initial sandbox runs failed on restricted uv cache access, multiprocessing sockets, and terminal checks; the slices passed with a writable cache and normal local process permissions. GitHub CI passed, including Linux, macOS, and Windows smoke checks. No live Adobe calls were needed.
